### PR TITLE
frontend: don't re-request messages on save to get raw data, instead …

### DIFF
--- a/frontend/src/components/pages/topics/Tab.Messages/index.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/index.tsx
@@ -786,7 +786,7 @@ class SaveMessagesDialog extends Component<{
                         <Button variant="outline" colorScheme="red" onClick={onClose}>
                             Cancel
                         </Button>
-                        <Button variant="solid" onClick={() => this.saveMessages()}>
+                        <Button variant="solid" onClick={() => this.saveMessages()} isDisabled={!this.props.messages || this.props.messages.length == 0}>
                             Save Messages
                         </Button>
                     </ModalFooter>
@@ -797,10 +797,9 @@ class SaveMessagesDialog extends Component<{
 
     async saveMessages() {
         const messages = this.props.messages;
-        if (!messages) {
-            console.error('cannot save messages, props array is empty');
+        if (!messages)
             return;
-        }
+
 
         const cleanMessages = this.cleanMessages(messages);
 


### PR DESCRIPTION
…always include it in every search; otherwise on fast moving topics our reuqest is outdated by the time the user clicks the save messages button (also, we are not even guaranteed that we get the messages from the exact same partitions and offsets each time)