### PR TITLE
backend: Add config to configure retries on startup

### DIFF
--- a/backend/pkg/config/kafka.go
+++ b/backend/pkg/config/kafka.go
@@ -28,6 +28,10 @@ type Kafka struct {
 
 	TLS  KafkaTLS  `yaml:"tls"`
 	SASL KafkaSASL `yaml:"sasl"`
+
+	// Startup contains relevant configurations such as connection max retries
+	// for the initial Kafka service creation.
+	Startup KafkaStartup `yaml:"startup"`
 }
 
 // RegisterFlags registers all nested config flags.
@@ -64,6 +68,11 @@ func (c *Kafka) Validate() error {
 		return fmt.Errorf("failed to validate msgpack config: %w", err)
 	}
 
+	err = c.Startup.Validate()
+	if err != nil {
+		return fmt.Errorf("failed to validate startup config: %w", err)
+	}
+
 	return nil
 }
 
@@ -74,6 +83,7 @@ func (c *Kafka) SetDefaults() {
 	c.SASL.SetDefaults()
 	c.Protobuf.SetDefaults()
 	c.MessagePack.SetDefaults()
+	c.Startup.SetDefaults()
 }
 
 // RedactedConfig returns a copy of the config object which redacts sensitive fields. This is useful if you

--- a/backend/pkg/config/kafka_startup.go
+++ b/backend/pkg/config/kafka_startup.go
@@ -1,0 +1,50 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package config
+
+import (
+	"fmt"
+	"math"
+	"time"
+)
+
+// KafkaStartup is a configuration block to specify how often and with what delays
+// we should try to connect to the Kafka service. If all attempts have failed the
+// application will exit with code 1.
+type KafkaStartup struct {
+	MaxRetries        int           `yaml:"maxRetries"`
+	RetryInterval     time.Duration `yaml:"retryInterval"`
+	MaxRetryInterval  time.Duration `yaml:"maxRetryInterval"`
+	BackoffMultiplier float64       `yaml:"backoffMultiplier"`
+}
+
+// SetDefaults for Kafka startup configuration.
+func (k *KafkaStartup) SetDefaults() {
+	k.MaxRetries = 5
+	k.RetryInterval = time.Second
+	k.MaxRetryInterval = 60 * time.Second
+	k.BackoffMultiplier = 2
+}
+
+// Validate startup config.
+func (k *KafkaStartup) Validate() error {
+	if k.MaxRetries < 0 {
+		return fmt.Errorf("max retries must be 0 for unlimited retries or a positive integer")
+	}
+	if k.MaxRetries == 0 {
+		k.MaxRetries = math.MaxInt
+	}
+
+	if k.BackoffMultiplier <= 0 {
+		return fmt.Errorf("the backoff multiplier must be greater than 0")
+	}
+
+	return nil
+}

--- a/backend/pkg/kafka/backoff.go
+++ b/backend/pkg/kafka/backoff.go
@@ -1,0 +1,35 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package kafka
+
+import (
+	"math"
+	"time"
+)
+
+// ExponentialBackoff is a helper struct that can calculate the wait
+// time between retries. Each retry increases the wait time exponentially,
+// based on the given multiplier.
+type ExponentialBackoff struct {
+	BaseInterval time.Duration
+	MaxInterval  time.Duration
+	Multiplier   float64
+}
+
+// Backoff returns the duration to wait before retrying.
+// Each successive call increases the wait time exponentially.
+func (e *ExponentialBackoff) Backoff(attempts int) time.Duration {
+	multiplied := math.Pow(e.Multiplier, float64(attempts))
+	wait := time.Duration(float64(e.BaseInterval) * multiplied)
+	if wait > e.MaxInterval {
+		wait = e.MaxInterval
+	}
+	return wait
+}

