### PR TITLE
backend: text decoding deserialized payload should be string

### DIFF
--- a/backend/pkg/console/list_messages_integration_test.go
+++ b/backend/pkg/console/list_messages_integration_test.go
@@ -621,8 +621,7 @@ func (s *ConsoleIntegrationTestSuite) TestListMessages() {
 
 		svc := createNewTestService(t, log, t.Name(), s.testSeedBroker, s.registryAddr)
 
-		code := `let keyStr = String.fromCharCode.apply(null, key)
-				return keyStr.endsWith('2') || keyStr.endsWith('3')`
+		code := `return key.endsWith('2') || key.endsWith('3')`
 
 		input := ListMessageRequest{
 			TopicName:             testTopicName,

--- a/backend/pkg/serde/service.go
+++ b/backend/pkg/serde/service.go
@@ -88,7 +88,7 @@ func (s *Service) deserializePayload(ctx context.Context, record *kgo.Record, pa
 		serdeEncoding = opts.ValueEncoding
 	}
 
-	// When deserializing, clients can optionally specify the deseired encoding
+	// When deserializing, clients can optionally specify the desired encoding
 	doSpecificEncoding := serdeEncoding != PayloadEncodingUnspecified && serdeEncoding != ""
 
 	// Try all registered SerDes in the order they were registered

--- a/backend/pkg/serde/service_integration_test.go
+++ b/backend/pkg/serde/service_integration_test.go
@@ -239,9 +239,9 @@ func (s *SerdeIntegrationTestSuite) TestDeserializeRecord() {
 		assert.Equal("payload is not null as expected for none encoding", dr.Value.Troubleshooting[0].Message)
 
 		// check key
-		keyObj, ok := (dr.Key.DeserializedPayload).([]byte)
-		require.Truef(ok, "parsed payload is not of type []byte")
-		assert.Equal("123", string(keyObj))
+		keyObj, ok := (dr.Key.DeserializedPayload).(string)
+		require.Truef(ok, "parsed payload is not of type string")
+		assert.Equal("123", keyObj)
 		assert.Empty(dr.Key.SchemaID)
 
 		// check key properties
@@ -377,9 +377,9 @@ func (s *SerdeIntegrationTestSuite) TestDeserializeRecord() {
 		require.Len(dr.Value.Troubleshooting, 0)
 
 		// check key
-		keyObj, ok := (dr.Key.DeserializedPayload).([]byte)
-		require.Truef(ok, "parsed payload is not of type []byte")
-		assert.Equal("123", string(keyObj))
+		keyObj, ok := (dr.Key.DeserializedPayload).(string)
+		require.Truef(ok, "parsed payload is not of type string")
+		assert.Equal("123", keyObj)
 		assert.Empty(dr.Key.SchemaID)
 
 		// check key properties
@@ -510,9 +510,9 @@ func (s *SerdeIntegrationTestSuite) TestDeserializeRecord() {
 		// assert.Equal("incorrect magic byte for protobuf schema", dr.Value.Troubleshooting[1].Message)
 
 		// check key
-		keyObj, ok := (dr.Key.DeserializedPayload).([]byte)
-		require.Truef(ok, "parsed payload is not of type []byte")
-		assert.Equal("123", string(keyObj))
+		keyObj, ok := (dr.Key.DeserializedPayload).(string)
+		require.Truef(ok, "parsed payload is not of type string")
+		assert.Equal("123", keyObj)
 		assert.Empty(dr.Key.SchemaID)
 
 		// check key properties
@@ -672,9 +672,9 @@ func (s *SerdeIntegrationTestSuite) TestDeserializeRecord() {
 		assert.Equal("incorrect magic byte for avro", dr.Value.Troubleshooting[4].Message)
 
 		// check key
-		keyObj, ok := (dr.Key.DeserializedPayload).([]byte)
-		require.Truef(ok, "parsed payload is not of type []byte")
-		assert.Equal("111", string(keyObj))
+		keyObj, ok := (dr.Key.DeserializedPayload).(string)
+		require.Truef(ok, "parsed payload is not of type string")
+		assert.Equal("111", keyObj)
 		assert.Empty(dr.Key.SchemaID)
 
 		// key properties
@@ -957,9 +957,9 @@ func (s *SerdeIntegrationTestSuite) TestDeserializeRecord() {
 		assert.Equal("incorrect magic byte for avro", dr.Value.Troubleshooting[4].Message)
 
 		// check key
-		keyObj, ok := (dr.Key.DeserializedPayload).([]byte)
-		require.Truef(ok, "parsed payload is not of type []byte")
-		assert.Equal("444", string(keyObj))
+		keyObj, ok := (dr.Key.DeserializedPayload).(string)
+		require.Truef(ok, "parsed payload is not of type string")
+		assert.Equal("444", keyObj)
 		assert.Empty(dr.Key.SchemaID)
 
 		// key properties
@@ -1147,9 +1147,9 @@ func (s *SerdeIntegrationTestSuite) TestDeserializeRecord() {
 		assert.Equal("failed to get message descriptor for payload: no prototype found for the given topic 'test.redpanda.console.serde_schema_protobuf'. Check your configured protobuf mappings", dr.Value.Troubleshooting[5].Message)
 
 		// check key
-		keyObj, ok := (dr.Key.DeserializedPayload).([]byte)
-		require.Truef(ok, "parsed payload is not of type []byte")
-		assert.Equal("222", string(keyObj))
+		keyObj, ok := (dr.Key.DeserializedPayload).(string)
+		require.Truef(ok, "parsed payload is not of type string")
+		assert.Equal("222", keyObj)
 		assert.Empty(dr.Key.SchemaID)
 
 		// key properties
@@ -1543,9 +1543,9 @@ func (s *SerdeIntegrationTestSuite) TestDeserializeRecord() {
 		assert.Equal("failed to get message descriptor for payload: no prototype found for the given topic 'test.redpanda.console.serde_schema_protobuf_multi'. Check your configured protobuf mappings", dr.Value.Troubleshooting[5].Message)
 
 		// check key
-		keyObj, ok := (dr.Key.DeserializedPayload).([]byte)
-		require.Truef(ok, "parsed payload is not of type []byte")
-		assert.Equal("gadget_0", string(keyObj))
+		keyObj, ok := (dr.Key.DeserializedPayload).(string)
+		require.Truef(ok, "parsed payload is not of type string")
+		assert.Equal("gadget_0", keyObj)
 		assert.Empty(dr.Key.SchemaID)
 
 		// key properties
@@ -2065,9 +2065,9 @@ func (s *SerdeIntegrationTestSuite) TestDeserializeRecord() {
 		assert.Equal("failed to get message descriptor for payload: no prototype found for the given topic 'test.redpanda.console.serde_schema_protobuf_ref'. Check your configured protobuf mappings", dr.Value.Troubleshooting[5].Message)
 
 		// check key
-		keyObj, ok := (dr.Key.DeserializedPayload).([]byte)
-		require.Truef(ok, "parsed payload is not of type []byte")
-		assert.Equal("123456789", string(keyObj))
+		keyObj, ok := (dr.Key.DeserializedPayload).(string)
+		require.Truef(ok, "parsed payload is not of type string")
+		assert.Equal("123456789", keyObj)
 		assert.Empty(dr.Key.SchemaID)
 
 		// key properties
@@ -2456,9 +2456,9 @@ func (s *SerdeIntegrationTestSuite) TestDeserializeRecord() {
 		assert.Empty(dr.Key.SchemaID)
 
 		// check value
-		valObj, ok := (dr.Value.DeserializedPayload).([]byte)
-		require.Truef(ok, "parsed payload is not of type []byte")
-		assert.Equal("my text value", string(valObj))
+		valObj, ok := (dr.Value.DeserializedPayload).(string)
+		require.Truef(ok, "parsed payload is not of type string")
+		assert.Equal("my text value", valObj)
 		assert.Empty(dr.Value.SchemaID)
 
 		assert.Equal("my text value", string(dr.Value.NormalizedPayload))
@@ -2544,9 +2544,9 @@ func (s *SerdeIntegrationTestSuite) TestDeserializeRecord() {
 		require.NotNil(dr)
 
 		// check key
-		obj, ok := (dr.Key.DeserializedPayload).([]byte)
-		require.Truef(ok, "parsed payload is not of type []byte")
-		assert.Equal("text", string(obj))
+		obj, ok := (dr.Key.DeserializedPayload).(string)
+		require.Truef(ok, "parsed payload is not of type string")
+		assert.Equal("text", obj)
 
 		assert.Equal("text", string(dr.Key.NormalizedPayload))
 
@@ -2559,9 +2559,9 @@ func (s *SerdeIntegrationTestSuite) TestDeserializeRecord() {
 		assert.Empty(dr.Key.SchemaID)
 
 		// check value
-		valObj, ok := (dr.Value.DeserializedPayload).([]byte)
-		require.Truef(ok, "parsed payload is not of type []byte")
-		assert.Equal("my text value", string(valObj))
+		valObj, ok := (dr.Value.DeserializedPayload).(string)
+		require.Truef(ok, "parsed payload is not of type string")
+		assert.Equal("my text value", valObj)
 		assert.Empty(dr.Value.SchemaID)
 
 		assert.Equal("my text value", string(dr.Value.NormalizedPayload))
@@ -2857,9 +2857,9 @@ func (s *SerdeIntegrationTestSuite) TestDeserializeRecord() {
 		assert.Equal("first byte indicates this it not valid XML", dr.Value.Troubleshooting[3].Message)
 
 		// check key
-		keyObj, ok := (dr.Key.DeserializedPayload).([]byte)
-		require.Truef(ok, "parsed payload is not of type []byte")
-		assert.Equal("order_0", string(keyObj))
+		keyObj, ok := (dr.Key.DeserializedPayload).(string)
+		require.Truef(ok, "parsed payload is not of type string")
+		assert.Equal("order_0", keyObj)
 		assert.Empty(dr.Key.SchemaID)
 
 		// key properties

--- a/backend/pkg/serde/text.go
+++ b/backend/pkg/serde/text.go
@@ -37,7 +37,7 @@ func (TextSerde) DeserializePayload(_ context.Context, record *kgo.Record, paylo
 	if len(trimmed) == 0 {
 		return &RecordPayload{
 			NormalizedPayload:   payload,
-			DeserializedPayload: payload,
+			DeserializedPayload: string(payload),
 			Encoding:            PayloadEncodingText,
 		}, nil
 	}
@@ -53,7 +53,7 @@ func (TextSerde) DeserializePayload(_ context.Context, record *kgo.Record, paylo
 
 	return &RecordPayload{
 		NormalizedPayload:   payload,
-		DeserializedPayload: payload,
+		DeserializedPayload: string(payload),
 		Encoding:            PayloadEncodingText,
 	}, nil
 }

--- a/backend/pkg/serde/text_test.go
+++ b/backend/pkg/serde/text_test.go
@@ -39,9 +39,9 @@ func TestTextSerde_DeserializePayload(t *testing.T) {
 				assert.Nil(t, payload.SchemaID)
 				assert.Equal(t, PayloadEncodingText, payload.Encoding)
 
-				val, ok := (payload.DeserializedPayload).([]byte)
+				val, ok := (payload.DeserializedPayload).(string)
 				require.Truef(t, ok, "parsed payload is not of type string")
-				assert.Equal(t, "\n", string(val))
+				assert.Equal(t, "\n", val)
 
 				assert.Equal(t, "\n", string(payload.NormalizedPayload))
 			},
@@ -58,9 +58,9 @@ func TestTextSerde_DeserializePayload(t *testing.T) {
 				assert.Nil(t, payload.SchemaID)
 				assert.Equal(t, PayloadEncodingText, payload.Encoding)
 
-				val, ok := (payload.DeserializedPayload).([]byte)
+				val, ok := (payload.DeserializedPayload).(string)
 				require.Truef(t, ok, "parsed payload is not of type string")
-				assert.Equal(t, " [^[:cntrl:]]*$", string(val))
+				assert.Equal(t, " [^[:cntrl:]]*$", val)
 
 				assert.Equal(t, " [^[:cntrl:]]*$", string(payload.NormalizedPayload))
 			},
@@ -77,9 +77,9 @@ func TestTextSerde_DeserializePayload(t *testing.T) {
 				assert.Nil(t, payload.SchemaID)
 				assert.Equal(t, PayloadEncodingText, payload.Encoding)
 
-				val, ok := (payload.DeserializedPayload).([]byte)
+				val, ok := (payload.DeserializedPayload).(string)
 				require.Truef(t, ok, "parsed payload is not of type string")
-				assert.Equal(t, " [^[:cntrl:]]*$", string(val))
+				assert.Equal(t, " [^[:cntrl:]]*$", val)
 
 				assert.Equal(t, " [^[:cntrl:]]*$", string(payload.NormalizedPayload))
 			},


### PR DESCRIPTION
Another fix for #1073
in text serde set deserialized payload to string rather than bytes