### PR TITLE
backend: add middleware support to ConfigConnectRPC hook

### DIFF
--- a/backend/pkg/api/hooks.go
+++ b/backend/pkg/api/hooks.go
@@ -49,6 +49,10 @@ type ConfigConnectRPCResponse struct {
 
 	// Instructs OSS to register these services in addition to the OSS ones
 	AdditionalServices []ConnectService
+
+	// HTTPMiddlewares are middlewares that shall be used for the router
+	// that serves all ConnectRPC requests.
+	HTTPMiddlewares []func(http.Handler) http.Handler
 }
 
 // ConnectService is a Connect handler along with its metadata


### PR DESCRIPTION
This PR allows to inject HTTP middlewares (e.g. for auth) via the ConfigConnectRPC hook. 