### PR TITLE
frontend: fix setting to determine when editting config as json is al…

### DIFF
--- a/frontend/src/components/pages/connect/Connector.Details.tsx
+++ b/frontend/src/components/pages/connect/Connector.Details.tsx
@@ -125,7 +125,7 @@ const KafkaConnectorMain = observer(
                         name: 'Configuration',
                         component: <Box mt="8">
                             <Box maxWidth="800px">
-                                <ConfigPage connectorStore={connectorStore} />
+                                <ConfigPage connectorStore={connectorStore} context="EDIT" />
                             </Box>
 
                             {/* Update Config Button */}

--- a/frontend/src/components/pages/connect/CreateConnector.tsx
+++ b/frontend/src/components/pages/connect/CreateConnector.tsx
@@ -301,7 +301,7 @@ const ConnectorWizard = observer(({ connectClusters, activeCluster }: ConnectorW
 
                     {selectedPlugin ? (
                         <Box maxWidth="800px">
-                            <ConfigPage connectorStore={connectClusterStore.getConnector(selectedPlugin.class)} />
+                            <ConfigPage connectorStore={connectClusterStore.getConnector(selectedPlugin.class)} context="CREATE" />
                         </Box>
                     ) : (
                         <div>no cluster or plugin selected</div>

--- a/frontend/src/components/pages/connect/dynamic-ui/components.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/components.tsx
@@ -26,9 +26,10 @@ import { isEmbedded } from '../../../../config';
 
 export interface ConfigPageProps {
     connectorStore: ConnectorPropertiesStore;
+    context: 'CREATE' | 'EDIT';
 }
 
-export const ConfigPage: React.FC<ConfigPageProps> = observer(({ connectorStore }: ConfigPageProps) => {
+export const ConfigPage: React.FC<ConfigPageProps> = observer(({ connectorStore, context }: ConfigPageProps) => {
     if (connectorStore.error)
         return (
             <div>
@@ -93,7 +94,7 @@ export const ConfigPage: React.FC<ConfigPageProps> = observer(({ connectorStore 
                 </>
                 : <>
                     <div style={{ margin: '0 auto 1.5rem' }}>
-                        <ConnectorJsonEditor connectorStore={connectorStore} />
+                        <ConnectorJsonEditor connectorStore={connectorStore} context={context} />
                     </div>
                 </>
             }
@@ -102,7 +103,8 @@ export const ConfigPage: React.FC<ConfigPageProps> = observer(({ connectorStore 
 });
 
 function ConnectorJsonEditor(p: {
-    connectorStore: ConnectorPropertiesStore
+    connectorStore: ConnectorPropertiesStore,
+    context: 'CREATE' | 'EDIT'
 }) {
     const connectorStore = p.connectorStore;
 
@@ -150,7 +152,7 @@ function ConnectorJsonEditor(p: {
             connectorStore.jsonText = x;
         }}
         options={{
-            readOnly: isEmbedded()
+            readOnly: isEmbedded() && p.context == 'EDIT'
         }}
     />
 }


### PR DESCRIPTION
…lowed; now the json editor is only "readonly" when in embedded mode *and* in edit mode (so embedded + in creating context, the json is now edittable)