### PR TITLE
Backend get topics tests

### DIFF
--- a/backend/pkg/api/api_integration_test.go
+++ b/backend/pkg/api/api_integration_test.go
@@ -132,8 +132,13 @@ func (s *APIIntegrationTestSuite) apiRequest(ctx context.Context,
 	method, path string, input interface{},
 ) (*http.Response, []byte) {
 	t := s.T()
-	data, err := json.Marshal(input)
-	require.NoError(t, err)
+
+	var err error
+	var data []byte
+	if input != nil {
+		data, err = json.Marshal(input)
+		require.NoError(t, err)
+	}
 
 	req, err := http.NewRequestWithContext(ctx, method, s.httpAddress()+path, bytes.NewReader(data))
 	require.NoError(t, err)

--- a/backend/pkg/api/api_integration_test.go
+++ b/backend/pkg/api/api_integration_test.go
@@ -16,14 +16,18 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"math"
 	"math/rand"
 	"net/http"
+	"runtime"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/cloudhut/common/logging"
 	"github.com/cloudhut/common/rest"
+	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -33,7 +37,11 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/redpanda-data/console/backend/pkg/config"
+	"github.com/redpanda-data/console/backend/pkg/connect"
+	"github.com/redpanda-data/console/backend/pkg/console"
 	"github.com/redpanda-data/console/backend/pkg/testutil"
+
+	rp "github.com/redpanda-data/console/backend/pkg/redpanda"
 )
 
 type APIIntegrationTestSuite struct {
@@ -153,4 +161,368 @@ func (s *APIIntegrationTestSuite) apiRequest(ctx context.Context,
 	assert.NoError(t, err)
 
 	return res, body
+}
+
+type assertCallReturnValue struct {
+	Err *rest.Error
+
+	BoolValue bool
+
+	SliceValue []string
+}
+
+func assertHookCall(t *testing.T) {
+	pc, _, _, _ := runtime.Caller(1)
+	fnName := runtime.FuncForPC(pc).Name()
+	assert.Fail(t, "unexpected call to hook function:"+fnName)
+}
+
+// assertHooks is the default hook for tests that deny everything by default and assert when functions are called
+type assertHooks struct {
+	t *testing.T
+
+	allowedCalls map[string]map[string]bool
+	returnValues map[string]map[string]assertCallReturnValue
+}
+
+func (a *assertHooks) isCallAllowed(topicName string) bool {
+	pc, _, _, _ := runtime.Caller(1)
+	fnName := runtime.FuncForPC(pc).Name()
+	parts := strings.Split(fnName, ".")
+	fnName = parts[len(parts)-1]
+	topicMap, ok := a.allowedCalls[fnName]
+	if !ok || len(topicMap) == 0 {
+		return false
+	}
+
+	if v, ok := topicMap["any"]; ok {
+		return v
+	}
+	return topicMap[topicName]
+
+}
+
+func (a *assertHooks) getCallReturnValue(topicName string) assertCallReturnValue {
+	pc, _, _, _ := runtime.Caller(1)
+	fnName := runtime.FuncForPC(pc).Name()
+	parts := strings.Split(fnName, ".")
+	fnName = parts[len(parts)-1]
+	topicMap, ok := a.returnValues[fnName]
+	if !ok || len(topicMap) == 0 {
+		return assertCallReturnValue{}
+	}
+	if v, ok := topicMap["any"]; ok {
+		return v
+	}
+	return topicMap[topicName]
+}
+
+func newAssertHooks(t *testing.T, returnValues map[string]map[string]assertCallReturnValue) *Hooks {
+	h := &assertHooks{
+		allowedCalls: map[string]map[string]bool{},
+		returnValues: map[string]map[string]assertCallReturnValue{},
+	}
+
+	for n, v := range returnValues {
+		for tn, _ := range v {
+			if len(h.allowedCalls[n]) == 0 {
+				h.allowedCalls[n] = map[string]bool{}
+			}
+
+			h.allowedCalls[n][tn] = true
+		}
+
+		h.returnValues[n] = v
+	}
+
+	return &Hooks{
+		Authorization: h,
+		Route:         h,
+		Console:       h,
+	}
+}
+
+// Router Hooks
+func (a *assertHooks) ConfigAPIRouter(_ chi.Router)      {}
+func (a *assertHooks) ConfigWsRouter(_ chi.Router)       {}
+func (a *assertHooks) ConfigInternalRouter(_ chi.Router) {}
+func (a *assertHooks) ConfigRouter(_ chi.Router)         {}
+
+// Authorization Hooks
+func (a *assertHooks) CanSeeTopic(_ context.Context, topic string) (bool, *rest.Error) {
+	if !a.isCallAllowed(topic) {
+		assertHookCall(a.t)
+	}
+
+	rv := a.getCallReturnValue(topic)
+
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) CanCreateTopic(_ context.Context, topic string) (bool, *rest.Error) {
+	if !a.isCallAllowed(topic) {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue(topic)
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) CanEditTopicConfig(_ context.Context, topic string) (bool, *rest.Error) {
+	if !a.isCallAllowed(topic) {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue(topic)
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) CanDeleteTopic(_ context.Context, topic string) (bool, *rest.Error) {
+	if !a.isCallAllowed(topic) {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue(topic)
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) CanPublishTopicRecords(_ context.Context, topic string) (bool, *rest.Error) {
+	if !a.isCallAllowed(topic) {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue(topic)
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) CanDeleteTopicRecords(_ context.Context, topic string) (bool, *rest.Error) {
+	if !a.isCallAllowed(topic) {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue(topic)
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) CanViewTopicPartitions(_ context.Context, topic string) (bool, *rest.Error) {
+	if !a.isCallAllowed(topic) {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue(topic)
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) CanViewTopicConfig(_ context.Context, topic string) (bool, *rest.Error) {
+	if !a.isCallAllowed(topic) {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue(topic)
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) CanViewTopicMessages(_ context.Context, r *ListMessagesRequest) (bool, *rest.Error) {
+	if !a.isCallAllowed(r.TopicName) {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue(r.TopicName)
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) CanUseMessageSearchFilters(_ context.Context, r *ListMessagesRequest) (bool, *rest.Error) {
+	if !a.isCallAllowed(r.TopicName) {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue(r.TopicName)
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) CanViewTopicConsumers(_ context.Context, topic string) (bool, *rest.Error) {
+	if !a.isCallAllowed(topic) {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue(topic)
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) AllowedTopicActions(_ context.Context, topic string) ([]string, *rest.Error) {
+	if !a.isCallAllowed(topic) {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue(topic)
+	return rv.SliceValue, rv.Err
+}
+
+func (a *assertHooks) PrintListMessagesAuditLog(_ *http.Request, r *console.ListMessageRequest) {
+	if !a.isCallAllowed(r.TopicName) {
+		assertHookCall(a.t)
+	}
+}
+
+func (a *assertHooks) CanListACLs(_ context.Context) (bool, *rest.Error) {
+	if !a.isCallAllowed("any") {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue("any")
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) CanCreateACL(_ context.Context) (bool, *rest.Error) {
+	if !a.isCallAllowed("any") {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue("any")
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) CanDeleteACL(_ context.Context) (bool, *rest.Error) {
+	if !a.isCallAllowed("any") {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue("any")
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) CanListQuotas(_ context.Context) (bool, *rest.Error) {
+	if !a.isCallAllowed("any") {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue("any")
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) CanSeeConsumerGroup(_ context.Context, topic string) (bool, *rest.Error) {
+	if !a.isCallAllowed(topic) {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue(topic)
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) CanEditConsumerGroup(_ context.Context, topic string) (bool, *rest.Error) {
+	if !a.isCallAllowed(topic) {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue(topic)
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) CanDeleteConsumerGroup(_ context.Context, topic string) (bool, *rest.Error) {
+	if !a.isCallAllowed(topic) {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue(topic)
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) AllowedConsumerGroupActions(_ context.Context, _ string) ([]string, *rest.Error) {
+	if !a.isCallAllowed("any") {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue("any")
+	return rv.SliceValue, rv.Err
+}
+
+func (a *assertHooks) CanPatchPartitionReassignments(_ context.Context) (bool, *rest.Error) {
+	if !a.isCallAllowed("any") {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue("any")
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) CanPatchConfigs(_ context.Context) (bool, *rest.Error) {
+	if !a.isCallAllowed("any") {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue("any")
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) CanViewConnectCluster(_ context.Context, topic string) (bool, *rest.Error) {
+	if !a.isCallAllowed(topic) {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue(topic)
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) CanEditConnectCluster(_ context.Context, topic string) (bool, *rest.Error) {
+	if !a.isCallAllowed(topic) {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue(topic)
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) CanDeleteConnectCluster(_ context.Context, topic string) (bool, *rest.Error) {
+	if !a.isCallAllowed(topic) {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue(topic)
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) AllowedConnectClusterActions(_ context.Context, topic string) ([]string, *rest.Error) {
+	if !a.isCallAllowed(topic) {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue(topic)
+	return rv.SliceValue, rv.Err
+}
+
+func (a *assertHooks) CanListKafkaUsers(_ context.Context) (bool, *rest.Error) {
+	if !a.isCallAllowed("any") {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue("any")
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) CanCreateKafkaUsers(_ context.Context) (bool, *rest.Error) {
+	if !a.isCallAllowed("any") {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue("any")
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) CanDeleteKafkaUsers(_ context.Context) (bool, *rest.Error) {
+	if !a.isCallAllowed("any") {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue("any")
+	return rv.BoolValue, rv.Err
+}
+
+func (a *assertHooks) IsProtectedKafkaUser(_ string) bool {
+	if !a.isCallAllowed("any") {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue("any")
+	return rv.BoolValue
+}
+
+// Console hooks
+func (a *assertHooks) ConsoleLicenseInformation(_ context.Context) rp.License {
+	if !a.isCallAllowed("any") {
+		assertHookCall(a.t)
+	}
+	return rp.License{Source: rp.LicenseSourceConsole, Type: rp.LicenseTypeOpenSource, ExpiresAt: math.MaxInt32}
+}
+
+func (a *assertHooks) EnabledFeatures() []string {
+	if !a.isCallAllowed("any") {
+		assertHookCall(a.t)
+	}
+	rv := a.getCallReturnValue("any")
+	return rv.SliceValue
+}
+
+func (a *assertHooks) EndpointCompatibility() []console.EndpointCompatibilityEndpoint {
+	if !a.isCallAllowed("any") {
+		assertHookCall(a.t)
+	}
+	return nil
+}
+
+func (a *assertHooks) EnabledConnectClusterFeatures(_ context.Context, _ string) []connect.ClusterFeature {
+	if !a.isCallAllowed("any") {
+		assertHookCall(a.t)
+	}
+	return nil
 }

--- a/backend/pkg/api/api_integration_test.go
+++ b/backend/pkg/api/api_integration_test.go
@@ -164,10 +164,8 @@ func (s *APIIntegrationTestSuite) apiRequest(ctx context.Context,
 }
 
 type assertCallReturnValue struct {
-	Err *rest.Error
-
-	BoolValue bool
-
+	Err        *rest.Error
+	BoolValue  bool
 	SliceValue []string
 }
 
@@ -194,12 +192,10 @@ func (a *assertHooks) isCallAllowed(topicName string) bool {
 	if !ok || len(topicMap) == 0 {
 		return false
 	}
-
 	if v, ok := topicMap["any"]; ok {
 		return v
 	}
 	return topicMap[topicName]
-
 }
 
 func (a *assertHooks) getCallReturnValue(topicName string) assertCallReturnValue {

--- a/backend/pkg/api/handle_topic_create_integration_test.go
+++ b/backend/pkg/api/handle_topic_create_integration_test.go
@@ -39,7 +39,6 @@ type restAPIError struct {
 
 func (s *APIIntegrationTestSuite) TestHandleCreateTopic() {
 	t := s.T()
-	t.Skip("temp skip")
 	require := require.New(t)
 	assert := assert.New(t)
 

--- a/backend/pkg/api/handle_topic_create_integration_test.go
+++ b/backend/pkg/api/handle_topic_create_integration_test.go
@@ -15,15 +15,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"net/http"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/cloudhut/common/rest"
-	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kerr"
@@ -31,10 +27,8 @@ import (
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"go.uber.org/zap"
 
-	"github.com/redpanda-data/console/backend/pkg/connect"
 	"github.com/redpanda-data/console/backend/pkg/console"
 	"github.com/redpanda-data/console/backend/pkg/kafka"
-	"github.com/redpanda-data/console/backend/pkg/redpanda"
 	"github.com/redpanda-data/console/backend/pkg/testutil"
 )
 
@@ -45,6 +39,7 @@ type restAPIError struct {
 
 func (s *APIIntegrationTestSuite) TestHandleCreateTopic() {
 	t := s.T()
+	t.Skip("temp skip")
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -238,9 +233,9 @@ func (s *APIIntegrationTestSuite) TestHandleCreateTopic() {
 		topicName := testutil.TopicNameForTest("no_permission")
 
 		oldHooks := s.api.Hooks
-		newHooks := newAssertHooks(t, map[string]map[string]bool{
+		newHooks := newAssertHooks(t, map[string]map[string]assertCallReturnValue{
 			"CanCreateTopic": {
-				topicName: false,
+				topicName: assertCallReturnValue{BoolValue: false, Err: nil},
 			},
 		})
 
@@ -366,328 +361,4 @@ func (s *APIIntegrationTestSuite) TestHandleCreateTopic() {
 
 		assert.Equal(503, apiErr.Status)
 	})
-}
-
-func assertHookCall(t *testing.T) {
-	pc, _, _, _ := runtime.Caller(1)
-	fnName := runtime.FuncForPC(pc).Name()
-	assert.Fail(t, "unexpected call to hook function:"+fnName)
-}
-
-// assertHooks is the default hook for tests that deny everything by default and assert when functions are called
-type assertHooks struct {
-	t *testing.T
-
-	allowedCalls map[string]map[string]bool
-	returnValues map[string]map[string]bool
-}
-
-func (a *assertHooks) isCallAllowed(topicName string) bool {
-	pc, _, _, _ := runtime.Caller(1)
-	fnName := runtime.FuncForPC(pc).Name()
-	parts := strings.Split(fnName, ".")
-	fnName = parts[len(parts)-1]
-	topicMap, ok := a.allowedCalls[fnName]
-	if !ok || len(topicMap) == 0 {
-		return false
-	}
-
-	if v, ok := topicMap["any"]; ok {
-		return v
-	}
-	return topicMap[topicName]
-
-}
-
-func (a *assertHooks) getCallReturnValue(topicName string) bool {
-	pc, _, _, _ := runtime.Caller(1)
-	fnName := runtime.FuncForPC(pc).Name()
-	parts := strings.Split(fnName, ".")
-	fnName = parts[len(parts)-1]
-	topicMap, ok := a.returnValues[fnName]
-	if !ok || len(topicMap) == 0 {
-		return false
-	}
-	if v, ok := topicMap["any"]; ok {
-		return v
-	}
-	return topicMap[topicName]
-}
-
-func newAssertHooks(t *testing.T, returnValues map[string]map[string]bool) *Hooks {
-	h := &assertHooks{
-		allowedCalls: map[string]map[string]bool{},
-		returnValues: map[string]map[string]bool{},
-	}
-
-	for n, v := range returnValues {
-		for tn, _ := range v {
-			if len(h.allowedCalls[n]) == 0 {
-				h.allowedCalls[n] = map[string]bool{}
-			}
-
-			h.allowedCalls[n][tn] = true
-		}
-
-		h.returnValues[n] = v
-	}
-
-	return &Hooks{
-		Authorization: h,
-		Route:         h,
-		Console:       h,
-	}
-}
-
-// Router Hooks
-func (a *assertHooks) ConfigAPIRouter(_ chi.Router)      {}
-func (a *assertHooks) ConfigWsRouter(_ chi.Router)       {}
-func (a *assertHooks) ConfigInternalRouter(_ chi.Router) {}
-func (a *assertHooks) ConfigRouter(_ chi.Router)         {}
-
-// Authorization Hooks
-func (a *assertHooks) CanSeeTopic(_ context.Context, topic string) (bool, *rest.Error) {
-	if !a.isCallAllowed(topic) {
-		assertHookCall(a.t)
-	}
-
-	return a.getCallReturnValue(topic), nil
-}
-
-func (a *assertHooks) CanCreateTopic(_ context.Context, topic string) (bool, *rest.Error) {
-	if !a.isCallAllowed(topic) {
-		assertHookCall(a.t)
-	}
-	return a.getCallReturnValue(topic), nil
-}
-
-func (a *assertHooks) CanEditTopicConfig(_ context.Context, topic string) (bool, *rest.Error) {
-	if !a.isCallAllowed(topic) {
-		assertHookCall(a.t)
-	}
-	return a.getCallReturnValue(topic), nil
-}
-
-func (a *assertHooks) CanDeleteTopic(_ context.Context, topic string) (bool, *rest.Error) {
-	if !a.isCallAllowed(topic) {
-		assertHookCall(a.t)
-	}
-	return a.getCallReturnValue(topic), nil
-}
-
-func (a *assertHooks) CanPublishTopicRecords(_ context.Context, topic string) (bool, *rest.Error) {
-	if !a.isCallAllowed(topic) {
-		assertHookCall(a.t)
-	}
-	return a.getCallReturnValue(topic), nil
-}
-
-func (a *assertHooks) CanDeleteTopicRecords(_ context.Context, topic string) (bool, *rest.Error) {
-	if !a.isCallAllowed(topic) {
-		assertHookCall(a.t)
-	}
-	return a.getCallReturnValue(topic), nil
-}
-
-func (a *assertHooks) CanViewTopicPartitions(_ context.Context, topic string) (bool, *rest.Error) {
-	if !a.isCallAllowed(topic) {
-		assertHookCall(a.t)
-	}
-	return a.getCallReturnValue(topic), nil
-}
-
-func (a *assertHooks) CanViewTopicConfig(_ context.Context, topic string) (bool, *rest.Error) {
-	if !a.isCallAllowed(topic) {
-		assertHookCall(a.t)
-	}
-	return a.getCallReturnValue(topic), nil
-}
-
-func (a *assertHooks) CanViewTopicMessages(_ context.Context, r *ListMessagesRequest) (bool, *rest.Error) {
-	if !a.isCallAllowed(r.TopicName) {
-		assertHookCall(a.t)
-	}
-	return a.getCallReturnValue(r.TopicName), nil
-}
-
-func (a *assertHooks) CanUseMessageSearchFilters(_ context.Context, r *ListMessagesRequest) (bool, *rest.Error) {
-	if !a.isCallAllowed(r.TopicName) {
-		assertHookCall(a.t)
-	}
-	return a.getCallReturnValue(r.TopicName), nil
-}
-
-func (a *assertHooks) CanViewTopicConsumers(_ context.Context, topic string) (bool, *rest.Error) {
-	if !a.isCallAllowed(topic) {
-		assertHookCall(a.t)
-	}
-	return a.getCallReturnValue(topic), nil
-}
-
-func (a *assertHooks) AllowedTopicActions(_ context.Context, topic string) ([]string, *rest.Error) {
-	if !a.isCallAllowed(topic) {
-		assertHookCall(a.t)
-	}
-	return []string{}, nil
-}
-
-func (a *assertHooks) PrintListMessagesAuditLog(_ *http.Request, r *console.ListMessageRequest) {
-	if !a.isCallAllowed(r.TopicName) {
-		assertHookCall(a.t)
-	}
-}
-
-func (a *assertHooks) CanListACLs(_ context.Context) (bool, *rest.Error) {
-	if !a.isCallAllowed("any") {
-		assertHookCall(a.t)
-	}
-	return a.getCallReturnValue("any"), nil
-}
-
-func (a *assertHooks) CanCreateACL(_ context.Context) (bool, *rest.Error) {
-	if !a.isCallAllowed("any") {
-		assertHookCall(a.t)
-	}
-	return a.getCallReturnValue("any"), nil
-}
-
-func (a *assertHooks) CanDeleteACL(_ context.Context) (bool, *rest.Error) {
-	if !a.isCallAllowed("any") {
-		assertHookCall(a.t)
-	}
-	return a.getCallReturnValue("any"), nil
-}
-
-func (a *assertHooks) CanListQuotas(_ context.Context) (bool, *rest.Error) {
-	if !a.isCallAllowed("any") {
-		assertHookCall(a.t)
-	}
-	return a.getCallReturnValue("any"), nil
-}
-
-func (a *assertHooks) CanSeeConsumerGroup(_ context.Context, topic string) (bool, *rest.Error) {
-	if !a.isCallAllowed(topic) {
-		assertHookCall(a.t)
-	}
-	return a.getCallReturnValue(topic), nil
-}
-
-func (a *assertHooks) CanEditConsumerGroup(_ context.Context, topic string) (bool, *rest.Error) {
-	if !a.isCallAllowed(topic) {
-		assertHookCall(a.t)
-	}
-	return a.getCallReturnValue(topic), nil
-}
-
-func (a *assertHooks) CanDeleteConsumerGroup(_ context.Context, topic string) (bool, *rest.Error) {
-	if !a.isCallAllowed(topic) {
-		assertHookCall(a.t)
-	}
-	return a.getCallReturnValue(topic), nil
-}
-
-func (a *assertHooks) AllowedConsumerGroupActions(_ context.Context, _ string) ([]string, *rest.Error) {
-	if !a.isCallAllowed("any") {
-		assertHookCall(a.t)
-	}
-	return []string{}, nil
-}
-
-func (a *assertHooks) CanPatchPartitionReassignments(_ context.Context) (bool, *rest.Error) {
-	if !a.isCallAllowed("any") {
-		assertHookCall(a.t)
-	}
-	return a.getCallReturnValue("any"), nil
-}
-
-func (a *assertHooks) CanPatchConfigs(_ context.Context) (bool, *rest.Error) {
-	if !a.isCallAllowed("any") {
-		assertHookCall(a.t)
-	}
-	return a.getCallReturnValue("any"), nil
-}
-
-func (a *assertHooks) CanViewConnectCluster(_ context.Context, topic string) (bool, *rest.Error) {
-	if !a.isCallAllowed(topic) {
-		assertHookCall(a.t)
-	}
-	return a.getCallReturnValue(topic), nil
-}
-
-func (a *assertHooks) CanEditConnectCluster(_ context.Context, topic string) (bool, *rest.Error) {
-	if !a.isCallAllowed(topic) {
-		assertHookCall(a.t)
-	}
-	return a.getCallReturnValue(topic), nil
-}
-
-func (a *assertHooks) CanDeleteConnectCluster(_ context.Context, topic string) (bool, *rest.Error) {
-	if !a.isCallAllowed(topic) {
-		assertHookCall(a.t)
-	}
-	return a.getCallReturnValue(topic), nil
-}
-
-func (a *assertHooks) AllowedConnectClusterActions(_ context.Context, topic string) ([]string, *rest.Error) {
-	if !a.isCallAllowed(topic) {
-		assertHookCall(a.t)
-	}
-	return []string{}, nil
-}
-
-func (a *assertHooks) CanListKafkaUsers(_ context.Context) (bool, *rest.Error) {
-	if !a.isCallAllowed("any") {
-		assertHookCall(a.t)
-	}
-	return a.getCallReturnValue("any"), nil
-}
-
-func (a *assertHooks) CanCreateKafkaUsers(_ context.Context) (bool, *rest.Error) {
-	if !a.isCallAllowed("any") {
-		assertHookCall(a.t)
-	}
-	return a.getCallReturnValue("any"), nil
-}
-
-func (a *assertHooks) CanDeleteKafkaUsers(_ context.Context) (bool, *rest.Error) {
-	if !a.isCallAllowed("any") {
-		assertHookCall(a.t)
-	}
-	return a.getCallReturnValue("any"), nil
-}
-
-func (a *assertHooks) IsProtectedKafkaUser(_ string) bool {
-	if !a.isCallAllowed("any") {
-		assertHookCall(a.t)
-	}
-	return false
-}
-
-// Console hooks
-func (a *assertHooks) ConsoleLicenseInformation(_ context.Context) redpanda.License {
-	if !a.isCallAllowed("any") {
-		assertHookCall(a.t)
-	}
-	return redpanda.License{Source: redpanda.LicenseSourceConsole, Type: redpanda.LicenseTypeOpenSource, ExpiresAt: math.MaxInt32}
-}
-
-func (a *assertHooks) EnabledFeatures() []string {
-	if !a.isCallAllowed("any") {
-		assertHookCall(a.t)
-	}
-	return []string{}
-}
-
-func (a *assertHooks) EndpointCompatibility() []console.EndpointCompatibilityEndpoint {
-	if !a.isCallAllowed("any") {
-		assertHookCall(a.t)
-	}
-	return nil
-}
-
-func (a *assertHooks) EnabledConnectClusterFeatures(_ context.Context, _ string) []connect.ClusterFeature {
-	if !a.isCallAllowed("any") {
-		assertHookCall(a.t)
-	}
-	return nil
 }

--- a/backend/pkg/api/handle_topic_create_integration_test.go
+++ b/backend/pkg/api/handle_topic_create_integration_test.go
@@ -67,9 +67,13 @@ func (s *APIIntegrationTestSuite) TestHandleCreateTopic() {
 
 		assert.Equal(200, res.StatusCode)
 
-		createTopicRes := console.CreateTopicResponse{}
-
 		topicName := testutil.TopicNameForTest("create_topic")
+
+		defer func() {
+			s.kafkaAdminClient.DeleteTopics(ctx, topicName)
+		}()
+
+		createTopicRes := console.CreateTopicResponse{}
 
 		err := json.Unmarshal(body, &createTopicRes)
 		assert.NoError(err)
@@ -113,9 +117,13 @@ func (s *APIIntegrationTestSuite) TestHandleCreateTopic() {
 
 		assert.Equal(200, res.StatusCode)
 
-		createTopicRes := console.CreateTopicResponse{}
-
 		topicName := testutil.TopicNameForTest("create_topic_multi")
+
+		defer func() {
+			s.kafkaAdminClient.DeleteTopics(ctx, topicName)
+		}()
+
+		createTopicRes := console.CreateTopicResponse{}
 
 		err := json.Unmarshal(body, &createTopicRes)
 		assert.NoError(err)

--- a/backend/pkg/api/handle_topics_integration_test.go
+++ b/backend/pkg/api/handle_topics_integration_test.go
@@ -86,14 +86,14 @@ func (s *APIIntegrationTestSuite) TestHandleGetTopics() {
 		topicName := testutil.TopicNameForTest("get_topics_1")
 
 		oldHooks := s.api.Hooks
-		newHooks := newAssertHooks(t, map[string]map[string]bool{
+		newHooks := newAssertHooks(t, map[string]map[string]assertCallReturnValue{
 			"CanSeeTopic": {
-				testutil.TopicNameForTest("get_topics_0"): true,
-				topicName: false,
-				testutil.TopicNameForTest("get_topics_2"): true,
+				testutil.TopicNameForTest("get_topics_0"): assertCallReturnValue{BoolValue: true, Err: nil},
+				topicName: assertCallReturnValue{BoolValue: false, Err: nil},
+				testutil.TopicNameForTest("get_topics_2"): assertCallReturnValue{BoolValue: true, Err: nil},
 			},
 			"AllowedTopicActions": {
-				"any": true,
+				"any": assertCallReturnValue{BoolValue: true, Err: nil},
 			},
 		})
 

--- a/backend/pkg/api/handle_topics_integration_test.go
+++ b/backend/pkg/api/handle_topics_integration_test.go
@@ -1,0 +1,77 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+//go:build integration
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/redpanda-data/console/backend/pkg/console"
+	"github.com/redpanda-data/console/backend/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func (s *APIIntegrationTestSuite) TestHandleGetTopics() {
+	// s.T().Skip("Asdf")
+	t := s.T()
+	// require := require.New(t)
+	assert := assert.New(t)
+
+	logCfg := zap.NewDevelopmentConfig()
+	logCfg.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
+	// log, err := logCfg.Build()
+	// require.NoError(err)
+
+	// create some test topics
+	testutil.CreateTestData(t, context.Background(), s.kafkaClient, s.kafkaAdminClient,
+		testutil.TopicNameForTest("get_topics_0"))
+
+	testutil.CreateTestData(t, context.Background(), s.kafkaClient, s.kafkaAdminClient,
+		testutil.TopicNameForTest("get_topics_1"))
+
+	testutil.CreateTestData(t, context.Background(), s.kafkaClient, s.kafkaAdminClient,
+		testutil.TopicNameForTest("get_topics_2"))
+
+	defer func() {
+		s.kafkaAdminClient.DeleteTopics(context.Background(),
+			testutil.TopicNameForTest("get_topics_0"),
+			testutil.TopicNameForTest("get_topics_1"),
+			testutil.TopicNameForTest("get_topics_2"))
+	}()
+
+	t.Run("happy path", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		res, body := s.apiRequest(ctx, http.MethodGet, "/api/topics", nil)
+
+		assert.Equal(200, res.StatusCode)
+
+		type response struct {
+			Topics []*console.TopicSummary `json:"topics"`
+		}
+
+		getRes := response{}
+
+		err := json.Unmarshal(body, &getRes)
+		assert.NoError(err)
+
+		assert.Len(getRes.Topics, 3)
+		assert.Equal(testutil.TopicNameForTest("get_topics_0"), getRes.Topics[0].TopicName)
+		assert.Equal(testutil.TopicNameForTest("get_topics_1"), getRes.Topics[1].TopicName)
+		assert.Equal(testutil.TopicNameForTest("get_topics_2"), getRes.Topics[2].TopicName)
+	})
+}

--- a/backend/pkg/api/handle_topics_integration_test.go
+++ b/backend/pkg/api/handle_topics_integration_test.go
@@ -14,26 +14,33 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/redpanda-data/console/backend/pkg/console"
+	"github.com/redpanda-data/console/backend/pkg/kafka"
 	"github.com/redpanda-data/console/backend/pkg/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kmsg"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func (s *APIIntegrationTestSuite) TestHandleGetTopics() {
-	// s.T().Skip("Asdf")
 	t := s.T()
-	// require := require.New(t)
+	require := require.New(t)
 	assert := assert.New(t)
 
 	logCfg := zap.NewDevelopmentConfig()
 	logCfg.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
-	// log, err := logCfg.Build()
-	// require.NoError(err)
+	log, err := logCfg.Build()
+	require.NoError(err)
 
 	// create some test topics
 	testutil.CreateTestData(t, context.Background(), s.kafkaClient, s.kafkaAdminClient,
@@ -119,5 +126,234 @@ func (s *APIIntegrationTestSuite) TestHandleGetTopics() {
 		assert.Len(getRes.Topics, 2)
 		assert.Equal(testutil.TopicNameForTest("get_topics_0"), getRes.Topics[0].TopicName)
 		assert.Equal(testutil.TopicNameForTest("get_topics_2"), getRes.Topics[1].TopicName)
+	})
+
+	t.Run("get metadata fail", func(t *testing.T) {
+		// fake cluster
+		fakeCluster, err := kfake.NewCluster(kfake.NumBrokers(1))
+		assert.NoError(err)
+
+		fakeClient, fakeAdminClient := testutil.CreateClients(t, fakeCluster.ListenAddrs())
+
+		// create fake data
+		testutil.CreateTestData(t, context.Background(), fakeClient, fakeAdminClient,
+			testutil.TopicNameForTest("get_topics_0"))
+
+		testutil.CreateTestData(t, context.Background(), fakeClient, fakeAdminClient,
+			testutil.TopicNameForTest("get_topics_1"))
+
+		testutil.CreateTestData(t, context.Background(), fakeClient, fakeAdminClient,
+			testutil.TopicNameForTest("get_topics_2"))
+
+		defer func() {
+			fakeCluster.Close()
+		}()
+
+		newConfig := s.copyConfig()
+
+		// new kafka service
+		newConfig.Kafka.Brokers = fakeCluster.ListenAddrs()
+		newKafkaSvc, err := kafka.NewService(newConfig, log,
+			testutil.MetricNameForTest(strings.ReplaceAll(t.Name(), " ", "")))
+		assert.NoError(err)
+
+		// new console service
+		newConsoleSvc, err := console.NewService(newConfig.Console, log, newKafkaSvc, s.api.RedpandaSvc, s.api.ConnectSvc)
+		assert.NoError(err)
+
+		// save old
+		oldConsoleSvc := s.api.ConsoleSvc
+		oldKafkaSvc := s.api.KafkaSvc
+
+		// switch
+		s.api.KafkaSvc = newKafkaSvc
+		s.api.ConsoleSvc = newConsoleSvc
+
+		// call the fake control and expect function
+		fakeCluster.Control(func(req kmsg.Request) (kmsg.Response, error, bool) {
+			fakeCluster.KeepControl()
+
+			switch v := req.(type) {
+			case *kmsg.ApiVersionsRequest:
+				return nil, nil, false
+			case *kmsg.MetadataRequest:
+				assert.Len(v.Topics, 0)
+
+				ctRes := v.ResponseKind().(*kmsg.MetadataResponse)
+				ctRes.Topics = make([]kmsg.MetadataResponseTopic, 3)
+				ctRes.Topics[0] = kmsg.NewMetadataResponseTopic()
+				ctRes.Topics[0].Topic = kmsg.StringPtr(testutil.TopicNameForTest("get_topics_0"))
+
+				ctRes.Topics[1] = kmsg.NewMetadataResponseTopic()
+				ctRes.Topics[1].Topic = kmsg.StringPtr(testutil.TopicNameForTest("get_topics_1"))
+				ctRes.Topics[1].ErrorCode = kerr.LeaderNotAvailable.Code
+
+				ctRes.Topics[2] = kmsg.NewMetadataResponseTopic()
+				ctRes.Topics[2].Topic = kmsg.StringPtr(testutil.TopicNameForTest("get_topics_2"))
+
+				return ctRes, nil, true
+
+			default:
+				assert.Fail(fmt.Sprintf("unexpected call to fake kafka request %+T", v))
+
+				return nil, nil, false
+			}
+		})
+
+		// undo switch
+		defer func() {
+			if oldKafkaSvc != nil {
+				s.api.KafkaSvc = oldKafkaSvc
+			}
+			if oldConsoleSvc != nil {
+				s.api.ConsoleSvc = oldConsoleSvc
+			}
+		}()
+
+		// make the request
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		res, body := s.apiRequest(ctx, http.MethodGet, "/api/topics", nil)
+
+		assert.Equal(500, res.StatusCode)
+
+		apiErr := restAPIError{}
+
+		err = json.Unmarshal(body, &apiErr)
+		assert.NoError(err)
+
+		assert.Equal(`Could not list topics from Kafka cluster`, apiErr.Message)
+
+		assert.Equal(500, apiErr.Status)
+	})
+
+	t.Run("describe configs fail", func(t *testing.T) {
+		// fake cluster
+		fakeCluster, err := kfake.NewCluster(kfake.NumBrokers(1))
+		assert.NoError(err)
+
+		fakeClient, fakeAdminClient := testutil.CreateClients(t, fakeCluster.ListenAddrs())
+
+		// create fake data
+		testutil.CreateTestData(t, context.Background(), fakeClient, fakeAdminClient,
+			testutil.TopicNameForTest("get_topics_0"))
+
+		testutil.CreateTestData(t, context.Background(), fakeClient, fakeAdminClient,
+			testutil.TopicNameForTest("get_topics_1"))
+
+		testutil.CreateTestData(t, context.Background(), fakeClient, fakeAdminClient,
+			testutil.TopicNameForTest("get_topics_2"))
+
+		defer func() {
+			fakeCluster.Close()
+		}()
+
+		newConfig := s.copyConfig()
+
+		core, obs := observer.New(zap.WarnLevel)
+		log := zap.New(core)
+
+		// new kafka service
+		newConfig.Kafka.Brokers = fakeCluster.ListenAddrs()
+		newKafkaSvc, err := kafka.NewService(newConfig, log,
+			testutil.MetricNameForTest(strings.ReplaceAll(t.Name(), " ", "")))
+		assert.NoError(err)
+
+		// new console service
+		newConsoleSvc, err := console.NewService(newConfig.Console, log, newKafkaSvc, s.api.RedpandaSvc, s.api.ConnectSvc)
+		assert.NoError(err)
+
+		// save old
+		oldConsoleSvc := s.api.ConsoleSvc
+		oldKafkaSvc := s.api.KafkaSvc
+
+		// switch
+		s.api.KafkaSvc = newKafkaSvc
+		s.api.ConsoleSvc = newConsoleSvc
+
+		// call the fake control and expect function
+		fakeCluster.Control(func(req kmsg.Request) (kmsg.Response, error, bool) {
+			fakeCluster.KeepControl()
+
+			switch v := req.(type) {
+			case *kmsg.ApiVersionsRequest:
+				return nil, nil, false
+			case *kmsg.MetadataRequest:
+				return nil, nil, false
+			case *kmsg.DescribeConfigsRequest:
+				// TODO(bojan) this request is not mocked / controlled by kfake yet
+				// See https://github.com/twmb/franz-go/blob/master/pkg/kfake/NOTES
+
+				assert.Len(v.Resources, 3)
+				assert.Equal(kmsg.ConfigResourceTypeTopic, v.Resources[0].ResourceType)
+				assert.Equal(testutil.TopicNameForTest("get_topics_0"), v.Resources[0].ResourceName)
+				assert.Equal([]string{"cleanup.policy"}, v.Resources[0].ConfigNames)
+
+				assert.Equal(kmsg.ConfigResourceTypeTopic, v.Resources[1].ResourceType)
+				assert.Equal(testutil.TopicNameForTest("get_topics_1"), v.Resources[1].ResourceName)
+				assert.Equal([]string{"cleanup.policy"}, v.Resources[1].ConfigNames)
+
+				assert.Equal(kmsg.ConfigResourceTypeTopic, v.Resources[2].ResourceType)
+				assert.Equal(testutil.TopicNameForTest("get_topics_2"), v.Resources[1].ResourceName)
+				assert.Equal([]string{"cleanup.policy"}, v.Resources[2].ConfigNames)
+
+				drRes := v.ResponseKind().(*kmsg.DescribeConfigsResponse)
+				drRes.Resources = make([]kmsg.DescribeConfigsResponseResource, 3)
+				drRes.Resources[0].Configs = make([]kmsg.DescribeConfigsResponseResourceConfig, 0)
+				drRes.Resources[1].Configs = make([]kmsg.DescribeConfigsResponseResourceConfig, 0)
+				drRes.Resources[2].Configs = make([]kmsg.DescribeConfigsResponseResourceConfig, 0)
+
+				drRes.Resources[2].ErrorCode = kerr.InvalidTopicException.Code
+
+				return drRes, nil, true
+
+			default:
+				assert.Fail(fmt.Sprintf("unexpected call to fake kafka request %+T", v))
+
+				return nil, nil, false
+			}
+		})
+
+		// undo switch
+		defer func() {
+			if oldKafkaSvc != nil {
+				s.api.KafkaSvc = oldKafkaSvc
+			}
+			if oldConsoleSvc != nil {
+				s.api.ConsoleSvc = oldConsoleSvc
+			}
+		}()
+
+		// make the request
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		res, body := s.apiRequest(ctx, http.MethodGet, "/api/topics", nil)
+
+		assert.Equal(200, res.StatusCode)
+
+		type response struct {
+			Topics []*console.TopicSummary `json:"topics"`
+		}
+
+		getRes := response{}
+
+		err = json.Unmarshal(body, &getRes)
+		assert.NoError(err)
+
+		assert.Len(getRes.Topics, 3)
+		assert.Equal(testutil.TopicNameForTest("get_topics_0"), getRes.Topics[0].TopicName)
+		assert.Equal(testutil.TopicNameForTest("get_topics_1"), getRes.Topics[1].TopicName)
+		assert.Equal(testutil.TopicNameForTest("get_topics_2"), getRes.Topics[2].TopicName)
+
+		// verify warning logs
+		allLogs := obs.All()
+
+		assert.Len(allLogs, 2)
+		assert.Equal("could not describe topic configs", allLogs[0].Message)
+		assert.Equal(zap.ErrorLevel, allLogs[0].Level)
+		assert.Equal("failed to fetch topic configs to return cleanup.policy", allLogs[1].Message)
+		assert.Equal(zap.WarnLevel, allLogs[1].Level)
 	})
 }

--- a/backend/pkg/api/handle_topics_integration_test.go
+++ b/backend/pkg/api/handle_topics_integration_test.go
@@ -141,7 +141,7 @@ func (s *APIIntegrationTestSuite) TestHandleGetTopics() {
 				testutil.TopicNameForTest("get_topics_0"): assertCallReturnValue{SliceValue: []string{}, Err: nil},
 				topicName: assertCallReturnValue{Err: &rest.Error{
 					Err:     fmt.Errorf("error from test"),
-					Status:  505,
+					Status:  http.StatusUnauthorized,
 					Message: "public error from test",
 				}},
 				testutil.TopicNameForTest("get_topics_2"): assertCallReturnValue{SliceValue: []string{}, Err: nil},
@@ -163,7 +163,7 @@ func (s *APIIntegrationTestSuite) TestHandleGetTopics() {
 
 		res, body := s.apiRequest(ctx, http.MethodGet, "/api/topics", nil)
 
-		assert.Equal(505, res.StatusCode)
+		assert.Equal(401, res.StatusCode)
 
 		apiErr := restAPIError{}
 
@@ -172,7 +172,7 @@ func (s *APIIntegrationTestSuite) TestHandleGetTopics() {
 
 		assert.Equal(`public error from test`, apiErr.Message)
 
-		assert.Equal(505, apiErr.Status)
+		assert.Equal(401, apiErr.Status)
 	})
 
 	t.Run("get metadata fail", func(t *testing.T) {


### PR DESCRIPTION
**Changes**

Adds tests for get topics route `GET /api/topics`. 

Minor refactoring of common testing hooks into `api_integration_test.go` and added ability to specify return values into the mocked hooks.