### PR TITLE
Migrated Empty component to Chakra

### DIFF
--- a/frontend/src/components/pages/acls/Acl.List.tsx
+++ b/frontend/src/components/pages/acls/Acl.List.tsx
@@ -8,10 +8,9 @@
  * the Business Source License, use of this software will be governed
  * by the Apache License, Version 2.0
  */
-/* eslint-disable */
 
 import { observer } from 'mobx-react';
-import { Empty, Input } from 'antd';
+import { Input } from 'antd';
 import { PageComponent, PageInitHelper } from '../Page';
 import { api } from '../../../state/backendApi';
 import { uiSettings } from '../../../state/ui';
@@ -22,7 +21,7 @@ import { appGlobal } from '../../../state/appGlobal';
 import { Code, DefaultSkeleton } from '../../../utils/tsxUtils';
 import { clone, toJson } from '../../../utils/jsonUtils';
 import { KowlColumnType, KowlTable } from '../../misc/KowlTable';
-import { LockIcon, QuestionIcon } from '@primer/octicons-react';
+import { QuestionIcon } from '@primer/octicons-react';
 import { TrashIcon } from '@heroicons/react/outline';
 import { AclFlat, AclPrincipalGroup, collectClusterAcls, collectConsumerGroupAcls, collectTopicAcls, collectTransactionalIdAcls, createEmptyClusterAcl, createEmptyConsumerGroupAcl, createEmptyTopicAcl, createEmptyTransactionalIdAcl } from './Models';
 import { AclPrincipalGroupEditor } from './PrincipalGroupEditor';
@@ -31,7 +30,7 @@ import PageContent from '../../misc/PageContent';
 import createAutoModal from '../../../utils/createAutoModal';
 import { CreateServiceAccountEditor, generatePassword } from './CreateServiceAccountEditor';
 import { Features } from '../../../state/supportedFeatures';
-import { Alert, AlertDialog, AlertDialogBody, AlertDialogContent, AlertDialogFooter, AlertDialogHeader, AlertDialogOverlay, AlertIcon, Badge, Button, createStandaloneToast, Icon, redpandaToastOptions, SearchField, Tooltip, Text, redpandaTheme, Menu, MenuButton, MenuItem, MenuList } from '@redpanda-data/ui';
+import { Alert, AlertDialog, AlertDialogBody, AlertDialogContent, AlertDialogFooter, AlertDialogHeader, AlertDialogOverlay, AlertIcon, Badge, Button, createStandaloneToast, Icon, redpandaToastOptions, SearchField, Tooltip, Text, redpandaTheme, Menu, MenuButton, MenuItem, MenuList, Result } from '@redpanda-data/ui';
 import React, { FC, useRef } from 'react';
 
 // TODO - once AclList is migrated to FC, we could should move this code to use useToast()
