### PR TITLE
Fix user integration test resource cleanup

### DIFF
--- a/backend/pkg/api/connect/integration/user_test.go
+++ b/backend/pkg/api/connect/integration/user_test.go
@@ -58,7 +58,7 @@ func (s *APISuite) TestListUsers() {
 		createUser(username1)
 		createUser(username2)
 		defer deleteUser(username1)
-		defer deleteUser(username1)
+		defer deleteUser(username2)
 
 		// 2. List users
 		client := v1alpha1connect.NewUserServiceClient(http.DefaultClient, s.httpAddress())
@@ -106,7 +106,7 @@ func (s *APISuite) TestListUsers() {
 		createUser(username1)
 		createUser(username2)
 		defer deleteUser(username1)
-		defer deleteUser(username1)
+		defer deleteUser(username2)
 
 		// 2. List users
 		type listUsersRes struct {


### PR DESCRIPTION
In the integration test introduced in https://github.com/redpanda-data/console/pull/1067 we cleanup the created resources after every individual test. Instead of deleting all created users, we accidentally deleted the same user twice.