### PR TITLE
On topic list, add lag column for each topic

### DIFF
--- a/frontend/src/components/pages/topics/DeleteRecordsModal/DeleteRecordsModal.test.tsx
+++ b/frontend/src/components/pages/topics/DeleteRecordsModal/DeleteRecordsModal.test.tsx
@@ -26,6 +26,10 @@ const testTopic: Topic = {
         hint: null,
         replicaErrors: [],
     },
+    consumerGroupSummary: {
+        consumerGroups: [],
+        maxLag: 0
+    }
 };
 
 it('renders all expected elements in step 1', () => {

--- a/frontend/src/components/pages/topics/Topic.List.tsx
+++ b/frontend/src/components/pages/topics/Topic.List.tsx
@@ -16,7 +16,7 @@ import { autorun, IReactionDisposer, makeObservable, observable } from 'mobx';
 import { observer } from 'mobx-react';
 import { appGlobal } from '../../../state/appGlobal';
 import { api } from '../../../state/backendApi';
-import { Topic, TopicAction, TopicActions, TopicConfigEntry } from '../../../state/restInterfaces';
+import { Topic, TopicAction, TopicActions, TopicConfigEntry, TopicConsumerGroupSummary } from '../../../state/restInterfaces';
 import { uiSettings } from '../../../state/ui';
 import { editQuery } from '../../../utils/queryHelper';
 import { Code, DefaultSkeleton, findPopupContainer, QuickTable } from '../../../utils/tsxUtils';
@@ -198,6 +198,14 @@ class TopicList extends PageComponent {
                                     a.logDirSummary.totalSizeBytes -
                                     b.logDirSummary.totalSizeBytes,
                                 width: '140px',
+                            },
+                            {
+                                title: 'Lag',
+                                render: (t, r) => renderConsumerGroupSummary(r.consumerGroupSummary),
+                                sorter: (a, b) =>
+                                    (a.consumerGroupSummary?.consumerGroups ? a.consumerGroupSummary.maxLag : -1) -
+                                    (b.consumerGroupSummary?.consumerGroups ? b.consumerGroupSummary.maxLag : -1),
+                                width: '70px',
                             },
                             {
                                 width: 1,
@@ -544,4 +552,21 @@ function makeCreateTopicModal(parent: TopicList) {
         content: (state) => <CreateTopicModalContent state={state} />,
     });
 
+}
+
+function renderConsumerGroupSummary(summary: TopicConsumerGroupSummary): JSX.Element {
+    if (!summary?.consumerGroups) return <></>;
+    const msg = QuickTable(
+        summary.consumerGroups.map((consumerGroup) => ({ key: `${consumerGroup.groupName}:`, value: consumerGroup.lag })),
+        {
+            keyAlign: 'right', keyStyle: { fontWeight: 500 },
+            gapWidth: 4,
+            valueAlign: 'right'
+        }
+    );
+    return <>
+        <Popover title="Consumer Groups" content={msg} placement="rightTop" overlayClassName="popoverSmall">
+            {summary.maxLag}
+        </Popover>
+    </>;
 }

--- a/frontend/src/state/restInterfaces.ts
+++ b/frontend/src/state/restInterfaces.ts
@@ -55,6 +55,7 @@ export interface Topic {
     cleanupPolicy: string;
     documentation: 'UNKNOWN' | 'NOT_CONFIGURED' | 'NOT_EXISTENT' | 'AVAILABLE';
     logDirSummary: TopicLogDirSummary;
+    consumerGroupSummary: TopicConsumerGroupSummary;
     allowedActions: TopicAction[] | undefined;
 }
 
@@ -65,6 +66,16 @@ export interface TopicLogDirSummary {
         error: string | null;
     }[] | null;
     hint: string | null;
+}
+
+export interface TopicConsumerGroupSummary {
+    maxLag: number;
+    consumerGroups: ConsumerGroupSummary[];
+}
+  
+export interface ConsumerGroupSummary {
+    groupName: string;
+    lag: number;
 }
 
 export interface GetTopicsResponse {


### PR DESCRIPTION
Similar to PR #537, add a new column on the topic list to show the lag information for each topic.

![image](https://user-images.githubusercontent.com/6736720/201544186-38903890-080f-453c-8104-ba2af3518136.png)

Since lag is a consumer group related information and a topic can be in zero or more consumer groups. Some decisions was made about what to display on that column:

- if the topic has no consumer groups, the column value will be empty;
- otherwise, the column value will be the max lag from all consumer groups that this topic is part of (e.g., if a topic is part of two consumer groups, one with lag 10 and another with lag 20, then the column value will be 20).
- If the topic is part of a consumer group which has other topics inside, the lag from these other topics will not be considered for the topic lag.

In addition, when mouse hover the column value, it will show a list with all topic consumer groups and their respective lags:

![Animação](https://user-images.githubusercontent.com/6736720/201544221-a6516713-e18f-473f-9989-500caaa2352b.gif)