@@ -287,6 +286,7 @@ class AclList extends PageComponent {
 
                 {this.edittingPrincipalGroup &&
                     <AclPrincipalGroupEditor
+                        // @ts-ignore
                         principalGroup={this.edittingPrincipalGroup}
                         type={this.editorType}
                         onClose={() => {
@@ -509,20 +509,19 @@ const AlertDeleteFailed: FC<{ aclFailed: { err: unknown } | null, onClose: () =>
 const PermissionDenied = <>
     <PageContent key="aclNoPerms">
         <Section>
-            <Empty description={null}>
-                <div style={{ marginBottom: '1.5rem' }}>
-                    <h2><span><LockIcon verticalAlign="middle" size={20} /></span> Permission Denied</h2>
-                    <p>
-                        You are not allowed to view this page.
-                        <br />
-                        Contact the administrator if you think this is an error.
-                    </p>
-                </div>
-
-                <a target="_blank" rel="noopener noreferrer" href="https://docs.redpanda.com/docs/manage/console/">
+            <Result
+                title="Permission Denied"
+                status={403}
+                userMessage={<Text>
+                    You are not allowed to view this page.
+                    <br/>
+                    Contact the administrator if you think this is an error.
+                </Text>
+                }
+                extra={<a target="_blank" rel="noopener noreferrer" href="https://docs.redpanda.com/docs/manage/console/">
                     <Button>Redpanda Console documentation</Button>
-                </a>
-            </Empty>
+                </a>}
+            />
         </Section>
     </PageContent>
 </>

--- a/frontend/src/components/pages/connect/helper.tsx
+++ b/frontend/src/components/pages/connect/helper.tsx
@@ -481,7 +481,7 @@ export function NotConfigured() {
     return (
         <PageContent key="b">
             <Section>
-                <VStack>
+                <VStack gap={4}>
                     <Empty description="Not Configured" />
                     <Text textAlign="center">
                         Kafka Connect is not configured in Redpanda Console.

--- a/frontend/src/components/pages/connect/helper.tsx
+++ b/frontend/src/components/pages/connect/helper.tsx
@@ -10,7 +10,7 @@
  */
 
 
-import { Alert, Empty } from 'antd';
+import { Alert } from 'antd';
 import { observer, useLocalObservable } from 'mobx-react';
 import React, { CSSProperties, useRef, useState } from 'react';
 import { api } from '../../../state/backendApi';
@@ -45,7 +45,7 @@ import { CheckCircleTwoTone, ExclamationCircleTwoTone, HourglassTwoTone, PauseCi
 import Section from '../../misc/Section';
 import PageContent from '../../misc/PageContent';
 import { isEmbedded } from '../../../config';
-import { AlertDialog, AlertDialogBody, AlertDialogContent, AlertDialogFooter, AlertDialogHeader, AlertDialogOverlay, Box, Button, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, ModalOverlay, Popover, useToast } from '@redpanda-data/ui';
+import { AlertDialog, AlertDialogBody, AlertDialogContent, AlertDialogFooter, AlertDialogHeader, AlertDialogOverlay, Box, Button, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, ModalOverlay, Popover, useToast, VStack, Text, Empty } from '@redpanda-data/ui';
 import { Statistic } from '../../misc/Statistic';
 
 interface ConnectorMetadata {
@@ -481,21 +481,17 @@ export function NotConfigured() {
     return (
         <PageContent key="b">
             <Section>
-                <Empty description={null}>
-                    <div style={{ marginBottom: '1.5rem' }}>
-                        <h2>Not Configured</h2>
-
-                        <p>
-                            Kafka Connect is not configured in Redpanda Console.
-                            <br />
-                            Setup the connection details to your Kafka Connect cluster in your Redpanda Console config, to view and control all your connectors and tasks.
-                        </p>
-                    </div>
-
+                <VStack>
+                    <Empty description="Not Configured" />
+                    <Text textAlign="center">
+                        Kafka Connect is not configured in Redpanda Console.
+                        <br />
+                        Setup the connection details to your Kafka Connect cluster in your Redpanda Console config, to view and control all your connectors and tasks.
+                    </Text>
                     <a target="_blank" rel="noopener noreferrer" href="https://docs.redpanda.com/docs/manage/console/">
                         <Button variant="solid">Redpanda Console Config Documentation</Button>
                     </a>
-                </Empty>
+                </VStack>
             </Section>
         </PageContent>
     );

--- a/frontend/src/components/pages/consumers/Group.Details.tsx
+++ b/frontend/src/components/pages/consumers/Group.Details.tsx
@@ -10,7 +10,7 @@
  */
 
 import React, { Component } from 'react';
-import { Table, Empty } from 'antd';
+import { Table } from 'antd';
 import { observer } from 'mobx-react';
 
 import { api } from '../../../state/backendApi';
@@ -28,7 +28,7 @@ import { EditOffsetsModal, GroupOffset, DeleteOffsetsModal, GroupDeletingMode } 
 import { ShortNum } from '../../misc/ShortNum';
 import AclList from '../topics/Tab.Acl/AclList';
 import { SkipIcon } from '@primer/octicons-react';
-import { Flex, Section, Tabs, Tag, Tooltip, Popover, Accordion, Text } from '@redpanda-data/ui';
+import { Flex, Section, Tabs, Tag, Tooltip, Popover, Accordion, Text, Empty } from '@redpanda-data/ui';
 import PageContent from '../../misc/PageContent';
 import { Features } from '../../../state/supportedFeatures';
 import { Statistic } from '../../misc/Statistic';
@@ -365,18 +365,11 @@ class GroupByTopics extends Component<{
                 : undefined; // more than one -> collapse
 
         const nullEntries = topicEntries.filter(e => e == null).length;
-        if (topicEntries.length == 0 || topicEntries.length == nullEntries)
+        if (topicEntries.length == 0 || topicEntries.length == nullEntries) {
             return (
-                <Empty
-                    style={{
-                        background: 'radial-gradient(hsl(0deg 0% 100%) 40%, hsl(0deg 0% 97%) 90%)',
-                        borderRadius: '5px',
-                        padding: '1.5em'
-                    }}
-                >
-                    {p.onlyShowPartitionsWithLag ? <span>All {topicEntries.length} topics have been filtered (no lag on any partition).</span> : null}
-                </Empty>
+                <Empty description={p.onlyShowPartitionsWithLag ? <span>All {topicEntries.length} topics have been filtered (no lag on any partition).</span> : 'No data found'}/>
             );
+        }
 
 
         return (
@@ -472,17 +465,9 @@ class GroupByMembers extends Component<{ group: GroupDescription; onlyShowPartit
                 : undefined; // more than one -> collapse
 
         const nullEntries = memberEntries.filter(e => e == null).length;
-        if (memberEntries.length == 0 || memberEntries.length == nullEntries)
-            return (
-                <Empty
-                    style={{
-                        background: 'radial-gradient(hsl(0deg 0% 100%) 40%, hsl(0deg 0% 97%) 90%)',
-                        borderRadius: '5px',
-                        padding: '1.5em'
-                    }}
-                >
-                    {p.onlyShowPartitionsWithLag ? <span>All {memberEntries.length} members have been filtered (no lag on any partition).</span> : null} </Empty>
-            );
+        if (memberEntries.length == 0 || memberEntries.length == nullEntries) {
+            return <Empty description={p.onlyShowPartitionsWithLag ? <span>All {memberEntries.length} members have been filtered (no lag on any partition).</span> : 'No data found'}/>
+        }
 
 
         return (

--- a/frontend/src/components/pages/quotas/Quotas.List.tsx
+++ b/frontend/src/components/pages/quotas/Quotas.List.tsx
@@ -10,7 +10,6 @@
  */
 
 import { observer } from 'mobx-react';
-import { Empty } from 'antd';
 import { PageComponent, PageInitHelper } from '../Page';
 import { api } from '../../../state/backendApi';
 import { uiSettings } from '../../../state/ui';
@@ -19,13 +18,13 @@ import { computed, makeObservable } from 'mobx';
 import { appGlobal } from '../../../state/appGlobal';
 import { DefaultSkeleton } from '../../../utils/tsxUtils';
 import { KowlColumnType, KowlTable } from '../../misc/KowlTable';
-import { LockIcon, SkipIcon } from '@primer/octicons-react';
+import { SkipIcon } from '@primer/octicons-react';
 import { toJson } from '../../../utils/jsonUtils';
 import { prettyBytes, prettyNumber } from '../../../utils/utils';
 import { QuotaType } from '../../../state/restInterfaces';
 import Section from '../../misc/Section';
 import PageContent from '../../misc/PageContent';
-import { Alert, AlertIcon, Button } from '@redpanda-data/ui';
+import { Alert, AlertIcon, Button, Result } from '@redpanda-data/ui';
 
 @observer
 class QuotasList extends PageComponent {
@@ -102,20 +101,17 @@ class QuotasList extends PageComponent {
 const PermissionDenied = <>
     <PageContent key="quotasNoPerms">
         <Section>
-            <Empty description={null}>
-                <div style={{ marginBottom: '1.5rem' }}>
-                    <h2><span><LockIcon verticalAlign="middle" size={20} /></span> Permission Denied</h2>
-                    <p>
-                        You are not allowed to view this page.
-                        <br />
-                        Contact the administrator if you think this is an error.
-                    </p>
-                </div>
-
-                <a target="_blank" rel="noopener noreferrer" href="https://docs.redpanda.com/docs/manage/console/">
+            <Result
+                title="Forbidden"
+                status={403}
+                userMessage={<p>You are not allowed to view this page.
+                    <br/>
+                    Contact the administrator if you think this is an error.</p>
+                }
+                extra={<a target="_blank" rel="noopener noreferrer" href="https://docs.redpanda.com/docs/manage/console/">
                     <Button variant="solid">Redpanda Console documentation for roles and permissions</Button>
-                </a>
-            </Empty>
+                </a>}
+            />
         </Section>
     </PageContent>
 </>

--- a/frontend/src/components/pages/reassign-partitions/Step3.Review.tsx
+++ b/frontend/src/components/pages/reassign-partitions/Step3.Review.tsx
@@ -11,7 +11,7 @@
 
 import { Component } from 'react';
 import { observer } from 'mobx-react';
-import { Empty, Table } from 'antd';
+import { Table } from 'antd';
 import { ColumnProps } from 'antd/lib/table';
 import { api } from '../../../state/backendApi';
 import { makePaginationConfig } from '../../misc/common';
@@ -23,6 +23,7 @@ import { BrokerList } from '../../misc/BrokerList';
 import ReassignPartitions, { PartitionSelection, } from './ReassignPartitions';
 import { uiSettings } from '../../../state/ui';
 import { BandwidthSlider } from './components/BandwidthSlider';
+import { Empty } from '@redpanda-data/ui';
 
 export type PartitionWithMoves = Partition & {
     brokersBefore: number[],

--- a/frontend/src/components/pages/schemas/EditCompatibility.tsx
+++ b/frontend/src/components/pages/schemas/EditCompatibility.tsx
@@ -13,14 +13,12 @@ import { useState } from 'react';
 import { observer } from 'mobx-react';
 import { PageComponent, PageInitHelper } from '../Page';
 import { api } from '../../../state/backendApi';
-import { Empty, } from 'antd';
 import { appGlobal } from '../../../state/appGlobal';
 import { DefaultSkeleton, Button } from '../../../utils/tsxUtils';
 import './Schema.List.scss';
 import Section from '../../misc/Section';
 import PageContent from '../../misc/PageContent';
-import { Box, CodeBlock, Flex, Grid, GridItem, Link, Stack, useToast } from '@redpanda-data/ui';
-import { Text } from '@redpanda-data/ui';
+import { Box, CodeBlock, Empty, Flex, Grid, GridItem, Link, Stack, useToast, VStack, Text } from '@redpanda-data/ui';
 import { Radio, RadioGroup } from '@chakra-ui/react';
 import { SchemaRegistryCompatibilityMode } from '../../../state/restInterfaces';
 import { getFormattedSchemaText, schemaTypeToCodeBlockLanguage } from './Schema.Details';
@@ -29,22 +27,20 @@ function renderNotConfigured() {
     return (
         <PageContent>
             <Section>
-                <Empty description={null}>
-                    <div style={{ marginBottom: '1.5rem' }}>
-                        <h2>Not Configured</h2>
-
-                        <p>
-                            Schema Registry is not configured in Redpanda Console.
-                            <br />
-                            To view all registered schemas, their documentation and their versioned history simply provide the connection credentials in the Redpanda Console config.
-                        </p>
-                    </div>
-
+                <VStack>
+                    <Empty
+                        description="Not Configured"
+                    />
+                    <Text textAlign="center">
+                        Schema Registry is not configured in Redpanda Console.
+                        <br />
+                        To view all registered schemas, their documentation and their versioned history simply provide the connection credentials in the Redpanda Console config.
+                    </Text>
                     {/* todo: fix link once we have a better guide */}
                     <a target="_blank" rel="noopener noreferrer" href="https://docs.redpanda.com/docs/manage/console/">
                         <Button variant="solid">Redpanda Console Config Documentation</Button>
                     </a>
-                </Empty>
+                </VStack>
             </Section>
         </PageContent>
     );

--- a/frontend/src/components/pages/schemas/EditCompatibility.tsx
+++ b/frontend/src/components/pages/schemas/EditCompatibility.tsx
@@ -27,7 +27,7 @@ function renderNotConfigured() {
     return (
         <PageContent>
             <Section>
-                <VStack>
+                <VStack gap={4}>
                     <Empty
                         description="Not Configured"
                     />

--- a/frontend/src/components/pages/schemas/Schema.List.tsx
+++ b/frontend/src/components/pages/schemas/Schema.List.tsx
@@ -55,7 +55,7 @@ function renderNotConfigured() {
     return (
         <PageContent>
             <Section>
-                <VStack>
+                <VStack gap={4}>
                     <Empty description="Not Configured" />
                     <Text textAlign="center">
                         Schema Registry is not configured in Redpanda Console.

--- a/frontend/src/components/pages/schemas/Schema.List.tsx
+++ b/frontend/src/components/pages/schemas/Schema.List.tsx
@@ -13,7 +13,6 @@ import React, { RefObject } from 'react';
 import { observer } from 'mobx-react';
 import { PageComponent, PageInitHelper } from '../Page';
 import { api } from '../../../state/backendApi';
-import { Empty, } from 'antd';
 import { appGlobal } from '../../../state/appGlobal';
 import { sortField } from '../../misc/common';
 import { DefaultSkeleton, InlineSkeleton, Button } from '../../../utils/tsxUtils';
@@ -25,7 +24,7 @@ import { makeObservable, observable } from 'mobx';
 import { KowlTable } from '../../misc/KowlTable';
 import Section from '../../misc/Section';
 import PageContent from '../../misc/PageContent';
-import { Alert, AlertIcon, Checkbox, Divider, Flex, Skeleton } from '@redpanda-data/ui';
+import { Alert, AlertIcon, Checkbox, Divider, Empty, Flex, Skeleton, VStack, Text } from '@redpanda-data/ui';
 import { SmallStat } from '../../misc/SmallStat';
 import { TrashIcon } from '@heroicons/react/outline';
 import { openDeleteModal, openPermanentDeleteModal } from './modals';
@@ -56,22 +55,19 @@ function renderNotConfigured() {
     return (
         <PageContent>
             <Section>
-                <Empty description={null}>
-                    <div style={{ marginBottom: '1.5rem' }}>
-                        <h2>Not Configured</h2>
-
-                        <p>
-                            Schema Registry is not configured in Redpanda Console.
-                            <br />
-                            To view all registered schemas, their documentation and their versioned history simply provide the connection credentials in the Redpanda Console config.
-                        </p>
-                    </div>
+                <VStack>
+                    <Empty description="Not Configured" />
+                    <Text textAlign="center">
+                        Schema Registry is not configured in Redpanda Console.
+                        <br/>
+                        To view all registered schemas, their documentation and their versioned history simply provide the connection credentials in the Redpanda Console config.
+                    </Text>
 
                     {/* todo: fix link once we have a better guide */}
                     <a target="_blank" rel="noopener noreferrer" href="https://docs.redpanda.com/docs/manage/console/">
                         <Button variant="solid">Redpanda Console Config Documentation</Button>
                     </a>
-                </Empty>
+                </VStack>
             </Section>
         </PageContent>
     );

--- a/frontend/src/components/pages/topics/Tab.Config.tsx
+++ b/frontend/src/components/pages/topics/Tab.Config.tsx
@@ -11,7 +11,6 @@
 
 import { Component } from 'react';
 import { ConfigEntryExtended, KafkaError, Topic } from '../../../state/restInterfaces';
-import { Empty, Typography } from 'antd';
 import { observer } from 'mobx-react';
 import { uiSettings } from '../../../state/ui';
 import '../../../utils/arrayExtensions';
@@ -24,9 +23,7 @@ import { computed, makeObservable } from 'mobx';
 import { formatConfigValue } from '../../../utils/formatters/ConfigValueFormatter';
 import colors from '../../../colors';
 import TopicConfigurationEditor from './TopicConfiguration';
-import { Box, Button, Code, CodeBlock, Flex, Result, Tooltip } from '@redpanda-data/ui';
-
-const { Text } = Typography;
+import { Box, Button, Code, CodeBlock, Empty, Flex, Result, Tooltip } from '@redpanda-data/ui';
 
 // todo: can we assume that config values for time and bytes will always be provided in the smallest units?
 // or is it possible we'll get something like 'segment.hours' instead of 'segment.ms'?
@@ -90,15 +87,7 @@ export class TopicConfiguration extends Component<{
 
         if (config === null || config.configEntries.length == 0) {
             // config===null should never happen, so we catch it together with empty
-            const desc = (
-                <>
-                    <Text type="secondary" strong style={{ fontSize: '125%' }}>
-                        No config entries
-                    </Text>
-                    <br />
-                </>
-            );
-            return <Empty description={desc} />;
+            return <Empty description="No config entries" />;
         }
         return null;
     }

--- a/frontend/src/components/pages/topics/Tab.Docu.tsx
+++ b/frontend/src/components/pages/topics/Tab.Docu.tsx
@@ -117,7 +117,7 @@ const errorEmpty = renderDocuError('Empty', <>
 function renderDocuError(title: string, body: JSX.Element) {
     return (
         <motion.div {...animProps} key={'b'} style={{ margin: '2rem 1rem' }}>
-            <VStack>
+            <VStack gap={4}>
                 <Empty
                     description={title}
                 />

--- a/frontend/src/components/pages/topics/Tab.Docu.tsx
+++ b/frontend/src/components/pages/topics/Tab.Docu.tsx
@@ -22,9 +22,8 @@ import { uriTransformer as baseUriTransformer } from 'react-markdown';
 import { DefaultSkeleton } from '../../../utils/tsxUtils';
 import { motion } from 'framer-motion';
 import { animProps } from '../../../utils/animationProps';
-import { Empty } from 'antd';
 import { observer } from 'mobx-react';
-import { Button } from '@redpanda-data/ui';
+import { Button, Empty, VStack } from '@redpanda-data/ui';
 
 
 // Test for link sanitizer
@@ -118,18 +117,15 @@ const errorEmpty = renderDocuError('Empty', <>
 function renderDocuError(title: string, body: JSX.Element) {
     return (
         <motion.div {...animProps} key={'b'} style={{ margin: '2rem 1rem' }}>
-            <Empty description={null}>
-                <div style={{ marginBottom: '1.5rem' }}>
-                    <h2>{title}</h2>
-
-                    {body}
-                </div>
-
-                {/* todo: fix link once we have a better guide */}
+            <VStack>
+                <Empty
+                    description={title}
+                />
+                {body}
                 <a target="_blank" rel="noopener noreferrer" href="https://docs.redpanda.com/docs/manage/console/">
                     <Button variant="solid">Redpanda Console Documentation</Button>
                 </a>
-            </Empty>
+            </VStack>
         </motion.div>
     );
 }

--- a/frontend/src/components/pages/topics/Tab.Messages/index.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/index.tsx
@@ -11,7 +11,7 @@
 
 import { ClockCircleOutlined, DeleteOutlined, DownloadOutlined, SettingFilled, SettingOutlined } from '@ant-design/icons';
 import { DownloadIcon, PlusIcon, SkipIcon, SyncIcon, XCircleIcon, KebabHorizontalIcon } from '@primer/octicons-react';
-import { ConfigProvider, DatePicker, Empty, Radio, Select, Table, Typography } from 'antd';
+import { ConfigProvider, DatePicker, Radio, Select, Table, Typography } from 'antd';
 import { ColumnProps } from 'antd/lib/table';
 import { SortOrder } from 'antd/lib/table/interface';
 import Paragraph from 'antd/lib/typography/Paragraph';
@@ -44,7 +44,7 @@ import { getPreviewTags, PreviewSettings } from './PreviewSettings';
 import styles from './styles.module.scss';
 import createAutoModal from '../../../../utils/createAutoModal';
 import { CollapsedFieldProps } from '@textea/json-viewer';
-import { Alert, AlertIcon, Box, Button, Flex, Input, InputGroup, Menu, MenuButton, MenuItem, MenuList, Modal, ModalBody, ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalOverlay, Popover, SearchField, Switch, Tabs as RpTabs, Tag, TagCloseButton, TagLabel, Text, Tooltip, useToast } from '@redpanda-data/ui';
+import { Alert, AlertIcon, Box, Button, Empty, Flex, Input, InputGroup, Menu, MenuButton, MenuItem, MenuList, Modal, ModalBody, ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalOverlay, Popover, SearchField, Switch, Tabs as RpTabs, Tag, TagCloseButton, TagLabel, Text, Tooltip, useToast, VStack } from '@redpanda-data/ui';
 import { MdExpandMore } from 'react-icons/md';
 import { SingleSelect } from '../../../misc/Select';
 import { isServerless } from '../../../../config';
@@ -658,10 +658,10 @@ export class TopicMessageView extends Component<TopicMessageViewProps> {
         </ul> : null;
 
         return (
-            <Empty description={<>
-                <Typography.Text type="secondary" strong style={{ fontSize: '125%' }}>No messages</Typography.Text>
+            <VStack>
+                <Empty description="No messages" />
                 {hintBox}
-            </>} />
+            </VStack>
         );
     };
 }

--- a/frontend/src/components/pages/topics/Tab.Messages/index.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/index.tsx
@@ -658,7 +658,7 @@ export class TopicMessageView extends Component<TopicMessageViewProps> {
         </ul> : null;
 
         return (
-            <VStack>
+            <VStack gap={4}>
                 <Empty description="No messages" />
                 {hintBox}
             </VStack>


### PR DESCRIPTION
Empty component migrated to Chakra

- In some places where it semantically make sense, we replaced `Empty` with `Result` - especially where backend returns 403.
- Our `Empty` component in `@redpanda-data/ui` doesn't support `extra` and secondary `description`  + it has two modes based on a code so it's not easy to add these params. That's why we solve these usecases with `VStack` for now, and we should re-think refactoring of `Empty` in the future.


<img width="1231" alt="Screenshot 2023-10-15 at 19 27 55" src="https://github.com/redpanda-data/console/assets/1083817/159801c5-1269-4d6d-a262-fcb2b8d225e6">

![Screenshot 2023-10-16 at 9 35 48](https://github.com/redpanda-data/console/assets/1083817/281be80e-cb65-4e56-b9a5-4e6334733055)

![Screenshot 2023-10-16 at 9 35 48](https://github.com/redpanda-data/console/assets/1083817/fea4a10b-3ac6-4f8f-a339-b408f2ea2183)

![Screenshot 2023-10-16 at 9 35 48](https://github.com/redpanda-data/console/assets/1083817/caa46f46-c2fe-4d3f-b1de-51ebbaf5894c)

![Screenshot 2023-10-16 at 9 50 17](https://github.com/redpanda-data/console/assets/1083817/fe5491ff-d1d3-44a6-a321-0376ace94b14)

![Screenshot 2023-10-16 at 10 03 56](https://github.com/redpanda-data/console/assets/1083817/3db56e0c-0570-4535-b642-b97930f17e6d)


Note: We've added a gap for a buttons in a VStack scenario. However, this will be DRYed later during refactor.