### PR TITLE
On topic list, add the number of messages for each topic

### DIFF
--- a/backend/pkg/console/topic_overview.go
+++ b/backend/pkg/console/topic_overview.go
@@ -39,6 +39,7 @@ type TopicSummary struct {
 	CleanupPolicy     string             `json:"cleanupPolicy"`
 	Documentation     DocumentationState `json:"documentation"`
 	LogDirSummary     TopicLogDirSummary `json:"logDirSummary"`
+	Messages          int64              `json:"messages"`
 
 	// What actions the logged in user is allowed to run on this topic
 	AllowedActions []string `json:"allowedActions"`
@@ -74,6 +75,37 @@ func (s *Service) GetTopicsOverview(ctx context.Context) ([]*TopicSummary, error
 		}
 	}()
 	logDirsByTopic := s.logDirsByTopic(childCtx, metadata)
+
+	// 4. Get the number of messages for each topic
+	topicWatermarkReqs := make(map[string][]int32)
+	for _, topic := range metadata.Topics {
+		topicErr := kerr.TypedErrorForCode(topic.ErrorCode)
+		if topicErr != nil {
+			// If there's an error on the topic level we won't have any partitions reported back
+			continue
+		}
+		topicName := *topic.Topic
+		for _, partition := range topic.Partitions {
+			partitionID := partition.Partition
+			topicWatermarkReqs[topicName] = append(topicWatermarkReqs[topicName], partitionID)
+		}
+	}
+	waterMarks, err := s.kafkaSvc.GetPartitionMarksBulk(childCtx, topicWatermarkReqs)
+	if err != nil {
+		return nil, err
+	}
+	messagesByTopic := make(map[string]int64)
+	for _, topic := range metadata.Topics {
+		topicName := *topic.Topic
+		topicMarks := waterMarks[topicName]
+		topicMessages := int64(0)
+		for _, partition := range topic.Partitions {
+			partitionMarks := topicMarks[partition.Partition]
+			topicMessages += partitionMarks.High - partitionMarks.Low
+		}
+		messagesByTopic[topicName] = topicMessages
+	}
+
 	wg.Wait()
 
 	// 4. Merge information from all requests and construct the TopicSummary object
@@ -109,6 +141,7 @@ func (s *Service) GetTopicsOverview(ctx context.Context) ([]*TopicSummary, error
 			ReplicationFactor: len(topic.Partitions[0].Replicas),
 			CleanupPolicy:     policy,
 			LogDirSummary:     logDirsByTopic[topicName],
+			Messages:          messagesByTopic[topicName],
 			Documentation:     docState,
 		}
 	}

--- a/frontend/src/components/pages/topics/DeleteRecordsModal/DeleteRecordsModal.test.tsx
+++ b/frontend/src/components/pages/topics/DeleteRecordsModal/DeleteRecordsModal.test.tsx
@@ -26,6 +26,7 @@ const testTopic: Topic = {
         hint: null,
         replicaErrors: [],
     },
+    messages: 3,
 };
 
 it('renders all expected elements in step 1', () => {

--- a/frontend/src/components/pages/topics/Topic.List.tsx
+++ b/frontend/src/components/pages/topics/Topic.List.tsx
@@ -200,6 +200,14 @@ class TopicList extends PageComponent {
                                 width: '140px',
                             },
                             {
+                                title: 'Messages',
+                                render: (t, r) => r.messages,
+                                sorter: (a, b) =>
+                                    a.messages -
+                                    b.messages,
+                                width: '140px',
+                            },
+                            {
                                 width: 1,
                                 title: ' ',
                                 key: 'action',

--- a/frontend/src/state/restInterfaces.ts
+++ b/frontend/src/state/restInterfaces.ts
@@ -56,6 +56,7 @@ export interface Topic {
     documentation: 'UNKNOWN' | 'NOT_CONFIGURED' | 'NOT_EXISTENT' | 'AVAILABLE';
     logDirSummary: TopicLogDirSummary;
     allowedActions: TopicAction[] | undefined;
+    messages: number;
 }
 
 export interface TopicLogDirSummary {


### PR DESCRIPTION
Add a column on topic list showing the current number of messages for each topic:

![image](https://user-images.githubusercontent.com/6736720/201540681-35e82db5-bd76-40c2-b25c-278642cc836f.png)

