### PR TITLE
backend: Fix origin check func

### DIFF
--- a/backend/pkg/api/util_cors.go
+++ b/backend/pkg/api/util_cors.go
@@ -19,6 +19,8 @@ import (
 // that returns true if the requester's origin is allowed to access our endpoints.
 // If you pass an empty allowedOrigins slice, the client will default to a same-site origin policy.
 // We check origins to protect against CSRF attacks.
+//
+// This origin check is used by the chi HTTP router, as well as by the websocket upgrader.
 func originsCheckFunc(allowedOrigins []string) func(r *http.Request) bool {
 	return func(r *http.Request) bool {
 		origin := r.Header.Get("Origin")
@@ -40,7 +42,7 @@ func originsCheckFunc(allowedOrigins []string) func(r *http.Request) bool {
 
 		// Check if it matches any other of the allowed origins
 		for _, allowedOrigin := range allowedOrigins {
-			isEqual := equalASCIIFold(allowedOrigin, u.Host)
+			isEqual := equalASCIIFold(allowedOrigin, origin)
 			if isEqual {
 				return true
 			}


### PR DESCRIPTION
We used to compare the URL host against the configured allowed origin. This doesn't work because the host omits the scheme whereas the configured allowed origin
does not. Hence the result was that the requester's origin does not match any of the configured allowed origin, unless we also omit the scheme in the configuration.