### PR TITLE
feat: toast component migration

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,7 @@
                 "@heroicons/react": "^1.0.6",
                 "@monaco-editor/react": "^4.5",
                 "@primer/octicons-react": "^17",
-                "@redpanda-data/ui": "^3.21.0",
+                "@redpanda-data/ui": "^3.24.0",
                 "@textea/json-viewer": "^1.24.4",
                 "antd": "^4.21",
                 "array-move": "^4",
@@ -6001,9 +6001,9 @@
             }
         },
         "node_modules/@redpanda-data/ui": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@redpanda-data/ui/-/ui-3.21.0.tgz",
-            "integrity": "sha512-Z1NnKhl8NSgr4hFNntRvCftH0ETiS1tzFGPJhR47Q0cxgperjcokzxB5542zV/fq8i7IgZviZXFBwRaeG/vrxQ==",
+            "version": "3.24.0",
+            "resolved": "https://registry.npmjs.org/@redpanda-data/ui/-/ui-3.24.0.tgz",
+            "integrity": "sha512-KTye7+GxDRzZ6HvihWKRtPtxSzABT0sZ85PBFWRxdoOr+wPyTHQcb8EBi9LvYHMXqOh5LXj5NsvLVz3q1/m/pg==",
             "dependencies": {
                 "@chakra-ui/icons": "^2.1.0",
                 "@chakra-ui/react": "^2.8.0",
@@ -33771,9 +33771,9 @@
             }
         },
         "@redpanda-data/ui": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@redpanda-data/ui/-/ui-3.21.0.tgz",
