### PR TITLE
frontend: fix base64 decoding of 'utf8WithControlChars'

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
                 "antd": "^4.21",
                 "array-move": "^4",
                 "framer-motion": "^7",
+                "js-base64": "^3.7.5",
                 "mobx": "^6.6",
                 "mobx-react": "^7.5",
                 "moment": "^2.29.4",
@@ -17648,6 +17649,11 @@
                 "@sideway/formula": "^3.0.1",
                 "@sideway/pinpoint": "^2.0.0"
             }
+        },
+        "node_modules/js-base64": {
+            "version": "3.7.5",
+            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.5.tgz",
+            "integrity": "sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA=="
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
         "antd": "^4.21",
         "array-move": "^4",
         "framer-motion": "^7",
+        "js-base64": "^3.7.5",
         "mobx": "^6.6",
         "mobx-react": "^7.5",
         "moment": "^2.29.4",

--- a/frontend/src/state/backendApi.ts
+++ b/frontend/src/state/backendApi.ts
@@ -19,7 +19,7 @@ import fetchWithTimeout from '../utils/fetchWithTimeout';
 import { toJson } from '../utils/jsonUtils';
 import { LazyMap } from '../utils/LazyMap';
 import { ObjToKv } from '../utils/tsxUtils';
-import { decodeBase64, TimeSince } from '../utils/utils';
+import { base64ToHexString, decodeBase64, TimeSince } from '../utils/utils';
 import { appGlobal } from './appGlobal';
 import {
     GetAclsRequest, AclRequestDefault, GetAclOverviewResponse, AdminInfo,
@@ -369,31 +369,18 @@ const apiStore = {
                 case 'message':
                     const m = msg.message as TopicMessage;
 
-                    const keyData = m.key.payload;
-                    if (keyData != null && keyData != undefined && keyData != '' && m.key.encoding == 'binary') {
-                        try {
-                            m.key.payload = decodeBase64(m.key.payload); // unpack base64 encoded key
-                        } catch (error) {
-                            // Empty
-                            // Only unpack if the key is base64 based
-                        }
+                    if (m.key.encoding == 'binary' || m.key.encoding == 'utf8WithControlChars') {
+                        m.key.payload = decodeBase64(m.key.payload);
+                        m.keyBinHexPreview = base64ToHexString(m.key.payload);
+                    }
+
+                    if (m.value.encoding == 'binary' || m.value.encoding == 'utf8WithControlChars') {
+                        m.value.payload = decodeBase64(m.value.payload);
+                        m.valueBinHexPreview = base64ToHexString(m.value.payload);
                     }
 
                     m.keyJson = JSON.stringify(m.key.payload);
                     m.valueJson = JSON.stringify(m.value.payload);
-
-                    if (m.key.encoding == 'binary' || m.key.encoding == 'utf8WithControlChars') {
-                        m.key.payload = decodeBase64(m.key.payload);
-                        m.keyBinHexPreview = this.base64ToHexString(m.key.payload);
-                    }
-
-                    if (m.value.encoding == 'binary' || m.key.encoding == 'utf8WithControlChars') {
-                        m.value.payload = decodeBase64(m.value.payload);
-                        m.valueBinHexPreview = this.base64ToHexString(m.value.payload);
-                    }
-
-
-                    //m = observable.object(m, undefined, { deep: false });
 
                     this.messages.push(m);
                     break;
@@ -402,24 +389,7 @@ const apiStore = {
         currentWS.onmessage = onMessageHandler;
     },
 
-    base64ToHexString(base64: string): string {
-        const binary = atob(base64);
-        const bytes = new Uint8Array(binary.length);
-        for (let i = 0; i < binary.length; i++) {
-            bytes[i] = binary.charCodeAt(i);
-        }
 
-        let hex = '';
-        for (let i = 0; i < bytes.length; i++) {
-            const b = bytes[i].toString(16);
-            hex += b.length === 1 ? '0' + b : b;
-
-            if (i < bytes.length - 1)
-                hex += ' ';
-        }
-
-        return hex;
-    },
 
     stopMessageSearch() {
         if (currentWS) {


### PR DESCRIPTION
Manually brings in ef7801a to release branch.
Tested by checking out `release-2.3` branch and I was able to reproduce the rendering issue with the JavaScript stack trace.
With this change the messages rendered fine.