### PR TITLE
Remove typo enconding 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://user-images.githubusercontent.com/23424570/220130537-7b0b8596-0a06-4132-
 
 ## Features
 
-- **Message viewer:** Explore your topics' messages in our message viewer through ad-hoc queries and dynamic filters. Find any message you want using JavaScript functions to filter messages. Supported encodings are: JSON, Avro, Protobuf, XML, MessagePack, Text and Binary (hex view). The used enconding (except Protobuf) is recognized automatically.
+- **Message viewer:** Explore your topics' messages in our message viewer through ad-hoc queries and dynamic filters. Find any message you want using JavaScript functions to filter messages. Supported encodings are: JSON, Avro, Protobuf, XML, MessagePack, Text and Binary (hex view). The used encoding (except Protobuf) is recognized automatically.
 - **Consumer groups:** List all your active consumer groups along with their active group offsets, edit group offsets (by group, topic or partition) or delete a consumer group.
 - **Topic overview:** Browse through the list of your Kafka topics, check their configuration, space usage, list all consumers who consume a single topic or watch partition details (such as low and high water marks, message count, ...), embed topic documentation from a git repository and more.
 - **Cluster overview:** List ACLs, available brokers, their space usage, rack id and other information to get a high level overview of your brokers in your cluster.


### PR DESCRIPTION
## Description:
This Pull Request fixes a typographical error in the README.md file.

## Changes Made:
Corrected " enconding " to " encoding " in the README.md file.

## Additional Information:
This fix is not related to any existing issue. It's a minor typo that I noticed while reviewing the README.

Thank you for considering this contribution.