### PR TITLE
Sj/connectors improvements

### DIFF
--- a/frontend/src/components/pages/connect/dynamic-ui/PropertyComponent.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/PropertyComponent.tsx
@@ -38,11 +38,7 @@ export const PropertyComponent = observer((props: { property: Property }) => {
         </div>
     );
 
-    let v = p.value;
-    if (typeof p.value != 'string') {
-        if (typeof p.value == 'number' || typeof p.value == 'boolean') v = String(v);
-        else v = '';
-    }
+    const v = p.value;
 
     switch (def.type) {
         case 'STRING':
@@ -110,7 +106,7 @@ export const PropertyComponent = observer((props: { property: Property }) => {
             break;
 
         case 'BOOLEAN':
-            inputComp = <Switch isChecked={Boolean(p.value)} onChange={(e) => (p.value = e.target.checked)} />;
+            inputComp = <Switch isChecked={Boolean(v)} onChange={(e) => (p.value = e.target.checked)} />;
             break;
 
         case 'LIST':


### PR DESCRIPTION
Update couple of frontend fixes on boolean and on the edit phase for the connectors page. include @tomasz-sadura suggestions for:
- make visible a reactive field
- make sure boolean like fields are correct when edition, even if the field is of type literal string, 'true'|'false'