### PR TITLE
Match display-text to unit of message timestamps (#923)

### DIFF
--- a/frontend/src/components/pages/topics/Tab.Messages/index.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/index.tsx
@@ -428,7 +428,7 @@ export class TopicMessageView extends Component<TopicMessageViewProps> {
         const columns: ColumnProps<TopicMessage>[] = [
             { width: 1, title: 'Offset', dataIndex: 'offset', sorter: sortField('offset'), defaultSortOrder: 'descend', render: (t: number) => numberToThousandsString(t) },
             { width: 1, title: 'Partition', dataIndex: 'partitionID', sorter: sortField('partitionID'), },
-            { width: 1, title: 'Timestamp', dataIndex: 'timestamp', sorter: sortField('timestamp'), render: (t: number) => <TimestampDisplay unixEpochSecond={t} format={tsFormat} /> },
+            { width: 1, title: 'Timestamp', dataIndex: 'timestamp', sorter: sortField('timestamp'), render: (t: number) => <TimestampDisplay unixEpochMillisecond={t} format={tsFormat} /> },
             {
                 width: hasKeyTags ? '30%' : 1, title: 'Key', dataIndex: 'key',
                 render: (_, r) => <MessageKeyPreview msg={r} previewFields={() => this.activePreviewTags} />,
@@ -1207,7 +1207,7 @@ const ColumnSettings: FC<{ getShowDialog: () => boolean; setShowDialog: (val: bo
                                 'Relative': 'relative',
                                 'Local Date': 'onlyDate',
                                 'Local Time': 'onlyTime',
-                                'Unix Seconds': 'unixSeconds',
+                                'Unix Millis': 'unixMillis',
                             }}
                             value={uiState.topicSettings.previewTimestamps}
                             onChange={e => uiState.topicSettings.previewTimestamps = e}

--- a/frontend/src/utils/tsxUtils.tsx
+++ b/frontend/src/utils/tsxUtils.tsx
@@ -54,16 +54,16 @@ export function numberToThousandsString(n: number): JSX.Element {
 }
 
 @observer
-export class TimestampDisplay extends Component<{ unixEpochSecond: number, format: TimestampDisplayFormat }>{
+export class TimestampDisplay extends Component<{ unixEpochMillisecond: number, format: TimestampDisplayFormat }>{
     render() {
-        const { unixEpochSecond: ts, format } = this.props;
+        const { unixEpochMillisecond: ts, format } = this.props;
         if (format == 'relative') DebugTimerStore.Instance.useSeconds();
 
         switch (format) {
             case 'unixTimestamp': return new Date(ts).toUTCString();
             case 'onlyDate': return new Date(ts).toLocaleDateString();
             case 'onlyTime': return new Date(ts).toLocaleTimeString();
-            case 'unixSeconds': return ts.toString();
+            case 'unixMillis': return ts.toString();
             case 'relative': return prettyMilliseconds(Date.now() - ts, { compact: true }) + ' ago';
         }
 


### PR DESCRIPTION
The timestamps of kafka messages passed around got changed from seconds to milliseconds since unix epoch time, with #184

Adjusts some leftovers from that change; in particular, the displayed text in the UI that was still showing the raw format as "Unix Seconds"