### PR TITLE
Extras are lists and not strings

### DIFF
--- a/helm/console/Chart.yaml
+++ b/helm/console/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/console/values.yaml
+++ b/helm/console/values.yaml
@@ -93,17 +93,17 @@ console:
   # roleBindings:
 
 # Additional environment variables for the Console Deployment
-extraEnv: ""
+extraEnv: []
   # - name: KAFKA_RACKID
   #   value: "1"
 
 # Additional environment variables for Console mapped from Secret or ConfigMap
-extraEnvFrom: ""
+extraEnvFrom: []
 # - secretRef:
 #     name: kowl-config-secret
 
 # Add additional volumes, e. g. for tls keys
-extraVolumes: ""
+extraVolumes: []
 # - name: kafka-certs
 #   secret:
 #     secretName: kafka-certs
@@ -112,7 +112,7 @@ extraVolumes: ""
 #     name: console-config
 
 # Add additional volumes mounts, e. g. for tls keys
-extraVolumeMounts: ""
+extraVolumeMounts: []
 # - name: kafka-certs # Must match the volume name
 #   mountPath: /etc/kafka/certs
 #   readOnly: true


### PR DESCRIPTION
Without this change helm throws error:

```text
Error: template: console/templates/deployment.yaml:103:20: 
executing "console/templates/deployment.yaml" at <.>: 
wrong type for value; expected string; got []interface {}
```