### PR TITLE
proto: allow multiple import paths

### DIFF
--- a/backend/pkg/config/proto.go
+++ b/backend/pkg/config/proto.go
@@ -24,6 +24,11 @@ type Proto struct {
 
 	// Mappings define what proto types shall be used for each Kafka topic. If SchemaRegistry is used, no mappings are required.
 	Mappings []ProtoTopicMapping `json:"mappings"`
+
+	// Proto import paths. By default, the baseDir/root is used. Set import paths
+	// if multiple import paths relative to the baseDir shall be used. The
+	// behavior is similar to the `-I` flag of protoc.
+	ImportPaths []string `json:"importPaths"`
 }
 
 // RegisterFlags registers all nested config flags.

--- a/backend/pkg/git/util.go
+++ b/backend/pkg/git/util.go
@@ -79,9 +79,14 @@ func (c *Service) readFiles(fs billy.Filesystem, res map[string]filesystem.File,
 
 		key := trimmedFilename
 		if c.Cfg.IndexByFullFilepath {
-			pathWithoutBasepath := strings.Trim(path.Clean(strings.Replace(filePath, c.Cfg.Repository.BaseDirectory, "", 1)), "\\")
-			key = pathWithoutBasepath
-			filePath = pathWithoutBasepath
+
+			// If base is ".", don't strip dots from the path.
+			if c.Cfg.Repository.BaseDirectory != "." {
+				key = strings.Trim(path.Clean(strings.Replace(filePath, c.Cfg.Repository.BaseDirectory, "", 1)), "\\")
+			} else {
+				key = strings.Trim(path.Clean(filePath), "\\")
+			}
+			filePath = key
 		}
 		res[key] = filesystem.File{
 			Path:            filePath,


### PR DESCRIPTION
add new config parameter proto.importPaths.
if import paths are configured, these paths are all treated as roots. if not configured, the already existing behavior is preserved.

in addition, if git.basePath is empty / "." (default), the dot from file extensions is dropped, resuling in paths where the dot of the file extension is missing. the dot is now not stripped anymore.