### PR TITLE
Fix for topic auto creation settings for connectors

### DIFF
--- a/backend/pkg/connector/interceptor/topic_creation_hook.go
+++ b/backend/pkg/connector/interceptor/topic_creation_hook.go
@@ -45,7 +45,7 @@ func KafkaConnectToConsoleTopicCreationHook(response model.ValidationResponse, _
 		Definition: model.ConfigDefinitionKey{
 			Name:          "topic.creation.default.replication.factor",
 			Type:          "LONG",
-			DefaultValue:  "-1",
+			DefaultValue:  "0",
 			Importance:    model.ConfigDefinitionImportanceLow,
 			Required:      false,
 			DisplayName:   "Topic creation replication factor",


### PR DESCRIPTION
When the `topic.creation.default.replication.factor` property value is set to -1, which is the default, the property value is not sent to Kafka Connect. 
This changes a default value for the `topic.creation.default.replication.factor` property to 0, so that the property is not removed by the UI when the value is set to -1.