--- a/backend/pkg/kafka/backoff_test.go
+++ b/backend/pkg/kafka/backoff_test.go
@@ -1,0 +1,53 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package kafka
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExponentialBackoff(t *testing.T) {
+	cases := []struct {
+		baseInterval time.Duration
+		maxInterval  time.Duration
+		multiplier   float64
+		attempts     int
+		expectedWait time.Duration
+	}{
+		// 5s base, 2x multiplier
+		{5 * time.Second, 60 * time.Second, 2.0, 0, 5 * time.Second},
+		{5 * time.Second, 60 * time.Second, 2.0, 1, 10 * time.Second},
+		{5 * time.Second, 60 * time.Second, 2.0, 2, 20 * time.Second},
+		{5 * time.Second, 60 * time.Second, 2.0, 3, 40 * time.Second},
+		{5 * time.Second, 60 * time.Second, 2.0, 4, 60 * time.Second},
+
+		// 1s base, 1.6x multiplier
+		{time.Second, 60 * time.Second, 1.6, 0, time.Second},
+		{time.Second, 60 * time.Second, 1.6, 1, 1600 * time.Millisecond},
+		{time.Second, 60 * time.Second, 1.6, 2, 2560 * time.Millisecond},
+		{time.Second, 60 * time.Second, 1.6, 3, 4096 * time.Millisecond},
+		{time.Second, 60 * time.Second, 1.6, 4, 6553600000 * time.Nanosecond},
+	}
+
+	for _, c := range cases {
+		eb := &ExponentialBackoff{
+			BaseInterval: c.baseInterval,
+			MaxInterval:  c.maxInterval,
+			Multiplier:   c.multiplier,
+		}
+
+		wait := eb.Backoff(c.attempts)
+		assert.Equal(t, c.expectedWait, wait, fmt.Sprintf("Attempt %d", c.attempts))
+	}
+}

--- a/backend/pkg/kafka/service.go
+++ b/backend/pkg/kafka/service.go
@@ -62,18 +62,25 @@ func NewService(cfg *config.Config, logger *zap.Logger, metricsNamespace string)
 	// Ensure Kafka connection works, otherwise fail fast. Allow up to 5 retries with exponentially increasing backoff.
 	// Retries with backoff is very helpful in environments where Console concurrently starts with the Kafka target,
 	// such as a docker-compose demo.
-	retries := 5
-	backoffDuration := 1 * time.Second
-	for retries > 0 {
+	eb := ExponentialBackoff{
+		BaseInterval: cfg.Kafka.Startup.RetryInterval,
+		MaxInterval:  cfg.Kafka.Startup.MaxRetryInterval,
+		Multiplier:   cfg.Kafka.Startup.BackoffMultiplier,
+	}
+	attempt := 0
+	for attempt < cfg.Kafka.Startup.MaxRetries {
 		err = testConnection(logger, kafkaClient, time.Second*15)
 		if err == nil {
 			break
 		}
-		logger.Warn(fmt.Sprintf("Failed to test Kafka connection, going to retry in %vs",
-			backoffDuration.Seconds()), zap.Int("remaining_retries", retries))
+
+		backoffDuration := eb.Backoff(attempt)
+		logger.Warn(
+			fmt.Sprintf("Failed to test Kafka connection, going to retry in %vs", backoffDuration.Seconds()),
+			zap.Int("remaining_retries", cfg.Kafka.Startup.MaxRetries-attempt),
+		)
+		attempt++
 		time.Sleep(backoffDuration)
-		backoffDuration *= 2
-		retries--
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to test kafka connection: %w", err)


### PR DESCRIPTION
Fixes #663

Sample configuration:

```yaml
kafka:
  startup:
    maxRetries: 0 # unlimited retries
    retryInterval: 2s
    maxRetryInterval: 15s
    backoffMultiplier: 1.8
```

defaults to:

```go
	k.MaxRetries = 5
	k.RetryInterval = time.Second
	k.MaxRetryInterval = 60 * time.Second
	k.BackoffMultiplier = 2
```