### PR TITLE
fix msgpack filtering

### DIFF
--- a/backend/pkg/kafka/deserializer.go
+++ b/backend/pkg/kafka/deserializer.go
@@ -289,7 +289,7 @@ func (d *deserializer) deserializePayload(payload []byte, topicName string, reco
 						RecognizedEncoding: messageEncodingMsgP,
 					},
 					IsPayloadNull:      payload == nil,
-					Object:             string(payload),
+					Object:             obj,
 					RecognizedEncoding: messageEncodingMsgP,
 					Size:               len(payload),
 				}


### PR DESCRIPTION
Currently msgpack-encoded message is passed as string into JS VM. So it does not allow filtering by object fields.

This little fix changes msgpack object to be the same as JSON, XML and other encoded messages.