### PR TITLE
backend: Fix basepath middleware

### DIFF
--- a/backend/pkg/api/middlewares.go
+++ b/backend/pkg/api/middlewares.go
@@ -92,6 +92,7 @@ func (b *basePathMiddleware) Wrap(next http.Handler) http.Handler {
 		if strings.HasPrefix(r.RequestURI, prefix) {
 			r.RequestURI = "/" + strings.TrimPrefix(r.RequestURI, prefix)
 		}
+		next.ServeHTTP(w, r)
 	})
 }
 


### PR DESCRIPTION
We stripped the prefix properly, but did not call the next handler in the request stack.