### PR TITLE
Auto Refresh button

### DIFF
--- a/frontend/src/components/misc/UserPreferences.tsx
+++ b/frontend/src/components/misc/UserPreferences.tsx
@@ -243,7 +243,7 @@ class AutoRefreshTab extends Component {
                                 uiSettings.autoRefreshIntervalSecs = e;
                             }
                         }}
-                        min={1} max={60}
+                        min={5} max={300}
                         style={{ maxWidth: '150px' }}
                     />
                 </Label>

--- a/frontend/src/components/misc/UserPreferences.tsx
+++ b/frontend/src/components/misc/UserPreferences.tsx
@@ -23,6 +23,7 @@ const settingsTabs: { name: string, component: () => ReactNode }[] = [
     { name: 'Statistics Bar', component: () => <StatsBarTab /> },
     { name: 'Json Viewer', component: () => <JsonViewerTab /> },
     { name: 'Import/Export', component: () => <ImportExportTab /> },
+    { name: 'Auto Refresh', component: () => <AutoRefreshTab /> },
 
     // pagination position
     // { name: "Message Search", component: () => <MessageSearchTab /> },
@@ -225,5 +226,28 @@ class ImportExportTab extends Component {
                 </>
             </Label>
         </>;
+    }
+}
+
+@observer
+class AutoRefreshTab extends Component {
+    render() {
+        return <div>
+            <p>Settings for the Auto Refresh Button</p>
+            <div style={{ display: 'inline-grid', gridAutoFlow: 'row', gridRowGap: '24px', gridColumnGap: '32px', marginRight: 'auto' }}>
+                <Label text="Interval in seconds">
+                    <InputNumber
+                        value={uiSettings.autoRefreshIntervalSecs}
+                        onChange={e => {
+                            if (e) {
+                                uiSettings.autoRefreshIntervalSecs = e;
+                            }
+                        }}
+                        min={1} max={60}
+                        style={{ maxWidth: '150px' }}
+                    />
+                </Label>
+            </div>
+        </div>;
     }
 }

--- a/frontend/src/components/misc/buttons/buttons.module.scss
+++ b/frontend/src/components/misc/buttons/buttons.module.scss
@@ -137,3 +137,16 @@
         opacity: 1;
     }
 }
+
+.rotation {
+    animation: rotation 2s infinite linear;
+}
+
+@keyframes rotation {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/frontend/src/state/ui.ts
+++ b/frontend/src/state/ui.ts
@@ -141,6 +141,7 @@ const defaultUiSettings = {
     topicDetailsActiveTabKey: undefined as TopicTabId | undefined,
 
     topicDetailsShowStatisticsBar: true, // for now: global for all topic details
+    autoRefreshIntervalSecs: 5,
     jsonViewer: {
         fontSize: '12px',
         lineHeight: '1em',

--- a/frontend/src/state/ui.ts
+++ b/frontend/src/state/ui.ts
@@ -141,7 +141,7 @@ const defaultUiSettings = {
     topicDetailsActiveTabKey: undefined as TopicTabId | undefined,
 
     topicDetailsShowStatisticsBar: true, // for now: global for all topic details
-    autoRefreshIntervalSecs: 5,
+    autoRefreshIntervalSecs: 10,
     jsonViewer: {
         fontSize: '12px',
         lineHeight: '1em',


### PR DESCRIPTION
Add an "Auto Refresh" button next to the "Force Refresh" button:

![image](https://user-images.githubusercontent.com/6736720/201536726-5a922811-9432-463d-af46-fef96b64e2d3.png)

When pressed, the page will be automatically force refreshed every `X` seconds where `X` can be configured in the "User Preferences" panel:

![image](https://user-images.githubusercontent.com/6736720/201536845-3e5da6f2-99c3-4b12-9230-3ae40efe73f0.png)

When the auto refresh is active, the "Auto Refresh" and "Force Refresh" button will be displayed with pulsating and rotation animations respectively:

![Animação](https://user-images.githubusercontent.com/6736720/201537370-694fad29-4242-4b70-a1ef-3708172155a2.gif)

Pressing the button again disables the auto refresh.
