### PR TITLE
Fix Kafka GetAPIVersions

### DIFF
--- a/backend/pkg/kafka/api_version.go
+++ b/backend/pkg/kafka/api_version.go
@@ -20,7 +20,7 @@ import (
 func (s *Service) GetAPIVersions(ctx context.Context) (*kmsg.ApiVersionsResponse, error) {
 	req := kmsg.NewApiVersionsRequest()
 	req.ClientSoftwareVersion = version.Version
-	req.ClientSoftwareName = "RP Console"
+	req.ClientSoftwareName = "RPConsole"
 
 	return req.RequestWith(ctx, s.KafkaClient)
 }


### PR DESCRIPTION
Remove illegal space character from Kafka get API versions request (#390).