### PR TITLE
pprof: fix configuration of internal routes

### DIFF
--- a/backend/pkg/api/routes.go
+++ b/backend/pkg/api/routes.go
@@ -212,7 +212,6 @@ func (api *API) routes() *chi.Mux {
 		// Debug routes
 		if api.Cfg.REST.Debug.Enabled {
 			router.Group(func(r chi.Router) {
-				api.Hooks.Route.ConfigInternalRouter(r)
 				if api.Cfg.REST.Debug.ForceLoopback {
 					r.Use(forceLoopbackMiddleware(api.Logger))
 				}


### PR DESCRIPTION
This caused a panic in our install. Internal router config should be applied once and after the middleware config.