### PR TITLE
fix: containsControlChars treat LF(10) as a control character

### DIFF
--- a/backend/pkg/kafka/deserializer.go
+++ b/backend/pkg/kafka/deserializer.go
@@ -522,7 +522,8 @@ func (*deserializer) deserializeConsumerOffset(record *kgo.Record) (*deserialize
 
 func (*deserializer) containsControlChars(b []byte) bool {
 	for _, v := range b {
-		if (v <= 31) || (v >= 127 && v <= 159) {
+		// Ignore LF(\n)/HT(\t)
+		if (v <= 31 && v != 10 && v != 9) || (v >= 127 && v <= 159) {
 			return true
 		}
 	}


### PR DESCRIPTION
Ref: https://github.com/redpanda-data/console/issues/946
