### PR TITLE
Fixed load yaml config: 'kafka.protobuf.FileSystem' has invalid keys: "skipHiddenFiles"

### DIFF
--- a/backend/pkg/config/filesystem.go
+++ b/backend/pkg/config/filesystem.go
@@ -35,7 +35,7 @@ type Filesystem struct {
 	Paths []string `yaml:"paths"`
 
 	// SkipHiddenFiles specifies whether or not hidden files should be watched or not
-	SkipHiddenFiles bool
+	SkipHiddenFiles bool `yaml:"skipHiddenFiles"`
 }
 
 // Validate all root and child config structs


### PR DESCRIPTION
Fixed load yaml config: 'kafka.protobuf.FileSystem' has invalid keys: "skipHiddenFiles"

```
{"level":"fatal","msg":"failed to load yaml config","error":"failed to unmarshal YAML config into config struct: 1 error(s) decoding:\n\n* 'kafka.protobuf.FileSystem' has invalid keys: skipHiddenFiles"}
```
the yaml:
![image](https://github.com/redpanda-data/console/assets/79898499/d44f58d9-a4c9-4922-bd5b-0c84d874c849)


The root issue: https://github.com/redpanda-data/console/issues/810