### PR TITLE
Migrates Skeleton component from AntD

### DIFF
--- a/frontend/src/components/pages/connect/Connector.Details.tsx
+++ b/frontend/src/components/pages/connect/Connector.Details.tsx
@@ -9,8 +9,6 @@
  * by the Apache License, Version 2.0
  */
 
-/* eslint-disable no-useless-escape */
-import { Skeleton } from 'antd';
 import { useEffect, useState } from 'react';
 import { observer, useLocalObservable } from 'mobx-react';
 import { comparer } from 'mobx';
@@ -28,7 +26,7 @@ import './helper';
 import { ConfirmModal, NotConfigured, statusColors, TaskState } from './helper';
 import PageContent from '../../misc/PageContent';
 import { delay } from '../../../utils/utils';
-import { Button, Alert, AlertIcon, Box, CodeBlock, Flex, Grid, Heading, Tabs, Text, useDisclosure, Modal as RPModal, ModalOverlay, ModalContent, ModalHeader, ModalCloseButton, ModalBody, ModalFooter, Tooltip } from '@redpanda-data/ui';
+import { Button, Alert, AlertIcon, Box, CodeBlock, Flex, Grid, Heading, Tabs, Text, useDisclosure, Modal as RPModal, ModalOverlay, ModalContent, ModalHeader, ModalCloseButton, ModalBody, ModalFooter, Tooltip, SkeletonText } from '@redpanda-data/ui';
 import Section from '../../misc/Section';
 import React from 'react';
 import { getConnectorFriendlyName } from './ConnectorBoxCard';
@@ -68,12 +66,9 @@ const KafkaConnectorMain = observer(
             restartingTask: null,
             deletingConnector: null,
         }));
-        if (!connectClusterStore.isInitialized)
-            return (
-                <div>
-                    <Skeleton loading={true} active={true} paragraph={{ rows: 20, width: '100%' }} />
-                </div>
-            );
+        if (!connectClusterStore.isInitialized) {
+            return <SkeletonText mt={5} noOfLines={20} spacing={5} skeletonHeight={4} />
+        }
 
         const connectorStore = connectClusterStore.getConnectorStore(connectorName);
 

--- a/frontend/src/components/pages/connect/CreateConnector.tsx
+++ b/frontend/src/components/pages/connect/CreateConnector.tsx
@@ -19,16 +19,34 @@ import { api } from '../../../state/backendApi';
 import { uiState } from '../../../state/uiState';
 import { appGlobal } from '../../../state/appGlobal';
 import { ClusterConnectors, ConnectorValidationResult } from '../../../state/restInterfaces';
-import { Alert, Select, Skeleton, Table } from 'antd';
+import { Alert, Select, Table } from 'antd';
 import { HiddenRadioList } from '../../misc/HiddenRadioList';
 import { ConnectorBoxCard, ConnectorPlugin, getConnectorFriendlyName } from './ConnectorBoxCard';
 import { ConfigPage } from './dynamic-ui/components';
 import KowlEditor from '../../misc/KowlEditor';
 import PageContent from '../../misc/PageContent';
 import { ConnectClusterStore, ConnectorValidationError } from '../../../state/connect/state';
-import { Flex, Text, Tabs, Link, SearchField, Box, Heading, Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, Spinner, useToast, useDisclosure } from '@redpanda-data/ui';
+import {
+    Box,
+    Flex,
+    Heading,
+    Link,
+    Modal,
+    ModalBody,
+    ModalContent,
+    ModalHeader,
+    ModalOverlay,
+    SearchField,
+    SkeletonText,
+    Spinner,
+    Tabs,
+    Text,
+    useDisclosure,
+    useToast
+} from '@redpanda-data/ui';
 import { findConnectorMetadata } from './helper';
 import { containsIgnoreCase, delay, TimeSince } from '../../../utils/utils';
