### PR TITLE
Fix construction of `connection.uri` for MongoDB source connector

### DIFF
--- a/backend/pkg/connector/interceptor/mongo_hook.go
+++ b/backend/pkg/connector/interceptor/mongo_hook.go
@@ -58,7 +58,7 @@ func KafkaConnectToConsoleMongoDBHook(config map[string]string) map[string]strin
 }
 
 func setConnectionURI(config map[string]any) {
-	if _, exists := config["connection.uri"]; !exists {
+	if _, exists := config["connection.uri"]; !exists || config["connection.uri"] == "mongodb://" {
 		if _, exists := config["connection.url"]; exists {
 			config["connection.uri"] = config["connection.url"]
 		} else {


### PR DESCRIPTION
For local URIs, without username and password, the MongoDB `connection.uri` wasn't populated from the `connection.url` field.