### PR TITLE
Persist consumers and partitions size in localstorage

### DIFF
--- a/frontend/src/components/pages/topics/Tab.Partitions.tsx
+++ b/frontend/src/components/pages/topics/Tab.Partitions.tsx
@@ -9,7 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
-import { Component } from 'react';
+import { FC } from 'react';
 import React from 'react';
 import { Partition, Topic, } from '../../../state/restInterfaces';
 import { observer } from 'mobx-react';
@@ -19,66 +19,109 @@ import { numberToThousandsString, DefaultSkeleton, InfoText, ZeroSizeWrapper } f
 import { BrokerList } from '../../misc/BrokerList';
 import { WarningTwoTone } from '@ant-design/icons';
 import { Alert, AlertIcon, DataTable, Popover } from '@redpanda-data/ui';
+import usePaginationParams from '../../../hooks/usePaginationParams';
+import { onPaginationChange } from '../../../utils/pagination';
+import { editQuery } from '../../../utils/queryHelper';
+import { uiState } from '../../../state/uiState';
 
+type TopicPartitionsProps = {
+    topic: Topic;
+};
 
-@observer
-export class TopicPartitions extends Component<{ topic: Topic }> {
+export const TopicPartitions: FC<TopicPartitionsProps> = observer(({topic}) => {
+    const paginationParams = usePaginationParams(uiState.topicSettings.partitionPageSize);
 
-    render() {
-        const topic = this.props.topic;
-        let partitions = api.topicPartitions.get(topic.topicName);
-        if (partitions === undefined) return DefaultSkeleton;
-        if (partitions === null) partitions = []; // todo: show the error (if one was reported);
-
-        let warning: JSX.Element = <></>
-        if (topic.cleanupPolicy.toLowerCase() == 'compact')
-            warning = <Alert status="warning" marginBottom="1em">
-                <AlertIcon />
+    let partitions = api.topicPartitions.get(topic.topicName);
+    if (partitions === undefined) return DefaultSkeleton;
+    if (partitions === null) partitions = []; // todo: show the error (if one was reported);
+    let warning: JSX.Element = <></>;
+    if (topic.cleanupPolicy.toLowerCase() === 'compact')
+        warning = (
+            <Alert status="warning" marginBottom="1em">
+                <AlertIcon/>
                 Topic cleanupPolicy is 'compact'. Message Count is an estimate!
             </Alert>
+        );
 
-        return <>
+    return (
+        <>
             {warning}
             <DataTable<Partition>
-                pagination
-                defaultPageSize={50}
+                pagination={paginationParams}
+                onPaginationChange={onPaginationChange(paginationParams, ({pageSize, pageIndex}) => {
+                    uiState.topicSettings.partitionPageSize = pageSize;
+                    editQuery(query => {
+                        query['page'] = String(pageIndex);
+                        query['pageSize'] = String(pageSize);
+                    });
+                })}
                 sorting
+                // @ts-ignore - we need to get rid of this enum in DataTable
+                defaultPageSize={uiState.topicSettings.partitionPageSize}
                 data={partitions}
                 columns={[
                     {
                         header: 'Partition ID',
                         accessorKey: 'id',
-                        cell: ({row: {original: partition}}) => partition.hasErrors ? <span style={{ display: 'inline-flex', width: '100%' }}>
-                            <span>{partition.id}</span>
-                            <span style={{ marginLeft: 'auto', marginRight: '2px', display: 'inline-block' }}>{renderPartitionError(partition)}</span>
-                        </span> : partition.id
+                        cell: ({row: {original: partition}}) =>
+                            partition.hasErrors ? (
+                                <span
+                                    style={{display: 'inline-flex', width: '100%'}}
+                                >
+                  <span>{partition.id}</span>
+                  <span
+                      style={{
+                          marginLeft: 'auto',
+                          marginRight: '2px',
+                          display: 'inline-block',
+                      }}
+                  >
+                    {renderPartitionError(partition)}
+                  </span>
+                </span>
+                            ) : (
+                                partition.id
+                            ),
                     },
                     {
                         id: 'waterMarkLow',
-                        header: () => <InfoText tooltip="Low Water Mark" tooltipOverText>Low</InfoText>,
+                        header: () => (
+                            <InfoText tooltip="Low Water Mark" tooltipOverText>
+                                Low
+                            </InfoText>
+                        ),
                         accessorKey: 'waterMarkLow',
-                        cell: ({row: {original: partition}}) => !partition.hasErrors && numberToThousandsString(partition.waterMarkLow),
-
+                        cell: ({row: {original: partition}}) =>
+                            !partition.hasErrors && numberToThousandsString(partition.waterMarkLow),
                     },
                     {
                         id: 'waterMarkHigh',
-                        header: () => <InfoText tooltip="High Water Mark" tooltipOverText>High</InfoText>,
+                        header: () => (
+                            <InfoText tooltip="High Water Mark" tooltipOverText>
+                                High
+                            </InfoText>
+                        ),
                         accessorKey: 'waterMarkHigh',
-                        cell: ({row: {original: partition}}) => !partition.hasErrors && numberToThousandsString(partition.waterMarkHigh),
+                        cell: ({row: {original: partition}}) =>
+                            !partition.hasErrors && numberToThousandsString(partition.waterMarkHigh),
                     },
                     {
                         header: 'Messages',
-                        cell: ({row: {original: partition}}) => !partition.hasErrors && numberToThousandsString(partition.waterMarkHigh - partition.waterMarkLow),
+                        cell: ({row: {original: partition}}) =>
+                            !partition.hasErrors &&
+                            numberToThousandsString(partition.waterMarkHigh - partition.waterMarkLow),
                     },
                     {
                         header: 'Brokers',
-                        cell: ({row: {original: partition}}) => <BrokerList partition={partition} />
-                    }
+                        cell: ({row: {original: partition}}) => (
+                            <BrokerList partition={partition}/>
+                        ),
+                    },
                 ]}
             />
         </>
-    }
-}
+    );
+});
 
 function renderPartitionError(partition: Partition) {
     const txt = [partition.partitionError, partition.waterMarksError].join('\n\n');
@@ -88,18 +131,18 @@ function renderPartitionError(partition: Partition) {
         placement="right-start"
         size="auto"
         hideCloseButton
-        content={<div style={{ maxWidth: '500px', whiteSpace: 'pre-wrap' }}>
+        content={<div style={{maxWidth: '500px', whiteSpace: 'pre-wrap'}}>
             {txt}
         </div>
         }
     >
         <span>
             <ZeroSizeWrapper justifyContent="center" alignItems="center" width="20px" height="18px">
-                <span style={{ fontSize: '19px' }}>
-                    <WarningTwoTone twoToneColor="orange" />
+                <span style={{fontSize: '19px'}}>
+                    <WarningTwoTone twoToneColor="orange"/>
                 </span>
             </ZeroSizeWrapper>
         </span>
-    </Popover>
+    </Popover>;
 
 }


### PR DESCRIPTION
Persists information about Topic Consumers and Topic Parititons table to a local storage.

In order to take advantage of `usePaginationParams` hook, we needed to convert these Classes to FC.

