### PR TITLE
Feature/configure schema registry timeout

### DIFF
--- a/backend/pkg/schema/client.go
+++ b/backend/pkg/schema/client.go
@@ -36,7 +36,7 @@ func newClient(cfg Config) (*Client, error) {
 		SetHeader("User-Agent", "Kowl").
 		SetHeader("Accept", "application/vnd.schemaregistry.v1+json").
 		SetError(&RestError{}).
-		SetTimeout(5 * time.Second)
+		SetTimeout(time.Duration(cfg.Timeout) * time.Second)
 
 	// Configure credentials
 	if cfg.Username != "" {

--- a/backend/pkg/schema/config.go
+++ b/backend/pkg/schema/config.go
@@ -33,7 +33,7 @@ func (c *Config) Validate() error {
 		return nil
 	}
 
-	if c.Timeout == 0 {
+	if c.Timeout <= 5 {
 		c.Timeout = 5
 	}
 

--- a/backend/pkg/schema/config.go
+++ b/backend/pkg/schema/config.go
@@ -17,6 +17,9 @@ type Config struct {
 
 	// TLS / Custom CA
 	TLS TLSConfig `yaml:"tls"`
+
+	// Timeouts
+	Timeout int `yaml:"timeout"`
 }
 
 // RegisterFlags registers all nested config flags.
@@ -28,6 +31,10 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 func (c *Config) Validate() error {
 	if c.Enabled == false {
 		return nil
+	}
+
+	if c.Timeout == 0 {
+		c.Timeout = 5
 	}
 
 	if len(c.URLs) == 0 {

--- a/docs/config/kowl-business.yaml
+++ b/docs/config/kowl-business.yaml
@@ -65,6 +65,7 @@ kafka:
   #   username: # Basic auth username
   #   password: # Basic auth password
   #   bearerToken:
+  #   timeout: 5 # timeout in seconds to wait for schema downloading
   #   tls:
   #     enabled: false # Enable Client certificate connexion to the schemaRegistry
   #     caFilepath: # Path to a custom CA file. If not specified the system's / trusted root ca is used.

--- a/docs/config/kowl.yaml
+++ b/docs/config/kowl.yaml
@@ -65,6 +65,7 @@ kafka:
   #   username: # Basic auth username
   #   password: # Basic auth password
   #   bearerToken:
+  #   timeout: 5 # timeout in seconds to wait for schema downloading
   #   tls:
   #     enabled: false # Enable Client certificate connexion to the schemaRegistry
   #     caFilepath: # Path to a custom CA file. If not specified the system's / trusted root ca is used.


### PR DESCRIPTION
We have noticed that when trying to determine if a message has to be deserialized using Avro, if schema fails to be fetched in the next 5 seconds an error is thrown and the deserializing logic thinks it is not an Avro message (when it really is).

This PR adds the possibility to configure it, using 5 as a default value if no one is given or the value provided is less than that.