### PR TITLE
backend: add interceptor that logs connect erors

### DIFF
--- a/backend/pkg/api/api_integration_test.go
+++ b/backend/pkg/api/api_integration_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sr"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/redpanda-data/console/backend/pkg/api/httptypes"
 	"github.com/redpanda-data/console/backend/pkg/config"
@@ -616,4 +617,8 @@ func (a *assertHooks) CheckWebsocketConnection(r *http.Request, _ httptypes.List
 		assertHookCall(a.t)
 	}
 	return r.Context(), nil
+}
+
+func (a *assertHooks) AdditionalLogFields(_ context.Context) []zapcore.Field {
+	return []zapcore.Field{}
 }

--- a/backend/pkg/api/connect/interceptor/error_log.go
+++ b/backend/pkg/api/connect/interceptor/error_log.go
@@ -50,8 +50,9 @@ func (in *ErrorLogInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFu
 			path, ok := runtime.RPCMethod(ctx)
 			if !ok {
 				procedure = "unknown"
+			} else {
+				procedure = path
 			}
-			procedure = path
 		}
 
 		protocol := req.Peer().Protocol

--- a/backend/pkg/api/connect/interceptor/error_log.go
+++ b/backend/pkg/api/connect/interceptor/error_log.go
@@ -1,0 +1,136 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package interceptor
+
+import (
+	"context"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+)
+
+var _ connect.Interceptor = &ErrorLogInterceptor{}
+
+// ErrorLogInterceptor prints access error log messages whenever a connect
+// handler returned an error. Some errors may not be printed here, because they
+// are written before the interceptors would be called, such as:
+// - Authentication errors (enterprise HTTP middleware)
+// - JSON Unmarshalling errors of request body (happens prior calling interceptors)
+type ErrorLogInterceptor struct {
+	logger *zap.Logger
+}
+
+// NewErrorLogInterceptor creates a new ErrorLogInterceptor.
+func NewErrorLogInterceptor(logger *zap.Logger) *ErrorLogInterceptor {
+	return &ErrorLogInterceptor{
+		logger: logger,
+	}
+}
+
+// WrapUnary creates an interceptor to validate Connect requests.
+func (in *ErrorLogInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		// 1. Gather request information
+		start := time.Now()
+
+		// For HTTP paths invoked via gRPC gateway procedure is expected not to be set.
+		// Let's try to retrieve it with gRPC gateway's runtime pkg.
+		procedure := req.Spec().Procedure
+		if procedure == "" {
+			path, ok := runtime.RPCMethod(ctx)
+			if !ok {
+				procedure = "unknown"
+			}
+			procedure = path
+		}
+
+		protocol := req.Peer().Protocol
+		if protocol == "" {
+			protocol = "http"
+		}
+
+		// Depending on the error case, the request size may be 0 for
+		// requests sent via the gRPC gateway.
+		var requestSize int
+		if req != nil {
+			if msg, ok := req.Any().(proto.Message); ok {
+				requestSize = proto.Size(msg)
+			}
+		}
+
+		// 2. Execute request
+		response, err := next(ctx, req)
+
+		// 3. Gather response information
+		requestDuration := time.Since(start)
+		statusCodeStr := in.statusCode(protocol, err)
+
+		if err != nil {
+			in.logger.Warn("",
+				zap.String("timestamp", start.Format(time.RFC3339)),
+				zap.String("procedure", procedure),
+				zap.String("request_duration", requestDuration.String()),
+				zap.String("status_code", statusCodeStr),
+				zap.Int("request_size_bytes", requestSize),
+				zap.String("peer_address", req.Peer().Addr), // Will be empty for requests made through gRPC GW
+				zap.Error(err),
+			)
+		}
+
+		return response, err
+	}
+}
+
+// WrapStreamingClient is the middleware handler for bidirectional requests from
+// the client perspective.
+func (*ErrorLogInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return next
+}
+
+// WrapStreamingHandler is the middleware handler for bidirectional requests from
+// the server handling perspective.
+func (*ErrorLogInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return next
+}
+
+func (*ErrorLogInterceptor) statusCode(protocol string, serverErr error) string {
+	grpcProtocol := "grpc"
+	grpcwebProtocol := "grpc_web"
+	connectProtocol := "connect_rpc"
+	httpProtocol := "http"
+
+	// Following the respective specifications, use integers and "status_code" for
+	// gRPC codes in contrast to strings and "error_code" for Connect codes.
+	// TODO: Check protocol case for gRPC gateway
+	switch protocol {
+	case grpcProtocol, grpcwebProtocol, httpProtocol:
+		if serverErr != nil {
+			return connect.CodeOf(serverErr).String()
+		}
+		return "ok"
+	case connectProtocol:
+		if connect.IsNotModifiedError(serverErr) {
+			// A "not modified" error is special: it's code is technically "unknown" but
+			// it would be misleading to label it as an unknown error since it's not really
+			// an error, but rather a sentinel to trigger a "304 Not Modified" HTTP status.
+			return "not_modified"
+		}
+		if serverErr != nil {
+			return connect.CodeOf(serverErr).String()
+		}
+		return "ok"
+	}
+	// This will yield "unknown" if serverErr is not known or the protocol
+	// is not a known protocol.
+	return connect.CodeOf(serverErr).String()
+}

