### PR TITLE
backend: list message concurrent stream send fix

### DIFF
--- a/backend/pkg/api/connect/service/console/service.go
+++ b/backend/pkg/api/connect/service/console/service.go
@@ -52,16 +52,6 @@ func NewService(logger *zap.Logger,
 
 // ListMessages consumes a Kafka topic and streams the Kafka records back.
 func (api *Service) ListMessages(ctx context.Context, req *connect.Request[v1alpha.ListMessagesRequest], stream *connect.ServerStream[v1alpha.ListMessagesResponse]) error {
-	timeout := 35 * time.Second
-	if req.Msg.GetFilterInterpreterCode() != "" || req.Msg.GetStartOffset() == console.StartOffsetNewest {
-		// Push-down filters and StartOffset = Newest may be long-running streams.
-		// There's already a client-side provided timeout which we usually trust.
-		// But additionally we want to ensure it never takes much longer than that.
-		timeout = 31 * time.Minute
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	lmq := httptypes.ListMessagesRequest{
 		TopicName:             req.Msg.GetTopic(),
@@ -121,6 +111,17 @@ func (api *Service) ListMessages(ctx context.Context, req *connect.Request[v1alp
 	}
 
 	api.authHooks.PrintListMessagesAuditLog(ctx, req, &listReq)
+
+	timeout := 35 * time.Second
+	if req.Msg.GetFilterInterpreterCode() != "" || req.Msg.GetStartOffset() == console.StartOffsetNewest {
+		// Push-down filters and StartOffset = Newest may be long-running streams.
+		// There's already a client-side provided timeout which we usually trust.
+		// But additionally we want to ensure it never takes much longer than that.
+		timeout = 31 * time.Minute
+	}
+
+	ctx, cancel := context.WithTimeoutCause(ctx, timeout, errors.New("list fetch timeout"))
+	defer cancel()
 
 	progress := &streamProgressReporter{
 		ctx:              ctx,

--- a/backend/pkg/kafka/consumer.go
+++ b/backend/pkg/kafka/consumer.go
@@ -115,8 +115,8 @@ func (s *Service) FetchMessages(ctx context.Context, progress IListMessagesProgr
 	// 2. Create consumer workers
 	jobs := make(chan *kgo.Record, 100)
 	resultsCh := make(chan *TopicMessage, 100)
-	workerCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	workerCtx, cancel := context.WithCancelCause(ctx)
+	defer cancel(errors.New("worker cancel"))
 
 	wg := sync.WaitGroup{}
 

--- a/frontend/src/state/backendApi.ts
+++ b/frontend/src/state/backendApi.ts
@@ -394,11 +394,10 @@ const apiStore = {
 
         // For StartOffset = Newest and any set push-down filter we need to bump the default timeout
         // from 30s to 30 minutes before ending the request gracefully.
-        const timeoutMs = 30 * 1000;
+        let timeoutMs = 30 * 1000;
         if (searchRequest.startOffset == PartitionOffsetOrigin.End || req.filterInterpreterCode != null) {
-            // const minuteMs = 60 * 1000;
-            // timeoutMs = 30 * minuteMs;
-            console.log('asdf')
+            const minuteMs = 60 * 1000;
+            timeoutMs = 30 * minuteMs;
         }
 
         abortController.signal.addEventListener('abort', () => {


### PR DESCRIPTION
Multiple goroutines may perform writes (stream `Send()`s) to the stream via stream reporter. In stream reporter ensure these are guarded using a mutex.

Minor frontend cleanup to only have a single Console service client.

Fixes #1073.