### PR TITLE
Connectors 717

### DIFF
--- a/frontend/src/components/pages/connect/Connector.Details.tsx
+++ b/frontend/src/components/pages/connect/Connector.Details.tsx
@@ -10,7 +10,7 @@
  */
 
 /* eslint-disable no-useless-escape */
-import { Modal, Skeleton, Tooltip } from 'antd';
+import { Skeleton, Tooltip } from 'antd';
 import { useEffect, useState } from 'react';
 import { observer, useLocalObservable } from 'mobx-react';
 import { comparer } from 'mobx';
@@ -85,9 +85,6 @@ const KafkaConnectorMain = observer(
         return <>
             {/* [Pause] [Restart] [Delete] */}
             <Flex flexDirection="row" alignItems="center" gap="3">
-
-                {/* [View JSON Config] */}
-                <ViewConfigModalButton connector={connector} />
 
                 {/* [Pause/Resume]  [Restart] */}
                 {connectClusterStore.validateConnectorState(connectorName, ['FAILED', 'UNASSIGNED']) ? (
@@ -439,6 +436,7 @@ class KafkaConnectorDetails extends PageComponent<{ clusterName: string; connect
     }
 
     async refreshData(force: boolean): Promise<void> {
+        ConnectClusterStore.connectClusters.clear();
         await api.refreshConnectClusters(force);
     }
 
@@ -457,31 +455,6 @@ class KafkaConnectorDetails extends PageComponent<{ clusterName: string; connect
 }
 
 export default KafkaConnectorDetails;
-
-const ViewConfigModalButton = (p: { connector: ClusterConnectorInfo }) => {
-    const [showConfig, setShowConfig] = useState(false);
-
-    const closeConfigModal = () => setShowConfig(false);
-    const viewConfigModal = <Modal open={showConfig} onOk={closeConfigModal} onCancel={closeConfigModal} cancelButtonProps={{ style: { display: 'none' } }}
-        bodyStyle={{ paddingBottom: '8px', paddingTop: '14px' }}
-        centered
-        closable={false} maskClosable={true}
-        okText="Close" width="60%"
-    >
-        <>
-            <Flex alignItems="center" mb="8px">
-                <Box fontSize="medium" fontWeight={500}>Connector Config (JSON)</Box>
-            </Flex>
-
-            <CodeBlock codeString={p.connector.jsonConfig} language="json" showCopyButton />
-        </>
-    </Modal>;
-
-    return <>
-        <Button variant="outline" onClick={() => setShowConfig(true)}>View JSON Config</Button>
-        {viewConfigModal}
-    </>
-};
 
 const ConnectorDetails = observer((p: {
     clusterName: string,

--- a/frontend/src/components/pages/connect/Connector.Details.tsx
+++ b/frontend/src/components/pages/connect/Connector.Details.tsx
@@ -86,35 +86,33 @@ const KafkaConnectorMain = observer(
             {/* [Pause] [Restart] [Delete] */}
             <Flex flexDirection="row" alignItems="center" gap="3">
 
-                {/* [Pause/Resume]  [Restart] */}
-                {connectClusterStore.validateConnectorState(connectorName, ['FAILED', 'UNASSIGNED']) ? (
-                    null
-                ) : (
-                    <>
-                        <Tooltip
-                            placement="top"
-                            trigger={!canEdit ? 'hover' : 'none'}
-                            mouseLeaveDelay={0}
-                            getPopupContainer={findPopupContainer}
-                            overlay={'You don\'t have \'canEditConnectCluster\' permissions for this connect cluster'}
-                        >
-                                <Button disabled={!canEdit} onClick={() => ($state.pausingConnector = connector)} variant="outline" minWidth="32">
-                                {connectClusterStore.validateConnectorState(connectorName, ['RUNNING']) ? 'Pause' : 'Resume'}
-                            </Button>
-                        </Tooltip>
-                        <Tooltip
-                            placement="top"
-                            trigger={!canEdit ? 'hover' : 'none'}
-                            mouseLeaveDelay={0}
-                            getPopupContainer={findPopupContainer}
-                            overlay={'You don\'t have \'canEditConnectCluster\' permissions for this connect cluster'}
-                        >
-                                <Button disabled={!canEdit} onClick={() => ($state.restartingConnector = connector)} variant="outline" minWidth="32">
-                                Restart
-                            </Button>
-                        </Tooltip>
-                    </>
-                )}
+                {/* [Pause/Resume] */}
+                {connectClusterStore.validateConnectorState(connectorName, ['RUNNING', 'PAUSED']) ? (
+                    <Tooltip
+                        placement="top"
+                        trigger={!canEdit ? 'hover' : 'none'}
+                        mouseLeaveDelay={0}
+                        getPopupContainer={findPopupContainer}
+                        overlay={'You don\'t have \'canEditConnectCluster\' permissions for this connect cluster'}
+                    >
+                        <Button disabled={!canEdit} onClick={() => ($state.pausingConnector = connector)} variant="outline" minWidth="32">
+                            {connectClusterStore.validateConnectorState(connectorName, ['RUNNING']) ? 'Pause' : 'Resume'}
+                        </Button>
+                    </Tooltip>
+                ) : null}
+
+                {/* [Restart] */}
+                <Tooltip
+                    placement="top"
+                    trigger={!canEdit ? 'hover' : 'none'}
+                    mouseLeaveDelay={0}
+                    getPopupContainer={findPopupContainer}
+                    overlay={'You don\'t have \'canEditConnectCluster\' permissions for this connect cluster'}
+                >
+                    <Button disabled={!canEdit} onClick={() => ($state.restartingConnector = connector)} variant="outline" minWidth="32">
+                        Restart
+                    </Button>
+                </Tooltip>
 
                 {/* [Delete] */}
                 <Tooltip

--- a/frontend/src/components/pages/connect/dynamic-ui/components.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/components.tsx
@@ -17,7 +17,12 @@ import { ConnectorPropertiesStore, PropertyGroup } from '../../../../state/conne
 import { observer } from 'mobx-react';
 import { ConnectorStepComponent } from './ConnectorStep';
 import { ConnectorStep } from '../../../../state/restInterfaces';
-import { Switch } from '@redpanda-data/ui';
+import { Box, RadioGroup, Switch } from '@redpanda-data/ui';
+import KowlEditor from '../../../misc/KowlEditor';
+import { api } from '../../../../state/backendApi';
+import { clone } from '../../../../utils/jsonUtils';
+import { useState } from 'react';
+import { isEmbedded } from '../../../../config';
 
 export interface ConfigPageProps {
     connectorStore: ConnectorPropertiesStore;
@@ -54,25 +59,98 @@ export const ConfigPage: React.FC<ConfigPageProps> = observer(({ connectorStore 
 
     return (
         <>
-            <Switch
-                isChecked={connectorStore.showAdvancedOptions}
-                onChange={(s) => (connectorStore.showAdvancedOptions = s.target.checked)}
-            >
-                Show advanced options
-            </Switch>
-
-            {steps.map(({ step, groups }) => {
-                return <ConnectorStepComponent
-                    key={step.stepIndex}
-                    step={step}
-                    groups={groups}
-                    allGroups={connectorStore.allGroups}
-                    showAdvancedOptions={connectorStore.showAdvancedOptions}
-                    connectorType={connectorStore.connectorType}
+            <Box mb="8">
+                <RadioGroup name="settingsMode"
+                    value={connectorStore.viewMode}
+                    defaultValue={connectorStore.viewMode}
+                    onChange={x => connectorStore.viewMode = x}
+                    options={[
+                        { value: 'form', label: <Box mx="4">Form</Box> },
+                        { value: 'json', label: <Box mx="4">JSON</Box> },
+                    ]}
                 />
-            })}
+            </Box>
 
-            {/* {IsDev && <DebugEditor observable={connectorStore} />} */}
+            {connectorStore.viewMode == 'form'
+                ? <>
+                    <Switch
+                        isChecked={connectorStore.showAdvancedOptions}
+                        onChange={(s) => (connectorStore.showAdvancedOptions = s.target.checked)}
+                    >
+                        Show advanced options
+                    </Switch>
+
+                    {steps.map(({ step, groups }) => {
+                        return <ConnectorStepComponent
+                            key={step.stepIndex}
+                            step={step}
+                            groups={groups}
+                            allGroups={connectorStore.allGroups}
+                            showAdvancedOptions={connectorStore.showAdvancedOptions}
+                            connectorType={connectorStore.connectorType}
+                        />
+                    })}
+                </>
+                : <>
+                    <div style={{ margin: '0 auto 1.5rem' }}>
+                        <ConnectorJsonEditor connectorStore={connectorStore} />
+                    </div>
+                </>
+            }
         </>
     );
 });
+
+function ConnectorJsonEditor(p: {
+    connectorStore: ConnectorPropertiesStore
+}) {
+    const connectorStore = p.connectorStore;
+
+    // Initialize connector with existing data
+    const [jsonText, setJsonText] = useState(() => {
+        const configObj = connectorStore.getConfigObject();
+        const connectorName = (configObj as any)?.name;
+
+        if (connectorName) {
+            console.log('trying to obtain initial config from existing connector...', { name: connectorName });
+            const cluster = api.connectConnectors?.clusters?.first(c => c.clusterName == connectorStore.clusterName);
+            const connector = cluster?.connectors.first(x => x.name == connectorName);
+            if (connector) {
+                console.log('success! found connector config', {
+                    clusterName: connectorStore.clusterName,
+                    connectorName,
+                    config: clone(connector.config),
+                });
+
+                return JSON.stringify(connector.config, undefined, 4);
+            }
+
+            console.log('unable to find existing connector for known connector name!', {
+                clusterName: connectorStore.clusterName,
+                connectorName
+            });
+        }
+
+        console.log('creating "new" config for connector', {
+            name: connectorName,
+            config: clone(configObj),
+        });
+
+        return JSON.stringify(configObj, undefined, 4);
+    });
+
+
+    return <KowlEditor
+        language="json"
+        value={jsonText}
+        height="600px"
+        onChange={x => {
+            if (!x) return;
+            setJsonText(x);
+            connectorStore.jsonText = x;
+        }}
+        options={{
+            readOnly: isEmbedded()
+        }}
+    />
+}

--- a/frontend/src/components/pages/topics/Tab.Messages/index.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/index.tsx
@@ -45,7 +45,6 @@ import { PublishMessageModalProps, PublishMessagesModalContent } from '../Publis
 import { getPreviewTags, PreviewSettings } from './PreviewSettings';
 import styles from './styles.module.scss';
 import createAutoModal from '../../../../utils/createAutoModal';
-import colors from '../../../../colors';
 import { CollapsedFieldProps } from '@textea/json-viewer';
 import { Button, Input, InputGroup, Switch, Alert, AlertIcon, Tabs as RpTabs, Box, SearchField } from '@redpanda-data/ui';
 import { MdExpandMore } from 'react-icons/md';
@@ -451,7 +450,7 @@ export class TopicMessageView extends Component<TopicMessageViewProps> {
                 onFilterDropdownVisibleChange: (_) => this.showColumnSettings = true,
                 filterIcon: (_) => {
                     return <Tooltip title="Column Settings" mouseEnterDelay={0.1} getPopupContainer={findPopupContainer} placement="left">
-                        <SettingFilled style={IsColumnSettingsEnabled ? { color: colors.brandOrange } : { color: '#a092a0' }} />
+                        <SettingFilled style={IsColumnSettingsEnabled ? { color: 'hsl(255 15% 65%)' } : { color: '#a092a0' }} />
                     </Tooltip>;
                 },
                 render: (_text, record) => !record.value.isPayloadNull && (

--- a/frontend/src/state/connect/state.ts
+++ b/frontend/src/state/connect/state.ts
@@ -389,6 +389,7 @@ export class ConnectorPropertiesStore {
     crud: 'create' | 'update' = 'create';
     secrets: SecretsStore | null = null;
     showAdvancedOptions = false;
+    viewMode: 'form' | 'json' = 'form';
     initPending = true;
     fallbackGroupName: string = '';
     reactionDisposers: IReactionDisposer[] = [];
@@ -396,8 +397,8 @@ export class ConnectorPropertiesStore {
     connectorStepDefinitions: ConnectorStep[] = [];
 
     constructor(
-        private clusterName: string,
-        private pluginClassName: string,
+        public clusterName: string,
+        public pluginClassName: string,
         public connectorType: 'sink' | 'source',
         private appliedConfig: Record<string, any> | undefined,
         features?: ConnectorClusterFeatures
@@ -438,6 +439,16 @@ export class ConnectorPropertiesStore {
             'connector.class': this.pluginClassName,
         } as any;
 
+        if (this.viewMode == 'json') {
+            let parsedConfig = {};
+            try {
+                parsedConfig = JSON.parse(this.jsonText);
+            } catch { }
+            Object.assign(config, parsedConfig);
+
+            return config;
+        }
+
         for (const g of this.allGroups)
             for (const p of g.properties) {
                 // Skip default values
@@ -470,7 +481,6 @@ export class ConnectorPropertiesStore {
 
         try {
             // Validate with empty object to get all properties initially
-
             const basicConfig = {
                 'connector.class': pluginClassName,
                 name: '',


### PR DESCRIPTION
- remove "View JSON Config" button in connector details
- add a new "JSON" mode of viewing config of connectors as an alternative to the "Form" view. 
In standalone mode the JSON mode can also be used to edit (not just view) the config and add/modify config properties arbitrarily
- change what buttons are shown (and when) in connector details:

    - Pause/Resume will show for states 'RUNNING', 'PAUSED'
    - Restart will now always be present (so, in any state)