### PR TITLE
Making aws.s3.region a basic option for S3 sink connector

### DIFF
--- a/backend/pkg/connect/guides/s3_sink_connector.json
+++ b/backend/pkg/connect/guides/s3_sink_connector.json
@@ -23,7 +23,7 @@
         "order": 2
       }
     },
-    
+
     {
       "nameSelector": "aws.s3.bucket.name",
       "definition": {
@@ -57,7 +57,16 @@
       "definition": {
         "display_name": "AWS S3 region",
         "group" : "Amazon S3",
+        "importance": "HIGH",
         "order": 4
+      }
+    },
+    {
+      "nameSelector": "aws.s3.bucket.check",
+      "definition": {
+        "display_name": "AWS S3 bucket check",
+        "group" : "Amazon S3",
+        "order": 5
       }
     },
     {
@@ -65,10 +74,10 @@
       "definition": {
         "display_name": "AWS S3 endpoint",
         "group" : "Amazon S3",
-        "order": 5
+        "order": 6
       }
     },
-   
+
     {
       "nameSelector": "aws.sts.role.arn",
       "definition": {
@@ -76,7 +85,7 @@
         "display_name": "AWS STS Role ARN",
         "group" : "Amazon S3",
         "importance" : "MEDIUM",
-        "order": 6
+        "order": 7
       }
     },
     {
@@ -85,7 +94,7 @@
         "display_name": "AWS STS Session name",
         "group" : "Amazon S3",
         "importance" : "MEDIUM",
-        "order": 7
+        "order": 8
       }
     },
     {
@@ -94,7 +103,7 @@
         "display_name": "AWS STS External Id",
         "group" : "Amazon S3",
         "importance" : "MEDIUM",
-        "order": 8
+        "order": 9
       }
     },
     {
@@ -103,7 +112,7 @@
         "display_name": "AWS STS Session duration",
         "group" : "Amazon S3",
         "importance" : "MEDIUM",
-        "order": 9
+        "order": 10
       }
     },
     {
@@ -112,13 +121,13 @@
         "display_name": "AWS STS Config endpoint",
         "group" : "Amazon S3",
         "importance" : "MEDIUM",
-        "order": 10
+        "order": 11
       }
     },
-    
-    
-   
-    
+
+
+
+
 
     {
       "nameSelector": "key.converter",
@@ -214,7 +223,7 @@
         "order" : 10
       }
     },
-    
+
     {
       "nameSelector": "file.max.records",
       "definition": {
@@ -312,7 +321,7 @@
         "order": 22
       }
     }
-    
+
 
 
 


### PR DESCRIPTION
Making aws.s3.region a basic option for S3 sink connector, adding aws.s3.bucket.check definition.