### PR TITLE
exclude tests from KICS scans

### DIFF
--- a/.github/workflows/kics-iac.yml
+++ b/.github/workflows/kics-iac.yml
@@ -18,6 +18,7 @@ jobs:
           path: .
           ignore_on_exit: results
           output_path: res/
+          exclude_paths: helm/examples/,helm/console/templates/
       - name: display kics results
         run: |
           cat res/results.json


### PR DESCRIPTION
don't scan test code with KICS to reduce noise 