### PR TITLE
backend: remove warning failed to parse avro schema

### DIFF
--- a/backend/pkg/schema/service.go
+++ b/backend/pkg/schema/service.go
@@ -183,6 +183,10 @@ func (s *Service) GetAvroSchemaByID(schemaID uint32) (avro.Schema, error) {
 			return nil, fmt.Errorf("failed to get schema from registry: %w", err)
 		}
 
+		if schemaRes.SchemaType != "AVRO" {
+			return nil, fmt.Errorf("schema type is not avro")
+		}
+
 		codec, err := s.ParseAvroSchemaWithReferences(schemaRes)
 		if err != nil {
 			s.logger.Warn("failed to parse avro schema", zap.Uint32("schema_id", schemaID), zap.Error(err))

--- a/backend/pkg/schema/service_test.go
+++ b/backend/pkg/schema/service_test.go
@@ -43,6 +43,7 @@ func TestService_GetAvroSchemaByID(t *testing.T) {
 					"subject": "referenced.schema",
 					"version": 1,
 				}},
+				"schemaType": "AVRO",
 			})
 		})
 
@@ -51,10 +52,11 @@ func TestService_GetAvroSchemaByID(t *testing.T) {
 	httpmock.RegisterResponder("GET", baseURL+"/subjects/referenced.schema/versions/1",
 		func(req *http.Request) (*http.Response, error) {
 			return httpmock.NewJsonResponse(http.StatusOK, map[string]interface{}{
-				"schema":  referencedSchemaStr,
-				"subject": "referenced.schema",
-				"version": 1,
-				"id":      1001,
+				"schema":     referencedSchemaStr,
+				"subject":    "referenced.schema",
+				"version":    1,
+				"schemaType": "AVRO",
+				"id":         1001,
 			})
 		})
 


### PR DESCRIPTION
When Console tries to deserialize a protobuf message in schemaregistry encoding it first tries to decode it as avro message. If that fails a warn message is logged. This PR returns early from deserializing it in avro when it notices that the pulled schema is of type protobuf.