### PR TITLE
`rbac.enabled` is `false` by default

### DIFF
--- a/helm/examples/console-enterprise.yaml
+++ b/helm/examples/console-enterprise.yaml
@@ -32,6 +32,7 @@ console:
           targetPrincipal: admin@mycompany.com
     enterprise:
       rbac:
+        enabled: true
         roleBindingsFilepath: /etc/console/configs/role-bindings.yaml
   roleBindings:
     - roleName: viewer


### PR DESCRIPTION
if not specified you get error:
```json
{"level":"fatal","msg":"failed to validate config","error":"failed to validate enterprise config: failed to validate RBAC config: RBAC must be enabled until a RBAC-less mode is supported in Redpanda Console"}
```

Source: https://docs.redpanda.com/docs/console/reference/config/
![image](https://user-images.githubusercontent.com/728243/198741587-f4a1ea94-75ef-4cdc-b6ad-c404d016f1bc.png)
