### PR TITLE
helm: git credentials secret

### DIFF
--- a/helm/console/templates/deployment.yaml
+++ b/helm/console/templates/deployment.yaml
@@ -110,6 +110,13 @@ spec:
                   name: {{ include "console.fullname" . }}
                   key: kafka-sasl-password
             {{- end }}
+             {{- if .Values.secret.kafka.protobufGitBasicAuthPassword }}
+            - name: KAFKA_PROTOBUF_GIT_BASICAUTH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "console.fullname" . }}
+                  key: kafka-protobuf-git-basicauth-password
+            {{- end }}
             {{- if .Values.secret.kafka.awsMskIamSecretKey }}
             - name: KAFKA_SASL_AWSMSKIAM_SECRETKEY
               valueFrom:

--- a/helm/console/templates/deployment.yaml
+++ b/helm/console/templates/deployment.yaml
@@ -110,7 +110,7 @@ spec:
                   name: {{ include "console.fullname" . }}
                   key: kafka-sasl-password
             {{- end }}
-             {{- if .Values.secret.kafka.protobufGitBasicAuthPassword }}
+            {{- if .Values.secret.kafka.protobufGitBasicAuthPassword }}
             - name: KAFKA_PROTOBUF_GIT_BASICAUTH_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/helm/console/templates/secret.yaml
+++ b/helm/console/templates/secret.yaml
@@ -11,6 +11,7 @@ data:
   # For this reason we can't use `with` to change the scope.
   # Kafka
   kafka-sasl-password: {{ .Values.secret.kafka.saslPassword | default "" | b64enc | quote }}
+  kafka-protobuf-git-basicauth-password: {{ .Values.secret.kafka.protobufGitBasicAuthPassword | default "" | b64enc | quote }}
   kafka-sasl-aws-msk-iam-secret-key: {{ .Values.secret.kafka.awsMskIamSecretKey | default "" | b64enc | quote }}
   kafka-tls-ca: {{ .Values.secret.kafka.tlsCa | default "" | b64enc | quote }}
   kafka-tls-cert: {{ .Values.secret.kafka.tlsCert | default "" | b64enc | quote }}

--- a/helm/console/values.yaml
+++ b/helm/console/values.yaml
@@ -149,6 +149,7 @@ secret:
     # tlsKey:
     # tlsPassphrase:
     # schemaRegistryPassword:
+    # protobufGitBasicAuthPassword
   # Enterprise version secrets
   # SSO secrets (enterprise version)
   login:


### PR DESCRIPTION
This commit adds support for a embedding a github basic auth password as a kubernetes `secret` in the helm chart.

Before this change, when setting up a git repository as a protobuf registry for
protobuf deserialization, you could provide basic auth credentials through the helm chart.
However you could not provide the secret to the helm chart without exposing it in a `configmap` resource.

After this change, you can now provide it to the helm chart via:

```yaml
secret:
    kafka:
        protobufGitBasicAuthPassword: <MYPASSWORD>
```

The change follows the pattern already present in the helm chart for console secrets:
1. add the value to the `secret` resource
2. map it the value from the `secret` to an environment variable using the `deployment` resource.
3. the environment variable name used is the config path that you would typically use in the yaml with the `.`s replaced by `_`s: i.e. `kafka.protobuf.git.basicAuth.Password`, becomes `KAFKA_PROTOBUF_GIT_BASICAUTH_PASSWORD`.

By doing this, its now possible for the user of the helm chart to embed the github basic auth password in the helm chart as a kubernetes `secret`.