-            "integrity": "sha512-Z1NnKhl8NSgr4hFNntRvCftH0ETiS1tzFGPJhR47Q0cxgperjcokzxB5542zV/fq8i7IgZviZXFBwRaeG/vrxQ==",
+            "version": "3.24.0",
+            "resolved": "https://registry.npmjs.org/@redpanda-data/ui/-/ui-3.24.0.tgz",
+            "integrity": "sha512-KTye7+GxDRzZ6HvihWKRtPtxSzABT0sZ85PBFWRxdoOr+wPyTHQcb8EBi9LvYHMXqOh5LXj5NsvLVz3q1/m/pg==",
             "requires": {
                 "@chakra-ui/icons": "^2.1.0",
                 "@chakra-ui/react": "^2.8.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,7 @@
                 "@heroicons/react": "^1.0.6",
                 "@monaco-editor/react": "^4.5",
                 "@primer/octicons-react": "^17",
-                "@redpanda-data/ui": "^3.17.2",
+                "@redpanda-data/ui": "^3.21.0",
                 "@textea/json-viewer": "^1.24.4",
                 "antd": "^4.21",
                 "array-move": "^4",
@@ -6001,9 +6001,9 @@
             }
         },
         "node_modules/@redpanda-data/ui": {
-            "version": "3.17.2",
-            "resolved": "https://registry.npmjs.org/@redpanda-data/ui/-/ui-3.17.2.tgz",
-            "integrity": "sha512-cYQs8e0Dto5YLni+g9I1gS/owEX4hEgEecXpGjT9xFWsORW6tL4pfr/eh7gKriC0Gn1Dvwdeqc5JNsJkg7kWgA==",
+            "version": "3.21.0",
+            "resolved": "https://registry.npmjs.org/@redpanda-data/ui/-/ui-3.21.0.tgz",
+            "integrity": "sha512-Z1NnKhl8NSgr4hFNntRvCftH0ETiS1tzFGPJhR47Q0cxgperjcokzxB5542zV/fq8i7IgZviZXFBwRaeG/vrxQ==",
             "dependencies": {
                 "@chakra-ui/icons": "^2.1.0",
                 "@chakra-ui/react": "^2.8.0",
@@ -6015,7 +6015,7 @@
                 "@hookform/devtools": "^4.3.1",
                 "@hookform/resolvers": "^3.1.1",
                 "@storybook/addon-coverage": "^0.0.9",
-                "@storybook/jest": "^0.2.1",
+                "@storybook/jest": "^0.2.2",
                 "@storybook/test-runner": "^0.13.0",
                 "@tanstack/react-table": "^8.9.3",
                 "@textea/json-viewer": "^3.1.1",
@@ -33771,9 +33771,9 @@
             }
         },
         "@redpanda-data/ui": {
-            "version": "3.17.2",
-            "resolved": "https://registry.npmjs.org/@redpanda-data/ui/-/ui-3.17.2.tgz",
-            "integrity": "sha512-cYQs8e0Dto5YLni+g9I1gS/owEX4hEgEecXpGjT9xFWsORW6tL4pfr/eh7gKriC0Gn1Dvwdeqc5JNsJkg7kWgA==",
+            "version": "3.21.0",
+            "resolved": "https://registry.npmjs.org/@redpanda-data/ui/-/ui-3.21.0.tgz",
+            "integrity": "sha512-Z1NnKhl8NSgr4hFNntRvCftH0ETiS1tzFGPJhR47Q0cxgperjcokzxB5542zV/fq8i7IgZviZXFBwRaeG/vrxQ==",
             "requires": {
                 "@chakra-ui/icons": "^2.1.0",
                 "@chakra-ui/react": "^2.8.0",
@@ -33785,7 +33785,7 @@
                 "@hookform/devtools": "^4.3.1",
                 "@hookform/resolvers": "^3.1.1",
                 "@storybook/addon-coverage": "^0.0.9",
-                "@storybook/jest": "^0.2.1",
+                "@storybook/jest": "^0.2.2",
                 "@storybook/test-runner": "^0.13.0",
                 "@tanstack/react-table": "^8.9.3",
                 "@textea/json-viewer": "^3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
         "@heroicons/react": "^1.0.6",
         "@monaco-editor/react": "^4.5",
         "@primer/octicons-react": "^17",
-        "@redpanda-data/ui": "^3.21.0",
+        "@redpanda-data/ui": "^3.24.0",
         "@textea/json-viewer": "^1.24.4",
         "antd": "^4.21",
         "array-move": "^4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
         "@heroicons/react": "^1.0.6",
         "@monaco-editor/react": "^4.5",
         "@primer/octicons-react": "^17",
-        "@redpanda-data/ui": "^3.17.2",
+        "@redpanda-data/ui": "^3.21.0",
         "@textea/json-viewer": "^1.24.4",
         "antd": "^4.21",
         "array-move": "^4",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -58,6 +58,7 @@ const App = () => {
                 inside an Ant modal.
              */}
             <ChakraProvider theme={redpandaTheme} toastOptions={redpandaToastOptions} portalZIndex={1001}>
+                <div id="portals" />
                 <ErrorBoundary>
                     <RequireAuth>
                         {isEmbedded()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -58,7 +58,6 @@ const App = () => {
                 inside an Ant modal.
              */}
             <ChakraProvider theme={redpandaTheme} toastOptions={redpandaToastOptions} portalZIndex={1001}>
-                <div id="portals" />
                 <ErrorBoundary>
                     <RequireAuth>
                         {isEmbedded()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,7 +24,7 @@ import './assets/fonts/inter.css';
 
 import { BrowserRouter } from 'react-router-dom';
 import { observer } from 'mobx-react';
-import { Container, Grid, Sidebar } from '@redpanda-data/ui';
+import { Container, Grid, redpandaToastOptions, Sidebar } from '@redpanda-data/ui';
 import { uiSettings } from './state/ui';
 import { createVisibleSidebarItems } from './components/routes';
 import { ErrorBoundary } from './components/misc/ErrorBoundary';
@@ -52,12 +52,12 @@ const App = () => {
     return (
         <BrowserRouter basename={getBasePath()}>
             <HistorySetter />
-            {/* 
+            {/*
                 Setting portalZIndex to 1001 allows popovers, tooltips and any component that uses portals
-                to render _above_ Ant's modal component (which sets its z-index to 1000) when they're 
+                to render _above_ Ant's modal component (which sets its z-index to 1000) when they're
                 inside an Ant modal.
              */}
-            <ChakraProvider theme={redpandaTheme} portalZIndex={1001}>
+            <ChakraProvider theme={redpandaTheme} toastOptions={redpandaToastOptions} portalZIndex={1001}>
                 <ErrorBoundary>
                     <RequireAuth>
                         {isEmbedded()

--- a/frontend/src/components/misc/ErrorBoundary.tsx
+++ b/frontend/src/components/misc/ErrorBoundary.tsx
@@ -9,18 +9,18 @@
  * by the Apache License, Version 2.0
  */
 
-import React, { CSSProperties } from 'react';
+import React, { CSSProperties, FC } from 'react';
 import { observer } from 'mobx-react';
 import { makeObservable, observable } from 'mobx';
 import { toJson } from '../../utils/jsonUtils';
-import { Layout, message, Space } from 'antd';
+import { Layout, Space } from 'antd';
 import { CopyOutlined, CloseOutlined } from '@ant-design/icons';
 import { envVarDebugAr } from '../../utils/env';
 import { NoClipboardPopover } from './NoClipboardPopover';
 import { isClipboardAvailable } from '../../utils/featureDetection';
 import { ObjToKv } from '../../utils/tsxUtils';
 import StackTrace from 'stacktrace-js';
-import { Button, Icon } from '@redpanda-data/ui';
+import { Button, Icon, useToast } from '@redpanda-data/ui';
 
 const { Content } = Layout;
 
@@ -156,7 +156,7 @@ export class ErrorBoundary extends React.Component<{ children?: React.ReactNode 
         this.hasError = true;
     }
 
-    copyError() {
+    getError() {
         let data = '';
 
         for (const e of this.infoItems) {
@@ -164,8 +164,7 @@ export class ErrorBoundary extends React.Component<{ children?: React.ReactNode 
             data += `${e.name}:\n${str}\n\n`;
         }
 
-        navigator.clipboard.writeText(data);
-        message.success('All info copied to clipboard!', 5);
+        return data
     }
 
     dismiss() {
@@ -188,13 +187,12 @@ export class ErrorBoundary extends React.Component<{ children?: React.ReactNode 
                         Dismiss
                     </Button>
                     <NoClipboardPopover>
-                        <Button variant="ghost" size="large"
+                        <CopyToClipboardButton
                             disabled={!isClipboardAvailable || !this.decodingDone}
                             isLoading={!this.decodingDone}
-                            onClick={() => this.copyError()}>
-                            <Icon as={CopyOutlined} />
-                            Copy Info
-                        </Button>
+                            message={this.getError()}
+                        />
+
                     </NoClipboardPopover>
                 </Space>
             </div>
@@ -217,6 +215,29 @@ function getStringFromInfo(info: InfoItem) {
     } catch (err) {
         return 'Error calling infoItem func: ' + err;
     }
+}
+
+const CopyToClipboardButton: FC<{message: string, disabled: boolean; isLoading: boolean}> = ({message, disabled, isLoading}) => {
+    const toast = useToast()
+
+    return (
+        <Button
+            variant="ghost"
+            size="large"
+            disabled={disabled}
+            isLoading={isLoading}
+            onClick={() => {
+                navigator.clipboard.writeText(message).then(() => {
+                    toast({
+                        status: 'success',
+                        description: 'All info copied to clipboard!'
+                    })
+                })
+            }}>
+            <Icon as={CopyOutlined}/>
+            Copy Info
+        </Button>
+    )
 }
 
 @observer

--- a/frontend/src/components/misc/ErrorBoundary.tsx
+++ b/frontend/src/components/misc/ErrorBoundary.tsx
@@ -18,7 +18,7 @@ import { CopyOutlined, CloseOutlined } from '@ant-design/icons';
 import { envVarDebugAr } from '../../utils/env';
 import { NoClipboardPopover } from './NoClipboardPopover';
 import { isClipboardAvailable } from '../../utils/featureDetection';
-import { ObjToKv } from '../../utils/tsxUtils';
+import { navigatorClipboardErrorHandler, ObjToKv } from '../../utils/tsxUtils';
 import StackTrace from 'stacktrace-js';
 import { Button, Icon, useToast } from '@redpanda-data/ui';
 
@@ -232,7 +232,7 @@ const CopyToClipboardButton: FC<{message: string, disabled: boolean; isLoading: 
                         status: 'success',
                         description: 'All info copied to clipboard!'
                     })
-                })
+                }).catch(navigatorClipboardErrorHandler)
             }}>
             <Icon as={CopyOutlined}/>
             Copy Info

--- a/frontend/src/components/misc/HideStatisticsBarButton.tsx
+++ b/frontend/src/components/misc/HideStatisticsBarButton.tsx
@@ -9,26 +9,25 @@
  * by the Apache License, Version 2.0
  */
 
-import { Component } from 'react';
-import React from 'react';
-import { message } from 'antd';
+import React, { FC } from 'react';
 import { EyeClosedIcon } from '@primer/octicons-react';
-import { Tooltip } from '@redpanda-data/ui';
-export class HideStatisticsBarButton extends Component<{ onClick: () => void }> {
-    handleClick = () => {
-        this.props.onClick();
-        message.info('Statistics bar hidden! You can enable it again in the preferences.', 8);
-    };
+import { Flex, Text, Tooltip, useToast } from '@redpanda-data/ui';
 
-    render() {
-        return (
-            <Tooltip label={<span style={{ whiteSpace: 'nowrap' }}>Hide statistics bar</span>} placement="right" hasArrow>
-                <div className="hideStatsBarButton" onClick={this.handleClick}>
-                    <div style={{ display: 'flex', width: '100%' }}>
-                        <EyeClosedIcon size="medium" />
-                    </div>
-                </div>
-            </Tooltip>
-        );
-    }
+export const HideStatisticsBarButton: FC<{ onClick: Function }> = ({onClick}) => {
+    const toast = useToast()
+    return (
+        <Tooltip label={<Text whiteSpace="nowrap">Hide statistics bar</Text>} placement="right" hasArrow>
+            <div className="hideStatsBarButton" onClick={() => {
+                onClick()
+                toast({
+                    status: 'info',
+                    description: 'Statistics bar hidden! You can enable it again in the preferences.'
+                });
+            }}>
+                <Flex width="100%">
+                    <EyeClosedIcon size="medium"/>
+                </Flex>
+            </div>
+        </Tooltip>
+    );
 }

--- a/frontend/src/components/misc/KowlJsonView.tsx
+++ b/frontend/src/components/misc/KowlJsonView.tsx
@@ -13,7 +13,7 @@ import { observer } from 'mobx-react';
 import React, { useEffect } from 'react';
 import JsonView, { ReactJsonViewProps } from '@textea/json-viewer';
 import { uiSettings } from '../../state/ui';
-import { Tooltip, useDisclosure, useToast } from '@redpanda-data/ui';
+import { Code, Text, Tooltip, useDisclosure, useToast } from '@redpanda-data/ui';
 import { navigatorClipboardErrorHandler } from '../../utils/tsxUtils';
 const { setTimeout } = window;
 
@@ -137,9 +137,7 @@ export const KowlJsonView = observer((props: ReactJsonViewProps) => {
                                 navigator.clipboard.writeText(String(e.value)).then(() => {
                                     toast({
                                         status: 'success',
-                                        description: <span>
-                                             Copied value of <span className="codeBox">{e.name}</span>
-                                        </span>,
+                                        description: <Text as="span">Copied value of <Code>{e.name}</Code></Text>,
                                         duration: 800
                                     })
                                 }).catch(navigatorClipboardErrorHandler)

--- a/frontend/src/components/misc/KowlJsonView.tsx
+++ b/frontend/src/components/misc/KowlJsonView.tsx
@@ -9,12 +9,11 @@
  * by the Apache License, Version 2.0
  */
 
-import { message } from 'antd';
 import { observer } from 'mobx-react';
 import React, { useEffect } from 'react';
 import JsonView, { ReactJsonViewProps } from '@textea/json-viewer';
 import { uiSettings } from '../../state/ui';
-import { Tooltip, useDisclosure } from '@redpanda-data/ui';
+import { Tooltip, useDisclosure, useToast } from '@redpanda-data/ui';
 const { setTimeout } = window;
 
 let ctrlDown = false;
@@ -35,6 +34,7 @@ type TooltipPopperRect = { x: number; y: number; width: number; height: number }
 
 export const KowlJsonView = observer((props: ReactJsonViewProps) => {
     const { style, ...restProps } = props;
+    const toast = useToast()
 
     const { isOpen, onOpen, onClose } = useDisclosure();
 
@@ -133,15 +133,15 @@ export const KowlJsonView = observer((props: ReactJsonViewProps) => {
                         collapsed={settings.collapsed}
                         onSelect={e => {
                             if (ctrlDown) {
-                                if (navigator?.clipboard) {
-                                    navigator.clipboard.writeText(String(e.value));
-                                    message.success(
-                                        <span>
-                                            Copied value of <span className="codeBox">{e.name}</span>
+                                navigator.clipboard.writeText(String(e.value)).then(() => {
+                                    toast({
+                                        status: 'success',
+                                        description: <span>
+                                             Copied value of <span className="codeBox">{e.name}</span>
                                         </span>,
-                                        0.8
-                                    );
-                                }
+                                        duration: 800
+                                    })
+                                })
                             }
                         }}
                         {...restProps}

--- a/frontend/src/components/misc/KowlJsonView.tsx
+++ b/frontend/src/components/misc/KowlJsonView.tsx
@@ -14,6 +14,7 @@ import React, { useEffect } from 'react';
 import JsonView, { ReactJsonViewProps } from '@textea/json-viewer';
 import { uiSettings } from '../../state/ui';
 import { Tooltip, useDisclosure, useToast } from '@redpanda-data/ui';
+import { navigatorClipboardErrorHandler } from '../../utils/tsxUtils';
 const { setTimeout } = window;
 
 let ctrlDown = false;
@@ -141,7 +142,7 @@ export const KowlJsonView = observer((props: ReactJsonViewProps) => {
                                         </span>,
                                         duration: 800
                                     })
-                                })
+                                }).catch(navigatorClipboardErrorHandler)
                             }
                         }}
                         {...restProps}

--- a/frontend/src/components/misc/UserPreferences.tsx
+++ b/frontend/src/components/misc/UserPreferences.tsx
@@ -233,23 +233,21 @@ const ImportExportTab: FC = observer(() => {
         </Label>
 
         <Label text="Reset">
-            <>
-                <div>
-                    <Input style={{ maxWidth: '360px', marginRight: '8px', fontFamily: 'monospace', fontSize: '0.85em' }} spellCheck={false}
-                           placeholder='type "reset" here to confirm and enable the button'
-                           value={$state.resetConfirm}
-                           onChange={str => $state.resetConfirm = str.target.value} />
-                    <Button onClick={() => {
-                        clearSettings();
-                        toast({
-                            status: 'success',
-                            description: 'All settings have been reset to their defaults'
-                        });
-                        $state.resetConfirm = '';
-                    }} colorScheme="red" isDisabled={$state.resetConfirm !== 'reset'}>Reset</Button>
-                </div>
-                <span className="smallText">Clear all your user settings, resetting them to the default values</span>
-            </>
+            <div>
+                <Input style={{maxWidth: '360px', marginRight: '8px', fontFamily: 'monospace', fontSize: '0.85em'}} spellCheck={false}
+                       placeholder='type "reset" here to confirm and enable the button'
+                       value={$state.resetConfirm}
+                       onChange={str => $state.resetConfirm = str.target.value}/>
+                <Button onClick={() => {
+                    clearSettings();
+                    toast({
+                        status: 'success',
+                        description: 'All settings have been reset to their defaults'
+                    });
+                    $state.resetConfirm = '';
+                }} colorScheme="red" isDisabled={$state.resetConfirm !== 'reset'}>Reset</Button>
+            </div>
+            <span className="smallText">Clear all your user settings, resetting them to the default values</span>
         </Label>
     </>;
 })

--- a/frontend/src/components/misc/UserPreferences.tsx
+++ b/frontend/src/components/misc/UserPreferences.tsx
@@ -13,7 +13,7 @@ import { Component, FC } from 'react';
 import { observer, useLocalObservable } from 'mobx-react';
 import { Menu, Modal, Input, InputNumber } from 'antd';
 import { clearSettings, uiSettings } from '../../state/ui';
-import { Label } from '../../utils/tsxUtils';
+import { Label, navigatorClipboardErrorHandler } from '../../utils/tsxUtils';
 import { makeObservable, observable, transaction } from 'mobx';
 import { ToolsIcon } from '@primer/octicons-react';
 import { Button, Checkbox, Flex, IconButton, useToast } from '@redpanda-data/ui';
@@ -220,20 +220,14 @@ const ImportExportTab: FC = observer(() => {
                         status: 'success',
                         description: 'Preferences copied to clipboard!'
                     })
-                }).catch((e) => {
-                    toast({
-                        status: 'error',
-                        description: 'Unable to copy settings to clipboard. See console for more information.'
-                    });
-                    console.error('unable to copy settings to clipboard', {error: e});
-                })
+                }).catch(navigatorClipboardErrorHandler)
             }}>
                 Export User Preferences
             </Button>
         </Label>
 
         <Label text="Reset">
