### PR TITLE
backend: Fallback to system cert pool if no ca configured

### DIFF
--- a/backend/pkg/config/connect_cluster_tls.go
+++ b/backend/pkg/config/connect_cluster_tls.go
@@ -49,12 +49,13 @@ func (c *ConnectClusterTLS) TLSConfig() (*tls.Config, error) {
 	}
 
 	// 1. Create CA cert pool
-	caCertPool := x509.NewCertPool()
+	var caCertPool *x509.CertPool
 	if c.CaFilepath != "" {
 		ca, err := os.ReadFile(c.CaFilepath)
 		if err != nil {
 			return nil, err
 		}
+		caCertPool = x509.NewCertPool()
 		isSuccessful := caCertPool.AppendCertsFromPEM(ca)
 		if !isSuccessful {
 			return nil, fmt.Errorf("failed to append ca file to cert pool, is this a valid PEM format?")

--- a/backend/pkg/config/redpanda_admin_api_tls.go
+++ b/backend/pkg/config/redpanda_admin_api_tls.go
@@ -31,13 +31,10 @@ func (c *RedpandaAdminAPITLS) BuildTLSConfig() (*tls.Config, error) {
 		return nil, nil
 	}
 
-	caCertPool := x509.NewCertPool()
-
 	// No ca certificate specified, so let's return a TLS config that uses
 	// the system cert pool.
 	if c.CaFilepath == "" {
 		return &tls.Config{
-			RootCAs: caCertPool,
 			//nolint:gosec // InsecureSkipVerify may be true upon user's responsibility.
 			InsecureSkipVerify: c.InsecureSkipTLSVerify,
 		}, nil
@@ -48,6 +45,7 @@ func (c *RedpandaAdminAPITLS) BuildTLSConfig() (*tls.Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read CA cert from filepath %s: %w", c.CaFilepath, err)
 	}
+	caCertPool := x509.NewCertPool()
 	if isSuccessful := caCertPool.AppendCertsFromPEM(caCert); !isSuccessful {
 		return nil, fmt.Errorf("failed to append ca file to cert pool, check if this is a valid PEM formatted file")
 	}

--- a/backend/pkg/schema/client.go
+++ b/backend/pkg/schema/client.go
@@ -60,13 +60,14 @@ func newClient(cfg config.Schema) (*Client, error) {
 	}
 
 	// Configure Client Certificate transport
+	var caCertPool *x509.CertPool
 	if cfg.TLS.Enabled {
-		caCertPool := x509.NewCertPool()
 		if cfg.TLS.CaFilepath != "" {
 			ca, err := os.ReadFile(cfg.TLS.CaFilepath)
 			if err != nil {
 				return nil, err
 			}
+			caCertPool = x509.NewCertPool()
 			isSuccessful := caCertPool.AppendCertsFromPEM(ca)
 			if !isSuccessful {
 				return nil, fmt.Errorf("failed to append ca file to cert pool, is this a valid PEM format?")


### PR DESCRIPTION
The schema registry connectivity may fail with a
x509: certificate signed by unknown authority error because we used to initialize an empty cert pool that is passed to the TLS config. Instead of always initializing the cert pool, we should pass a nil cert pool if no CA has been specified so that the clients will implicitly load the system cert pool.