### PR TITLE
backend: Include redpanda version only if set

### DIFF
--- a/backend/pkg/console/overview.go
+++ b/backend/pkg/console/overview.go
@@ -37,7 +37,7 @@ type Overview struct {
 type OverviewRedpanda struct {
 	IsAdminAPIConfigured    bool                           `json:"isAdminApiConfigured"`
 	License                 *redpanda.License              `json:"license,omitempty"`
-	Version                 string                         `json:"version"`
+	Version                 string                         `json:"version,omitempty"`
 	UserCount               *int                           `json:"userCount,omitempty"`
 	PartitionBalancerStatus *admin.PartitionBalancerStatus `json:"partitionBalancerStatus,omitempty"`
 }


### PR DESCRIPTION
Omit the redpanda version if we aren't talking to a Redpanda cluster with admin api enabled.