### PR TITLE
Better license expiration warning

### DIFF
--- a/frontend/src/components/layout/Content.tsx
+++ b/frontend/src/components/layout/Content.tsx
@@ -19,6 +19,7 @@ import { ErrorDisplay } from '../misc/ErrorDisplay';
 import { renderErrorModals } from '../misc/ErrorModal';
 import { RouteView } from '../routes';
 import { ModalContainer } from '../../utils/ModalContainer';
+import { Alert, AlertIcon, Box, Flex, Link, Text } from '@redpanda-data/ui';
 
 
 @observer
@@ -62,26 +63,29 @@ class LicenseNotification extends Component {
         });
 
         const warnings = withRemainingTime.filter(x => x.isExpiringSoon || x.isExpired);
-        if (!warnings.length)
+        if (!warnings.length) {
             return null;
+        }
 
-        return <div className="expiringLicenses">
-            {warnings.map(e =>
-                <div key={e.source}>
-                    <div>
-                        Your Redpanda Enterprise license (<span className="source">{e.sourceDisplayName}</span>)
-                        {e.isExpired
-                            ? <> has expired <span className="date">{e.prettyDateTime}</span> ({e.prettyDuration} ago)</>
-                            : <> will expire <span className="date">{e.prettyDateTime}</span> ({e.prettyDuration} remaining)</>
-                        }
-                    </div>
-                    <div>
-                        To renew your license key, request a new/trial license at:{' '}
-                        <a href="https://redpanda.com/license-request" target="_blank" rel="noreferrer">https://redpanda.com/license-request</a>
-                    </div>
-                </div>
+        return <Box>
+            {warnings.map(e => <Alert key={e.source} status="warning" mb={4}>
+                    <AlertIcon/>
+                    <Flex flexDirection="column">
+                        <Box>
+                            Your Redpanda Enterprise license (<Text textTransform="capitalize" display="inline">{e.sourceDisplayName}</Text>)
+                            {e.isExpired
+                                ? <> has expired <span>{e.prettyDateTime}</span> ({e.prettyDuration} ago)</>
+                                : <> will expire <span>{e.prettyDateTime}</span> ({e.prettyDuration} remaining)</>
+                            }
+                        </Box>
+                        <Box>
+                            To renew your license key, request a new/trial license at:{' '}
+                            <Link href="https://redpanda.com/license-request" target="_blank" rel="noreferrer">https://redpanda.com/license-request</Link>
+                        </Box>
+                    </Flex>
+                </Alert>
             )}
-        </div>
+        </Box>
     }
 }
 

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -3480,25 +3480,6 @@ input::placeholder {
     }
 }
 
-.expiringLicenses {
-    display: flex;
-    flex-direction: column;
-    gap: 1em;
-
-    margin: 1em;
-    padding: 0.5em;
-    border: solid 2px #e142267a;
-    background: #e1422638;
-    color: #ff2f00;
-    font-weight: 500;
-
-
-    a {
-        text-decoration: underline 1px solid;
-    }
-}
-
-
 .iconSelectOption {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Before:

![Screenshot 2023-11-14 at 10 16 18](https://github.com/redpanda-data/console/assets/1083817/28f08e3d-1792-4199-8077-3618387993e5)

After:

![Screenshot 2023-11-14 at 10 19 44](https://github.com/redpanda-data/console/assets/1083817/7813010a-1eb5-4f4f-b9e9-45a40ee47026)


Semantically it's a warning, also in the code it's called a warning so I've changed the type.
