### PR TITLE
backend: Fix panic when deserializing schema registry wrapper

### DIFF
--- a/backend/pkg/proto/service_test.go
+++ b/backend/pkg/proto/service_test.go
@@ -1,0 +1,37 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package proto
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_decodeConfluentBinaryWrapper(t *testing.T) {
+	buf := new(bytes.Buffer)
+
+	schemaID := uint32(1000)
+	var schemaIdBuf []byte
+	schemaIdBuf = binary.BigEndian.AppendUint32(schemaIdBuf, schemaID)
+
+	binary.Write(buf, binary.BigEndian, byte(0))
+	binary.Write(buf, binary.BigEndian, schemaIdBuf)
+
+	var arrLengthBuf []byte
+	arrLengthBuf = binary.AppendVarint(arrLengthBuf, 1<<60)
+	binary.Write(buf, binary.BigEndian, arrLengthBuf)
+
+	svc := Service{}
+	_, err := svc.decodeConfluentBinaryWrapper(buf.Bytes())
+	assert.Error(t, err)
+}


### PR DESCRIPTION
When decoding a binary message that by accident has a valid starting sequence we may ended up with a slice allocation that is too large. This commit will mitigate the problem by returning an error in all cases where we would want to allocate more than 128 message type ids.