### PR TITLE
connectors: added `producer.override.max.request.size` property to Mongo source connector UI

### DIFF
--- a/backend/pkg/connector/guide/mongo_source.go
+++ b/backend/pkg/connector/guide/mongo_source.go
@@ -72,6 +72,7 @@ func NewMongoSourceGuide(opts ...Option) Guide {
 							"publish.full.document.only",
 							"publish.full.document.only.tombstone.on.delete",
 							"mongo.errors.tolerance",
+							"producer.override.max.request.size",
 						},
 					},
 				},

--- a/backend/pkg/connector/interceptor/mongo_hook.go
+++ b/backend/pkg/connector/interceptor/mongo_hook.go
@@ -197,6 +197,24 @@ func KafkaConnectValidateToConsoleMongoDBHook(response model.ValidationResponse,
 				Errors:            []string{},
 			},
 		},
+		model.ConfigDefinition{
+			Definition: model.ConfigDefinitionKey{
+				Name:          "producer.override.max.request.size",
+				Type:          "INT",
+				DefaultValue:  "1048576",
+				Importance:    "MEDIUM",
+				Required:      false,
+				DisplayName:   "Max size of a request",
+				Documentation: "The maximum size of a request in bytes. This setting will limit the number of record batches the producer will send in a single request to avoid sending huge requests. This is also effectively a cap on the maximum uncompressed record batch size. Note that the server has its own cap on the record batch size (after compression if compression is enabled) which may be different from this. The default is 1048576",
+			},
+			Value: model.ConfigDefinitionValue{
+				Name:              "producer.override.max.request.size",
+				Value:             "1048576",
+				RecommendedValues: []string{},
+				Visible:           true,
+				Errors:            []string{},
+			},
+		},
 	)
 
 	return response


### PR DESCRIPTION
Added `producer.override.max.request.size` property to Mongo source connector UI