### PR TITLE
pprof: allow to disable REST handler

### DIFF
--- a/backend/pkg/api/routes.go
+++ b/backend/pkg/api/routes.go
@@ -208,8 +208,10 @@ func (api *API) routes() *chi.Mux {
 			r.Handle("/admin/health", api.handleLivenessProbe())
 			r.Handle("/admin/startup", api.handleStartupProbe())
 
-			// Path must be prefixed with /debug otherwise it will be overridden, see: https://golang.org/pkg/net/http/pprof/
-			r.Mount("/debug", chimiddleware.Profiler())
+			if api.Cfg.REST.Debug.Enabled {
+				// Path must be prefixed with /debug otherwise it will be overridden, see: https://golang.org/pkg/net/http/pprof/
+				r.Mount("/debug", chimiddleware.Profiler())
+			}
 		})
 
 		// API routes

--- a/backend/pkg/config/server.go
+++ b/backend/pkg/config/server.go
@@ -26,6 +26,14 @@ type Server struct {
 	// API. By default, a same-site policy is enforced. This setting is required to prevent
 	// CSRF-attacks.
 	AllowedOrigins []string `yaml:"allowedOrigins"`
+
+	// Debug allows to configure the pprof debug handler options.
+	Debug DebugConfig `yaml:"debug"`
+}
+
+// DebugConfig contains configuration for the pprof debug handler.
+type DebugConfig struct {
+	Enabled bool `yaml:"enabled"`
 }
 
 // SetDefaults for server config.
@@ -40,4 +48,6 @@ func (s *Server) SetDefaults() {
 	// 2. https://github.com/connectrpc/connect-go/issues/356
 	s.HTTPServerWriteTimeout = 32 * time.Minute
 	s.AllowedOrigins = nil
+	// Debug is enabled by default for backward compatibility.
+	s.Debug.Enabled = true
 }


### PR DESCRIPTION
It's enabled by default for backward compatibility, but it can now be turned off and enabled on demand.