### PR TITLE
Fix flaky integration tests

### DIFF
--- a/backend/pkg/kafka/deserializer_integration_test.go
+++ b/backend/pkg/kafka/deserializer_integration_test.go
@@ -845,6 +845,7 @@ func (s *KafkaIntegrationTestSuite) TestDeserializeRecord() {
 		}
 
 		msgData, err := serde.Encode(msg.GetGizmo())
+		require.NoError(err)
 
 		r := &kgo.Record{
 			// Key:   []byte(msg.GetIdentity()),


### PR DESCRIPTION
The integration tests for connectors have been flaky (mostly failing) for me, because the connector hasn't produced the number of expected records in time.