### PR TITLE
frontend/connectors: swap success message for Paused/Resumed

### DIFF
--- a/frontend/src/components/pages/connect/Connector.Details.tsx
+++ b/frontend/src/components/pages/connect/Connector.Details.tsx
@@ -336,7 +336,7 @@ class KafkaConnectorDetails extends PageComponent<{ clusterName: string, connect
                     clearTarget={() => this.pausingConnector = null}
 
                     content={(c) => <>{isRunning ? 'Pause' : 'Resume'} connector <strong>{c.name}</strong>?</>}
-                    successMessage={(c) => <> {isRunning ? 'Resumed' : 'Paused'} connector <strong>{c.name}</strong></>}
+                    successMessage={(c) => <> {isRunning ? 'Paused' : 'Resumed'} connector <strong>{c.name}</strong></>}
 
                     onOk={async (c) => {
                         if (isRunning)


### PR DESCRIPTION
When clicking Pause, it says "Resumed". Apparently it's displaying exactly the opposite of what we expect.