### PR TITLE
Fix setting importance of MongoDB connectors config options

### DIFF
--- a/backend/pkg/connector/patch/mongo.go
+++ b/backend/pkg/connector/patch/mongo.go
@@ -119,12 +119,12 @@ func (*ConfigPatchMongoDB) PatchDefinition(d model.ConfigDefinition, connectorCl
 		d.SetDefaultValue("mongodb-" + extractType(connectorClass, mongoClassSelectorRegexp) + "-connector-" + strings.ToLower(random.String(4)))
 	}
 
-	patchImportance(d)
+	d = patchImportance(d)
 
 	return d
 }
 
-func patchImportance(d model.ConfigDefinition) {
+func patchImportance(d model.ConfigDefinition) model.ConfigDefinition {
 	// Importance Patches
 	switch d.Definition.Name {
 	case "topic.prefix",
@@ -141,6 +141,8 @@ func patchImportance(d model.ConfigDefinition) {
 		"output.schema.value":
 		d.SetImportance(model.ConfigDefinitionImportanceLow)
 	}
+
+	return d
 }
 
 func isSink(connectorClass string) bool {


### PR DESCRIPTION
The importance settings for the MongoDB connectors configs were set inside a method and lost, resulting in some config options missing in the connector creation basic form.
Returning the updated `model.ConfigDefinition` from the method to fix the importance settings.