### PR TITLE
update SECURITY.md for Redpanda Console rename

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,13 +1,13 @@
-# Kowl Security and Disclosure Information
+# Redpanda Console Security and Disclosure Information
 
 As with any complex system, it is certain that bugs will be found, some of them security-relevant.
-If you find a _security bug_ please report it privately via email to info@cloudhut.dev. We will fix the issue as soon
+If you find a _security bug_ please report it privately via email to security@redpanda.com. We will fix the issue as soon
 as possible and coordinate a release date with you. You will be able to choose if you want public acknowledgement of
 your effort and if you want to be mentioned by name.
 
 ## Public Disclosure Timing
 
-The public disclosure date is agreed between the CloudHut Team and the bug submitter.
+The public disclosure date is agreed between the Redpanda Console Team and the bug submitter.
 We prefer to fully disclose the bug as soon as possible, but only after a mitigation or fix is available.
 We will ask for delay if the bug or the fix is not yet fully understood or the solution is not tested to our standards
 yet. While there is no fixed time frame for fix & disclosure, we will try our best to be quick and do not expect to need


### PR DESCRIPTION
This PR updates wording of the security doc to say `Redpanda Console` instead of `Kowl` because of [rename](https://redpanda.com/blog/redpanda-acquires-cloudhut-kowl-data-streaming-kafka-ui).

Also changed the contact email from info@cloudhut.dev to security@redpanda.com to line up with the [email mentioned in redpanda repo](https://github.com/redpanda-data/redpanda/blob/v22.2.2/SECURITY.md).