### PR TITLE
update kics

### DIFF
--- a/.github/workflows/kics-iac.yml
+++ b/.github/workflows/kics-iac.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: run kics Scan
-        uses: checkmarx/kics-github-action@v1.6
+        uses: checkmarx/kics-github-action@v1.6.3
         with:
           path: .
           ignore_on_exit: results


### PR DESCRIPTION
this update to kics brings it up to the latest version and should also fix a failure in the GH action that has prevented the action from completing for the last 9 days. 