### PR TITLE
Iceberg guide fix

### DIFF
--- a/backend/pkg/connector/guide/iceberg_sink.go
+++ b/backend/pkg/connector/guide/iceberg_sink.go
@@ -19,6 +19,9 @@ func NewIcebergSinkGuide(opts ...Option) Guide {
 	}
 
 	return &WizardGuide{
+		DefaultGuide: DefaultGuide{
+			options: o,
+		},
 		className: "io.tabular.iceberg.connect.IcebergSinkConnector",
 		wizardSteps: []model.ValidationResponseStep{
 			{

--- a/backend/pkg/connector/interceptor/iceberg_sink_hook.go
+++ b/backend/pkg/connector/interceptor/iceberg_sink_hook.go
@@ -8,33 +8,34 @@ import (
 // KafkaConnectToConsoleIcebergSinkHook adds Iceberg sink specific config options
 // missing in Validate Kafka Connect response
 func KafkaConnectToConsoleIcebergSinkHook(response model.ValidationResponse, config map[string]any) model.ValidationResponse {
-	response.Configs = append(response.Configs, model.ConfigDefinition{
-		Definition: model.ConfigDefinitionKey{
-			Name:          "iceberg.catalog.type",
-			Type:          "STRING",
-			DefaultValue:  "",
-			Importance:    model.ConfigDefinitionImportanceHigh,
-			Required:      false,
-			DisplayName:   "Iceberg catalog type",
-			Documentation: "To set the catalog type. For other catalog types, you need to instead set 'iceberg.catalog.catalog-impl' to the name of the catalog class",
-			Dependents:    []string{},
-		},
-		Value: model.ConfigDefinitionValue{
-			Name:              "iceberg.catalog.type",
-			Value:             "rest",
-			RecommendedValues: []string{},
-			Visible:           true,
-			Errors:            []string{},
-		},
-		Metadata: model.ConfigDefinitionMetadata{
-			ComponentType: model.ComponentRadioGroup,
-			RecommendedValues: []model.RecommendedValueWithMetadata{
-				{Value: "rest", DisplayName: "REST"},
-				{Value: "hive", DisplayName: "HIVE"},
-				{Value: "hadoop", DisplayName: "HADOOP"},
+	response.Configs = append(response.Configs,
+		model.ConfigDefinition{
+			Definition: model.ConfigDefinitionKey{
+				Name:          "iceberg.catalog.type",
+				Type:          "STRING",
+				DefaultValue:  "",
+				Importance:    model.ConfigDefinitionImportanceHigh,
+				Required:      false,
+				DisplayName:   "Iceberg catalog type",
+				Documentation: "To set the catalog type. For other catalog types, you need to instead set 'iceberg.catalog.catalog-impl' to the name of the catalog class",
+				Dependents:    []string{},
+			},
+			Value: model.ConfigDefinitionValue{
+				Name:              "iceberg.catalog.type",
+				Value:             "rest",
+				RecommendedValues: []string{},
+				Visible:           true,
+				Errors:            []string{},
+			},
+			Metadata: model.ConfigDefinitionMetadata{
+				ComponentType: model.ComponentRadioGroup,
+				RecommendedValues: []model.RecommendedValueWithMetadata{
+					{Value: "rest", DisplayName: "REST"},
+					{Value: "hive", DisplayName: "HIVE"},
+					{Value: "hadoop", DisplayName: "HADOOP"},
+				},
 			},
 		},
-	},
 		model.ConfigDefinition{
 			Definition: model.ConfigDefinitionKey{
 				Name:          "iceberg.catalog.uri",
@@ -42,8 +43,8 @@ func KafkaConnectToConsoleIcebergSinkHook(response model.ValidationResponse, con
 				DefaultValue:  "",
 				Importance:    model.ConfigDefinitionImportanceHigh,
 				Required:      false,
-				DisplayName:   "Iceberg catalog uri",
-				Documentation: "Iceberg REST catalog uri",
+				DisplayName:   "Iceberg REST catalog URI",
+				Documentation: "Use for Iceberg REST catalog type. Use JSON configuration for other catalog types",
 				Dependents:    []string{},
 			},
 			Value: model.ConfigDefinitionValue{
@@ -183,25 +184,6 @@ func KafkaConnectToConsoleIcebergSinkHook(response model.ValidationResponse, con
 				Value:             "",
 				RecommendedValues: []string{},
 				Visible:           true,
-				Errors:            []string{},
-			},
-		},
-		model.ConfigDefinition{
-			Definition: model.ConfigDefinitionKey{
-				Name:          "iceberg.catalog.uri",
-				Type:          "STRING",
-				DefaultValue:  "",
-				Importance:    model.ConfigDefinitionImportanceHigh,
-				Required:      false,
-				DisplayName:   "Iceberg REST catalog URI",
-				Documentation: "Use for Iceberg REST catalog type. Use JSON configuration for other catalog types",
-				Dependents:    []string{},
-			},
-			Value: model.ConfigDefinitionValue{
-				Name:              "iceberg.catalog.uri",
-				Value:             "",
-				RecommendedValues: []string{},
-				Visible:           isRestCatalogType(response.Configs),
 				Errors:            []string{},
 			},
 		},

--- a/backend/pkg/connector/interceptor/iceberg_sink_hook.go
+++ b/backend/pkg/connector/interceptor/iceberg_sink_hook.go
@@ -5,9 +5,9 @@ import (
 	"github.com/redpanda-data/console/backend/pkg/connector/patch"
 )
 
-// KafkaConnectToConsoleIcebergSinkHook adds Iceberg sink specific config options
+// KafkaConnectValidateToConsoleIcebergSinkHook adds Iceberg sink specific config options
 // missing in Validate Kafka Connect response
-func KafkaConnectToConsoleIcebergSinkHook(response model.ValidationResponse, config map[string]any) model.ValidationResponse {
+func KafkaConnectValidateToConsoleIcebergSinkHook(response model.ValidationResponse, config map[string]any) model.ValidationResponse {
 	response.Configs = append(response.Configs,
 		model.ConfigDefinition{
 			Definition: model.ConfigDefinitionKey{

--- a/backend/pkg/connector/interceptor/interceptor.go
+++ b/backend/pkg/connector/interceptor/interceptor.go
@@ -82,7 +82,7 @@ func CommunityGuides(opts ...guide.Option) []guide.Guide {
 		),
 		guide.NewDebeziumMySQLGuide(guide.WithKafkaConnectValidateToConsoleHookFn(KafkaConnectToConsoleDebeziumMysqlSourceHook),
 			guide.WithKafkaConnectValidateToConsoleHookFn(KafkaConnectToConsoleCloudEventsConverterHook)),
-		guide.NewIcebergSinkGuide(guide.WithKafkaConnectValidateToConsoleHookFn(KafkaConnectToConsoleIcebergSinkHook)),
+		guide.NewIcebergSinkGuide(guide.WithKafkaConnectValidateToConsoleHookFn(KafkaConnectValidateToConsoleIcebergSinkHook)),
 		guide.NewSnowflakeSinkGuide(guide.WithKafkaConnectValidateToConsoleHookFn(KafkaConnectToConsoleSnowflakeHook)),
 		guide.NewBigQuerySinkGuide(guide.WithConsoleToKafkaConnectHookFn(ConsoleToKafkaConnectBigQueryHook),
 			guide.WithKafkaConnectValidateToConsoleHookFn(KafkaConnectToConsoleJSONSchemaHook)),


### PR DESCRIPTION
This fixes missing `iceberg.catalog.*` properties in the Iceberg sink connector guide.