--- a/backend/pkg/api/hooks.go
+++ b/backend/pkg/api/hooks.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cloudhut/common/rest"
 	"github.com/go-chi/chi/v5"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/redpanda-data/console/backend/pkg/api/httptypes"
 	pkgconnect "github.com/redpanda-data/console/backend/pkg/connect"
@@ -177,6 +178,12 @@ type ConsoleHooks interface {
 	// The returned context must be used for subsequent requests. The Websocket
 	// connection must be closed if an error is returned.
 	CheckWebsocketConnection(r *http.Request, req httptypes.ListMessagesRequest) (context.Context, error)
+
+	// AdditionalLogFields is a func that returns key/value pairs that
+	// will be attached to log messages inside route handlers. This
+	// can be used to get context about the authenticated user that issued
+	// the request.
+	AdditionalLogFields(ctx context.Context) []zapcore.Field
 }
 
 // defaultHooks is the default hook which is used if you don't attach your own hooks
@@ -363,6 +370,10 @@ func (*defaultHooks) EndpointCompatibility() []console.EndpointCompatibilityEndp
 
 func (*defaultHooks) CheckWebsocketConnection(r *http.Request, _ httptypes.ListMessagesRequest) (context.Context, error) {
 	return r.Context(), nil
+}
+
+func (*defaultHooks) AdditionalLogFields(_ context.Context) []zapcore.Field {
+	return []zapcore.Field{}
 }
 
 func (*defaultHooks) EnabledConnectClusterFeatures(_ context.Context, _ string) []pkgconnect.ClusterFeature {

--- a/backend/pkg/api/routes.go
+++ b/backend/pkg/api/routes.go
@@ -47,7 +47,7 @@ func (api *API) setupConnectWithGRPCGateway(r chi.Router) {
 
 	// Base baseInterceptors configured in OSS.
 	baseInterceptors := []connect.Interceptor{
-		interceptor.NewErrorLogInterceptor(api.Logger.Named("error_log")),
+		interceptor.NewErrorLogInterceptor(api.Logger.Named("error_log"), api.Hooks.Console.AdditionalLogFields),
 		interceptor.NewRequestValidationInterceptor(v, api.Logger.Named("validator")),
 		interceptor.NewEndpointCheckInterceptor(&api.Cfg.Console.API, api.Logger.Named("endpoint_checker")),
 	}

--- a/backend/pkg/api/routes.go
+++ b/backend/pkg/api/routes.go
@@ -47,6 +47,7 @@ func (api *API) setupConnectWithGRPCGateway(r chi.Router) {
 
 	// Base baseInterceptors configured in OSS.
 	baseInterceptors := []connect.Interceptor{
+		interceptor.NewErrorLogInterceptor(api.Logger.Named("error_log")),
 		interceptor.NewRequestValidationInterceptor(v, api.Logger.Named("validator")),
 		interceptor.NewEndpointCheckInterceptor(&api.Cfg.Console.API, api.Logger.Named("endpoint_checker")),
 	}


### PR DESCRIPTION
Whenever a connect handler returns an error it is
currently not logged. However, usually this should be of interest. This PR adds an interceptor that
always logs returns errors by any connect handler.