### PR TITLE
chart: deprecate the helm chart from this repo

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -1,5 +1,10 @@
 # Redpanda Console Helm Chart
 
+:warning: __*WARNING*__: This chart repo has been deprecated.
+See [redpanda-data/helm-charts](https://github.com/redpanda-data/helm-charts) for continued development.
+
+---
+
 This Helm chart allows you to deploy Redpanda Console to your Redpanda cluster.
 You can install the chart by running the following commands:
 

--- a/helm/console/Chart.yaml
+++ b/helm/console/Chart.yaml
@@ -18,7 +18,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
+
+# The chart in this repo is deprecated. Please use the chart in https://charts.redpanda.com
+# hosted at https://github.com/redpanda-data/helm-charts
+deprecated: true
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Deprecate the helm chart in this repository in favor of [redpanda-data/helm-charts](https://github.com/redpanda-data/helm-charts)