### PR TITLE
Add stopped status for connectors

### DIFF
--- a/backend/pkg/connect/get_connectors.go
+++ b/backend/pkg/connect/get_connectors.go
@@ -29,6 +29,7 @@ const (
 	connectorStateUnassigned connectorState = "UNASSIGNED"
 	connectorStateRunning    connectorState = "RUNNING"
 	connectorStatePaused     connectorState = "PAUSED"
+	connectorStateStopped    connectorState = "STOPPED"
 	connectorStateFailed     connectorState = "FAILED"
 	connectorStateRestarting connectorState = "RESTARTING"
 	connectorStateDestroyed  connectorState = "DESTROYED"
@@ -43,6 +44,7 @@ const (
 	connectorStatusUnhealthy  connectorStatus = "UNHEALTHY"
 	connectorStatusDegraded   connectorStatus = "DEGRADED"
 	connectorStatusPaused     connectorStatus = "PAUSED"
+	connectorStatusStopped    connectorStatus = "STOPPED"
 	connectorStatusRestarting connectorStatus = "RESTARTING"
 	connectorStatusUnassigned connectorStatus = "UNASSIGNED"
 	connectorStatusDestroyed  connectorStatus = "DESTROYED"
@@ -338,6 +340,8 @@ func connectorsResponseToClusterConnectorInfo(c *con.ListConnectorsResponseExpan
 			c.Info.Name, strings.ToLower(c.Status.Connector.State), failedTasks, totalTasks)
 	} else if c.Status.Connector.State == connectorStatePaused {
 		connStatus = connectorStatusPaused
+	} else if c.Status.Connector.State == connectorStateStopped {
+		connStatus = connectorStatusStopped
 	} else if (c.Status.Connector.State == connectorStateRestarting) ||
 		(totalTasks > 0 && restartingTasks > 0) {
 		connStatus = connectorStatusRestarting

--- a/backend/pkg/connect/get_connectors_test.go
+++ b/backend/pkg/connect/get_connectors_test.go
@@ -1057,6 +1057,86 @@ func Test_connectorsResponseToClusterConnectorInfo(t *testing.T) {
 			},
 		},
 		{
+			name: "stopped - connector stopped, no tasks",
+			input: &connect.ListConnectorsResponseExpanded{
+				Info: connect.ListConnectorsResponseExpandedInfo{
+					Name: "http-source-connector-wtue",
+					Config: map[string]string{
+						"connector.class":                           "com.github.castorm.kafka.connect.http.HttpSourceConnector",
+						"header.converter":                          "org.apache.kafka.connect.storage.SimpleHeaderConverter",
+						"http.request.url":                          "https://httpbin.org/uuid",
+						"http.timer.catchup.interval.millis":        "30000",
+						"http.timer.interval.millis":                "180000",
+						"kafka.topic":                               "httpbin-input",
+						"key.converter":                             "org.apache.kafka.connect.json.JsonConverter",
+						"key.converter.schemas.enable":              "false",
+						"name":                                      "http-source-connector-wtue",
+						"topic.creation.default.partitions":         "1",
+						"topic.creation.default.replication.factor": "1",
+						"topic.creation.enable":                     "true",
+						"value.converter":                           "org.apache.kafka.connect.json.JsonConverter",
+						"value.converter.schemas.enable":            "false",
+					},
+					Tasks: []struct {
+						Connector string `json:"connector"`
+						Task      int    `json:"task"`
+					}{
+						{
+							Connector: "http-source-connector-wtue",
+							Task:      0,
+						},
+					},
+					Type: "source",
+				},
+				Status: connect.ListConnectorsResponseExpandedStatus{
+					Name: "http-source-connector-wtue",
+					Connector: struct {
+						State    string `json:"state"`
+						WorkerID string `json:"worker_id"`
+						Trace    string `json:"trace,omitempty"`
+					}{
+						State:    "STOPPED",
+						WorkerID: "172.21.0.5:8083",
+					},
+					Tasks: []struct {
+						ID       int    `json:"id"`
+						State    string `json:"state"`
+						WorkerID string `json:"worker_id"`
+						Trace    string `json:"trace,omitempty"`
+					}{},
+				},
+			},
+			expected: &ClusterConnectorInfo{
+				Name:  "http-source-connector-wtue",
+				Class: "com.github.castorm.kafka.connect.http.HttpSourceConnector",
+				Config: map[string]string{
+					"connector.class":                           "com.github.castorm.kafka.connect.http.HttpSourceConnector",
+					"header.converter":                          "org.apache.kafka.connect.storage.SimpleHeaderConverter",
+					"http.request.url":                          "https://httpbin.org/uuid",
+					"http.timer.catchup.interval.millis":        "30000",
+					"http.timer.interval.millis":                "180000",
+					"kafka.topic":                               "httpbin-input",
+					"key.converter":                             "org.apache.kafka.connect.json.JsonConverter",
+					"key.converter.schemas.enable":              "false",
+					"name":                                      "http-source-connector-wtue",
+					"topic.creation.default.partitions":         "1",
+					"topic.creation.default.replication.factor": "1",
+					"topic.creation.enable":                     "true",
+					"value.converter":                           "org.apache.kafka.connect.json.JsonConverter",
+					"value.converter.schemas.enable":            "false",
+				},
+				Type:         "source",
+				Topic:        "httpbin-input",
+				State:        connectorStateStopped,
+				Status:       connectorStatusStopped,
+				TotalTasks:   0,
+				RunningTasks: 0,
+				Trace:        "",
+				Errors:       []ClusterConnectorInfoError{},
+				Tasks:        []ClusterConnectorTaskInfo{},
+			},
+		},
+		{
 			name: "restarting - connector restarting, > 0 tasks",
 			input: &connect.ListConnectorsResponseExpanded{
 				Info: connect.ListConnectorsResponseExpandedInfo{


### PR DESCRIPTION
STOPPED state for connectors has been introduced in Kafka Connect 3.5.0. This PR adds support to display STOPPED status for connectors.