### PR TITLE
frontend: update modal to create new user

### DIFF
--- a/frontend/src/components/pages/acls/Acl.List.tsx
+++ b/frontend/src/components/pages/acls/Acl.List.tsx
@@ -14,7 +14,7 @@ import { PageComponent, PageInitHelper } from '../Page';
 import { api } from '../../../state/backendApi';
 import { uiSettings } from '../../../state/ui';
 import { sortField } from '../../misc/common';
-import { AclRequestDefault, CreateUserRequest } from '../../../state/restInterfaces';
+import { AclRequestDefault } from '../../../state/restInterfaces';
 import { comparer, computed, makeObservable, observable } from 'mobx';
 import { appGlobal } from '../../../state/appGlobal';
 import { Code, DefaultSkeleton } from '../../../utils/tsxUtils';
@@ -26,11 +26,10 @@ import { AclFlat, AclPrincipalGroup, collectClusterAcls, collectConsumerGroupAcl
 import { AclPrincipalGroupEditor } from './PrincipalGroupEditor';
 import Section from '../../misc/Section';
 import PageContent from '../../misc/PageContent';
-import createAutoModal from '../../../utils/createAutoModal';
-import { CreateServiceAccountEditor, generatePassword } from './CreateServiceAccountEditor';
 import { Features } from '../../../state/supportedFeatures';
-import { Alert, AlertDialog, AlertDialogBody, AlertDialogContent, AlertDialogFooter, AlertDialogHeader, AlertDialogOverlay, AlertIcon, Badge, Button, createStandaloneToast, Icon, redpandaToastOptions, SearchField, Tooltip, Text, redpandaTheme, Menu, MenuButton, MenuItem, MenuList, Result, PasswordInput } from '@redpanda-data/ui';
+import { Alert, AlertDialog, AlertDialogBody, AlertDialogContent, AlertDialogFooter, AlertDialogHeader, AlertDialogOverlay, AlertIcon, Badge, Button, createStandaloneToast, Icon, redpandaToastOptions, SearchField, Tooltip, Text, redpandaTheme, Menu, MenuButton, MenuItem, MenuList, Result } from '@redpanda-data/ui';
 import React, { FC, useRef } from 'react';
+import { openCreateUserModal } from './CreateServiceAccountModal';
 
 // TODO - once AclList is migrated to FC, we could should move this code to use useToast()
 const { ToastContainer, toast } = createStandaloneToast({
@@ -171,76 +170,9 @@ class AclList extends PageComponent {
     @observable aclFailed: { err: unknown } | null = null;
     @observable edittingPrincipalGroup?: AclPrincipalGroup;
 
-    CreateServiceAccountModal;
-    showCreateServiceAccountModal;
-
     constructor(p: any) {
         super(p);
         makeObservable(this);
-
-        const m = createAutoModal({
-            modalProps: {
-                title: 'Create User',
-                style: { width: '80%', minWidth: '400px', maxWidth: '600px', top: '50px' },
-
-                okText: 'Create',
-                successTitle: 'User Created',
-
-                closable: false,
-                keyboard: false,
-                maskClosable: false,
-            },
-
-            onCreate: () => observable({
-                username: '',
-                password: generatePassword(30, false),
-                mechanism: 'SCRAM-SHA-256',
-            } as CreateUserRequest),
-
-            isOkEnabled: state => {
-                if (state.username.length === 0) return false
-                if (state.password.length <= 3 || state.password.length > 64) return false
-
-                // Check that the username only contains allowed characters (alphanumeric, hypen, underscore, at symbol)
-                if (/[^a-zA-Z0-9._@-]+/.test(state.username))
-                    return false;
-
-                return true;
-            },
-            onOk: async state => {
-                await api.createServiceAccount({
-                    username: state.username,
-                    password: state.password,
-                    mechanism: state.mechanism,
-                });
-
-                return <div style={{
-                    display: 'grid',
-                    gridTemplateColumns: 'auto auto',
-                    justifyContent: 'center',
-                    justifyItems: 'end',
-                    alignItems: 'center',
-                    columnGap: '8px',
-                    rowGap: '4px'
-                }}>
-                    <span>Username:</span><span style={{ justifySelf: 'start' }}>
-                        <Code>{state.username}</Code>
-                    </span>
-                    <span>Password:</span><span style={{ justifySelf: 'start' }}>
-                        <PasswordInput value={state.password} isReadOnly />
-                    </span>
-                    <span>Mechanism:</span><span style={{ justifySelf: 'start' }}>
-                        <Code>{state.mechanism}</Code>
-                    </span>
-                </div>
-            },
-            onSuccess: (_state, _result) => {
-                this.refreshData(true);
-            },
-            content: (state) => <CreateServiceAccountEditor state={state} />,
-        });
-        this.CreateServiceAccountModal = m.Component;
-        this.showCreateServiceAccountModal = m.show;
     }
 
     initPage(p: PageInitHelper): void {
@@ -298,8 +230,6 @@ class AclList extends PageComponent {
                             this.refreshData(true);
                         }}
                     />}
-
-                <this.CreateServiceAccountModal />
 
                 <Section>
                     <this.SearchControls />
@@ -445,7 +375,9 @@ class AclList extends PageComponent {
                 <span style={{ marginLeft: 'auto' }}> </span>
 
                 <Tooltip isDisabled={Features.createUser} label="The cluster does not support this feature" placement="top" hasArrow>
-                    <Button variant="outline" isDisabled={!Features.createUser} onClick={this.showCreateServiceAccountModal}>
+                    <Button variant="outline"
+                            isDisabled={!Features.createUser}
+                            onClick={() => openCreateUserModal()}>
                         Create user
                     </Button>
                 </Tooltip>

--- a/frontend/src/components/pages/acls/CreateServiceAccountModal.tsx
+++ b/frontend/src/components/pages/acls/CreateServiceAccountModal.tsx
@@ -1,0 +1,306 @@
+import {
+    Box,
+    Button,
+    Checkbox,
+    CopyButton,
+    Flex,
+    FormField,
+    Input,
+    Modal,
+    ModalBody,
+    ModalCloseButton,
+    ModalContent,
+    ModalFooter,
+    ModalHeader,
+    ModalOverlay,
+    PasswordInput,
+    Tooltip,
+    Text,
+    createStandaloneToast,
+    redpandaTheme,
+    redpandaToastOptions,
+    Grid,
+    Alert,
+    AlertIcon,
+} from '@redpanda-data/ui';
+import { generatePassword } from './CreateServiceAccountEditor';
+import { AclRequestDefault, CreateUserRequest } from '../../../state/restInterfaces';
+import { openModal } from '../../../utils/ModalContainer';
+import { observable } from 'mobx';
+import { observer } from 'mobx-react';
+import { ReloadOutlined } from '@ant-design/icons';
+import { SingleSelect } from '../../misc/Select';
+import { api } from '../../../state/backendApi';
+import { CheckCircleIcon } from '@chakra-ui/icons';
+
+const { ToastContainer, toast } = createStandaloneToast({
+    theme: redpandaTheme,
+    defaultOptions: {
+        ...redpandaToastOptions.defaultOptions,
+        isClosable: false,
+        duration: 2000,
+    },
+});
+
+export type CreateUserModalState = CreateUserRequest & {
+    generateWithSpecialChars: boolean;
+    step: 'CREATE_USER' | 'CREATE_USER_CONFIRMATION';
+    isCreating: boolean;
+    isValidUsername: boolean;
+    isValidPassword: boolean;
+};
+
+const CreateUserRootModal = observer(
+    (p: {
+        state: CreateUserModalState;
+        onCreateUser: (state: CreateUserModalState) => Promise<boolean>;
+        closeModal: () => void;
+    }) => {
+        return (
+            <Modal isOpen onClose={p.closeModal} isCentered size="2xl">
+                {p.state.step === 'CREATE_USER' ? <CreateUserModal {...p} /> : <CreateUserConfirmationModal {...p} />}
+            </Modal>
+        );
+    }
+);
+
+const CreateUserModal = observer(
+    (p: {
+        state: CreateUserModalState;
+        onCreateUser: (state: CreateUserModalState) => Promise<boolean>;
+        closeModal: () => void;
+    }) => {
+        const isValidUsername = /^[a-zA-Z0-9._@-]+$/.test(p.state.username);
+        const isValidPassword = p.state.password && p.state.password.length >= 4 && p.state.password.length <= 64;
+
+        return (
+            <>
+                <ModalOverlay />
+                <ModalContent>
+                    <ToastContainer />
+                    <ModalHeader mr="4">Create user</ModalHeader>
+                    <ModalCloseButton />
+                    <ModalBody>
+                        <Flex gap="2em" direction="column">
+                            <FormField
+                                description="Must not contain any whitespace. Dots, hyphens and underscores may be used."
+                                label="Username"
+                                showRequiredIndicator
+                                isInvalid={!isValidUsername}
+                                errorText="The username contains invalid characters. Use only letters, numbers, dots, underscores, at symbols, and hyphens."
+                            >
+                                <Input
+                                    value={p.state.username}
+                                    onChange={(v) => (p.state.username = v.target.value)}
+                                    width="100%"
+                                    autoFocus
+                                    spellCheck={false}
+                                    placeholder="Username"
+                                    autoComplete="off"
+                                />
+                            </FormField>
+
+                            <FormField
+                                description="Must be at least 4 characters and should not exceed 64 characters."
+                                showRequiredIndicator={true}
+                                label="Password"
+                            >
+                                <Flex direction="column" gap="2">
+                                    <Flex alignItems="center" gap="2">
+                                        <PasswordInput
+                                            name="test"
+                                            value={p.state.password}
+                                            onChange={(e) => (p.state.password = e.target.value)}
+                                            isInvalid={!isValidPassword}
+                                        />
+
+                                        <Tooltip label={'Generate new random password'} placement="top" hasArrow>
+                                            <Button
+                                                onClick={() =>
+                                                    (p.state.password = generatePassword(
+                                                        30,
+                                                        p.state.generateWithSpecialChars
+                                                    ))
+                                                }
+                                                variant="ghost"
+                                                width="35px"
+                                                display="inline-flex"
+                                            >
+                                                <ReloadOutlined />
+                                            </Button>
+                                        </Tooltip>
+                                        <Tooltip label={'Copy password'} placement="top" hasArrow>
+                                            <CopyButton content={p.state.password} variant="ghost" />
+                                        </Tooltip>
+                                    </Flex>
+                                    <Checkbox
+                                        isChecked={p.state.generateWithSpecialChars}
+                                        onChange={(e) => {
+                                            p.state.generateWithSpecialChars = e.target.checked;
+                                            p.state.password = generatePassword(30, e.target.checked);
+                                        }}
+                                    >
+                                        Generate with special characters
+                                    </Checkbox>
+                                </Flex>
+                            </FormField>
+
+                            <FormField label="SASL Mechanism" showRequiredIndicator>
+                                <SingleSelect<'SCRAM-SHA-256' | 'SCRAM-SHA-512'>
+                                    options={[
+                                        {
+                                            value: 'SCRAM-SHA-256',
+                                            label: 'SCRAM-SHA-256',
+                                        },
+                                        {
+                                            value: 'SCRAM-SHA-512',
+                                            label: 'SCRAM-SHA-512',
+                                        },
+                                    ]}
+                                    value={p.state.mechanism}
+                                    onChange={(e) => {
+                                        p.state.mechanism = e;
+                                    }}
+                                />
+                            </FormField>
+                        </Flex>
+                    </ModalBody>
+
+                    <ModalFooter>
+                        <Button
+                            mr={3}
+                            onClick={() => {
+                                p.onCreateUser(p.state);
+                            }}
+                            isDisabled={p.state.isCreating || !isValidUsername || !isValidPassword}
+                            isLoading={p.state.isCreating}
+                            loadingText="Creating..."
+                        >
+                            Create
+                        </Button>
+                        <Button variant="outline" onClick={p.closeModal} isDisabled={p.state.isCreating}>
+                            Cancel
+                        </Button>
+                    </ModalFooter>
+                </ModalContent>
+            </>
+        );
+    }
+);
+
+const CreateUserConfirmationModal = observer((p: { state: CreateUserModalState; closeModal: () => void }) => {
+    return (
+        <>
+            <ModalOverlay />
+            <ModalContent>
+                <ToastContainer />
+                <ModalHeader mr="4">
+                    <Flex alignItems="center">
+                        <CheckCircleIcon color="green.500" mr={2} transform="translateY(-1px)" />
+                        User created
+                    </Flex>
+                </ModalHeader>
+                <ModalCloseButton />
+                <ModalBody>
+                    <Grid templateColumns="max-content 1fr" gridRowGap={2} gridColumnGap={6} alignItems="center">
+                        <Box fontWeight="bold" data-testid="username">
+                            Username
+                        </Box>
+                        <Box>
+                            <Flex alignItems="center" gap={2}>
+                                <Text textOverflow="ellipsis" whiteSpace="nowrap" overflow="hidden" isTruncated={true}>
+                                    {p.state.username}
+                                </Text>
+
+                                <Tooltip label={'Copy username'} placement="top" hasArrow>
+                                    <CopyButton content={p.state.username} variant="ghost" />
+                                </Tooltip>
+                            </Flex>
+                        </Box>
+
+                        <Box fontWeight="bold" data-testid="password">
+                            Password
+                        </Box>
+                        <Box>
+                            <Flex alignItems="center" gap={2}>
+                                <PasswordInput
+                                    name="test"
+                                    value={p.state.password}
+                                    isDisabled={true}
+                                    isReadOnly={true}
+                                />
+
+                                <Tooltip label={'Copy password'} placement="top" hasArrow>
+                                    <CopyButton content={p.state.password} variant="ghost" />
+                                </Tooltip>
+                            </Flex>
+                        </Box>
+
+                        <Box fontWeight="bold" data-testid="password">
+                            Mechanism
+                        </Box>
+                        <Box>
+                            <Text textOverflow="ellipsis" whiteSpace="nowrap" overflow="hidden" isTruncated={true}>
+                                {p.state.mechanism}
+                            </Text>
+                        </Box>
+                    </Grid>
+
+                    <Alert status="info" variant="left-accent" mt={4}>
+                        <AlertIcon />
+                        You can't see the user's password again after this modal is closed.
+                    </Alert>
+                </ModalBody>
+
+                <ModalFooter>
+                    <Button onClick={p.closeModal}>Close</Button>
+                </ModalFooter>
+            </ModalContent>
+        </>
+    );
+});
+
+export function openCreateUserModal() {
+    const state = observable({
+        username: '',
+        password: generatePassword(30, false),
+        mechanism: 'SCRAM-SHA-256',
+        generateWithSpecialChars: false,
+        step: 'CREATE_USER',
+        isCreating: false,
+        isValidUsername: false,
+        isValidPassword: false,
+    } as CreateUserModalState);
+
+    const onCreateUser = async (state: CreateUserModalState): Promise<boolean> => {
+        try {
+            state.isCreating = true;
+            await api.createServiceAccount({
+                username: state.username,
+                password: state.password,
+                mechanism: state.mechanism,
+            });
+
+            // Refresh user list
+            if (api.userData != null && !api.userData.canListAcls) return false;
+            await Promise.allSettled([api.refreshAcls(AclRequestDefault, true), api.refreshServiceAccounts(true)]);
+            state.step = 'CREATE_USER_CONFIRMATION';
+        } catch (err) {
+            toast({
+                status: 'error',
+                duration: null,
+                isClosable: true,
+                title: 'Failed to create user',
+                description: String(err),
+            });
+        } finally {
+            state.isCreating = false;
+        }
+        return true;
+    };
+
+    openModal(CreateUserRootModal, {
+        state: state,
+        onCreateUser: onCreateUser,
+    });
+}

--- a/frontend/src/components/pages/acls/CreateServiceAccountModal.tsx
+++ b/frontend/src/components/pages/acls/CreateServiceAccountModal.tsx
@@ -248,7 +248,7 @@ const CreateUserConfirmationModal = observer((p: { state: CreateUserModalState; 
 
                     <Alert status="info" variant="left-accent" mt={4}>
                         <AlertIcon />
-                        You can't see the user's password again after this modal is closed.
+                        Password will be inaccessible after this modal is closed.
                     </Alert>
                 </ModalBody>
 


### PR DESCRIPTION
This commit uses a new modal for creating new users. Visually only the user confirmation modal is different and more in line with the new Redpanda theme.


https://github.com/redpanda-data/console/assets/23424570/7019e517-f11f-469e-aed4-a19221b9d4d4
