### PR TITLE
backend: de-dupe remote log dirs

### DIFF
--- a/backend/pkg/kafka/log_dir.go
+++ b/backend/pkg/kafka/log_dir.go
@@ -11,9 +11,11 @@ package kafka
 
 import (
 	"context"
+	"strings"
 
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
+	"golang.org/x/exp/slices"
 )
 
 // LogDirResponseSharded is a helper type that carries the sum of all log dir response shards.
@@ -39,18 +41,112 @@ func (s *Service) DescribeLogDirs(ctx context.Context, topicPartitions []kmsg.De
 	req.Topics = topicPartitions
 	shardedResp := s.KafkaClient.RequestSharded(ctx, &req)
 
-	result := make([]LogDirResponse, len(shardedResp))
-	for i, kresp := range shardedResp {
+	result := make([]LogDirResponse, 0, len(shardedResp))
+	sharedLogDirs := make([]kmsg.DescribeLogDirsResponseDir, 0)
+
+	// Collect all shared log dirs
+	for _, kresp := range shardedResp {
 		res, ok := kresp.Resp.(*kmsg.DescribeLogDirsResponse)
 		if !ok {
 			res = &kmsg.DescribeLogDirsResponse{}
 		}
-		result[i] = LogDirResponse{
+
+		// Strip all remote/shared dirs, but keep local dirs in response
+		// The shared dirs will be unified and then returned by a single broker once.
+		localDirs := make([]kmsg.DescribeLogDirsResponseDir, 0, len(res.Dirs))
+		for _, dir := range res.Dirs {
+			if strings.HasPrefix(dir.Dir, "remote://") {
+				sharedLogDirs = append(sharedLogDirs, dir)
+				continue
+			}
+			localDirs = append(localDirs, dir)
+		}
+		res.Dirs = localDirs
+
+		result = append(result, LogDirResponse{
 			BrokerMetadata: kresp.Meta,
 			LogDirs:        *res,
 			Error:          kresp.Err,
-		}
+		})
+	}
+
+	// unify/de-dupe all shared log dirs and mount them to the first response
+	if len(sharedLogDirs) > 0 && len(result) > 0 {
+		unifiedLogDirs := unifyLogDirs(sharedLogDirs)
+		firstEntry := result[0]
+		firstEntry.LogDirs.Dirs = append(firstEntry.LogDirs.Dirs, unifiedLogDirs...)
+		result[0] = firstEntry
 	}
 
 	return result
+}
+
+// unifyLogDirs accepts multiple log dirs and merges it into
+// a single log dir. This is used for shared/remote log dirs, that
+// is reported by multiple brokers. Because each broker may only own
+// a subset of the data that is hosted in the log dir, the responses
+// of the brokers will be inconsistent and incomplete.
+// At least one log dir must be passed into this function.
+//
+// Because you may have more than one remote dir, this function
+// will return a slice of log dirs as well.
+func unifyLogDirs(logDirs []kmsg.DescribeLogDirsResponseDir) []kmsg.DescribeLogDirsResponseDir {
+	if len(logDirs) == 0 {
+		return nil
+	}
+
+	// Find the maximum reported size for each unique log dir partition.
+	// Some brokers may report a smaller size if they are lagging
+	// behind (e.g. after a recovery).
+	sizeByDirTopicPartition := make(map[string]map[string]map[int32]int64)
+	for _, dir := range logDirs {
+		if _, exists := sizeByDirTopicPartition[dir.Dir]; !exists {
+			sizeByDirTopicPartition[dir.Dir] = make(map[string]map[int32]int64)
+		}
+
+		for _, topic := range dir.Topics {
+			if _, exists := sizeByDirTopicPartition[dir.Dir][topic.Topic]; !exists {
+				sizeByDirTopicPartition[dir.Dir][topic.Topic] = make(map[int32]int64)
+			}
+
+			for _, partition := range topic.Partitions {
+				if sizeByDirTopicPartition[dir.Dir][topic.Topic][partition.Partition] < partition.Size {
+					sizeByDirTopicPartition[dir.Dir][topic.Topic][partition.Partition] = partition.Size
+				}
+			}
+		}
+	}
+
+	// Create one final log dir for each found log dir
+	unifiedLogDirs := make([]kmsg.DescribeLogDirsResponseDir, 0, len(sizeByDirTopicPartition))
+	for dir, topics := range sizeByDirTopicPartition {
+		logDirTopics := make([]kmsg.DescribeLogDirsResponseDirTopic, 0)
+		for topic, partitions := range topics {
+			logDirPartitions := make([]kmsg.DescribeLogDirsResponseDirTopicPartition, 0)
+			for partitionID, size := range partitions {
+				logDirPartitions = append(logDirPartitions, kmsg.DescribeLogDirsResponseDirTopicPartition{
+					Partition: partitionID,
+					Size:      size,
+				})
+			}
+			slices.SortFunc(logDirPartitions, func(a, b kmsg.DescribeLogDirsResponseDirTopicPartition) bool {
+				return a.Partition < b.Partition
+			})
+
+			logDirTopics = append(logDirTopics, kmsg.DescribeLogDirsResponseDirTopic{
+				Topic:      topic,
+				Partitions: logDirPartitions,
+			})
+		}
+		slices.SortFunc(logDirTopics, func(a, b kmsg.DescribeLogDirsResponseDirTopic) bool {
+			return a.Topic < b.Topic
+		})
+
+		unifiedLogDirs = append(unifiedLogDirs, kmsg.DescribeLogDirsResponseDir{
+			Dir:    dir,
+			Topics: logDirTopics,
+		})
+	}
+
+	return unifiedLogDirs
 }

--- a/backend/pkg/kafka/log_dir_test.go
+++ b/backend/pkg/kafka/log_dir_test.go
@@ -1,0 +1,210 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package kafka
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+func TestUnifyLogDirs(t *testing.T) {
+	tests := []struct {
+		name     string
+		logDirs  []kmsg.DescribeLogDirsResponseDir
+		expected []kmsg.DescribeLogDirsResponseDir
+	}{
+		{
+			name: "SingleLogDir",
+			logDirs: []kmsg.DescribeLogDirsResponseDir{
+				{
+					Dir: "/var/lib/data",
+					Topics: []kmsg.DescribeLogDirsResponseDirTopic{
+						{
+							Topic: "topic-1",
+							Partitions: []kmsg.DescribeLogDirsResponseDirTopicPartition{
+								{
+									Partition: 0,
+									Size:      100,
+								},
+								{
+									Partition: 1,
+									Size:      200,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []kmsg.DescribeLogDirsResponseDir{
+				{
+					Dir: "/var/lib/data",
+					Topics: []kmsg.DescribeLogDirsResponseDirTopic{
+						{
+							Topic: "topic-1",
+							Partitions: []kmsg.DescribeLogDirsResponseDirTopicPartition{
+								{
+									Partition: 0,
+									Size:      100,
+								},
+								{
+									Partition: 1,
+									Size:      200,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name: "MultiLogDirDifferentPartitionSizes",
+			logDirs: []kmsg.DescribeLogDirsResponseDir{
+				{
+					Dir: "remote://s3-bucket",
+					Topics: []kmsg.DescribeLogDirsResponseDirTopic{
+						{
+							Topic: "topic-1",
+							Partitions: []kmsg.DescribeLogDirsResponseDirTopicPartition{
+								{
+									Partition: 0,
+									Size:      100,
+								},
+								{
+									Partition: 1,
+									Size:      500,
+								},
+							},
+						},
+					},
+				},
+				{
+					Dir: "remote://s3-bucket",
+					Topics: []kmsg.DescribeLogDirsResponseDirTopic{
+						{
+							Topic: "topic-1",
+							Partitions: []kmsg.DescribeLogDirsResponseDirTopicPartition{
+								{
+									Partition: 0,
+									Size:      125,
+								},
+								{
+									Partition: 1,
+									Size:      155,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []kmsg.DescribeLogDirsResponseDir{
+				{
+					Dir: "remote://s3-bucket",
+					Topics: []kmsg.DescribeLogDirsResponseDirTopic{
+						{
+							Topic: "topic-1",
+							Partitions: []kmsg.DescribeLogDirsResponseDirTopicPartition{
+								{
+									Partition: 0,
+									Size:      125,
+								},
+								{
+									Partition: 1,
+									Size:      500,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name: "MultiLogDirWithSomeResponsesMissingPartitions",
+			logDirs: []kmsg.DescribeLogDirsResponseDir{
+				{
+					Dir: "remote://s3-bucket",
+					Topics: []kmsg.DescribeLogDirsResponseDirTopic{
+						{
+							Topic: "topic-1",
+							Partitions: []kmsg.DescribeLogDirsResponseDirTopicPartition{
+								{
+									Partition: 0,
+									Size:      100,
+								},
+								// Partition 1 missing on purpose here!
+								{
+									Partition: 2,
+									Size:      5000,
+								},
+							},
+						},
+					},
+				},
+				{
+					Dir: "remote://s3-bucket",
+					Topics: []kmsg.DescribeLogDirsResponseDirTopic{
+						{
+							Topic: "topic-1",
+							Partitions: []kmsg.DescribeLogDirsResponseDirTopicPartition{
+								{
+									Partition: 0,
+									Size:      300,
+								},
+								{
+									Partition: 1,
+									Size:      100,
+								},
+								{
+									Partition: 2,
+									Size:      500,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []kmsg.DescribeLogDirsResponseDir{
+				{
+					Dir: "remote://s3-bucket",
+					Topics: []kmsg.DescribeLogDirsResponseDirTopic{
+						{
+							Topic: "topic-1",
+							Partitions: []kmsg.DescribeLogDirsResponseDirTopicPartition{
+								{
+									Partition: 0,
+									Size:      300,
+								},
+								{
+									Partition: 1,
+									Size:      100,
+								},
+								{
+									Partition: 2,
+									Size:      5000,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := unifyLogDirs(tt.logDirs)
+
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
Clusters that support tiered storage, each broker may report the same shared log dir information for the same partition. Thus, for logdirs that are mounted under `remote://` we de-duplicate reported log dirs for the same partition. In the end we will attach this log dir information to a single broker, so that the total size will still be returned.