### PR TITLE
Add support for editing existing MongoDB connectors with guide

### DIFF
--- a/backend/pkg/connector/guide/mongo_sink.go
+++ b/backend/pkg/connector/guide/mongo_sink.go
@@ -30,6 +30,7 @@ func NewMongoSinkGuide(opts ...Option) Guide {
 					{
 						// No Group name and description here
 						ConfigKeys: []string{
+							"connection.uri",
 							"connection.url",
 							"connection.username",
 							"connection.password",

--- a/backend/pkg/connector/guide/mongo_source.go
+++ b/backend/pkg/connector/guide/mongo_source.go
@@ -38,6 +38,7 @@ func NewMongoSourceGuide(opts ...Option) Guide {
 					{
 						// No Group name and description here
 						ConfigKeys: []string{
+							"connection.uri",
 							"connection.url",
 							"connection.username",
 							"connection.password",

--- a/backend/pkg/connector/interceptor/mongo_hook.go
+++ b/backend/pkg/connector/interceptor/mongo_hook.go
@@ -35,6 +35,10 @@ func setConnectionURI(config map[string]any) {
 		}
 	}
 
+	if _, exists := config["connection.url"]; !exists {
+		config["connection.url"] = config["connection.uri"]
+	}
+
 	if config["connection.username"] != nil && config["connection.password"] != nil && config["connection.url"] != nil {
 		password := config["connection.password"].(string)
 		if hasKafkaConnectConfigProvider(config["connection.password"].(string)) {

--- a/backend/pkg/connector/model/config_definition.go
+++ b/backend/pkg/connector/model/config_definition.go
@@ -58,6 +58,12 @@ func (c *ConfigDefinition) SetVisible(visible bool) *ConfigDefinition {
 	return c
 }
 
+// SetType sets the type of the config definition.
+func (c *ConfigDefinition) SetType(configDefinitionType ConfigDefinitionType) *ConfigDefinition {
+	c.Definition.Type = configDefinitionType
+	return c
+}
+
 // SetDisplayName sets the display name of the config definition.
 func (c *ConfigDefinition) SetDisplayName(displayName string) *ConfigDefinition {
 	c.Definition.DisplayName = displayName

--- a/backend/pkg/connector/patch/mongo.go
+++ b/backend/pkg/connector/patch/mongo.go
@@ -54,7 +54,9 @@ func (*ConfigPatchMongoDB) PatchDefinition(d model.ConfigDefinition, connectorCl
 	// Misc patches
 	switch d.Definition.Name {
 	case "connection.uri":
-		d.SetDefaultValue("mongodb://")
+		d.SetDefaultValue("mongodb://").
+			SetVisible(false).
+			SetType(model.ConfigDefinitionTypePassword)
 	case keyConverter, valueConverter:
 		converterType, _, _ := strings.Cut(d.Definition.Name, ".")
 		d.SetDefaultValue("org.apache.kafka.connect.storage.StringConverter")


### PR DESCRIPTION
Add support to edit MongoDB source and sink connectors configuration, that were created prior to the UI guide.

Ref.: https://github.com/redpanda-data/console/issues/679