### PR TITLE
Make bytes default header converter for MirrorSourceConnector

### DIFF
--- a/backend/pkg/api/api_integration_test.go
+++ b/backend/pkg/api/api_integration_test.go
@@ -236,10 +236,11 @@ func newAssertHooks(t *testing.T, returnValues map[string]map[string]assertCallR
 }
 
 // Router Hooks
-func (a *assertHooks) ConfigAPIRouter(_ chi.Router)      {}
-func (a *assertHooks) ConfigWsRouter(_ chi.Router)       {}
-func (a *assertHooks) ConfigInternalRouter(_ chi.Router) {}
-func (a *assertHooks) ConfigRouter(_ chi.Router)         {}
+func (a *assertHooks) ConfigAPIRouter(_ chi.Router)                 {}
+func (a *assertHooks) ConfigAPIRouterPostRegistration(_ chi.Router) {}
+func (a *assertHooks) ConfigWsRouter(_ chi.Router)                  {}
+func (a *assertHooks) ConfigInternalRouter(_ chi.Router)            {}
+func (a *assertHooks) ConfigRouter(_ chi.Router)                    {}
 
 // Authorization Hooks
 func (a *assertHooks) CanSeeTopic(_ context.Context, topic string) (bool, *rest.Error) {

--- a/backend/pkg/connector/interceptor/mirror_hook.go
+++ b/backend/pkg/connector/interceptor/mirror_hook.go
@@ -11,6 +11,7 @@ import (
 func ConsoleToKafkaConnectMirrorSourceHook(config map[string]any) map[string]any {
 	setIfNotExists(config, "source.cluster.ssl.truststore.type", "PEM")
 	setIfNotExists(config, "source.cluster.ssl.keystore.type", "PEM")
+	setIfNotExists(config, "header.converter", "org.apache.kafka.connect.converters.ByteArrayConverter")
 
 	if _, exists := config["source.cluster.security.protocol"]; exists {
 		setIfNotExists(config, "security.protocol", config["source.cluster.security.protocol"])

--- a/backend/pkg/connector/interceptor/mirror_hook_test.go
+++ b/backend/pkg/connector/interceptor/mirror_hook_test.go
@@ -14,34 +14,52 @@ func TestConsoleToKafkaConnectMirrorSourceHook(t *testing.T) {
 		want   map[string]any
 	}{
 		{
-			name: "Should not set truststore and keystore types if given",
+			name: "Should not set default props if given",
 			config: map[string]any{
 				"source.cluster.ssl.truststore.type": "JKS",
 				"source.cluster.ssl.keystore.type":   "JKS",
+				"header.converter":                   "org.apache.kafka.connect.storage.StringConverter",
 			},
 			want: map[string]any{
 				"source.cluster.ssl.truststore.type": "JKS",
 				"source.cluster.ssl.keystore.type":   "JKS",
+				"header.converter":                   "org.apache.kafka.connect.storage.StringConverter",
 			},
 		},
 		{
 			name: "Should set source.cluster.ssl.truststore.type if not given",
 			config: map[string]any{
 				"source.cluster.ssl.keystore.type": "JKS",
+				"header.converter":                 "org.apache.kafka.connect.storage.StringConverter",
 			},
 			want: map[string]any{
 				"source.cluster.ssl.truststore.type": "PEM",
 				"source.cluster.ssl.keystore.type":   "JKS",
+				"header.converter":                   "org.apache.kafka.connect.storage.StringConverter",
 			},
 		},
 		{
 			name: "Should set source.cluster.ssl.keystore.type if not given",
 			config: map[string]any{
 				"source.cluster.ssl.truststore.type": "JKS",
+				"header.converter":                   "org.apache.kafka.connect.storage.StringConverter",
 			},
 			want: map[string]any{
 				"source.cluster.ssl.truststore.type": "JKS",
 				"source.cluster.ssl.keystore.type":   "PEM",
+				"header.converter":                   "org.apache.kafka.connect.storage.StringConverter",
+			},
+		},
+		{
+			name: "Should set header.converter if not given",
+			config: map[string]any{
+				"source.cluster.ssl.truststore.type": "JKS",
+				"source.cluster.ssl.keystore.type":   "JKS",
+			},
+			want: map[string]any{
+				"source.cluster.ssl.truststore.type": "JKS",
+				"source.cluster.ssl.keystore.type":   "JKS",
+				"header.converter":                   "org.apache.kafka.connect.converters.ByteArrayConverter",
 			},
 		},
 		{
@@ -49,11 +67,13 @@ func TestConsoleToKafkaConnectMirrorSourceHook(t *testing.T) {
 			config: map[string]any{
 				"source.cluster.ssl.truststore.type": "PEM",
 				"source.cluster.ssl.keystore.type":   "PEM",
+				"header.converter":                   "org.apache.kafka.connect.converters.ByteArrayConverter",
 				"source.cluster.security.protocol":   "SASL_SSL",
 			},
 			want: map[string]any{
 				"source.cluster.ssl.truststore.type": "PEM",
 				"source.cluster.ssl.keystore.type":   "PEM",
+				"header.converter":                   "org.apache.kafka.connect.converters.ByteArrayConverter",
 				"source.cluster.security.protocol":   "SASL_SSL",
 				"security.protocol":                  "SASL_SSL",
 			},
@@ -63,12 +83,14 @@ func TestConsoleToKafkaConnectMirrorSourceHook(t *testing.T) {
 			config: map[string]any{
 				"source.cluster.ssl.truststore.type": "PEM",
 				"source.cluster.ssl.keystore.type":   "PEM",
+				"header.converter":                   "org.apache.kafka.connect.converters.ByteArrayConverter",
 				"source.cluster.security.protocol":   "SASL_SSL",
 				"security.protocol":                  "SASL_PLAINTEXT",
 			},
 			want: map[string]any{
 				"source.cluster.ssl.truststore.type": "PEM",
 				"source.cluster.ssl.keystore.type":   "PEM",
+				"header.converter":                   "org.apache.kafka.connect.converters.ByteArrayConverter",
 				"source.cluster.security.protocol":   "SASL_SSL",
 				"security.protocol":                  "SASL_PLAINTEXT",
 			},
@@ -78,6 +100,7 @@ func TestConsoleToKafkaConnectMirrorSourceHook(t *testing.T) {
 			config: map[string]any{
 				"source.cluster.ssl.truststore.type": "PEM",
 				"source.cluster.ssl.keystore.type":   "PEM",
+				"header.converter":                   "org.apache.kafka.connect.converters.ByteArrayConverter",
 				"source.cluster.security.protocol":   "SASL_SSL",
 				"source.cluster.sasl.mechanism":      "PLAIN",
 				"source.cluster.sasl.username":       "user",
@@ -86,6 +109,7 @@ func TestConsoleToKafkaConnectMirrorSourceHook(t *testing.T) {
 			want: map[string]any{
 				"source.cluster.ssl.truststore.type": "PEM",
 				"source.cluster.ssl.keystore.type":   "PEM",
+				"header.converter":                   "org.apache.kafka.connect.converters.ByteArrayConverter",
 				"source.cluster.security.protocol":   "SASL_SSL",
 				"security.protocol":                  "SASL_SSL",
 				"source.cluster.sasl.mechanism":      "PLAIN",
@@ -99,6 +123,7 @@ func TestConsoleToKafkaConnectMirrorSourceHook(t *testing.T) {
 			config: map[string]any{
 				"source.cluster.ssl.truststore.type": "PEM",
 				"source.cluster.ssl.keystore.type":   "PEM",
+				"header.converter":                   "org.apache.kafka.connect.converters.ByteArrayConverter",
 				"source.cluster.security.protocol":   "SASL_SSL",
 				"source.cluster.sasl.mechanism":      "SCRAM-SHA-256",
 				"source.cluster.sasl.username":       "user",
@@ -107,6 +132,7 @@ func TestConsoleToKafkaConnectMirrorSourceHook(t *testing.T) {
 			want: map[string]any{
 				"source.cluster.ssl.truststore.type": "PEM",
 				"source.cluster.ssl.keystore.type":   "PEM",
+				"header.converter":                   "org.apache.kafka.connect.converters.ByteArrayConverter",
 				"source.cluster.security.protocol":   "SASL_SSL",
 				"security.protocol":                  "SASL_SSL",
 				"source.cluster.sasl.mechanism":      "SCRAM-SHA-256",
@@ -120,6 +146,7 @@ func TestConsoleToKafkaConnectMirrorSourceHook(t *testing.T) {
 			config: map[string]any{
 				"source.cluster.ssl.truststore.type": "PEM",
 				"source.cluster.ssl.keystore.type":   "PEM",
+				"header.converter":                   "org.apache.kafka.connect.converters.ByteArrayConverter",
 				"source.cluster.security.protocol":   "SASL_SSL",
 				"source.cluster.sasl.mechanism":      "PLAIN",
 				"source.cluster.sasl.username":       "user",
@@ -129,6 +156,7 @@ func TestConsoleToKafkaConnectMirrorSourceHook(t *testing.T) {
 			want: map[string]any{
 				"source.cluster.ssl.truststore.type": "PEM",
 				"source.cluster.ssl.keystore.type":   "PEM",
+				"header.converter":                   "org.apache.kafka.connect.converters.ByteArrayConverter",
 				"source.cluster.security.protocol":   "SASL_SSL",
 				"security.protocol":                  "SASL_SSL",
 				"source.cluster.sasl.mechanism":      "PLAIN",


### PR DESCRIPTION
Add `org.apache.kafka.connect.converters.ByteArrayConverter` as default `header.converter` for MirrorSourceConnnector.