### PR TITLE
Escape & unescape all url & query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Master
+
+- [BUGFIX] Escape all URL & query parameters. Consumer groups or Kafka connectors with special characters will no longer fail in Console
+
 ## v2.2.0 / 2023-02-17
 
 - [FEATURE] Editing topic configurations

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/basgys/goxml2json v1.1.0
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
-	github.com/cloudhut/common v0.7.0
+	github.com/cloudhut/common v0.8.0
 	github.com/cloudhut/connect-client v0.0.0-20220929214026-6c714f7b6651
 	github.com/dop251/goja v0.0.0-20221229151140-b95230a9dbad
 	github.com/go-chi/chi/v5 v5.0.8
@@ -78,7 +78,7 @@ require (
 	github.com/pjbgf/sha1cd v0.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
-	github.com/prometheus/common v0.39.0 // indirect
+	github.com/prometheus/common v0.40.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/rogpeppe/go-internal v1.6.1 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect
@@ -95,7 +95,7 @@ require (
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/crypto v0.5.0 // indirect
 	golang.org/x/mod v0.7.0 // indirect
-	golang.org/x/sys v0.4.0 // indirect
+	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.6.0 // indirect
 	golang.org/x/tools v0.5.0 // indirect
 	google.golang.org/genproto v0.0.0-20230104163317-caabf589fcbf // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -93,8 +93,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
 github.com/cloudflare/circl v1.3.1 h1:4OVCZRL62ijwEwxnF6I7hLwxvIYi3VaZt8TflkqtrtA=
 github.com/cloudflare/circl v1.3.1/go.mod h1:+CauBF6R70Jqcyl8N2hC8pAXYbWkGIezuSbuGLtRhnw=
-github.com/cloudhut/common v0.7.0 h1:Uk62BslqqQdB+V41vDRHB4f3CmZl6XMPVrIwRdmk7t0=
-github.com/cloudhut/common v0.7.0/go.mod h1:QLavQ2LKUJwfdBVhLBqSO1Paer+NXJFwfsAOi86qiRA=
+github.com/cloudhut/common v0.8.0 h1:hfsiuRyou9y54zES3o5HWg0yDPklHsSoMnH2dGb/RrA=
+github.com/cloudhut/common v0.8.0/go.mod h1:XoriOltDOhfkw8dcjYUCGEHOCVgpOlQgPqriq9m050c=
 github.com/cloudhut/connect-client v0.0.0-20220929214026-6c714f7b6651 h1:QdBHcaLwShl6xSZCe9KqMiLNc+UXVvfaX/5+60hO1GY=
 github.com/cloudhut/connect-client v0.0.0-20220929214026-6c714f7b6651/go.mod h1:Kfy2sPCGDgWZGkjyu3ei9uacNA2CMBLU9/PBpCcyiGg=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -431,8 +431,8 @@ github.com/prometheus/client_model v0.3.0/go.mod h1:LDGWKZIo7rky3hgvBe+caln+Dr3d
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9VFqTh1DIvc=
-github.com/prometheus/common v0.39.0 h1:oOyhkDq05hPZKItWVBkJ6g6AtGxi+fy7F4JvUV8uhsI=
-github.com/prometheus/common v0.39.0/go.mod h1:6XBZ7lYdLCbkAVhwRsWTZn+IN5AB9F/NXd5w0BbEX0Y=
+github.com/prometheus/common v0.40.0 h1:Afz7EVRqGg2Mqqf4JuF9vdvp1pi220m55Pi9T2JnO4Q=
+github.com/prometheus/common v0.40.0/go.mod h1:L65ZJPSmfn/UBWLQIHV7dBrKFidB/wPlF1y5TlSt9OE=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
@@ -724,8 +724,8 @@ golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
-golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
+golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.0.0-20220722155259-a9ba230a4035/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/backend/pkg/api/handle_brokers.go
+++ b/backend/pkg/api/handle_brokers.go
@@ -15,7 +15,6 @@ import (
 	"strconv"
 
 	"github.com/cloudhut/common/rest"
-	"github.com/go-chi/chi/v5"
 
 	"github.com/redpanda-data/console/backend/pkg/console"
 )
@@ -45,7 +44,7 @@ func (api *API) handleBrokerConfig() http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		// 1. Parse broker ID parameter and validate input
-		brokerIDStr := chi.URLParam(r, "brokerID")
+		brokerIDStr := rest.GetURLParam(r, "brokerID")
 		if brokerIDStr == "" || len(brokerIDStr) > 10 {
 			restErr := &rest.Error{
 				Err:      fmt.Errorf("broker id in URL not set"),

--- a/backend/pkg/api/handle_consumer_group.go
+++ b/backend/pkg/api/handle_consumer_group.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 
 	"github.com/cloudhut/common/rest"
-	"github.com/go-chi/chi/v5"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -67,7 +66,7 @@ func (api *API) handleGetConsumerGroup() http.HandlerFunc {
 		ConsumerGroup console.ConsumerGroupOverview `json:"consumerGroup"`
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
-		groupID := chi.URLParam(r, "groupId")
+		groupID := rest.GetURLParam(r, "groupId")
 
 		canSee, restErr := api.Hooks.Authorization.CanSeeConsumerGroup(r.Context(), groupID)
 		if restErr != nil {
@@ -283,7 +282,7 @@ func (api *API) handleDeleteConsumerGroupOffsets() http.HandlerFunc {
 
 func (api *API) handleDeleteConsumerGroup() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		groupID := chi.URLParam(r, "groupId")
+		groupID := rest.GetURLParam(r, "groupId")
 
 		// 1. Check if logged in user is allowed to delete Consumer Group (always true for Console OSS, but not for
 		// Console Business)

--- a/backend/pkg/api/handle_kafka_connect.go
+++ b/backend/pkg/api/handle_kafka_connect.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/cloudhut/common/rest"
 	con "github.com/cloudhut/connect-client"
-	"github.com/go-chi/chi/v5"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -73,7 +72,7 @@ func (api *API) handleGetConnectors() http.HandlerFunc {
 
 func (api *API) handleGetClusterConnectors() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		clusterName := chi.URLParam(r, "clusterName")
+		clusterName := rest.GetURLParam(r, "clusterName")
 
 		ctx, cancel := context.WithTimeout(r.Context(), api.ConnectSvc.Cfg.RequestTimeout)
 		defer cancel()
@@ -106,7 +105,7 @@ func (api *API) handleGetClusterConnectors() http.HandlerFunc {
 
 func (api *API) handleGetClusterInfo() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		clusterName := chi.URLParam(r, "clusterName")
+		clusterName := rest.GetURLParam(r, "clusterName")
 
 		canSee, restErr := api.Hooks.Authorization.CanViewConnectCluster(r.Context(), clusterName)
 		if restErr != nil {
@@ -139,8 +138,8 @@ func (api *API) handleGetClusterInfo() http.HandlerFunc {
 
 func (api *API) handleGetConnector() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		clusterName := chi.URLParam(r, "clusterName")
-		connector := chi.URLParam(r, "connector")
+		clusterName := rest.GetURLParam(r, "clusterName")
+		connector := rest.GetURLParam(r, "connector")
 
 		ctx, cancel := context.WithTimeout(r.Context(), api.ConnectSvc.Cfg.RequestTimeout)
 		defer cancel()
@@ -190,8 +189,8 @@ func (c *putConnectorConfigRequest) ToClientRequest() con.PutConnectorConfigOpti
 
 func (api *API) handlePutConnectorConfig() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		clusterName := chi.URLParam(r, "clusterName")
-		connectorName := chi.URLParam(r, "connector")
+		clusterName := rest.GetURLParam(r, "clusterName")
+		connectorName := rest.GetURLParam(r, "connector")
 
 		canEdit, restErr := api.Hooks.Authorization.CanEditConnectCluster(r.Context(), clusterName)
 		if restErr != nil {
@@ -227,8 +226,8 @@ func (api *API) handlePutConnectorConfig() http.HandlerFunc {
 
 func (api *API) handlePutValidateConnectorConfig() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		clusterName := chi.URLParam(r, "clusterName")
-		pluginClassName := chi.URLParam(r, "pluginClassName")
+		clusterName := rest.GetURLParam(r, "clusterName")
+		pluginClassName := rest.GetURLParam(r, "pluginClassName")
 
 		canEdit, restErr := api.Hooks.Authorization.CanEditConnectCluster(r.Context(), clusterName)
 		if restErr != nil {
@@ -281,7 +280,7 @@ func (c *createConnectorRequest) ToClientRequest() con.CreateConnectorRequest {
 
 func (api *API) handleCreateConnector() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		clusterName := chi.URLParam(r, "clusterName")
+		clusterName := rest.GetURLParam(r, "clusterName")
 
 		canEdit, restErr := api.Hooks.Authorization.CanEditConnectCluster(r.Context(), clusterName)
 		if restErr != nil {
@@ -318,8 +317,8 @@ func (api *API) handleCreateConnector() http.HandlerFunc {
 
 func (api *API) handleDeleteConnector() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		clusterName := chi.URLParam(r, "clusterName")
-		connector := chi.URLParam(r, "connector")
+		clusterName := rest.GetURLParam(r, "clusterName")
+		connector := rest.GetURLParam(r, "connector")
 
 		ctx, cancel := context.WithTimeout(r.Context(), api.ConnectSvc.Cfg.RequestTimeout)
 		defer cancel()
@@ -352,8 +351,8 @@ func (api *API) handleDeleteConnector() http.HandlerFunc {
 
 func (api *API) handlePauseConnector() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		clusterName := chi.URLParam(r, "clusterName")
-		connector := chi.URLParam(r, "connector")
+		clusterName := rest.GetURLParam(r, "clusterName")
+		connector := rest.GetURLParam(r, "connector")
 
 		ctx, cancel := context.WithTimeout(r.Context(), api.ConnectSvc.Cfg.RequestTimeout)
 		defer cancel()
@@ -386,8 +385,8 @@ func (api *API) handlePauseConnector() http.HandlerFunc {
 
 func (api *API) handleResumeConnector() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		clusterName := chi.URLParam(r, "clusterName")
-		connector := chi.URLParam(r, "connector")
+		clusterName := rest.GetURLParam(r, "clusterName")
+		connector := rest.GetURLParam(r, "connector")
 
 		ctx, cancel := context.WithTimeout(r.Context(), api.ConnectSvc.Cfg.RequestTimeout)
 		defer cancel()
@@ -420,8 +419,8 @@ func (api *API) handleResumeConnector() http.HandlerFunc {
 
 func (api *API) handleRestartConnector() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		clusterName := chi.URLParam(r, "clusterName")
-		connector := chi.URLParam(r, "connector")
+		clusterName := rest.GetURLParam(r, "clusterName")
+		connector := rest.GetURLParam(r, "connector")
 
 		ctx, cancel := context.WithTimeout(r.Context(), api.ConnectSvc.Cfg.RequestTimeout)
 		defer cancel()
@@ -454,9 +453,9 @@ func (api *API) handleRestartConnector() http.HandlerFunc {
 
 func (api *API) handleRestartConnectorTask() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		clusterName := chi.URLParam(r, "clusterName")
-		connector := chi.URLParam(r, "connector")
-		taskIDstr := chi.URLParam(r, "taskID")
+		clusterName := rest.GetURLParam(r, "clusterName")
+		connector := rest.GetURLParam(r, "connector")
+		taskIDstr := rest.GetURLParam(r, "taskID")
 		taskID, err := strconv.Atoi(taskIDstr)
 		if err != nil {
 			rest.SendRESTError(w, r, api.Logger, &rest.Error{

--- a/backend/pkg/api/handle_operations.go
+++ b/backend/pkg/api/handle_operations.go
@@ -27,7 +27,7 @@ func (api *API) handleGetAllTopicDetails() http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		var topicNames []string
-		requestedTopicNames := r.URL.Query().Get("topicNames")
+		requestedTopicNames := rest.GetQueryParam(r, "topicNames")
 		if requestedTopicNames != "" {
 			topicNames = strings.Split(requestedTopicNames, ",")
 		}

--- a/backend/pkg/api/handle_schema.go
+++ b/backend/pkg/api/handle_schema.go
@@ -16,7 +16,6 @@ import (
 	"net/url"
 
 	"github.com/cloudhut/common/rest"
-	"github.com/go-chi/chi/v5"
 
 	"github.com/redpanda-data/console/backend/pkg/console"
 )
@@ -61,11 +60,11 @@ func (api *API) handleGetSchemaDetails() http.HandlerFunc {
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		subject := chi.URLParam(r, "subject")
+		subject := rest.GetURLParam(r, "subject")
 		if subjectUnescaped, err := url.PathUnescape(subject); err == nil {
 			subject = subjectUnescaped
 		}
-		version := chi.URLParam(r, "version")
+		version := rest.GetURLParam(r, "version")
 		schemaDetails, err := api.ConsoleSvc.GetSchemaDetails(r.Context(), subject, version)
 		if err != nil {
 			if errors.Is(err, console.ErrSchemaRegistryNotConfigured) {

--- a/backend/pkg/api/handle_topic_documentation.go
+++ b/backend/pkg/api/handle_topic_documentation.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 
 	"github.com/cloudhut/common/rest"
-	"github.com/go-chi/chi/v5"
 	"go.uber.org/zap"
 
 	"github.com/redpanda-data/console/backend/pkg/console"
@@ -27,7 +26,7 @@ func (api *API) handleGetTopicDocumentation() http.HandlerFunc {
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		topicName := chi.URLParam(r, "topicName")
+		topicName := rest.GetURLParam(r, "topicName")
 		logger := api.Logger.With(zap.String("topic_name", topicName))
 
 		doc := api.ConsoleSvc.GetTopicDocumentation(topicName)

--- a/backend/pkg/api/handle_topics.go
+++ b/backend/pkg/api/handle_topics.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 
 	"github.com/cloudhut/common/rest"
-	"github.com/go-chi/chi/v5"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -78,7 +77,7 @@ func (api *API) handleGetPartitions() http.HandlerFunc {
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		topicName := chi.URLParam(r, "topicName")
+		topicName := rest.GetURLParam(r, "topicName")
 		logger := api.Logger.With(zap.String("topic_name", topicName))
 
 		// Check if logged in user is allowed to view partitions for the given topic
@@ -130,7 +129,7 @@ func (api *API) handleGetTopicConfig() http.HandlerFunc {
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		topicName := chi.URLParam(r, "topicName")
+		topicName := rest.GetURLParam(r, "topicName")
 		logger := api.Logger.With(zap.String("topic_name", topicName))
 
 		// Check if logged in user is allowed to view partitions for the given topic
@@ -169,7 +168,7 @@ func (api *API) handleDeleteTopic() http.HandlerFunc {
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		topicName := chi.URLParam(r, "topicName")
+		topicName := rest.GetURLParam(r, "topicName")
 
 		// Check if logged in user is allowed to view partitions for the given topic
 		canDelete, restErr := api.Hooks.Authorization.CanDeleteTopic(r.Context(), topicName)
@@ -230,7 +229,7 @@ func (d *deleteTopicRecordsRequest) OK() error {
 
 func (api *API) handleDeleteTopicRecords() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		topicName := chi.URLParam(r, "topicName")
+		topicName := rest.GetURLParam(r, "topicName")
 
 		// 1. Parse and validate request
 		var req deleteTopicRecordsRequest
@@ -320,7 +319,7 @@ func (e *editTopicConfigRequest) OK() error {
 func (api *API) handleEditTopicConfig() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// 1. Parse and validate request
-		topicName := chi.URLParam(r, "topicName")
+		topicName := rest.GetURLParam(r, "topicName")
 		if topicName == "" {
 			rest.SendRESTError(w, r, api.Logger, &rest.Error{
 				Err:      fmt.Errorf("topic name must be set"),
@@ -390,13 +389,13 @@ func (api *API) handleGetTopicsConfigs() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// 1. Parse optional filters. If no filter is set they will be treated as wildcards
 		var topicNames []string
-		requestedTopicNames := r.URL.Query().Get("topicNames")
+		requestedTopicNames := rest.GetQueryParam(r, "topicNames")
 		if requestedTopicNames != "" {
 			topicNames = strings.Split(requestedTopicNames, ",")
 		}
 
 		var configKeys []string
-		requestedConfigKeys := r.URL.Query().Get("configKeys")
+		requestedConfigKeys := rest.GetQueryParam(r, "configKeys")
 		if requestedConfigKeys != "" {
 			configKeys = strings.Split(requestedConfigKeys, ",")
 		}
@@ -470,7 +469,7 @@ func (api *API) handleGetTopicConsumers() http.HandlerFunc {
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		topicName := chi.URLParam(r, "topicName")
+		topicName := rest.GetURLParam(r, "topicName")
 		logger := api.Logger.With(zap.String("topic_name", topicName))
 
 		// Check if logged in user is allowed to view partitions for the given topic
@@ -517,7 +516,7 @@ func (api *API) handleGetTopicsOffsets() http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		// 1. Parse topic names and timestamp from URL. It's a list of topic names that is comma separated
-		requestedTopicNames := r.URL.Query().Get("topicNames")
+		requestedTopicNames := rest.GetQueryParam(r, "topicNames")
 		if requestedTopicNames == "" {
 			restErr := &rest.Error{
 				Err:      fmt.Errorf("required parameter topicNames is missing"),
@@ -530,7 +529,7 @@ func (api *API) handleGetTopicsOffsets() http.HandlerFunc {
 		}
 		topicNames := strings.Split(requestedTopicNames, ",")
 
-		timestampStr := r.URL.Query().Get("timestamp")
+		timestampStr := rest.GetQueryParam(r, "timestamp")
 		if timestampStr == "" {
 			restErr := &rest.Error{
 				Err:      fmt.Errorf("required parameter timestamp is missing"),

--- a/backend/pkg/api/handle_users.go
+++ b/backend/pkg/api/handle_users.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 
 	"github.com/cloudhut/common/rest"
-	"github.com/go-chi/chi/v5"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
 )
 
@@ -164,7 +163,7 @@ func (api *API) handleCreateUser() http.HandlerFunc {
 
 func (api *API) handleDeleteUser() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		principalID := chi.URLParam(r, "principalID")
+		principalID := rest.GetURLParam(r, "principalID")
 		if principalID == "" {
 			rest.SendRESTError(w, r, api.Logger, &rest.Error{
 				Err:     fmt.Errorf("user must be set"),

--- a/frontend/src/components/pages/connect/Cluster.Details.tsx
+++ b/frontend/src/components/pages/connect/Cluster.Details.tsx
@@ -37,7 +37,7 @@ class KafkaClusterDetails extends PageComponent<{ clusterName: string }> {
     }
 
     initPage(p: PageInitHelper): void {
-        const clusterName = this.props.clusterName;
+        const clusterName = decodeURIComponent(this.props.clusterName);
         p.title = clusterName;
         p.addBreadcrumb('Connectors', '/connect-clusters');
         p.addBreadcrumb(clusterName, `/connect-clusters/${clusterName}`);
@@ -48,11 +48,13 @@ class KafkaClusterDetails extends PageComponent<{ clusterName: string }> {
 
     refreshData(force: boolean) {
         api.refreshConnectClusters(force);
-        api.refreshClusterAdditionalInfo(this.props.clusterName, force);
+
+        const clusterName = decodeURIComponent(this.props.clusterName);
+        api.refreshClusterAdditionalInfo(clusterName, force);
     }
 
     render() {
-        const clusterName = this.props.clusterName;
+        const clusterName = decodeURIComponent(this.props.clusterName);
 
         if (api.connectConnectors?.isConfigured === false) return <NotConfigured />;
 

--- a/frontend/src/components/pages/connect/Cluster.Details.tsx
+++ b/frontend/src/components/pages/connect/Cluster.Details.tsx
@@ -82,7 +82,7 @@ class KafkaClusterDetails extends PageComponent<{ clusterName: string }> {
                                     width: '35%',
                                     render: (_, r) => (
                                         <span className="hoverLink" style={{ display: 'inline-block', width: '100%' }}
-                                            onClick={() => appGlobal.history.push(`/connect-clusters/${clusterName}/${r.name}`)}>
+                                            onClick={() => appGlobal.history.push(`/connect-clusters/${encodeURIComponent(clusterName)}/${encodeURIComponent(r.name)}`)}>
                                             {r.name}
                                         </span>
                                     ),

--- a/frontend/src/components/pages/connect/Connector.Details.tsx
+++ b/frontend/src/components/pages/connect/Connector.Details.tsx
@@ -351,12 +351,12 @@ const KafkaConnectorMain = observer(
 @observer
 class KafkaConnectorDetails extends PageComponent<{ clusterName: string; connector: string }> {
     initPage(p: PageInitHelper): void {
-        const clusterName = this.props.clusterName;
-        const connector = this.props.connector;
+        const clusterName = decodeURIComponent(this.props.clusterName);
+        const connector = decodeURIComponent(this.props.connector);
         p.title = connector;
         p.addBreadcrumb('Connectors', '/connect-clusters');
-        p.addBreadcrumb(clusterName, `/connect-clusters/${clusterName}`);
-        p.addBreadcrumb(connector, `/connect-clusters/${clusterName}/${connector}`);
+        p.addBreadcrumb(clusterName, `/connect-clusters/${encodeURIComponent(clusterName)}`);
+        p.addBreadcrumb(connector, `/connect-clusters/${encodeURIComponent(clusterName)}/${encodeURIComponent(connector)}`);
         this.refreshData(false);
         appGlobal.onRefresh = () => this.refreshData(true);
     }
@@ -366,8 +366,8 @@ class KafkaConnectorDetails extends PageComponent<{ clusterName: string; connect
     }
 
     render() {
-        const clusterName = this.props.clusterName;
-        const connectorName = this.props.connector;
+        const clusterName = decodeURIComponent(this.props.clusterName);
+        const connectorName = decodeURIComponent(this.props.connector);
 
         if (api.connectConnectors?.isConfigured === false) return <NotConfigured />;
 

--- a/frontend/src/components/pages/connect/Connector.Details.tsx
+++ b/frontend/src/components/pages/connect/Connector.Details.tsx
@@ -298,7 +298,7 @@ const KafkaConnectorMain = observer(
                     onOk={async (c) => {
                         connectClusterStore.getConnectorStore(c.connectorName);
                         await connectClusterStore.updateConnnector(c.connectorName);
-                        appGlobal.history.push(`/connect-clusters/${clusterName}`);
+                        appGlobal.history.push(`/connect-clusters/${encodeURIComponent(clusterName)}`);
                         await refreshData(true);
                     }}
                 />
@@ -339,7 +339,7 @@ const KafkaConnectorMain = observer(
                     )}
                     onOk={async (_connectorName) => {
                         await connectClusterStore.deleteConnector(connectorName);
-                        appGlobal.history.push(`/connect-clusters/${clusterName}`);
+                        appGlobal.history.push(`/connect-clusters/${encodeURIComponent(clusterName)}`);
                         await refreshData(true);
                     }}
                 />

--- a/frontend/src/components/pages/connect/CreateConnector.tsx
+++ b/frontend/src/components/pages/connect/CreateConnector.tsx
@@ -177,10 +177,10 @@ const ConnectorWizard = observer(({ connectClusters, activeCluster }: ConnectorW
                     onActiveClusterChange={(clusterName) => {
                         uiState.pageBreadcrumbs = [
                             { title: 'Connectors', linkTo: '/connect-clusters' },
-                            { title: clusterName!, linkTo: `/connect-clusters/${clusterName}` },
-                            { title: 'Create Connector', linkTo: `/connect-clusters/${clusterName}/create-connector` },
+                            { title: clusterName!, linkTo: `/connect-clusters/${encodeURIComponent(clusterName!)}` },
+                            { title: 'Create Connector', linkTo: `/connect-clusters/${encodeURIComponent(clusterName!)}/create-connector` },
                         ];
-                        history.push(`/connect-clusters/${clusterName}/create-connector`);
+                        history.push(`/connect-clusters/${encodeURIComponent(clusterName!)}/create-connector`);
                     }}
                     selectedPlugin={selectedPlugin}
                     onPluginSelectionChange={setSelectedPlugin}
@@ -307,7 +307,7 @@ const ConnectorWizard = observer(({ connectClusters, activeCluster }: ConnectorW
                     }
 
                     if (isLast()) {
-                        return history.push(`/connect-clusters/${activeCluster}`);
+                        return history.push(`/connect-clusters/${encodeURIComponent(activeCluster)}`);
                     }
 
                     return currentStep < steps.length - 1 ? setCurrentStep((n) => n + 1) : undefined;

--- a/frontend/src/components/pages/connect/CreateConnector.tsx
+++ b/frontend/src/components/pages/connect/CreateConnector.tsx
@@ -88,11 +88,11 @@ const ConnectorType = observer(
 @observer
 class CreateConnector extends PageComponent<{ clusterName: string }> {
     initPage(p: PageInitHelper) {
-        const clusterName = this.props.clusterName;
+        const clusterName = decodeURIComponent(this.props.clusterName);
         p.title = 'Create Connector';
         p.addBreadcrumb('Connectors', '/connect-clusters');
-        p.addBreadcrumb(clusterName, `/connect-clusters/${clusterName}`);
-        p.addBreadcrumb('Create Connector', `/connect-clusters/${clusterName}/create-connector`);
+        p.addBreadcrumb(clusterName, `/connect-clusters/${encodeURIComponent(clusterName)}`);
+        p.addBreadcrumb('Create Connector', `/connect-clusters/${encodeURIComponent(clusterName)}/create-connector`);
 
         this.refreshData(false);
         appGlobal.onRefresh = () => this.refreshData(true);
@@ -105,12 +105,13 @@ class CreateConnector extends PageComponent<{ clusterName: string }> {
     render() {
         const clusters = api.connectConnectors?.clusters;
         if (clusters == null) return null;
+        const clusterName = decodeURIComponent(this.props.clusterName);
 
         return (
             <PageContent>
                 <Section>
                     <div className={styles.wizardView}>
-                        <ConnectorWizard connectClusters={clusters} activeCluster={this.props.clusterName} />
+                        <ConnectorWizard connectClusters={clusters} activeCluster={clusterName} />
                     </div>
                 </Section>
             </PageContent>

--- a/frontend/src/components/pages/connect/Overview.tsx
+++ b/frontend/src/components/pages/connect/Overview.tsx
@@ -95,7 +95,7 @@ class TabClusters extends Component {
                         }
 
                         return <span className="hoverLink" style={{ display: 'inline-block', width: '100%' }}
-                            onClick={() => appGlobal.history.push(`/connect-clusters/${r.clusterName}`)}>
+                            onClick={() => appGlobal.history.push(`/connect-clusters/${encodeURIComponent(r.clusterName)}`)}>
                             {r.clusterName}
                         </span>
                     },
@@ -149,7 +149,7 @@ class TabConnectors extends Component {
                     render: (_, r) => (
                         <Tooltip placement="topLeft" title={r.name} getPopupContainer={findPopupContainer}>
                             <span className="hoverLink" style={{ display: 'inline-block', width: '100%' }}
-                                onClick={() => appGlobal.history.push(`/connect-clusters/${r.cluster.clusterName}/${r.name}`)}>
+                                onClick={() => appGlobal.history.push(`/connect-clusters/${encodeURIComponent(r.cluster.clusterName)}/${encodeURIComponent(r.name)}`)}>
                                 {r.name}
                             </span>
                         </Tooltip>
@@ -228,7 +228,7 @@ class TabTasks extends Component {
                     width: '35%',
                     sorter: sortField('connectorName'), defaultSortOrder: 'ascend',
                     render: (_, r) => (
-                        <span className="hoverLink" onClick={() => appGlobal.history.push(`/connect-clusters/${r.cluster.clusterName}/${r.connectorName}`)}>
+                        <span className="hoverLink" onClick={() => appGlobal.history.push(`/connect-clusters/${encodeURIComponent(r.cluster.clusterName)}/${encodeURIComponent(r.connectorName)}`)}>
                             {r.connectorName}
                         </span>
                     )

--- a/frontend/src/components/pages/consumers/Group.Details.tsx
+++ b/frontend/src/components/pages/consumers/Group.Details.tsx
@@ -326,7 +326,7 @@ class GroupByTopics extends Component<{
                         <Button
                             size="small"
                             style={{ marginLeft: 'auto' }}
-                            onClick={() => appGlobal.history.push('/topics/' + g.topicName)}
+                            onClick={() => appGlobal.history.push(`/topics/${encodeURIComponent(g.topicName)}`)}
                         >View Topic</Button>
                     </div>
                 }>
@@ -474,7 +474,7 @@ class GroupByMembers extends Component<{ group: GroupDescription, onlyShowPartit
                                 width: 130, title: 'Topic', dataIndex: 'topicName', sorter: sortField('topicName'),
                                 render: (_, record) => <div
                                     className="hoverLink"
-                                    onClick={() => appGlobal.history.push('/topics/' + record.topicName)}>
+                                    onClick={() => appGlobal.history.push(`/topics/${encodeURIComponent(record.topicName)}`)}>
                                     {record.topicName}
                                 </div>
                             },

--- a/frontend/src/components/pages/consumers/Group.Details.tsx
+++ b/frontend/src/components/pages/consumers/Group.Details.tsx
@@ -51,7 +51,7 @@ class GroupDetails extends PageComponent<{ groupId: string }> {
     }
 
     initPage(p: PageInitHelper): void {
-        const group = this.props.groupId;
+        const group = decodeURIComponent(this.props.groupId);
 
         p.title = this.props.groupId;
         p.addBreadcrumb('Consumer Groups', '/groups');
@@ -62,8 +62,9 @@ class GroupDetails extends PageComponent<{ groupId: string }> {
     }
 
     refreshData(force: boolean) {
-        api.refreshConsumerGroup(this.props.groupId, force);
-        api.refreshConsumerGroupAcls(this.props.groupId, force);
+        const group = decodeURIComponent(this.props.groupId);
+        api.refreshConsumerGroup(group, force);
+        api.refreshConsumerGroupAcls(group, force);
     }
 
     renderPartitions(group: GroupDescription) {
@@ -208,7 +209,8 @@ class GroupDetails extends PageComponent<{ groupId: string }> {
     }
 
     @computed get group() {
-        return api.consumerGroups.get(this.props.groupId);
+        const groupId = decodeURIComponent(this.props.groupId);
+        return api.consumerGroups.get(groupId);
     }
 
     @action editGroup() {

--- a/frontend/src/components/pages/consumers/Group.List.tsx
+++ b/frontend/src/components/pages/consumers/Group.List.tsx
@@ -175,7 +175,7 @@ class GroupList extends PageComponent {
                     rowClassName="hoverLink"
                     onRow={(record) => ({
                       onClick: () =>
-                        appGlobal.history.push('/groups/' + encodeURIComponent(record.groupId)),
+                        appGlobal.history.push(`/groups/${encodeURIComponent(record.groupId)}`),
                     })}
                   />
                 </Section>

--- a/frontend/src/components/pages/consumers/Group.List.tsx
+++ b/frontend/src/components/pages/consumers/Group.List.tsx
@@ -175,7 +175,7 @@ class GroupList extends PageComponent {
                     rowClassName="hoverLink"
                     onRow={(record) => ({
                       onClick: () =>
-                        appGlobal.history.push('/groups/' + record.groupId),
+                        appGlobal.history.push('/groups/' + encodeURIComponent(record.groupId)),
                     })}
                   />
                 </Section>

--- a/frontend/src/components/pages/topics/Tab.Consumers.tsx
+++ b/frontend/src/components/pages/topics/Tab.Consumers.tsx
@@ -42,7 +42,7 @@ export class TopicConsumers extends Component<{ topic: Topic }> {
                     showSorterTooltip={false}
                     onRow={(record) =>
                     ({
-                        onClick: () => appGlobal.history.push('/groups/' + record.groupId),
+                        onClick: () => appGlobal.history.push(`/groups/${encodeURIComponent(record.groupId)}`),
                     })}
                     pagination={this.pageConfig}
                     onChange={(pagination) => {

--- a/frontend/src/components/pages/topics/Topic.List.tsx
+++ b/frontend/src/components/pages/topics/Topic.List.tsx
@@ -234,7 +234,7 @@ class TopicList extends PageComponent {
                         observableSettings={uiSettings.topicList}
                         onRow={(record) => ({
                             onClick: () =>
-                                appGlobal.history.push('/topics/' + record.topicName),
+                                appGlobal.history.push(`/topics/${encodeURIComponent(record.topicName)}`),
                         })}
                         rowClassName="hoverLink"
                     />

--- a/frontend/src/state/backendApi.ts
+++ b/frontend/src/state/backendApi.ts
@@ -45,7 +45,7 @@ import {
     TopicDocumentation, TopicDocumentationResponse, TopicMessage, TopicOffset,
     TopicPermissions, UserData, WrappedApiError, CreateACLRequest,
     DeleteACLsRequest, RedpandaLicense, AclResource, GetUsersResponse, CreateUserRequest,
-    PatchTopicConfigsRequest, CreateSecretResponse, ClusterOverview, BrokerWithConfigAndStorage, 
+    PatchTopicConfigsRequest, CreateSecretResponse, ClusterOverview, BrokerWithConfigAndStorage,
     OverviewNewsEntry
 } from './restInterfaces';
 import { uiState } from './uiState';
@@ -777,7 +777,7 @@ const apiStore = {
     },
 
     refreshConsumerGroup(groupId: string, force?: boolean) {
-        cachedApiRequest<GetConsumerGroupResponse>(`${appConfig.restBasePath}/consumer-groups/${groupId}`, force)
+        cachedApiRequest<GetConsumerGroupResponse>(`${appConfig.restBasePath}/consumer-groups/${encodeURIComponent(groupId)}`, force)
             .then(v => {
                 addFrontendFieldsForConsumerGroup(v.consumerGroup);
                 this.consumerGroups.set(v.consumerGroup.groupId, v.consumerGroup);
@@ -1497,9 +1497,12 @@ function normalizeAcls(acls: AclResource[]) {
 }
 
 export function aclRequestToQuery(request: GetAclsRequest): string {
-    const filters = ObjToKv(request).filter(kv => !!kv.value);
-    const query = filters.map(x => `${x.key}=${x.value}`).join('&');
-    return query;
+    const filters = ObjToKv(request)
+        .filter(kv => !!kv.value)
+        .map(x => [x.key, x.value]);
+
+    const searchParams = new URLSearchParams(filters);
+    return searchParams.toString();
 }
 
 export async function partialTopicConfigs(configKeys: string[], topics?: string[]): Promise<PartialTopicConfigsResponse> {

--- a/frontend/src/state/backendApi.ts
+++ b/frontend/src/state/backendApi.ts
@@ -301,7 +301,7 @@ const apiStore = {
                 }
             } : {})
         }
-        const url = `${appConfig.websocketBasePath}/topics/${searchRequest.topicName}/messages`;
+        const url = `${appConfig.websocketBasePath}/topics/${encodeURIComponent(searchRequest.topicName)}/messages`;
 
         console.debug('connecting to "' + url + '"');
 
@@ -439,7 +439,7 @@ const apiStore = {
     },
 
     async refreshTopicConfig(topicName: string, force?: boolean): Promise<void> {
-        const promise = cachedApiRequest<TopicConfigResponse | null>(`${appConfig.restBasePath}/topics/${topicName}/configuration`, force)
+        const promise = cachedApiRequest<TopicConfigResponse | null>(`${appConfig.restBasePath}/topics/${encodeURIComponent(topicName)}/configuration`, force)
             .then(v => {
                 if (!v) {
                     this.topicConfig.delete(topicName);
@@ -476,7 +476,7 @@ const apiStore = {
     },
 
     refreshTopicDocumentation(topicName: string, force?: boolean) {
-        cachedApiRequest<TopicDocumentationResponse>(`${appConfig.restBasePath}/topics/${topicName}/documentation`, force)
+        cachedApiRequest<TopicDocumentationResponse>(`${appConfig.restBasePath}/topics/${encodeURIComponent(topicName)}/documentation`, force)
             .then(v => {
                 const text = v.documentation.markdown == null ? null : decodeBase64(v.documentation.markdown);
                 v.documentation.text = text;
@@ -487,7 +487,7 @@ const apiStore = {
     refreshTopicPermissions(topicName: string, force?: boolean) {
         if (!AppFeatures.SINGLE_SIGN_ON) return; // without SSO there can't be a permissions endpoint
         if (this.userData?.user?.providerID == -1) return; // debug user
-        cachedApiRequest<TopicPermissions | null>(`${appConfig.restBasePath}/permissions/topics/${topicName}`, force)
+        cachedApiRequest<TopicPermissions | null>(`${appConfig.restBasePath}/permissions/topics/${encodeURIComponent(topicName)}`, force)
             .then(x => this.topicPermissions.set(topicName, x), addError);
     },
 
@@ -521,7 +521,7 @@ const apiStore = {
     },
 
     async deleteTopicRecordsFromMultiplePartitionOffsetPairs(topicName: string, pairs: Array<{ partitionId: number, offset: number; }>) {
-        return rest<DeleteRecordsResponseData>(`${appConfig.restBasePath}/topics/${topicName}/records`, {
+        return rest<DeleteRecordsResponseData>(`${appConfig.restBasePath}/topics/${encodeURIComponent(topicName)}/records`, {
             method: 'DELETE',
             headers: [
                 ['Content-Type', 'application/json']
@@ -603,7 +603,7 @@ const apiStore = {
     },
 
     refreshPartitionsForTopic(topicName: string, force?: boolean) {
-        cachedApiRequest<GetPartitionsResponse | null>(`${appConfig.restBasePath}/topics/${topicName}/partitions`, force)
+        cachedApiRequest<GetPartitionsResponse | null>(`${appConfig.restBasePath}/topics/${encodeURIComponent(topicName)}/partitions`, force)
             .then(response => {
                 if (response?.partitions) {
                     const partitionErrors: Array<{ id: number, partitionError: string; }> = [], waterMarksErrors: Array<{ id: number, waterMarksError: string; }> = [];
@@ -680,7 +680,7 @@ const apiStore = {
     },
 
     refreshTopicConsumers(topicName: string, force?: boolean) {
-        cachedApiRequest<GetTopicConsumersResponse>(`${appConfig.restBasePath}/topics/${topicName}/consumers`, force)
+        cachedApiRequest<GetTopicConsumersResponse>(`${appConfig.restBasePath}/topics/${encodeURIComponent(topicName)}/consumers`, force)
             .then(v => this.topicConsumers.set(topicName, v.topicConsumers), addError);
     },
 
@@ -1088,7 +1088,7 @@ const apiStore = {
     // PATCH /topics/configuration               // default config
     async changeTopicConfig(topicName: string | null, configs: PatchTopicConfigsRequest['configs']): Promise<void> {
         const url = topicName
-            ? `${appConfig.restBasePath}/topics/${topicName}/configuration`
+            ? `${appConfig.restBasePath}/topics/${encodeURIComponent(topicName)}/configuration`
             : `${appConfig.restBasePath}/topics/configuration`;
 
         const response = await appConfig.fetch(url, {
@@ -1184,7 +1184,7 @@ const apiStore = {
 
     async deleteConnector(clusterName: string, connector: string): Promise<void> {
         // DELETE "/kafka-connect/clusters/{clusterName}/connectors/{connector}"
-        const response = await appConfig.fetch(`${appConfig.restBasePath}/kafka-connect/clusters/${clusterName}/connectors/${connector}`, {
+        const response = await appConfig.fetch(`${appConfig.restBasePath}/kafka-connect/clusters/${encodeURIComponent(clusterName)}/connectors/${encodeURIComponent(connector)}`, {
             method: 'DELETE',
             headers: [
                 ['Content-Type', 'application/json']
@@ -1195,7 +1195,7 @@ const apiStore = {
 
     async pauseConnector(clusterName: string, connector: string): Promise<void> {
         // PUT  "/kafka-connect/clusters/{clusterName}/connectors/{connector}/pause"  (idempotent)
-        const response = await appConfig.fetch(`${appConfig.restBasePath}/kafka-connect/clusters/${clusterName}/connectors/${connector}/pause`, {
+        const response = await appConfig.fetch(`${appConfig.restBasePath}/kafka-connect/clusters/${encodeURIComponent(clusterName)}/connectors/${encodeURIComponent(connector)}/pause`, {
             method: 'PUT',
             headers: [
                 ['Content-Type', 'application/json']
@@ -1206,7 +1206,7 @@ const apiStore = {
 
     async resumeConnector(clusterName: string, connector: string): Promise<void> {
         // PUT  "/kafka-connect/clusters/{clusterName}/connectors/{connector}/resume" (idempotent)
-        const response = await appConfig.fetch(`${appConfig.restBasePath}/kafka-connect/clusters/${clusterName}/connectors/${connector}/resume`, {
+        const response = await appConfig.fetch(`${appConfig.restBasePath}/kafka-connect/clusters/${encodeURIComponent(clusterName)}/connectors/${encodeURIComponent(connector)}/resume`, {
             method: 'PUT',
             headers: [
                 ['Content-Type', 'application/json']
@@ -1217,7 +1217,7 @@ const apiStore = {
 
     async restartConnector(clusterName: string, connector: string): Promise<void> {
         // POST "/kafka-connect/clusters/{clusterName}/connectors/{connector}/restart"
-        const response = await appConfig.fetch(`${appConfig.restBasePath}/kafka-connect/clusters/${clusterName}/connectors/${connector}/restart`, {
+        const response = await appConfig.fetch(`${appConfig.restBasePath}/kafka-connect/clusters/${encodeURIComponent(clusterName)}/connectors/${encodeURIComponent(connector)}/restart`, {
             method: 'POST',
             headers: [
                 ['Content-Type', 'application/json']
@@ -1343,7 +1343,7 @@ const apiStore = {
     },
 
     async deleteServiceAccount(principalId: string): Promise<void> {
-        const response = await appConfig.fetch(`${appConfig.restBasePath}/users/${principalId}`, {
+        const response = await appConfig.fetch(`${appConfig.restBasePath}/users/${encodeURIComponent(principalId)}`, {
             method: 'DELETE',
         });
 


### PR DESCRIPTION
Prior to this PR some requests & pages failed to load in Console. For instance special characters like a slash are allowed in Consumer groups but were not supported due to missing escaping. This PR escapes & unescapes all URL & query parameters