### PR TITLE
backend: Refactor base path middleware

### DIFF
--- a/backend/pkg/api/middlewares.go
+++ b/backend/pkg/api/middlewares.go
@@ -22,74 +22,84 @@ import (
 // BasePathCtxKey is a helper to avoid allocations, idea taken from chi
 var BasePathCtxKey = &struct{ name string }{"ConsoleURLPrefix"}
 
-// Uses checks if X-Forwarded-Prefix or settings.basePath are set,
-// and then strips the set prefix from any requests.
-// When a prefix is set, this function adds it under the key 'BasePathCtxKey' to the context
-//
-//nolint:gocognit // TODO: Simplify this function, seems currently broken too, see: https://github.com/redpanda-data/console/issues/564
-func createHandleBasePathMiddleware(basePath string, useXForwardedPrefix bool, stripPrefix bool) func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		fn := func(w http.ResponseWriter, r *http.Request) {
-			prefix := ""
+type basePathMiddleware struct {
+	// basePath is the static base path that shall be applied.
+	basePath string
+	// useDynamicBasePathFromHeaders inherits the base-path from the X-Forwarded-Prefix header.
+	useDynamicBasePathFromHeaders bool
+	// If a base-path is set (either by the 'base-path' setting, or by the 'X-Forwarded-Prefix' header),
+	// they will be removed from the request url. You probably want to leave this enabled, unless you
+	// are using a proxy that can remove the prefix automatically (like Traefik's 'StripPrefix' option)
+	stripPrefix bool
+}
 
-			// Static base path (from settings)
-			if len(basePath) > 0 {
-				prefix = basePath
-			}
-
-			// Dynamic base path (from header)
-			if useXForwardedPrefix {
-				xForwardedPrefix := r.Header.Get("X-Forwarded-Prefix")
-				if len(xForwardedPrefix) > 0 {
-					prefix = xForwardedPrefix
-				}
-			}
-
-			// If we have a prefix...
-			if len(prefix) > 0 {
-				// ensure correct prefix slashes
-				prefix = ensurePrefixFormat(prefix)
-
-				// Store prefix in context so handle_frontend can use it to inject it into the html
-				r = r.WithContext(context.WithValue(r.Context(), BasePathCtxKey, prefix))
-
-				// Remove it from the request url (if allowed by settings)
-				if stripPrefix {
-					var path string
-					rctx := chi.RouteContext(r.Context())
-					if rctx.RoutePath != "" {
-						path = rctx.RoutePath
-					} else {
-						path = r.URL.Path
-					}
-
-					// route path
-					if strings.HasPrefix(path, prefix) {
-						rctx.RoutePath = "/" + strings.TrimPrefix(path, prefix)
-					}
-
-					// URL.path
-					if strings.HasPrefix(r.URL.Path, prefix) {
-						r.URL.Path = "/" + strings.TrimPrefix(r.URL.Path, prefix)
-					}
-
-					// requestURI
-					if strings.HasPrefix(r.RequestURI, prefix) {
-						r.RequestURI = "/" + strings.TrimPrefix(r.RequestURI, prefix)
-					}
-				}
-			}
-
-			next.ServeHTTP(w, r)
-		}
-		return http.HandlerFunc(fn)
+func newBasePathMiddleware(basePath string, useDynamicBasePathFromHeaders, stripPrefix bool) *basePathMiddleware {
+	return &basePathMiddleware{
+		basePath:                      basePath,
+		useDynamicBasePathFromHeaders: useDynamicBasePathFromHeaders,
+		stripPrefix:                   stripPrefix,
 	}
 }
 
-// prefix must start and end with a slash
+// Wrap implements the middleware interface. It propagates the basePath that shall be used
+// to the frontend by injecting it into the HTML as a variable. The frontend therefore knows
+// the to be used basePath without sending an HTTP request.
+// The basePath can be either a static configuration or dynamically set based on the
+// request header 'X-Forwarded-Prefix'.
+// Additionally, it may be in charge of stripping the prefix from any requests.
+func (b *basePathMiddleware) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		prefix := b.basePath
+		if b.useDynamicBasePathFromHeaders && r.Header.Get("X-Forwarded-Prefix") != "" {
+			prefix = r.Header.Get("X-Forwarded-Prefix")
+		}
+		if prefix == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// ensure correct prefix slashes
+		prefix = ensurePrefixFormat(prefix)
+
+		// Store prefix in context so handle_frontend can use it to inject it into the html
+		r = r.WithContext(context.WithValue(r.Context(), BasePathCtxKey, prefix))
+
+		if !b.stripPrefix {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Strip prefix from the request url
+		var path string
+		rctx := chi.RouteContext(r.Context())
+		if rctx.RoutePath != "" {
+			path = rctx.RoutePath
+		} else {
+			path = r.URL.Path
+		}
+
+		// route path
+		if strings.HasPrefix(path, prefix) {
+			rctx.RoutePath = "/" + strings.TrimPrefix(path, prefix)
+		}
+
+		// URL.path
+		if strings.HasPrefix(r.URL.Path, prefix) {
+			r.URL.Path = "/" + strings.TrimPrefix(r.URL.Path, prefix)
+		}
+
+		// requestURI
+		if strings.HasPrefix(r.RequestURI, prefix) {
+			r.RequestURI = "/" + strings.TrimPrefix(r.RequestURI, prefix)
+		}
+	})
+}
+
+// ensurePrefixFormat ensures that the given path starts and ends with a slash
 func ensurePrefixFormat(path string) string {
-	if path == "" || (len(path) == 1 && path[0] == '/') {
-		return "" // nil / empty / slash
+	isRootPath := len(path) == 1 && path[0] == '/'
+	if path == "" || isRootPath {
+		return ""
 	}
 
 	// add leading slash

--- a/backend/pkg/api/routes.go
+++ b/backend/pkg/api/routes.go
@@ -32,13 +32,14 @@ func (api *API) routes() *chi.Mux {
 	instrument := middleware.NewInstrument(api.Cfg.MetricsNamespace)
 	recoverer := middleware.Recoverer{Logger: api.Logger}
 	checkOriginFn := originsCheckFunc(api.Cfg.REST.AllowedOrigins)
-	handleBasePath := createHandleBasePathMiddleware(api.Cfg.REST.BasePath,
+	basePath := newBasePathMiddleware(
+		api.Cfg.REST.BasePath,
 		api.Cfg.REST.SetBasePathFromXForwardedPrefix,
 		api.Cfg.REST.StripPrefix)
 
 	baseRouter.Use(recoverer.Wrap)
 	baseRouter.Use(chimiddleware.RealIP)
-	baseRouter.Use(handleBasePath)
+	baseRouter.Use(basePath.Wrap)
 	baseRouter.Use(cors.Handler(cors.Options{
 		AllowOriginFunc: func(r *http.Request, _ string) bool {
 			return checkOriginFn(r)


### PR DESCRIPTION
The middleware does still the same, but this refactoring simplifies the code for better maintainability.