-            <div>
+            <>
                 <Input style={{maxWidth: '360px', marginRight: '8px', fontFamily: 'monospace', fontSize: '0.85em'}} spellCheck={false}
                        placeholder='type "reset" here to confirm and enable the button'
                        value={$state.resetConfirm}
@@ -246,8 +240,8 @@ const ImportExportTab: FC = observer(() => {
                     });
                     $state.resetConfirm = '';
                 }} colorScheme="red" isDisabled={$state.resetConfirm !== 'reset'}>Reset</Button>
-            </div>
-            <span className="smallText">Clear all your user settings, resetting them to the default values</span>
+                <span className="smallText">Clear all your user settings, resetting them to the default values</span>
+            </>
         </Label>
     </>;
 })

--- a/frontend/src/components/pages/acls/Acl.List.tsx
+++ b/frontend/src/components/pages/acls/Acl.List.tsx
@@ -114,7 +114,7 @@ class AclList extends PageComponent {
                             await api.deleteServiceAccount(record.principalName);
                             toast({
                                 status: 'success',
-                                description: <span>Deleted user <Code>{record.principalName}</Code></span>
+                                description: <Text as="span">Deleted user <Code>{record.principalName}</Code></Text>
                             });
                         } catch (err: unknown) {
                             console.error('failed to delete acls', { error: err });

--- a/frontend/src/components/pages/acls/Acl.List.tsx
+++ b/frontend/src/components/pages/acls/Acl.List.tsx
@@ -10,7 +10,7 @@
  */
 
 import { observer } from 'mobx-react';
-import { Empty, Input, message, Dropdown, Menu, Modal } from 'antd';
+import { Empty, Input, Dropdown, Menu, Modal } from 'antd';
 import { PageComponent, PageInitHelper } from '../Page';
 import { api } from '../../../state/backendApi';
 import { uiSettings } from '../../../state/ui';
@@ -30,7 +30,16 @@ import PageContent from '../../misc/PageContent';
 import createAutoModal from '../../../utils/createAutoModal';
 import { CreateServiceAccountEditor, generatePassword } from './CreateServiceAccountEditor';
 import { Features } from '../../../state/supportedFeatures';
-import { Alert, AlertIcon, Badge, Button, Icon, SearchField, Tooltip } from '@redpanda-data/ui';
+import { Alert, AlertIcon, Badge, Button, createStandaloneToast, Icon, redpandaToastOptions, SearchField, Tooltip } from '@redpanda-data/ui';
+
+// TODO - once AclList is migrated to FC, we could should move this code to use useToast()
+const { ToastContainer, toast } = createStandaloneToast({
+    defaultOptions: {
+        ...redpandaToastOptions.defaultOptions,
+        isClosable: false,
+        duration: 2000
+    }
+})
 
 @observer
 class AclList extends PageComponent {
@@ -86,7 +95,10 @@ class AclList extends PageComponent {
                                 operation: 'Any',
                                 permissionType: 'Any',
                             });
-                            message.success(<>Deleted ACLs for <Code>{record.principalName}</Code></>);
+                            toast({
+                                status: 'success',
+                                description: <>Deleted ACLs for <Code>{record.principalName}</Code></>
+                            });
                         } catch (err: unknown) {
                             console.error('failed to delete acls', { error: err });
 
@@ -100,7 +112,10 @@ class AclList extends PageComponent {
                     if (user) {
                         try {
                             await api.deleteServiceAccount(record.principalName);
-                            message.success(<>Deleted user <Code>{record.principalName}</Code></>);
+                            toast({
+                                status: 'success',
+                                description: <span>Deleted user <Code>{record.principalName}</Code></span>
+                            });
                         } catch (err: unknown) {
                             console.error('failed to delete acls', { error: err });
 
@@ -254,6 +269,7 @@ class AclList extends PageComponent {
         const groups = this.principalGroups;
 
         return <>
+            <ToastContainer />
             <PageContent>
 
                 {this.edittingPrincipalGroup &&

--- a/frontend/src/components/pages/acls/Acl.List.tsx
+++ b/frontend/src/components/pages/acls/Acl.List.tsx
@@ -30,7 +30,7 @@ import PageContent from '../../misc/PageContent';
 import createAutoModal from '../../../utils/createAutoModal';
 import { CreateServiceAccountEditor, generatePassword } from './CreateServiceAccountEditor';
 import { Features } from '../../../state/supportedFeatures';
-import { Alert, AlertIcon, Badge, Button, createStandaloneToast, Icon, redpandaToastOptions, SearchField, Tooltip } from '@redpanda-data/ui';
+import { Alert, Text, AlertIcon, Badge, Button, createStandaloneToast, Icon, redpandaToastOptions, SearchField, Tooltip } from '@redpanda-data/ui';
 
 // TODO - once AclList is migrated to FC, we could should move this code to use useToast()
 const { ToastContainer, toast } = createStandaloneToast({
@@ -97,7 +97,7 @@ class AclList extends PageComponent {
                             });
                             toast({
                                 status: 'success',
-                                description: <>Deleted ACLs for <Code>{record.principalName}</Code></>
+                                description: <Text as="span">Deleted ACLs for <Code>{record.principalName}</Code></Text>
                             });
                         } catch (err: unknown) {
                             console.error('failed to delete acls', { error: err });

--- a/frontend/src/components/pages/acls/PrincipalGroupEditor.tsx
+++ b/frontend/src/components/pages/acls/PrincipalGroupEditor.tsx
@@ -20,7 +20,7 @@ import { Code, Label, LabelTooltip } from '../../../utils/tsxUtils';
 import { HiOutlineTrash } from 'react-icons/hi';
 import { AclPrincipalGroup, createEmptyConsumerGroupAcl, createEmptyTopicAcl, createEmptyTransactionalIdAcl, ResourceACLs, unpackPrincipalGroup } from './Models';
 import { Operation } from './Operation';
-import { Button, Icon, Input, InputGroup, useToast } from '@redpanda-data/ui';
+import { Button, Icon, Text, Input, InputGroup, useToast } from '@redpanda-data/ui';
 const { Option } = Select;
 
 
@@ -101,16 +101,16 @@ export const AclPrincipalGroupEditor = observer((p: {
                 if (p.type == 'create') {
                     toast({
                         status: 'success',
-                        description: <span>
+                        description: <Text as="span">
                             Created ACLs for principal <Code>{group.principalName}</Code>
-                        </span>
+                        </Text>
                     });
                 } else {
                     toast({
                         status: 'success',
-                        description: <span>
+                        description: <Text as="span">
                             Updated ACLs for principal <Code>{group.principalName}</Code>
-                        </span>
+                        </Text>
                     });
                 }
 

--- a/frontend/src/components/pages/acls/PrincipalGroupEditor.tsx
+++ b/frontend/src/components/pages/acls/PrincipalGroupEditor.tsx
@@ -11,7 +11,7 @@
 
 import { useState } from 'react';
 import { observer } from 'mobx-react';
-import { Select, Modal, AutoComplete, message } from 'antd';
+import { Select, Modal, AutoComplete } from 'antd';
 import { api } from '../../../state/backendApi';
 import { AclOperation, AclStrOperation, AclStrResourceType } from '../../../state/restInterfaces';
 import { AnimatePresence, animProps_radioOptionGroup, MotionDiv } from '../../../utils/animationProps';
@@ -20,7 +20,7 @@ import { Code, Label, LabelTooltip } from '../../../utils/tsxUtils';
 import { HiOutlineTrash } from 'react-icons/hi';
 import { AclPrincipalGroup, createEmptyConsumerGroupAcl, createEmptyTopicAcl, createEmptyTransactionalIdAcl, ResourceACLs, unpackPrincipalGroup } from './Models';
 import { Operation } from './Operation';
-import { Button, Icon, Input, InputGroup } from '@redpanda-data/ui';
+import { Button, Icon, Input, InputGroup, useToast } from '@redpanda-data/ui';
 const { Option } = Select;
 
 
@@ -30,6 +30,7 @@ export const AclPrincipalGroupEditor = observer((p: {
     onClose: () => void
 }) => {
     const group = p.principalGroup;
+    const toast = useToast()
 
     const existingPrincipals: string[] = [];
     const principalOptions = existingPrincipals.map(p => ({ value: p }));
@@ -97,18 +98,21 @@ export const AclPrincipalGroupEditor = observer((p: {
                     return;
                 }
 
-                if (p.type == 'create')
-                    message.success(
-                        <>
+                if (p.type == 'create') {
+                    toast({
+                        status: 'success',
+                        description: <span>
                             Created ACLs for principal <Code>{group.principalName}</Code>
-                        </>
-                    );
-                else
-                    message.success(
-                        <>
+                        </span>
+                    });
+                } else {
+                    toast({
+                        status: 'success',
+                        description: <span>
                             Updated ACLs for principal <Code>{group.principalName}</Code>
-                        </>
-                    );
+                        </span>
+                    });
+                }
 
                 setIsLoading(false);
                 p.onClose();

--- a/frontend/src/components/pages/connect/CreateConnector.tsx
+++ b/frontend/src/components/pages/connect/CreateConnector.tsx
@@ -11,7 +11,6 @@
 
 import React, { useEffect, useState } from 'react';
 import { comparer } from 'mobx';
-import { message } from 'antd';
 import { PageComponent, PageInitHelper } from '../Page';
 import { ApiOutlined, DatabaseOutlined, SearchOutlined } from '@ant-design/icons';
 import { Wizard, WizardStep } from '../../misc/Wizard';
@@ -27,7 +26,7 @@ import { ConfigPage } from './dynamic-ui/components';
 import KowlEditor from '../../misc/KowlEditor';
 import PageContent from '../../misc/PageContent';
 import { ConnectClusterStore, ConnectorValidationError } from '../../../state/connect/state';
-import { Flex, Text, Tabs, Link, SearchField, Box, Heading, Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, Spinner } from '@redpanda-data/ui';
+import { Flex, Text, Tabs, Link, SearchField, Box, Heading, Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, Spinner, useToast } from '@redpanda-data/ui';
 import { findConnectorMetadata } from './helper';
 import { containsIgnoreCase, delay, TimeSince } from '../../../utils/utils';
 import { useDisclosure } from '@chakra-ui/react-use-disclosure';
@@ -222,6 +221,7 @@ interface ConnectorWizardProps {
 }
 
 const ConnectorWizard = observer(({ connectClusters, activeCluster }: ConnectorWizardProps) => {
+    const toast = useToast()
     const history = appGlobal.history;
     const [currentStep, setCurrentStep] = useState(0);
     const [selectedPlugin, setSelectedPlugin] = useState<ConnectorPlugin | null>(null);
@@ -393,7 +393,10 @@ const ConnectorWizard = observer(({ connectClusters, activeCluster }: ConnectorW
 
                         await delay(intervalSec);
                     }
-                    message.success({ content: `Connector ${connectorName} created` });
+                    toast({
+                        status: 'success',
+                        description: `Connector ${connectorName} created`}
+                    );
 
                 } catch (e: any) {
                     switch (e?.name) {

--- a/frontend/src/components/pages/reassign-partitions/components/ActiveReassignments.tsx
+++ b/frontend/src/components/pages/reassign-partitions/components/ActiveReassignments.tsx
@@ -464,6 +464,7 @@ export class ReassignmentDetailsDialog extends Component<{ state: ReassignmentSt
 
         const partitions = state.partitions.map(p => p.partitionId);
 
+        // TODO Toast to be migrated with a dialog
         const msg = new Message(`Cancelling reassignment of '${state.topicName}'...`);
         try {
             const cancelRequest = {

--- a/frontend/src/components/pages/reassign-partitions/components/ActiveReassignments.tsx
+++ b/frontend/src/components/pages/reassign-partitions/components/ActiveReassignments.tsx
@@ -169,7 +169,6 @@ export const ThrottleDialog: FC<{ visible: boolean, lastKnownMinThrottle: number
     const noChange = ($state.newThrottleValue === lastKnownMinThrottle)
         || ($state.newThrottleValue == null);
 
-    // console.log('nochange:', { noChange, newVal: this.newThrottleValue, lastKnown: this.props.lastKnownMinThrottle })
 
     const applyBandwidthThrottle = async () => {
         toastRef.current = toast({

--- a/frontend/src/components/pages/schemas/Schema.Details.tsx
+++ b/frontend/src/components/pages/schemas/Schema.Details.tsx
@@ -15,7 +15,7 @@ import { observer } from 'mobx-react';
 import { appGlobal } from '../../../state/appGlobal';
 import { api } from '../../../state/backendApi';
 import { PageComponent, PageInitHelper } from '../Page';
-import { DefaultSkeleton, Label, OptionGroup, toSafeString } from '../../../utils/tsxUtils';
+import { DefaultSkeleton, Label, navigatorClipboardErrorHandler, OptionGroup, toSafeString } from '../../../utils/tsxUtils';
 import { KowlJsonView } from '../../misc/KowlJsonView';
 import { JsonField, JsonFieldType, JsonSchema, Schema, SchemaField, SchemaType } from '../../../state/restInterfaces';
 import { uiSettings } from '../../../state/ui';
@@ -239,7 +239,7 @@ class SchemaDetailsView extends PageComponent<{ subjectName: string }> {
                                             onClick={() => {
                                                 navigator.clipboard.writeText(rawSchema).then(() => {
                                                     toast({status: 'success', description: 'Schema copied to clipboard', duration: 1200});
-                                                })
+                                                }).catch(navigatorClipboardErrorHandler)
                                             }}
                                         >
                                             <Icon as={AiOutlineCopy} color="#555" width="18px"/>

--- a/frontend/src/components/pages/schemas/Schema.Details.tsx
+++ b/frontend/src/components/pages/schemas/Schema.Details.tsx
@@ -10,7 +10,7 @@
  */
 
 import React from 'react';
-import { message, Select, Table } from 'antd';
+import { Select, Table } from 'antd';
 import { observer } from 'mobx-react';
 import { appGlobal } from '../../../state/appGlobal';
 import { api } from '../../../state/backendApi';
@@ -25,7 +25,7 @@ import Section from '../../misc/Section';
 import PageContent from '../../misc/PageContent';
 import { makeObservable, observable } from 'mobx';
 import { editQuery } from '../../../utils/queryHelper';
-import { Button, Flex, Icon, Tag, Tooltip } from '@redpanda-data/ui';
+import { Button, createStandaloneToast, Flex, Icon, redpandaToastOptions, Tag, Tooltip } from '@redpanda-data/ui';
 import { AiOutlineCopy } from 'react-icons/ai';
 import { Statistic } from '../../misc/Statistic';
 
@@ -86,6 +86,11 @@ function convertJsonField(name: string, field: JsonField): SchemaField {
         type: field.type,
     };
 }
+
+// TODO - once SchemaDetailsView is migrated to FC, we could should move this code to use useToast()
+const { ToastContainer, toast } = createStandaloneToast({
+    defaultOptions: redpandaToastOptions.defaultOptions
+})
 
 @observer
 class SchemaDetailsView extends PageComponent<{ subjectName: string }> {
@@ -166,121 +171,125 @@ class SchemaDetailsView extends PageComponent<{ subjectName: string }> {
         const defaultVersion = queryVersion ?? (versions.length > 0 ? versions[versions.length - 1] : 'latest');
 
         return (
-            <PageContent key="b">
-                <Section py={4}>
-                    <Flex>
-                        <Statistic title="Type" value={schemaType}></Statistic>
-                        <Statistic title="Subject" value={this.subjectNameRaw}></Statistic>
-                        <Statistic title="Schema ID" value={schemaId}></Statistic>
-                        <Statistic title="Version" value={version}></Statistic>
-                        <Statistic title="Compatibility" value={<span style={{ textTransform: 'capitalize' }}>{compatibility.toLowerCase()}</span>}></Statistic>
-                    </Flex>
-                </Section>
+            <>
+                <ToastContainer/>
+                <PageContent key="b">
+                    <Section py={4}>
+                        <Flex>
+                            <Statistic title="Type" value={schemaType}></Statistic>
+                            <Statistic title="Subject" value={this.subjectNameRaw}></Statistic>
+                            <Statistic title="Schema ID" value={schemaId}></Statistic>
+                            <Statistic title="Version" value={version}></Statistic>
+                            <Statistic title="Compatibility" value={<span style={{textTransform: 'capitalize'}}>{compatibility.toLowerCase()}</span>}></Statistic>
+                        </Flex>
+                    </Section>
 
-                <Section>
-                    <div style={{ display: 'flex', alignItems: 'flex-start', columnGap: '1.5em', marginBottom: '1em' }}>
-                        <Label text="Version">
-                            <Select style={{ minWidth: '200px' }}
-                                defaultValue={defaultVersion}
-                                onChange={(version) => {
-                                    this.version = version as 'latest' | number;
-                                    this.refreshData(true);
-                                    editQuery(x => {
-                                        x.version = String(this.version);
-                                    });
-                                }}
-                                disabled={versions.length == 0}
-                            >
-                                {versions.map(v => <Select.Option value={v} key={v}>Version {v} {v == versions[versions.length - 1] ? '(latest)' : null}</Select.Option>)}
-                            </Select>
-                        </Label>
-
-                        <Label text="Details" style={{ alignSelf: 'stretch' }}>
-                            <div style={{ display: 'inline-flex', flexWrap: 'wrap', minHeight: '32px', alignItems: 'center', rowGap: '.3em' }}>
-                                {Object.entries({
-                                    'Type': type,
-                                    'Name': name,
-                                    'Namespace': namespace,
-                                }).map(([k, v]) => {
-                                    if (!k || v === undefined || v === null) return null;
-                                    return <Tag key={k}><span style={{ color: '#2d5b86' }}>{k}:</span> {toSafeString(v)}</Tag>
-                                })}
-                                {!!doc && <a href={doc}>
-                                    <Tag style={{ cursor: 'pointer' }}><span style={{ color: '#2d5b86' }}>Documentation:</span> <a style={{ textDecoration: 'underline' }} href={doc}>{doc}</a></Tag>
-                                </a>}
-                            </div>
-
-                        </Label>
-                    </div>
-
-                    <div style={{ marginBottom: '1.5em', display: 'flex', gap: '1em' }}>
-                        <OptionGroup label=""
-                            options={{
-                                'Show Fields': 'fields',
-                                'Show JSON': 'json',
-                            }}
-                            value={uiSettings.schemaDetails.viewMode}
-                            onChange={s => uiSettings.schemaDetails.viewMode = s}
-                        />
-
-                        <NoClipboardPopover placement="top">
-                            <div>
-                                {' '}
-                                {/* the additional div is necessary because popovers do not trigger on disabled elements, even on hover */}
-                                <Tooltip label="Copy raw JSON to clipboard" placement="top" hasArrow={true} isDisabled={!isClipboardAvailable}>
-                                    <Button
-                                        isDisabled={!isClipboardAvailable}
-                                        onClick={() => {
-                                            navigator.clipboard.writeText(rawSchema);
-                                            message.success('Schema copied to clipboard', 1.2);
+                    <Section>
+                        <div style={{display: 'flex', alignItems: 'flex-start', columnGap: '1.5em', marginBottom: '1em'}}>
+                            <Label text="Version">
+                                <Select style={{minWidth: '200px'}}
+                                        defaultValue={defaultVersion}
+                                        onChange={(version) => {
+                                            this.version = version as 'latest' | number;
+                                            this.refreshData(true);
+                                            editQuery(x => {
+                                                x.version = String(this.version);
+                                            });
                                         }}
-                                    >
-                                        <Icon as={AiOutlineCopy} color="#555" width="18px" />
-                                    </Button>
-                                </Tooltip>
-                            </div>
-                        </NoClipboardPopover>
+                                        disabled={versions.length == 0}
+                                >
+                                    {versions.map(v => <Select.Option value={v} key={v}>Version {v} {v == versions[versions.length - 1] ? '(latest)' : null}</Select.Option>)}
+                                </Select>
+                            </Label>
 
-                    </div>
+                            <Label text="Details" style={{alignSelf: 'stretch'}}>
+                                <div style={{display: 'inline-flex', flexWrap: 'wrap', minHeight: '32px', alignItems: 'center', rowGap: '.3em'}}>
+                                    {Object.entries({
+                                        'Type': type,
+                                        'Name': name,
+                                        'Namespace': namespace,
+                                    }).map(([k, v]) => {
+                                        if (!k || v === undefined || v === null) return null;
+                                        return <Tag key={k}><span style={{color: '#2d5b86'}}>{k}:</span> {toSafeString(v)}</Tag>
+                                    })}
+                                    {!!doc && <a href={doc}>
+                                        <Tag style={{cursor: 'pointer'}}><span style={{color: '#2d5b86'}}>Documentation:</span> <a style={{textDecoration: 'underline'}} href={doc}>{doc}</a></Tag>
+                                    </a>}
+                                </div>
 
-                    <div>
-                        {uiSettings.schemaDetails.viewMode == 'json' &&
-                            <KowlJsonView
-                                shouldCollapse={false}
-                                collapsed={false}
-                                src={jsonViewObject}
-                                style={{
-                                    border: 'solid thin lightgray',
-                                    borderRadius: '.25em',
-                                    padding: '1em 1em 1em 2em',
-                                    marginBottom: '1.5rem',
-                                }}
+                            </Label>
+                        </div>
+
+                        <div style={{marginBottom: '1.5em', display: 'flex', gap: '1em'}}>
+                            <OptionGroup label=""
+                                         options={{
+                                             'Show Fields': 'fields',
+                                             'Show JSON': 'json',
+                                         }}
+                                         value={uiSettings.schemaDetails.viewMode}
+                                         onChange={s => uiSettings.schemaDetails.viewMode = s}
                             />
-                        }
 
-                        {uiSettings.schemaDetails.viewMode == 'fields' &&
-                            <Table
-                                size="small"
-                                columns={[
-                                    { title: 'Name', dataIndex: 'name', className: 'whiteSpaceDefault', }, // sorter: sortField('name')
-                                    { title: 'Type', dataIndex: 'type', className: 'whiteSpaceDefault', render: renderSchemaType }, //  sorter: sortField('type'),
-                                    { title: 'Default', dataIndex: 'default', className: 'whiteSpaceDefault' },
-                                    { title: 'Documentation', dataIndex: 'doc', className: 'whiteSpaceDefault' },
-                                ]}
-                                rowKey="name"
-                                dataSource={fields}
-                                pagination={false}
-                                style={{
-                                    maxWidth: '100%',
-                                    marginTop: '1.5rem',
-                                    marginBottom: '1.5rem',
-                                }}
-                            />
-                        }
+                            <NoClipboardPopover placement="top">
+                                <div>
+                                    {' '}
+                                    {/* the additional div is necessary because popovers do not trigger on disabled elements, even on hover */}
+                                    <Tooltip label="Copy raw JSON to clipboard" placement="top" hasArrow={true} isDisabled={!isClipboardAvailable}>
+                                        <Button
+                                            isDisabled={!isClipboardAvailable}
+                                            onClick={() => {
+                                                navigator.clipboard.writeText(rawSchema).then(() => {
+                                                    toast({status: 'success', description: 'Schema copied to clipboard', duration: 1200});
+                                                })
+                                            }}
+                                        >
+                                            <Icon as={AiOutlineCopy} color="#555" width="18px"/>
+                                        </Button>
+                                    </Tooltip>
+                                </div>
+                            </NoClipboardPopover>
 
-                    </div>
-                </Section>
-            </PageContent>
+                        </div>
+
+                        <div>
+                            {uiSettings.schemaDetails.viewMode == 'json' &&
+                                <KowlJsonView
+                                    shouldCollapse={false}
+                                    collapsed={false}
+                                    src={jsonViewObject}
+                                    style={{
+                                        border: 'solid thin lightgray',
+                                        borderRadius: '.25em',
+                                        padding: '1em 1em 1em 2em',
+                                        marginBottom: '1.5rem',
+                                    }}
+                                />
+                            }
+
+                            {uiSettings.schemaDetails.viewMode == 'fields' &&
+                                <Table
+                                    size="small"
+                                    columns={[
+                                        {title: 'Name', dataIndex: 'name', className: 'whiteSpaceDefault',}, // sorter: sortField('name')
+                                        {title: 'Type', dataIndex: 'type', className: 'whiteSpaceDefault', render: renderSchemaType}, //  sorter: sortField('type'),
+                                        {title: 'Default', dataIndex: 'default', className: 'whiteSpaceDefault'},
+                                        {title: 'Documentation', dataIndex: 'doc', className: 'whiteSpaceDefault'},
+                                    ]}
+                                    rowKey="name"
+                                    dataSource={fields}
+                                    pagination={false}
+                                    style={{
+                                        maxWidth: '100%',
+                                        marginTop: '1.5rem',
+                                        marginBottom: '1.5rem',
+                                    }}
+                                />
+                            }
+
+                        </div>
+                    </Section>
+                </PageContent>
+            </>
         );
     }
 }

--- a/frontend/src/components/pages/topics/DeleteRecordsModal/DeleteRecordsModal.tsx
+++ b/frontend/src/components/pages/topics/DeleteRecordsModal/DeleteRecordsModal.tsx
@@ -9,8 +9,8 @@
  * by the Apache License, Version 2.0
  */
 
-import { useEffect, useState } from 'react';
-import { Input, Modal, notification, Select, Slider } from 'antd';
+import React, { useEffect, useState } from 'react';
+import { Input, Modal, Select, Slider } from 'antd';
 import { observer } from 'mobx-react';
 import { api } from '../../../../state/backendApi';
 import { DeleteRecordsResponseData, Partition, Topic } from '../../../../state/restInterfaces';
@@ -20,7 +20,7 @@ import { range } from '../../../misc/common';
 
 import styles from './DeleteRecordsModal.module.scss';
 import { KowlTimePicker } from '../../../misc/KowlTimePicker';
-import { Spinner, Alert, AlertIcon } from '@redpanda-data/ui';
+import { Spinner, Alert, AlertIcon, useToast } from '@redpanda-data/ui';
 
 type AllPartitions = 'allPartitions';
 type SpecificPartition = 'specificPartition';
@@ -343,6 +343,7 @@ interface DeleteRecordsModalProps {
 
 export default function DeleteRecordsModal(props: DeleteRecordsModalProps): JSX.Element {
     const { visible, topic, onCancel, onFinish, afterClose } = props;
+    const toast = useToast()
 
     useEffect(() => {
         topic?.topicName && api.refreshPartitionsForTopic(topic.topicName, true);
@@ -379,9 +380,10 @@ export default function DeleteRecordsModal(props: DeleteRecordsModalProps): JSX.
             setOkButtonLoading(false);
         } else {
             onFinish();
-            notification['success']({
-                message: 'Records deleted successfully',
-            });
+            toast({
+                description: 'Records deleted successfully',
+                status: 'success',
+            })
         }
     };
 

--- a/frontend/src/components/pages/topics/Tab.Messages/index.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/index.tsx
@@ -35,7 +35,7 @@ import { FilterableDataSource } from '../../../../utils/filterableDataSource';
 import { sanitizeString, wrapFilterFragment } from '../../../../utils/filterHelper';
 import { toJson } from '../../../../utils/jsonUtils';
 import { editQuery } from '../../../../utils/queryHelper';
-import { Ellipsis, Label, numberToThousandsString, OptionGroup, StatusIndicator, TimestampDisplay, toSafeString } from '../../../../utils/tsxUtils';
+import { Ellipsis, Label, navigatorClipboardErrorHandler, numberToThousandsString, OptionGroup, StatusIndicator, TimestampDisplay, toSafeString } from '../../../../utils/tsxUtils';
 import { cullText, encodeBase64, prettyBytes, prettyMilliseconds, titleCase } from '../../../../utils/utils';
 import { makePaginationConfig, range, sortField } from '../../../misc/common';
 import { KowlJsonView } from '../../../misc/KowlJsonView';
@@ -78,7 +78,7 @@ const CopyDropdown: FC<{ record: TopicMessage, onSaveToFile: Function }> = ({rec
                         status: 'success',
                         description: 'Key copied to clipboard'
                     })
-                })
+                }).catch(navigatorClipboardErrorHandler)
             }}>
                 Copy Key
             </Menu.Item>
@@ -88,7 +88,7 @@ const CopyDropdown: FC<{ record: TopicMessage, onSaveToFile: Function }> = ({rec
                         status: 'success',
                         description: 'Value copied to clipboard'
                     })
-                })
+                }).catch(navigatorClipboardErrorHandler)
             }}>
                 Copy Value
             </Menu.Item>
@@ -98,7 +98,7 @@ const CopyDropdown: FC<{ record: TopicMessage, onSaveToFile: Function }> = ({rec
                         status: 'success',
                         description: 'Epoch Timestamp copied to clipboard'
                     })
-                })
+                }).catch(navigatorClipboardErrorHandler)
             }}>
                 Copy Epoch Timestamp
             </Menu.Item>

--- a/frontend/src/components/pages/topics/Tab.Messages/index.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/index.tsx
@@ -72,7 +72,7 @@ const CopyDropdown: FC<{ record: TopicMessage, onSaveToFile: Function }> = ({rec
     const toast = useToast()
     return (
         <Menu>
-            <Menu.Item key="0" disabled={record.key.isPayloadNull} onClick={() => {
+            <Menu.Item disabled={record.key.isPayloadNull} onClick={() => {
                 navigator.clipboard.writeText(getStringValue(record)).then(() => {
                     toast({
                         status: 'success',
@@ -82,7 +82,7 @@ const CopyDropdown: FC<{ record: TopicMessage, onSaveToFile: Function }> = ({rec
             }}>
                 Copy Key
             </Menu.Item>
-            <Menu.Item key="2" disabled={record.value.isPayloadNull} onClick={() => {
+            <Menu.Item disabled={record.value.isPayloadNull} onClick={() => {
                 navigator.clipboard.writeText(getStringValue(record)).then(() => {
                     toast({
                         status: 'success',
@@ -92,7 +92,7 @@ const CopyDropdown: FC<{ record: TopicMessage, onSaveToFile: Function }> = ({rec
             }}>
                 Copy Value
             </Menu.Item>
-            <Menu.Item key="4" onClick={() => {
+            <Menu.Item onClick={() => {
                 navigator.clipboard.writeText(record.timestamp.toString()).then(() => {
                     toast({
                         status: 'success',
@@ -102,7 +102,7 @@ const CopyDropdown: FC<{ record: TopicMessage, onSaveToFile: Function }> = ({rec
             }}>
                 Copy Epoch Timestamp
             </Menu.Item>
-            <Menu.Item key="5" onClick={() => onSaveToFile()}>
+            <Menu.Item onClick={() => onSaveToFile()}>
                 Save to File
             </Menu.Item>
         </Menu>

--- a/frontend/src/components/pages/topics/Topic.List.tsx
+++ b/frontend/src/components/pages/topics/Topic.List.tsx
@@ -28,7 +28,7 @@ import createAutoModal from '../../../utils/createAutoModal';
 import { CreateTopicModalContent, CreateTopicModalState, RetentionSizeUnit, RetentionTimeUnit } from './CreateTopicModal/CreateTopicModal';
 import Section from '../../misc/Section';
 import PageContent from '../../misc/PageContent';
-import { Button, Icon, Checkbox, Alert, AlertIcon, Flex, Tooltip, Popover, useToast } from '@redpanda-data/ui';
+import { Button, Icon, Text, Checkbox, Alert, AlertIcon, Flex, Tooltip, Popover, useToast } from '@redpanda-data/ui';
 import { HiOutlineTrash } from 'react-icons/hi';
 import { isServerless } from '../../../config';
 import { Statistic } from '../../misc/Statistic';
@@ -340,7 +340,7 @@ function ConfirmDeletionModal({ topicToDelete, onFinish, onCancel }: { topicToDe
 
         toast({
             title: 'Topic Deleted',
-            description: <>Topic <Code>{topicToDelete?.topicName}</Code> deleted successfully</>,
+            description: <Text as="span">Topic <Code>{topicToDelete?.topicName}</Code> deleted successfully</Text>,
             status: 'success',
         })
     };

--- a/frontend/src/components/pages/topics/Topic.List.tsx
+++ b/frontend/src/components/pages/topics/Topic.List.tsx
@@ -10,7 +10,7 @@
  */
 
 import React from 'react';
-import { Modal, notification } from 'antd';
+import { Modal } from 'antd';
 import { autorun, IReactionDisposer, makeObservable, observable } from 'mobx';
 import { observer } from 'mobx-react';
 import { appGlobal } from '../../../state/appGlobal';
@@ -28,7 +28,7 @@ import createAutoModal from '../../../utils/createAutoModal';
 import { CreateTopicModalContent, CreateTopicModalState, RetentionSizeUnit, RetentionTimeUnit } from './CreateTopicModal/CreateTopicModal';
 import Section from '../../misc/Section';
 import PageContent from '../../misc/PageContent';
-import { Button, Icon, Checkbox, Alert, AlertIcon, Flex, Tooltip, Popover } from '@redpanda-data/ui';
+import { Button, Icon, Checkbox, Alert, AlertIcon, Flex, Tooltip, Popover, useToast } from '@redpanda-data/ui';
 import { HiOutlineTrash } from 'react-icons/hi';
 import { isServerless } from '../../../config';
 import { Statistic } from '../../misc/Statistic';
@@ -327,6 +327,7 @@ const renderName = (topic: Topic) => {
 function ConfirmDeletionModal({ topicToDelete, onFinish, onCancel }: { topicToDelete: Topic | null; onFinish: () => void; onCancel: () => void }) {
     const [deletionPending, setDeletionPending] = useState(false);
     const [error, setError] = useState<string | Error | null>(null);
+    const toast = useToast()
 
     const cleanup = () => {
         setDeletionPending(false);
@@ -336,9 +337,12 @@ function ConfirmDeletionModal({ topicToDelete, onFinish, onCancel }: { topicToDe
     const finish = () => {
         onFinish();
         cleanup();
-        notification['success']({
-            message: <>Topic <Code>{topicToDelete?.topicName}</Code> deleted successfully</>,
-        });
+
+        toast({
+            title: 'Topic Deleted',
+            description: <>Topic <Code>{topicToDelete?.topicName}</Code> deleted successfully</>,
+            status: 'success',
+        })
     };
 
     const cancel = () => {

--- a/frontend/src/state/backendApi.ts
+++ b/frontend/src/state/backendApi.ts
@@ -12,7 +12,6 @@
 
 /*eslint block-scoped-var: "error"*/
 
-import { notification } from 'antd';
 import { comparer, computed, observable, transaction } from 'mobx';
 import { AppFeatures, getBasePath } from '../utils/env';
 import fetchWithTimeout from '../utils/fetchWithTimeout';
@@ -50,9 +49,12 @@ import {
 } from './restInterfaces';
 import { uiState } from './uiState';
 import { config as appConfig, isEmbedded } from '../config';
+import { createStandaloneToast } from '@redpanda-data/ui';
 
 const REST_TIMEOUT_SEC = 25;
 export const REST_CACHE_DURATION_SEC = 20;
+
+const { toast } = createStandaloneToast()
 
 /*
     - If statusCode is not 2xx (any sort of error) -> response content will always be an `ApiError` json object
@@ -368,13 +370,12 @@ const apiStore = {
                 case 'error':
                     // error doesn't neccesarily mean the whole request is done
                     console.info('ws backend error: ' + msg.message);
-                    const notificationKey = `errorNotification-${Date.now()}`;
-                    notification['error']({
-                        key: notificationKey,
-                        message: 'Backend Error',
+                    toast({
+                        title: 'Backend Error',
                         description: msg.message,
-                        duration: 5,
+                        status: 'error'
                     });
+
                     break;
 
                 case 'message':

--- a/frontend/src/utils/tsxUtils.tsx
+++ b/frontend/src/utils/tsxUtils.tsx
@@ -562,3 +562,12 @@ export function IconButton(p: { onClick?: React.MouseEventHandler<HTMLElement>; 
         </Tooltip>
     );
 }
+
+
+export const navigatorClipboardErrorHandler = (e: DOMException) => {
+    toast({
+        status: 'error',
+        description: 'Unable to copy settings to clipboard. See console for more information.'
+    });
+    console.error('unable to copy settings to clipboard', {error: e});
+}

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -622,6 +622,11 @@ export function titleCase(str: string): string {
 
 
 type NoticeType = 'info' | 'success' | 'error' | 'warning' | 'loading';
+
+/**
+ * @deprecated - we should use Chakra's useToast instead
+ * This class should be removed together with its usage in the modals.
+ */
 export class Message {
     private key: string;
     private hideFunc: MessageType;


### PR DESCRIPTION
This PR migrates the message and toast component to use Chakra's Toast implementation.

WIP: I'm in a middle of testing, but I think this PR can be already looked at.

- Chakra's Toast is implemented using a hook, so a functional component is required. 
  1. On a couple of places, I've migrated the component to a FC, this needs to be tested
  2. At the same time, I wanted to minimise the number of changes, so on some places I've left React as a component class and left a comment about a future migration. In these cases, I use Chakra's standalone toasts.
  3. A couple of messages are not migrated, because of the problem with Modals. Chakra's toast and Ant design modals doesn't play well together, because of ChakraProvider that kills the toasts on its removal. This will be addressed together with a modal migration.



<img width="1446" alt="Screenshot 2023-09-19 at 7 38 43" src="https://github.com/redpanda-data/console/assets/1083817/4287398f-aa4d-4c98-8fff-e057598c0b94">


There are a couple of "special" places in the platform worth checking out:

-  Using Toast as a loader indicator
 Video:  https://www.loom.com/share/9749918a941b497688c8a0b56ea72258
 Code: https://github.com/redpanda-data/console/pull/846/files#diff-b8d5e9131eed247da5d345f825ecaccfed927cb04939825ae7a8335374bc7819
- Error screen
 Screen: 
<img width="1457" alt="Screenshot 2023-09-19 at 8 00 43" src="https://github.com/redpanda-data/console/assets/1083817/798d2ed5-70ac-4834-93af-fd95a8fa1b7a">

- Updating existing Toast
   https://www.loom.com/share/4127a1ac5c8144a6ad8462a35607af4a?from_recorder=1&focus_title=1
