### PR TITLE
proto: add name to buf.yaml to enable BSR

### DIFF
--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -5,6 +5,7 @@ deps:
   - buf.build/googleapis/googleapis
   - buf.build/bufbuild/protovalidate
   - buf.build/redpandadata/common
+name: buf.build/redpandadata/dataplane
 breaking:
   use:
     - FILE


### PR DESCRIPTION
this enables us to maintain the protos in the Buf Schema Registry at https://buf.build/redpandadata/dataplane