+
 const { Option } = Select;
 
 const ConnectorType = observer(
@@ -423,12 +441,11 @@ const ConnectorWizard = observer(({ connectClusters, activeCluster }: ConnectorW
 
     const isLast = () => currentStep === steps.length - 1;
 
-    if (!connectClusterStore.isInitialized)
+    if (!connectClusterStore.isInitialized) {
         return (
-            <div>
-                <Skeleton loading={true} active={true} paragraph={{ rows: 20, width: '100%' }} />
-            </div>
+            <SkeletonText mt={5} noOfLines={20} spacing={5} skeletonHeight={4} />
         );
+    }
 
     return <>
         <Wizard
@@ -530,9 +547,7 @@ function Review({
             ) : null}
 
             {isCreating ? (
-                <>
-                    <Skeleton loading={true} active={true} paragraph={{ rows: 5, width: '100%' }} style={{ marginTop: 20 }} />
-                </>
+                <SkeletonText mt={5} noOfLines={6} spacing={5} skeletonHeight={4} />
             ) : (
                 <>
                     {invalidValidationResult != null ? <ValidationDisplay validationResult={invalidValidationResult} /> : null}

--- a/frontend/src/components/pages/connect/dynamic-ui/components.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/components.tsx
@@ -9,15 +9,13 @@
  * by the Apache License, Version 2.0
  */
 
-/* eslint-disable no-useless-escape */
-import { Skeleton } from 'antd';
 // import { IsDev } from '../../../../utils/env';
 // import { DebugEditor } from './DebugEditor';
 import { ConnectorPropertiesStore, PropertyGroup } from '../../../../state/connect/state';
 import { observer } from 'mobx-react';
 import { ConnectorStepComponent } from './ConnectorStep';
 import { ConnectorStep } from '../../../../state/restInterfaces';
-import { Box, RadioGroup, Switch } from '@redpanda-data/ui';
+import { Box, RadioGroup, SkeletonText, Switch } from '@redpanda-data/ui';
 import KowlEditor from '../../../misc/KowlEditor';
 import { api } from '../../../../state/backendApi';
 import { clone } from '../../../../utils/jsonUtils';
@@ -38,12 +36,11 @@ export const ConfigPage: React.FC<ConfigPageProps> = observer(({ connectorStore,
             </div>
         );
 
-    if (connectorStore.initPending)
+    if (connectorStore.initPending) {
         return (
-            <div>
-                <Skeleton loading={true} active={true} paragraph={{ rows: 20, width: '100%' }} />
-            </div>
+            <SkeletonText mt={5} noOfLines={20} spacing={5} skeletonHeight={4} />
         );
+    }
 
     if (connectorStore.allGroups.length == 0) return <div>debug: no groups</div>;
 

--- a/frontend/src/components/pages/overview/Overview.tsx
+++ b/frontend/src/components/pages/overview/Overview.tsx
@@ -10,7 +10,6 @@
  */
 
 import { observer } from 'mobx-react';
-import { Skeleton } from 'antd';
 import { PageComponent, PageInitHelper } from '../Page';
 import { api } from '../../../state/backendApi';
 import { uiSettings } from '../../../state/ui';
@@ -25,7 +24,7 @@ import { KowlColumnType, KowlTable } from '../../misc/KowlTable';
 import Section from '../../misc/Section';
 import PageContent from '../../misc/PageContent';
 import './Overview.scss';
-import { Heading, Icon, Link, Button, Flex, Tooltip } from '@redpanda-data/ui';
+import { Button, Flex, Heading, Icon, Link, SkeletonText, Tooltip } from '@redpanda-data/ui';
 import { CheckIcon } from '@primer/octicons-react';
 import { Link as ReactRouterLink } from 'react-router-dom';
 import React from 'react';
@@ -213,20 +212,23 @@ class Overview extends PageComponent {
                             </ul>
 
                             <ul className="resource-list">
-                                {news
-                                    ? news.map((x, i) => <li key={i}>
-                                        <a href={x.url} rel="noopener noreferrer" target="_blank" className="resource-link">
+                                <SkeletonText
+                                    isLoaded={Boolean(news)}
+                                    noOfLines={4}
+                                    spacing={5}
+                                    skeletonHeight={4}
+                                >
+                                    {news?.map((x, i) => <li key={i}>
+                                        <a href={x.url} rel="noopener noreferrer" target="_blank"
+                                           className="resource-link">
                                             <span className="dot">&bull;</span>
                                             <span>
                                                 {x.title}
-                                                <ResourcesBadge type={x.badge} />
+                                                <ResourcesBadge type={x.badge}/>
                                             </span>
                                         </a>
-                                    </li>)
-                                    : <>
-                                        <Skeleton loading={true} active={true} paragraph={{ rows: 3 }} />
-                                    </>
-                                }
+                                    </li>)}
+                                </SkeletonText>
                             </ul>
                         </div>
 
@@ -261,8 +263,10 @@ const ResourcesBadge = (p: { type?: string | undefined }) => {
 function ClusterDetails() {
     const overview = api.clusterOverview;
     const brokers = api.brokers;
-    if (!overview || !brokers)
-        return <Skeleton paragraph={{ rows: 16 }} />
+
+    if (!overview || !brokers) {
+        return <SkeletonText mt={5} noOfLines={13} spacing={5} skeletonHeight={4} speed={0} />
+    }
 
     const totalStorageBytes = brokers.sum(x => x.totalLogDirSizeBytes ?? 0);
     const totalPrimaryStorageBytes = brokers.sum(x => x.totalPrimaryLogDirSizeBytes ?? 0);

--- a/frontend/src/components/pages/reassign-partitions/components/ActiveReassignments.tsx
+++ b/frontend/src/components/pages/reassign-partitions/components/ActiveReassignments.tsx
@@ -10,7 +10,6 @@
  */
 
 import React, { Component, FC, useRef } from 'react';
-import { Skeleton } from 'antd';
 import { ConfigEntry } from '../../../../state/restInterfaces';
 import { api } from '../../../../state/backendApi';
 import { computed, makeObservable, observable } from 'mobx';
@@ -24,7 +23,7 @@ import { reassignmentTracker } from '../ReassignPartitions';
 import { BandwidthSlider } from './BandwidthSlider';
 import { KowlColumnType, KowlTable } from '../../../misc/KowlTable';
 import { BrokerList } from '../../../misc/BrokerList';
-import { Box, Button, Checkbox, createStandaloneToast, Flex, ListItem, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, ModalOverlay, Popover, PopoverCloseButton, PopoverArrow, PopoverContent, PopoverHeader, PopoverTrigger, Progress, redpandaTheme, redpandaToastOptions, Text, ToastId, UnorderedList, useDisclosure, useToast, PopoverFooter, PopoverBody, ButtonGroup } from '@redpanda-data/ui';
+import { Box, Button, Checkbox, createStandaloneToast, Flex, ListItem, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, ModalOverlay, Popover, PopoverCloseButton, PopoverArrow, PopoverContent, PopoverHeader, PopoverTrigger, Progress, redpandaTheme, redpandaToastOptions, Text, ToastId, UnorderedList, useDisclosure, useToast, PopoverFooter, PopoverBody, ButtonGroup, SkeletonText } from '@redpanda-data/ui';
 
 // TODO - once ActiveReassignments is migrated to FC, we could should move this code to use useToast()
 const { ToastContainer, toast } = createStandaloneToast({
@@ -375,7 +374,7 @@ export class ReassignmentDetailsDialog extends Component<{ state: ReassignmentSt
                 {/* Cancel */}
                 <CancelReassignmentButton onConfirm={() => this.cancelReassignment()}/>
             </Flex>
-        ) : <Skeleton loading={true} active={true} paragraph={{ rows: 5 }} />;
+        ) : <SkeletonText mt={5} noOfLines={5} spacing={5} skeletonHeight={4} />
 
         return (
             <Modal isOpen={visible} onClose={this.props.onClose}>

--- a/frontend/src/utils/tsxUtils.tsx
+++ b/frontend/src/utils/tsxUtils.tsx
@@ -12,7 +12,7 @@
 import React, { Component, CSSProperties, ReactNode, useState } from 'react';
 import { toJson } from './jsonUtils';
 import { DebugTimerStore, prettyMilliseconds, simpleUniqueId } from './utils';
-import { Radio, Skeleton } from 'antd';
+import { Radio } from 'antd';
 import { Box, Button as RpButton, ButtonProps as RpButtonProps, createStandaloneToast, Flex, PlacementWithLogical, Progress, redpandaTheme, redpandaToastOptions, Text, ToastId, Tooltip } from '@redpanda-data/ui';
 import { CopyOutlined, DownloadOutlined, QuestionCircleOutlined } from '@ant-design/icons';
 import { TimestampDisplayFormat } from '../state/ui';
@@ -474,7 +474,7 @@ export class ZeroSizeWrapper extends Component<{ width?: string, height?: string
 
 
 const defaultSkeletonStyle = { margin: '2rem' };
-const innerSkeleton = <Skeleton loading={true} active={true} paragraph={{ rows: 8 }} />
+const innerSkeleton = <SkeletonText noOfLines={8} spacing={5} skeletonHeight={4} />
 export const DefaultSkeleton = (
     <motion.div {...animProps} key={'defaultSkeleton'} style={defaultSkeletonStyle}>
         {innerSkeleton}


### PR DESCRIPTION
This PR Migrates `Skeleton` to Chakra's `SkeletonText`. I think the look'n'feel is very similar to the original.

<img width="1444" alt="Screenshot 2023-10-27 at 9 19 35" src="https://github.com/redpanda-data/console/assets/1083817/5f87b801-9823-47dc-b00a-a592115460ee">
<img width="1413" alt="Screenshot 2023-10-27 at 9 19 16" src="https://github.com/redpanda-data/console/assets/1083817/e9194d1c-d062-41f6-9c18-6e7781358b17">

