### PR TITLE
Sj/tooling/taskfiles

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,7 +1,10 @@
 version: 3
 
 vars:
+  GO_VERSION: 1.21.6
   BUILD_ROOT: "{{ .ROOT_DIR }}/build"
+  GO_BUILD_ROOT: '{{.BUILD_ROOT}}/go/{{.GO_VERSION}}'
+  PATH_PREFIX: PATH={{.BUILD_ROOT}}/bin:{{.GO_BUILD_ROOT}}/bin:{{.BUILD_ROOT}}/bin/go:$PATH GOBIN={{ .BUILD_ROOT }}/bin/go GOROOT=
   BACKEND_ROOT: "{{ .ROOT_DIR }}/backend"
   FRONTEND_ROOT: "{{ .ROOT_DIR }}/frontend"
   BRANCH_SLUG:

--- a/backend/pkg/api/connect/integration/topic_test.go
+++ b/backend/pkg/api/connect/integration/topic_test.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build integration
+
 package integration
 
 import (

--- a/taskfiles/backend.yaml
+++ b/taskfiles/backend.yaml
@@ -1,5 +1,19 @@
 version: 3
 tasks:
+  install-go:
+    desc: install golang compiler
+    run: once
+    vars:
+      GOLANG_URL_DEFAULT: https://golang.org/dl/go{{.GO_VERSION}}.{{OS}}-{{ARCH}}.tar.gz
+      GOLANG_URL: '{{default .GOLANG_URL_DEFAULT .GOLANG_URL}}'
+    cmds:
+      - rm -rf {{.GO_BUILD_ROOT}}
+      - mkdir -p '{{.GO_BUILD_ROOT}}'
+      - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 '{{.GOLANG_URL}}' | tar -xz -C '{{.GO_BUILD_ROOT}}' --strip 1
+    status:
+      - test -f '{{.GO_BUILD_ROOT}}/bin/go'
+      - '[[ $({{.GO_BUILD_ROOT}}/bin/go version) == *"go version go{{ .GO_VERSION }}"* ]]'
+
   install-golangci-lint:
     desc: install golangci linter
     vars:
@@ -13,8 +27,11 @@ tasks:
 
   install-goimports:
     desc: install goimports
+    deps:
+      - install-go
     cmds:
-      - GOBIN={{ .BUILD_ROOT }}/bin/go go install golang.org/x/tools/cmd/goimports@latest
+      - |
+        {{ .PATH_PREFIX }} go install golang.org/x/tools/cmd/goimports@latest
     status:
       - '[ -f ''{{ .BUILD_ROOT }}/bin/go'' ] || command -v {{ .BUILD_ROOT }}/bin/go/goimports >/dev/null 2>&1'
 
@@ -22,9 +39,11 @@ tasks:
     vars:
       GOFUMPT_VERSION: 0.4.0
     desc: install gofumpt go formater
+    deps:
+      - install-go
     cmds:
       - |
-        GOBIN={{ .BUILD_ROOT }}/bin/go go install mvdan.cc/gofumpt@v{{ .GOFUMPT_VERSION }}
+        {{ .PATH_PREFIX }} go install mvdan.cc/gofumpt@v{{ .GOFUMPT_VERSION }}
     status:
       - '[ -f ''{{ .BUILD_ROOT }}/bin/go'' ] || command -v {{ .BUILD_ROOT }}/bin/go/gofumpt >/dev/null 2>&1'
       - '[[ $({{ .BUILD_ROOT }}/bin/go/gofumpt --version) == v{{.GOFUMPT_VERSION}} ]]'
@@ -33,8 +52,11 @@ tasks:
     vars:
       GCI_VERSION: 0.9.0
     desc: install gci
+    deps:
+      - install-go
     cmds:
-      - GOBIN={{ .BUILD_ROOT }}/bin/go go install github.com/daixiang0/gci@v{{.GCI_VERSION}}
+      - |
+        {{ .PATH_PREFIX }} go install github.com/daixiang0/gci@v{{.GCI_VERSION}}
     status:
       - '[ -f ''{{ .BUILD_ROOT }}/bin/go'' ] || command -v {{ .BUILD_ROOT }}/bin/go/gci >/dev/null 2>&1'
 
@@ -42,9 +64,11 @@ tasks:
     vars:
       TPARSE_VERSION: 0.12.1
     desc: install tparse go test parser
+    deps:
+      - install-go
     cmds:
       - |
-        GOBIN={{ .BUILD_ROOT }}/bin/go go install github.com/mfridman/tparse@v{{ .TPARSE_VERSION }}
+        {{ .PATH_PREFIX }} go install github.com/mfridman/tparse@v{{ .TPARSE_VERSION }}
     status:
       - '[ -f ''{{ .BUILD_ROOT }}/bin/go'' ] || command -v {{ .BUILD_ROOT }}/bin/go/tparse >/dev/null 2>&1'
       - '[[ $({{ .BUILD_ROOT }}/bin/go/tparse --version) == tparse version:v{{.TPARSE_VERSION}} ]]'
@@ -53,9 +77,11 @@ tasks:
     vars:
       GOMOCK_VERSION: 1.6.0
     desc: install gomock
+    deps:
+      - install-go
     cmds:
       - |
-        GOBIN={{ .BUILD_ROOT }}/bin/go go install github.com/golang/mock/mockgen@v{{ .GOMOCK_VERSION }}
+        {{ .PATH_PREFIX }} go install github.com/golang/mock/mockgen@v{{ .GOMOCK_VERSION }}
     status:
       - "[ -f '{{ .BUILD_ROOT }}/bin/go' ] || command -v {{ .BUILD_ROOT }}/bin/go/mockgen >/dev/null 2>&1"
       - "[[ $({{ .BUILD_ROOT }}/bin/go/mockgen --version) == 'v{{.GOMOCK_VERSION}}' ]]"
@@ -64,9 +90,11 @@ tasks:
     vars:
       IFACEMAKER_VERSION: 1.2.1
     desc: install ifacemaker
+    deps:
+      - install-go
     cmds:
       - |
-        GOBIN={{ .BUILD_ROOT }}/bin/go go install github.com/vburenin/ifacemaker@v{{ .IFACEMAKER_VERSION }}
+        {{ .PATH_PREFIX }} go install github.com/vburenin/ifacemaker@v{{ .IFACEMAKER_VERSION }}
     status:
       - "[ -f '{{ .BUILD_ROOT }}/bin/go' ] || command -v {{ .BUILD_ROOT }}/bin/go/ifacemaker >/dev/null 2>&1"
 
@@ -107,8 +135,7 @@ tasks:
       - install-ifacemaker
     cmds:
       - |
-        export PATH=$PATH:{{ .BUILD_ROOT }}/bin/go
-        GOBIN={{ .BUILD_ROOT }}/bin/go go generate ./...
+        {{ .PATH_PREFIX }} go generate ./...
       - task: ':proto:generate'
       - task: 'fmt'
 
@@ -119,7 +146,7 @@ tasks:
       - generate
     cmds:
       - |
-        GOBIN={{ .BUILD_ROOT }}/bin/go go test ./...
+        {{ .PATH_PREFIX }} go test ./...
 
   test-integration:
     dir: "{{.BACKEND_ROOT}}"
@@ -128,7 +155,7 @@ tasks:
       - generate
     cmds:
       - |
-        GOBIN={{ .BUILD_ROOT }}/bin/go go test -v -race --tags=integration -p=1 ./...
+        {{ .PATH_PREFIX }} go test -v -race --tags=integration -p=1 ./...
 
   cover:
     dir: "{{.BACKEND_ROOT}}"
@@ -139,11 +166,11 @@ tasks:
     cmds:
       - task: 'lint'
       - |
-        GOBIN={{ .BUILD_ROOT }}/bin/go go test -race --tags=integration -json -cover ./... | {{ .BUILD_ROOT }}/bin/go/tparse
+        {{ .PATH_PREFIX }} go test -race --tags=integration -json -cover ./... | {{ .BUILD_ROOT }}/bin/go/tparse
 
   verify:
     dir: "{{.BACKEND_ROOT}}"
     desc: Run lint and tests
-    cmds: 
+    cmds:
       - task: 'lint'
       - task: 'test-integration'

--- a/taskfiles/proto.yaml
+++ b/taskfiles/proto.yaml
@@ -5,22 +5,26 @@ tasks:
       - install-buf
     desc: lint proto files
     cmds:
-      - PATH={{.BUILD_ROOT}}/bin:$PATH buf lint
-      - PATH={{.BUILD_ROOT}}/bin:$PATH buf format {{.ROOT_DIR}}/proto -w
+      - |
+        {{ .PATH_PREFIX }} buf lint
+      - |
+        {{ .PATH_PREFIX }} buf format {{.ROOT_DIR}}/proto -w
 
   format:
     deps:
       - install-buf
     desc: format proto files
     cmds:
-      - PATH={{.BUILD_ROOT}}/bin:$PATH buf format -w --exit-code
+      - |
+        {{ .PATH_PREFIX }} buf format -w --exit-code
 
   mod-update:
     deps:
       - install-buf
     desc: update mod
     cmds:
-      - PATH={{.BUILD_ROOT}}/bin:$PATH buf mod update {{.ROOT_DIR}}/proto
+      - |
+        {{ .PATH_PREFIX }} buf mod update {{.ROOT_DIR}}/proto
 
   generate:
     dir: "{{.ROOT_DIR}}"
@@ -38,9 +42,10 @@ tasks:
       - rm -rf {{.FRONTEND_ROOT}}/src/protogen
       - task: lint
       - task: format
-      - cmd: PATH={{.BUILD_ROOT}}/bin:$PATH:{{ .BUILD_ROOT }}/bin/go buf generate --template=proto/buf.gen.yaml buf.build/redpandadata/common
+      - |
+        {{ .PATH_PREFIX }} buf generate --template=proto/buf.gen.yaml buf.build/redpandadata/common
       - for: { var: BUF_INPUTS }
-        cmd: PATH={{.BUILD_ROOT}}/bin:$PATH:{{ .BUILD_ROOT }}/bin/go buf generate --template={{ .ITEM }}/buf.gen.yaml {{ .ITEM }}
+        cmd: "{{ .PATH_PREFIX }} buf generate --template={{ .ITEM }}/buf.gen.yaml {{ .ITEM }}"
       - task: :backend:fmt
       - task: generate-openapi3
       - if [[ $CI == "true" ]]; then git diff --exit-code; fi
@@ -52,7 +57,8 @@ tasks:
       - install-yq
     cmds:
       - rm -rf ./proto/gen/openapi
-      - cmd: PATH={{.BUILD_ROOT}}/bin:$PATH buf generate --template=proto/buf.gen.openapi.yaml --path proto/redpanda/api/dataplane
+      - |
+        {{ .PATH_PREFIX }} buf generate --template=proto/buf.gen.openapi.yaml --path proto/redpanda/api/dataplane
       - cd backend && go run ./pkg/tools/openapi-generator -in ../proto/gen/openapi/apidocs.swagger.json -out ../proto/gen/openapi/openapi.json
       - 'yq -p json ./proto/gen/openapi/openapi.json -o yaml > ./proto/gen/openapi/openapi.yaml'
       - rm -f ./proto/gen/openapi/apidocs.swagger.json
@@ -72,21 +78,27 @@ tasks:
       - '[[ $({{ .BUILD_ROOT }}/bin/buf --version) == {{.BUF_VERSION}} ]]'
 
   install-yq:
+    deps:
+      - :backend:install-go
     desc: install yq
+    run: once
     vars:
       YQ_VERSION: 4.35.1
     cmds:
-      - 'go install github.com/mikefarah/yq/v4@v{{.YQ_VERSION}}'
+      - '{{ .PATH_PREFIX }} go install github.com/mikefarah/yq/v4@v{{.YQ_VERSION}}'
     status:
-      - '[[ $(yq --version) == *"{{.YQ_VERSION}}"* ]]'
+      - '[ -f ''{{ .BUILD_ROOT }}/bin/go'' ] || command -v {{ .BUILD_ROOT }}/bin/go/yq >/dev/null 2>&1'
+      - '[[ $({{.BUILD_ROOT}}/bin/go/yq --version) == *"{{.YQ_VERSION}}"* ]]'
 
   install-connect-gateway:
+    deps:
+      - :backend:install-go
     desc: install connect-gateway
     vars:
       VERSION: 0.3.1
     cmds:
       - |
-        GOBIN={{ .BUILD_ROOT }}/bin/go go install go.vallahaye.net/connect-gateway/cmd/protoc-gen-connect-gateway@v{{.VERSION}}
+        {{ .PATH_PREFIX }} go install go.vallahaye.net/connect-gateway/cmd/protoc-gen-connect-gateway@v{{.VERSION}}
     status:
       - "[ -f '{{ .BUILD_ROOT }}/bin/go' ] || command -v {{ .BUILD_ROOT }}/bin/go/protoc-gen-connect-gateway >/dev/null 2>&1"
       - '[[ $({{ .BUILD_ROOT }}/bin/go/protoc-gen-connect-gateway --version) == "{{.VERSION}}" ]]'


### PR DESCRIPTION
 improve tasks in the repository.

- Install go as part of the repository build, you won't need to have go intalled or any other dependency really, using `./taskw` you will be able to run any repository related task.
- Add integration tag to the topics integration tests, it won`t compile properly since we don't have the APISuite availble for the unit-test for instance.