### PR TITLE
Helm: Set same key for login-oidc-client-secret in Secret and Deployment

### DIFF
--- a/helm/console/Chart.yaml
+++ b/helm/console/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/console/templates/secret.yaml
+++ b/helm/console/templates/secret.yaml
@@ -29,7 +29,7 @@ data:
   login-github-personal-access-token: {{ .Values.secret.login.github.personalAccessToken | default "" | b64enc | quote }}
   login-okta-client-secret: {{ .Values.secret.login.okta.clientSecret | default "" | b64enc | quote }}
   login-okta-directory-api-token: {{ .Values.secret.login.okta.directoryApiToken | default "" | b64enc | quote }}
-  login-generic-oidc-client-secret: {{ .Values.secret.login.oidc.clientSecret | default "" | b64enc | quote }}
+  login-oidc-client-secret: {{ .Values.secret.login.oidc.clientSecret | default "" | b64enc | quote }}
 
   # Enterprise
   enterprise-license: {{ .Values.secret.enterprise.license | default "" | b64enc | quote }}


### PR DESCRIPTION
Currently, in the Helm chart the name for the login-oidc-client-secret key in the Secret does not match the key reference in the Deployment. In the Deployment the key login-oidc-client-secret is referenced, but in the Secret it is named login-generic-oidc-client-secret. I would drop the "generic-" part in the Secret, because in the values file it is configured under secret.login.oidc.clientSecret, also without "generic".

Key in the Deployment: https://github.com/redpanda-data/console/blob/master/helm/console/templates/deployment.yaml#L207