### PR TITLE
backend: configurable maxDepth for git repositories

### DIFF
--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -1,0 +1,132 @@
+package config
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/cloudhut/common/logging"
+	"github.com/cloudhut/common/rest"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+const configPathKey = "CONFIG_FILEPATH"
+
+var (
+	logger, _            = zap.NewDevelopment()
+	defaultConfiguration = Config{
+		MetricsNamespace: "console",
+		ServeFrontend:    true,
+		Console: Console{
+			Enabled: true,
+			TopicDocumentation: ConsoleTopicDocumentation{
+				Git: Git{
+					AllowedFileExtensions: []string{".md"},
+					MaxFileSize:           500000,
+					RefreshInterval:       60000000000,
+					Repository: GitRepository{
+						BaseDirectory: ".",
+						MaxDepth:      15,
+					},
+				},
+			},
+		},
+		Connect: Connect{
+			ConnectTimeout: 15000000000,
+			ReadTimeout:    6000000000,
+			RequestTimeout: 6000000000,
+		},
+		REST: Server{
+			Config: rest.Config{
+				ServerGracefulShutdownTimeout:   30000000000,
+				HTTPListenPort:                  8080,
+				HTTPServerReadTimeout:           30000000000,
+				HTTPServerWriteTimeout:          30000000000,
+				HTTPServerIdleTimeout:           30000000000,
+				HTTPSListenPort:                 8081,
+				CompressionLevel:                4,
+				SetBasePathFromXForwardedPrefix: true,
+				StripPrefix:                     true,
+			},
+		},
+		Kafka: Kafka{
+			ClientID: "redpanda-console",
+			Protobuf: Proto{
+				SchemaRegistry: ProtoSchemaRegistry{
+					RefreshInterval: 300000000000,
+				},
+				Git: Git{
+					AllowedFileExtensions: []string{"proto"},
+					MaxFileSize:           500000,
+					IndexByFullFilepath:   true,
+					RefreshInterval:       60000000000,
+					Repository: GitRepository{
+						BaseDirectory: ".",
+						MaxDepth:      15,
+					},
+				},
+				FileSystem: Filesystem{
+					AllowedFileExtensions: []string{"proto"},
+					MaxFileSize:           500000,
+					IndexByFullFilepath:   true,
+					RefreshInterval:       300000000000,
+				},
+			},
+			MessagePack: Msgpack{
+				TopicNames: []string{"/.*/"},
+			},
+			SASL: KafkaSASL{
+				Mechanism: "PLAIN",
+				GSSAPIConfig: KafkaSASLGSSAPI{
+					EnableFast: true,
+				},
+			},
+			Startup: KafkaStartup{
+				EstablishConnectionEagerly: true,
+				MaxRetries:                 5,
+				RetryInterval:              1000000000,
+				MaxRetryInterval:           60000000000,
+				BackoffMultiplier:          2,
+			},
+		},
+		Logger: logging.Config{
+			LogLevelInput: "info",
+			LogLevel:      zap.NewAtomicLevelAt(zap.InfoLevel),
+		},
+	}
+)
+
+func setup(t *testing.T, configPath string) {
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	t.Setenv(configPathKey, configPath)
+}
+
+func TestDefaultConfiguration(t *testing.T) {
+	setup(t, "")
+	cfg, err := LoadConfig(logger)
+	assert.NoError(t, err)
+	assert.Equal(t, defaultConfiguration, cfg)
+}
+
+func TestGitConfiguration(t *testing.T) {
+	setup(t, "testdata/git-config.yaml")
+	expected := defaultConfiguration
+	expected.Kafka.Protobuf.Enabled = true
+	expected.Kafka.Protobuf.Git.Enabled = true
+	expected.Kafka.Protobuf.Git.Repository = GitRepository{
+		URL:           "https://github.com/redpanda-data/console.git",
+		Branch:        "release-1.0",
+		BaseDirectory: ".",
+		MaxDepth:      3,
+	}
+	cfg, err := LoadConfig(logger)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, cfg)
+}
+
+func TestInvalidConfiguration(t *testing.T) {
+	setup(t, "testdata/invalid-config.yaml")
+	_, err := LoadConfig(logger)
+	assert.Error(t, err)
+}

--- a/backend/pkg/config/git_repository.go
+++ b/backend/pkg/config/git_repository.go
@@ -12,11 +12,12 @@ package config
 import "fmt"
 
 // GitRepository is the configuration options that determine what Git repository, branch and
-// directory shall be used.
+// directory shall be used, as well as the max depth for fetching markdown and proto files.
 type GitRepository struct {
 	URL           string `yaml:"url"`
 	Branch        string `yaml:"branch"`
 	BaseDirectory string `yaml:"baseDirectory"`
+	MaxDepth      int    `yaml:"maxDepth"`
 }
 
 // Validate given input for config properties
