### PR TITLE
frontend: enable copy dropdown also when record value is null

### DIFF
--- a/frontend/src/components/pages/topics/Tab.Messages/index.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/index.tsx
@@ -445,7 +445,7 @@ export class TopicMessageView extends Component<TopicMessageViewProps> {
                         <SettingFilled style={IsColumnSettingsEnabled ? { color: colors.brandOrange } : { color: '#a092a0' }} />
                     </Tooltip>;
                 },
-                render: (_text, record) => !record.value.isPayloadNull && (
+                render: (_text, record) => (
                     <NoClipboardPopover placement="left">
                         <div> {/* the additional div is necessary because popovers do not trigger on disabled elements, even on hover */}
                             <Dropdown disabled={!isClipboardAvailable} overlayClassName="disableAnimation" overlay={this.copyDropdown(record)} trigger={['click']}>
@@ -559,10 +559,10 @@ export class TopicMessageView extends Component<TopicMessageViewProps> {
 
     copyDropdown = (record: TopicMessage) => (
         <Menu>
-            <Menu.Item key="0" onClick={() => copyMessage(record, 'jsonKey')}>
+            <Menu.Item key="0" disabled={record.key.isPayloadNull} onClick={() => copyMessage(record, 'jsonKey')}>
                 Copy Key
             </Menu.Item>
-            <Menu.Item key="2" onClick={() => copyMessage(record, 'jsonValue')}>
+            <Menu.Item key="2" disabled={record.value.isPayloadNull} onClick={() => copyMessage(record, 'jsonValue')}>
                 Copy Value
             </Menu.Item>
             <Menu.Item key="4" onClick={() => copyMessage(record, 'timestamp')}>


### PR DESCRIPTION
Fixes #724 

I'm not a frontend dev, but I think I managed to implement this one. 
I removed the condition that hides the dropdown when the value is `null`. Instead, there is now a condition that disables the 'Copy value' and 'Copy key' menu item based on whether the key or value is null respectively. This also means that 'Copy epoch timestamp' (and 'save to file') is always available in the dropdown menu.

It seems to work for me locally. 
Please let me know if there are any comments or requests for changes. 