### PR TITLE
Add goimports to fmt task

### DIFF
--- a/backend/pkg/api/api_integration_test.go
+++ b/backend/pkg/api/api_integration_test.go
@@ -39,9 +39,8 @@ import (
 	"github.com/redpanda-data/console/backend/pkg/config"
 	"github.com/redpanda-data/console/backend/pkg/connect"
 	"github.com/redpanda-data/console/backend/pkg/console"
-	"github.com/redpanda-data/console/backend/pkg/testutil"
-
 	rp "github.com/redpanda-data/console/backend/pkg/redpanda"
+	"github.com/redpanda-data/console/backend/pkg/testutil"
 )
 
 type APIIntegrationTestSuite struct {
@@ -220,7 +219,7 @@ func newAssertHooks(t *testing.T, returnValues map[string]map[string]assertCallR
 	}
 
 	for n, v := range returnValues {
-		for tn, _ := range v {
+		for tn := range v {
 			if len(h.allowedCalls[n]) == 0 {
 				h.allowedCalls[n] = map[string]bool{}
 			}

--- a/backend/pkg/api/handle_topic_create_integration_test.go
+++ b/backend/pkg/api/handle_topic_create_integration_test.go
@@ -228,7 +228,6 @@ func (s *APIIntegrationTestSuite) TestHandleCreateTopic() {
 	})
 
 	t.Run("no permission", func(t *testing.T) {
-
 		topicName := testutil.TopicNameForTest("no_permission")
 
 		oldHooks := s.api.Hooks

--- a/backend/pkg/api/handle_topics_integration_test.go
+++ b/backend/pkg/api/handle_topics_integration_test.go
@@ -21,9 +21,6 @@ import (
 	"time"
 
 	"github.com/cloudhut/common/rest"
-	"github.com/redpanda-data/console/backend/pkg/console"
-	"github.com/redpanda-data/console/backend/pkg/kafka"
-	"github.com/redpanda-data/console/backend/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kerr"
@@ -31,6 +28,10 @@ import (
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/redpanda-data/console/backend/pkg/console"
+	"github.com/redpanda-data/console/backend/pkg/kafka"
+	"github.com/redpanda-data/console/backend/pkg/testutil"
 )
 
 func (s *APIIntegrationTestSuite) TestHandleGetTopics() {

--- a/backend/pkg/console/describe_quotas.go
+++ b/backend/pkg/console/describe_quotas.go
@@ -10,10 +10,10 @@
 package console
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/twmb/franz-go/pkg/kerr"
-	"golang.org/x/net/context"
 )
 
 // QuotaResponse is a helper type that carries the sum of all quota responses

--- a/backend/pkg/kafka/describe_quotas.go
+++ b/backend/pkg/kafka/describe_quotas.go
@@ -10,8 +10,9 @@
 package kafka
 
 import (
+	"context"
+
 	"github.com/twmb/franz-go/pkg/kmsg"
-	"golang.org/x/net/context"
 )
 
 // DescribeQuotas requests a list of configured Quota rules via the Kafka API.

--- a/backend/pkg/kafka/mocks/kafka.go
+++ b/backend/pkg/kafka/mocks/kafka.go
@@ -8,6 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+
 	kafka "github.com/redpanda-data/console/backend/pkg/kafka"
 )
 

--- a/taskfiles/backend.yaml
+++ b/taskfiles/backend.yaml
@@ -11,6 +11,13 @@ tasks:
       - '[ -f ''{{ .BUILD_ROOT }}/bin/go'' ] || command -v {{ .BUILD_ROOT }}/bin/go/golangci-lint >/dev/null 2>&1'
       - '[[ $({{ .BUILD_ROOT }}/bin/go/golangci-lint --version) == *"version {{ .GO_LINT_VERSION }} built"* ]]'
 
+  install-goimports:
+    desc: install goimports
+    cmds:
+      - GOBIN={{ .BUILD_ROOT }}/bin/go go install golang.org/x/tools/cmd/goimports@latest
+    status:
+      - '[ -f ''{{ .BUILD_ROOT }}/bin/go'' ] || command -v {{ .BUILD_ROOT }}/bin/go/goimports >/dev/null 2>&1'
+
   install-gofumpt:
     vars:
       GOFUMPT_VERSION: 0.4.0
@@ -53,13 +60,25 @@ tasks:
       - "[ -f '{{ .BUILD_ROOT }}/bin/go' ] || command -v {{ .BUILD_ROOT }}/bin/go/mockgen >/dev/null 2>&1"
       - "[[ $({{ .BUILD_ROOT }}/bin/go/mockgen --version) == 'v{{.GOMOCK_VERSION}}' ]]"
 
+  install-ifacemaker:
+    vars:
+      IFACEMAKER_VERSION: 1.2.1
+    desc: install ifacemaker
+    cmds:
+      - |
+        GOBIN={{ .BUILD_ROOT }}/bin/go go install github.com/vburenin/ifacemaker@v{{ .IFACEMAKER_VERSION }}
+    status:
+      - "[ -f '{{ .BUILD_ROOT }}/bin/go' ] || command -v {{ .BUILD_ROOT }}/bin/go/ifacemaker >/dev/null 2>&1"
+
   fmt:
     desc: Format Go code
     deps:
+      - install-goimports
       - install-gci
       - install-gofumpt
     dir: "{{.BACKEND_ROOT}}"
     cmds:
+      - '{{ .BUILD_ROOT }}/bin/go/goimports -l -w -local "github.com/redpanda-data/console/backend" .'
       - '{{ .BUILD_ROOT }}/bin/go/gofumpt -l -w .'
       - '{{ .BUILD_ROOT }}/bin/go/gci write -s standard -s default -s ''Prefix(github.com/redpanda-data/console/backend)'' .'
 
@@ -76,10 +95,12 @@ tasks:
     desc: Run Go generate
     deps:
       - install-gomock
+      - install-ifacemaker
     cmds:
       - |
         export PATH=$PATH:{{ .BUILD_ROOT }}/bin/go
         GOBIN={{ .BUILD_ROOT }}/bin/go go generate ./...
+      - task: 'fmt'
 
   test-unit:
     dir: "{{.BACKEND_ROOT}}"


### PR DESCRIPTION
This PR adds goimports to the `backend:fmt` task. The changes after running this commit have been put into a separate commit.