@@ -31,4 +32,5 @@ func (c *GitRepository) Validate() error {
 // SetDefaults for Git repository configurations.
 func (c *GitRepository) SetDefaults() {
 	c.BaseDirectory = "."
+	c.MaxDepth = 15
 }

--- a/backend/pkg/config/testdata/git-config.yaml
+++ b/backend/pkg/config/testdata/git-config.yaml
@@ -1,0 +1,9 @@
+kafka:
+  protobuf:
+    enabled: true
+    git:
+      enabled: true
+      repository:
+        url: https://github.com/redpanda-data/console.git
+        branch: release-1.0
+        maxDepth: 3

--- a/backend/pkg/config/testdata/invalid-config.yaml
+++ b/backend/pkg/config/testdata/invalid-config.yaml
@@ -1,0 +1,2 @@
+kafka:
+  non-existing: true

--- a/backend/pkg/git/service.go
+++ b/backend/pkg/git/service.go
@@ -121,7 +121,7 @@ func (c *Service) CloneRepository(ctx context.Context) error {
 
 	// 2. Put files into cache
 	empty := make(map[string]filesystem.File)
-	files, err := c.readFiles(fs, empty, c.Cfg.Repository.BaseDirectory, 15)
+	files, err := c.readFiles(fs, empty, c.Cfg.Repository.BaseDirectory, c.Cfg.Repository.MaxDepth)
 	if err != nil {
 		return fmt.Errorf("failed to get files: %w", err)
 	}
@@ -178,7 +178,7 @@ func (c *Service) SyncRepo() {
 
 			// Update cache with new markdowns
 			empty := make(map[string]filesystem.File)
-			files, err := c.readFiles(c.memFs, empty, c.Cfg.Repository.BaseDirectory, 5)
+			files, err := c.readFiles(c.memFs, empty, c.Cfg.Repository.BaseDirectory, c.Cfg.Repository.MaxDepth)
 			if err != nil {
 				c.logger.Error("failed to read files after pulling", zap.Error(err))
 				continue

--- a/docs/config/console.yaml
+++ b/docs/config/console.yaml
@@ -104,6 +104,7 @@ kafka:
   #       url:
   #       branch: (defaults to primary/default branch)
   #       baseDirectory: (defaults to the root directory of the repo/branch above)
+  #       maxDepth: (defaults to 15)
   #     # How often Console shall pull the repository to look for new files. Set 0 to disable periodic pulls
   #     refreshInterval: 1m
   #     # Basic Auth
@@ -111,15 +112,15 @@ kafka:
   #     basicAuth:
   #       enabled: true
   #       username: token
-  #       password: #  This can be set via the via the --owl.topic-documentation.git.basic-auth.password flag as well
+  #       password: #  This can be set via the --owl.topic-documentation.git.basic-auth.password flag as well
   #     # SSH Auth
   #     # You can either pass the private key file directly via flag or yaml config or refer to a mounted key file
   #     ssh:
   #       enabled: false
   #       username:
-  #       privateKey: # This can be set via the via the --owl.topic-documentation.git.ssh.private-key flag as well
+  #       privateKey: # This can be set via the --owl.topic-documentation.git.ssh.private-key flag as well
   #       privateKeyFilepath:
-  #       passphrase: # This can be set via the via the --owl.topic-documentation.git.ssh.passphrase flag as well
+  #       passphrase: # This can be set via the --owl.topic-documentation.git.ssh.passphrase flag as well
   # messagePack:
   #   enabled: false
   #   topicNames: ["/.*/"] # List of topic name regexes, defaults to /.*/
@@ -158,8 +159,8 @@ kafka:
 #         # keyFilepath:
 #         # insecureSkipTlsVerify: false
 #       username:
-#       password: # This can be set via the via the --connect.clusters.i.password flag as well (i to be replaced with the array index)
-#       token: # This can be set via the via the --connect.clusters.i.token flag as well (i to be replaced with the array index)
+#       password: # This can be set via the --connect.clusters.i.password flag as well (i to be replaced with the array index)
+#       token: # This can be set via the --connect.clusters.i.token flag as well (i to be replaced with the array index)
 #   connectTimeout: 15s # used to test cluster connectivity
 #   readTimeout: 60s    # overall REST timeout
 #   requestTimeout: 6s  # timeout for REST requests
@@ -175,6 +176,7 @@ kafka:
 #         url:
 #         branch: (defaults to primary/default branch)
 #         baseDirectory: .
+#         maxDepth: (defaults to 15)
 #       # How often Console shall pull the repository to look for new files. Set 0 to disable periodic pulls
 #       refreshInterval: 1m
 #       # Basic Auth
@@ -182,15 +184,15 @@ kafka:
 #       basicAuth:
 #         enabled: true
 #         username: token
-#         password: #  This can be set via the via the --console.topic-documentation.git.basic-auth.password flag as well
+#         password: #  This can be set via the --console.topic-documentation.git.basic-auth.password flag as well
 #       # SSH Auth
 #       # You can either pass the private key file directly via flag or yaml config or refer to a mounted key file
 #       ssh:
 #         enabled: false
 #         username:
-#         privateKey: # This can be set via the via the --console.topic-documentation.git.ssh.private-key flag as well
+#         privateKey: # This can be set via the --console.topic-documentation.git.ssh.private-key flag as well
 #         privateKeyFilepath:
-#         passphrase: # This can be set via the via the --console.topic-documentation.git.ssh.passphrase flag as well
+#         passphrase: # This can be set via the --console.topic-documentation.git.ssh.passphrase flag as well
 
 # analytics configures the telemetry service that sends anonymized usage statistics to Redpanda.
 # Redpanda uses these statistics to evaluate feature usage.


### PR DESCRIPTION
1. maxDepth for git is now configurable through:
  a. `kafka:protobuf:git:repository:maxDepth`
  b. `kafka:console:git:repository:maxDepth`
Previously, both were hardcoded to 5 and 15 respectively.
2. Adds units test for the above and for default configuration.

Resolves https://github.com/redpanda-data/console/issues/277
