### PR TITLE
feat(frontend): extend injectApp to return root container

### DIFF
--- a/frontend/src/injectApp.tsx
+++ b/frontend/src/injectApp.tsx
@@ -17,8 +17,8 @@ const injector = async (parentElementId: string, props: EmbeddedProps) => {
 
 const container = document.getElementById(parentElementId)  
 const root = createRoot(container!)
-  return  root.render(<EmbeddedApp {...props} />);
-
+  root.render(<EmbeddedApp {...props} />);
+  return root;
 }
 
 export default injector;


### PR DESCRIPTION
return react-dom/client Root on injectApp function to allow the user to unmount the remote app