### PR TITLE
frontend: Add user preference for collapsing JSON objects

### DIFF
--- a/frontend/src/components/misc/KowlJsonView.tsx
+++ b/frontend/src/components/misc/KowlJsonView.tsx
@@ -98,7 +98,7 @@ export const KowlJsonView = observer((props: ReactJsonViewProps) => {
                     groupArraysAfterLength={100}
                     indentWidth={5}
                     iconStyle="triangle"
-                    collapsed={2}
+                    collapsed={settings.collapsed}
                     onSelect={e => {
                         if (ctrlDown) {
                             if (navigator?.clipboard) {

--- a/frontend/src/components/misc/UserPreferences.tsx
+++ b/frontend/src/components/misc/UserPreferences.tsx
@@ -143,6 +143,9 @@ class JsonViewerTab extends Component {
                 <Label text="Maximum string length before collapsing">
                     <InputNumber value={settings.maxStringLength} onChange={e => settings.maxStringLength = (e ?? 200)} min={0} max={10000} style={{ maxWidth: '150px' }} />
                 </Label>
+                <Label text="Maximum depth before collapsing nested objects">
+                    <InputNumber value={settings.collapsed} onChange={e => settings.collapsed = (e ?? 2)} min={1} max={50} style={{ maxWidth: '150px' }} />
+                </Label>
             </div>
         </div>;
     }

--- a/frontend/src/state/ui.ts
+++ b/frontend/src/state/ui.ts
@@ -146,6 +146,7 @@ const defaultUiSettings = {
         fontSize: '12px',
         lineHeight: '1em',
         maxStringLength: 200,
+        collapsed: 2,
     },
 
     // todo: refactor into: brokers.list, brokers.detail, topics.messages, topics.config, ...


### PR DESCRIPTION
See https://github.com/redpanda-data/console/issues/607 for discussion of feature.

I couldn't think of a sensible way to implement the ability to set a default `collapsed` setting from the config.yaml on the backend, so I skipped that.