### PR TITLE
Better handling of long names in the tables & breadcrumbs

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -14,62 +14,67 @@ import { observer } from 'mobx-react';
 import { Link, useRouteMatch } from 'react-router-dom';
 import { isEmbedded } from '../../config';
 import { uiState } from '../../state/uiState';
-import { MotionDiv } from '../../utils/animationProps';
-import { ZeroSizeWrapper } from '../../utils/tsxUtils';
 import { UserPreferencesButton } from '../misc/UserPreferences';
 import DataRefreshButton from '../misc/buttons/data-refresh/Component';
 import { IsDev } from '../../utils/env';
-import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbLinkProps, ColorModeSwitch, Flex } from '@redpanda-data/ui';
+import { Box, Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbLinkProps, ColorModeSwitch, Flex } from '@redpanda-data/ui';
 
 const AppPageHeader = observer(() => {
     const showRefresh = useShouldShowRefresh();
 
-    return <MotionDiv identityKey={uiState.pageTitle} className="pageTitle" style={{ display: 'flex', paddingRight: '16px', alignItems: 'center', marginBottom: '10px' }}>
-        <Breadcrumb spacing="8px" separator={<ChevronRightIcon/>}>
-            {!isEmbedded() && uiState.selectedClusterName &&
-                <BreadcrumbItem>
-                    <BreadcrumbLink as={Link} to="/">
-                        Cluster
-                    </BreadcrumbLink>
-                </BreadcrumbItem>
-            }
-            {uiState.pageBreadcrumbs.filter((_,i,arr) => {
-                const isCurrentPage = arr.length - 1 === i
-                return !isEmbedded() || isCurrentPage
-            }).map((entry, i, arr) => {
-                    const isCurrentPage = arr.length - 1 === i;
-                    const currentBreadcrumbProps: BreadcrumbLinkProps = isCurrentPage ? {
-                        as: 'span',
-                        fontWeight: 700,
-                        fontSize: 'xl',
-                    } : {};
-
-                    return (
-                        <BreadcrumbItem key={entry.linkTo} isCurrentPage={isCurrentPage}>
-                            <BreadcrumbLink
-                                to={entry.linkTo}
-                                as={isCurrentPage ? 'span': Link}
-                                {...currentBreadcrumbProps}
-                            >
-                                {entry.title}
-                            </BreadcrumbLink>
-
-                            {isCurrentPage && showRefresh && (
-                                <ZeroSizeWrapper justifyContent="start">
-                                    <DataRefreshButton/>
-                                </ZeroSizeWrapper>
-                            )}
-                        </BreadcrumbItem>
-                    );
+    return <Box> {/* we need to refactor out #mainLayout > div rule, for now I've added this box as a workaround */}
+        <Flex mb={5} alignItems="center" justifyContent="space-between">
+            <Breadcrumb spacing="8px" separator={<ChevronRightIcon/>}>
+                {!isEmbedded() && uiState.selectedClusterName &&
+                    <BreadcrumbItem>
+                        <BreadcrumbLink as={Link} to="/">
+                            Cluster
+                        </BreadcrumbLink>
+                    </BreadcrumbItem>
                 }
-            )}
-        </Breadcrumb>
+                {uiState.pageBreadcrumbs.filter((_, i, arr) => {
+                    const isCurrentPage = arr.length - 1 === i;
+                    return !isEmbedded() || isCurrentPage;
+                }).map((entry, i, arr) => {
+                        const isCurrentPage = arr.length - 1 === i;
+                        const currentBreadcrumbProps: BreadcrumbLinkProps = isCurrentPage ? {
+                            as: 'span',
+                            fontWeight: 700,
+                            fontSize: 'xl',
+                            wordBreak: 'break-all',
+                            whiteSpace: 'break-spaces',
+                        } : {
+                            whiteSpace: 'nowrap'
+                        };
 
-        <Flex ml="auto" alignItems="center" gap={3}>
-            <UserPreferencesButton />
-            {(IsDev && !isEmbedded()) && <ColorModeSwitch />}
+                        return (
+                            <BreadcrumbItem key={entry.linkTo} isCurrentPage={isCurrentPage}>
+                                <BreadcrumbLink
+                                    to={entry.linkTo}
+                                    as={isCurrentPage ? 'span' : Link}
+                                    noOfLines={1}
+                                    {...currentBreadcrumbProps}
+                                >
+                                    {entry.title}
+                                </BreadcrumbLink>
+
+                                {isCurrentPage && showRefresh && (
+                                    <Box minW={250}>
+                                        <DataRefreshButton/>
+                                    </Box>
+                                )}
+                            </BreadcrumbItem>
+                        );
+                    }
+                )}
+            </Breadcrumb>
+
+            <Flex alignItems="center" gap={1}>
+                <UserPreferencesButton/>
+                {(IsDev && !isEmbedded()) && <ColorModeSwitch/>}
+            </Flex>
         </Flex>
-    </MotionDiv>;
+    </Box>;
 });
 
 export default AppPageHeader;

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -17,7 +17,7 @@ import { uiState } from '../../state/uiState';
 import { UserPreferencesButton } from '../misc/UserPreferences';
 import DataRefreshButton from '../misc/buttons/data-refresh/Component';
 import { IsDev } from '../../utils/env';
-import { Box, Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbLinkProps, ColorModeSwitch, Flex } from '@redpanda-data/ui';
+import { Box, Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbLinkProps, CopyButton, ColorModeSwitch, Flex } from '@redpanda-data/ui';
 
 const AppPageHeader = observer(() => {
     const showRefresh = useShouldShowRefresh();
@@ -41,10 +41,7 @@ const AppPageHeader = observer(() => {
                             as: 'span',
                             fontWeight: 700,
                             fontSize: 'xl',
-                            wordBreak: 'break-all',
-                            whiteSpace: 'break-spaces',
                         } : {
-                            whiteSpace: 'nowrap'
                         };
 
                         return (
@@ -54,15 +51,26 @@ const AppPageHeader = observer(() => {
                                     as={isCurrentPage ? 'span' : Link}
                                     noOfLines={1}
                                     {...currentBreadcrumbProps}
+                                    {...(entry.options?.canBeTruncated ? {
+                                        wordBreak: 'break-all',
+                                        whiteSpace: 'break-spaces',
+                                    } : {
+                                        whiteSpace: 'nowrap'
+                                    })}
                                 >
                                     {entry.title}
                                 </BreadcrumbLink>
 
-                                {isCurrentPage && showRefresh && (
-                                    <Box minW={250}>
-                                        <DataRefreshButton/>
-                                    </Box>
-                                )}
+                                <Flex ml={2}>
+                                    {isCurrentPage && entry.options?.canBeCopied && <CopyButton content={entry.title} variant="ghost"/>}
+
+                                    {isCurrentPage && showRefresh && (
+                                        <Box minW={250}>
+                                            <DataRefreshButton/>
+                                        </Box>
+                                    )}
+                                </Flex>
+
                             </BreadcrumbItem>
                         );
                     }

--- a/frontend/src/components/misc/buttons/buttons.module.scss
+++ b/frontend/src/components/misc/buttons/buttons.module.scss
@@ -13,7 +13,6 @@
 .dataRefreshButton {
     height: 32px;
     display: inline-flex;
-    margin-left: 10px;
 
     background: $color-reload-spinner-bg;
     color: $color-reload-spinner;

--- a/frontend/src/components/pages/Page.ts
+++ b/frontend/src/components/pages/Page.ts
@@ -11,7 +11,7 @@
 
 import { makeAutoObservable } from 'mobx';
 import React from 'react';
-import { uiState } from '../../state/uiState';
+import { BreadcrumbOptions, uiState } from '../../state/uiState';
 
 
 //
@@ -24,7 +24,7 @@ export class PageInitHelper {
         makeAutoObservable(this);
     }
     set title(title: string) { uiState.pageTitle = title; }
-    addBreadcrumb(title: string, to: string) { uiState.pageBreadcrumbs.push({ title: title, linkTo: to }) }
+    addBreadcrumb(title: string, to: string, options?: BreadcrumbOptions) { uiState.pageBreadcrumbs.push({ title: title, linkTo: to, options }) }
 }
 export abstract class PageComponent<TRouteParams = Record<string, unknown>> extends React.Component<PageProps<TRouteParams>> {
 

--- a/frontend/src/components/pages/acls/Acl.List.tsx
+++ b/frontend/src/components/pages/acls/Acl.List.tsx
@@ -25,7 +25,7 @@ import { AclPrincipalGroupEditor } from './PrincipalGroupEditor';
 import Section from '../../misc/Section';
 import PageContent from '../../misc/PageContent';
 import { Features } from '../../../state/supportedFeatures';
-import { Alert, AlertDialog, AlertDialogBody, AlertDialogContent, AlertDialogFooter, AlertDialogHeader, AlertDialogOverlay, AlertIcon, Badge, Button, createStandaloneToast, Icon, redpandaToastOptions, SearchField, Tooltip, Text, redpandaTheme, Menu, MenuButton, MenuItem, MenuList, Result, DataTable } from '@redpanda-data/ui';
+import { Alert, AlertDialog, AlertDialogBody, AlertDialogContent, AlertDialogFooter, AlertDialogHeader, AlertDialogOverlay, AlertIcon, Badge, Button, createStandaloneToast, DataTable, Flex, Icon, Menu, MenuButton, MenuItem, MenuList, redpandaTheme, redpandaToastOptions, Result, SearchField, Text, Tooltip } from '@redpanda-data/ui';
 import React, { FC, useRef } from 'react';
 import { openCreateUserModal } from './CreateServiceAccountModal';
 
@@ -142,15 +142,17 @@ class AclList extends PageComponent {
                                             this.editorType = 'edit';
                                             this.edittingPrincipalGroup = clone(record);
                                         }}>
-                                            <Badge variant="subtle" mr="2">{principalType}</Badge>
-                                            <span>{record.principalName}</span>
-                                            {showWarning && (
-                                                <Tooltip label="User / ServiceAccount does not exist" placement="top" hasArrow>
+                                            <Flex>
+                                                <Badge variant="subtle" mr="2">{principalType}</Badge>
+                                                <Text as="span" wordBreak="break-word" whiteSpace="break-spaces" noOfLines={1}>{record.principalName}</Text>
+                                                {showWarning && (
+                                                    <Tooltip label="User / ServiceAccount does not exist" placement="top" hasArrow>
                                 <span style={{marginLeft: '4px'}}>
                                     <QuestionIcon fill="orange" size={16}/>
                                 </span>
-                                                </Tooltip>
-                                            )}
+                                                    </Tooltip>
+                                                )}
+                                            </Flex>
                                         </button>
                                     );
                                 },

--- a/frontend/src/components/pages/acls/CreateServiceAccountModal.tsx
+++ b/frontend/src/components/pages/acls/CreateServiceAccountModal.tsx
@@ -208,7 +208,7 @@ const CreateUserConfirmationModal = observer((p: { state: CreateUserModalState; 
                         </Box>
                         <Box>
                             <Flex alignItems="center" gap={2}>
-                                <Text textOverflow="ellipsis" whiteSpace="nowrap" overflow="hidden" isTruncated={true}>
+                                <Text wordBreak="break-all" overflow="hidden">
                                     {p.state.username}
                                 </Text>
 

--- a/frontend/src/components/pages/connect/Cluster.Details.tsx
+++ b/frontend/src/components/pages/connect/Cluster.Details.tsx
@@ -20,7 +20,7 @@ import { PageComponent, PageInitHelper } from '../Page';
 import { ClusterStatisticsCard, ConnectorClass, NotConfigured, TasksColumn, TaskState } from './helper';
 import { isEmbedded } from '../../../config';
 import { Link } from 'react-router-dom';
-import { Box, Button, DataTable } from '@redpanda-data/ui';
+import { Box, Button, DataTable, Text } from '@redpanda-data/ui';
 import { ClusterAdditionalInfo, ClusterConnectorInfo } from '../../../state/restInterfaces';
 import SearchBar from '../../misc/SearchBar';
 import { uiSettings } from '../../../state/ui';
@@ -116,7 +116,7 @@ class KafkaClusterDetails extends PageComponent<{ clusterName: string }> {
                                     accessorKey: 'name',
                                     cell: ({row: {original}}) => (
                                         <Link to={`/connect-clusters/${encodeURIComponent(clusterName)}/${encodeURIComponent(original.name)}`}>
-                                            {original.name}
+                                            <Text wordBreak="break-word" whiteSpace="break-spaces" noOfLines={1}>{original.name}</Text>
                                         </Link>
                                     ),
                                     size: Infinity

--- a/frontend/src/components/pages/connect/Connector.Details.tsx
+++ b/frontend/src/components/pages/connect/Connector.Details.tsx
@@ -348,7 +348,7 @@ const ConnectorErrorModal = observer((p: { error: ConnectorError }) => {
     return <>
         <Alert status={errorType} variant="solid" height="12" borderRadius="8px" onClick={onOpen}>
             <AlertIcon />
-            {p.error.title}
+            <Box wordBreak="break-all" whiteSpace="break-spaces">{p.error.title}</Box>
             <Button ml="auto" variant="ghost" colorScheme="gray" size="sm" mt="1px">View details</Button>
         </Alert>
 
@@ -380,7 +380,10 @@ class KafkaConnectorDetails extends PageComponent<{ clusterName: string; connect
         p.title = connector;
         p.addBreadcrumb('Connectors', '/connect-clusters');
         p.addBreadcrumb(clusterName, `/connect-clusters/${encodeURIComponent(clusterName)}`);
-        p.addBreadcrumb(connector, `/connect-clusters/${encodeURIComponent(clusterName)}/${encodeURIComponent(connector)}`);
+        p.addBreadcrumb(connector, `/connect-clusters/${encodeURIComponent(clusterName)}/${encodeURIComponent(connector)}`, {
+            canBeTruncated: true,
+            canBeCopied: true
+        });
         this.refreshData(true);
         appGlobal.onRefresh = () => this.refreshData(true);
     }

--- a/frontend/src/components/pages/connect/Overview.tsx
+++ b/frontend/src/components/pages/connect/Overview.tsx
@@ -21,7 +21,7 @@ import { PageComponent, PageInitHelper } from '../Page';
 import { ConnectorClass, ConnectorsColumn, errIcon, mr05, NotConfigured, OverviewStatisticsCard, TasksColumn, TaskState } from './helper';
 import Section from '../../misc/Section';
 import PageContent from '../../misc/PageContent';
-import { DataTable, Tooltip } from '@redpanda-data/ui';
+import { DataTable, Tooltip, Text } from '@redpanda-data/ui';
 
 @observer
 class KafkaConnectOverview extends PageComponent {
@@ -212,9 +212,9 @@ class TabTasks extends Component {
                         header: 'Connector',
                         accessorKey: 'name', // Assuming 'name' is correct based on your initial dataIndex
                         cell: ({ row: { original } }) => (
-                            <span className="hoverLink" onClick={() => appGlobal.history.push(`/connect-clusters/${encodeURIComponent(original.cluster.clusterName)}/${encodeURIComponent(original.connectorName)}`)}>
+                            <Text wordBreak="break-word" whiteSpace="break-spaces" noOfLines={1} className="hoverLink" onClick={() => appGlobal.history.push(`/connect-clusters/${encodeURIComponent(original.cluster.clusterName)}/${encodeURIComponent(original.connectorName)}`)}>
                 {original.connectorName}
-            </span>
+            </Text>
                         ),
                         size: 300
                     },

--- a/frontend/src/components/pages/consumers/Group.Details.tsx
+++ b/frontend/src/components/pages/consumers/Group.Details.tsx
@@ -50,7 +50,10 @@ class GroupDetails extends PageComponent<{ groupId: string }> {
 
         p.title = this.props.groupId;
         p.addBreadcrumb('Consumer Groups', '/groups');
-        if (group) p.addBreadcrumb(group, '/' + group);
+        if (group) p.addBreadcrumb(group, '/' + group, {
+            canBeCopied: true,
+            canBeTruncated: true,
+        });
 
         this.refreshData(true);
         appGlobal.onRefresh = () => this.refreshData(true);

--- a/frontend/src/components/pages/consumers/Group.List.tsx
+++ b/frontend/src/components/pages/consumers/Group.List.tsx
@@ -25,7 +25,7 @@ import { BrokerList } from '../../misc/BrokerList';
 import { ShortNum } from '../../misc/ShortNum';
 import Section from '../../misc/Section';
 import PageContent from '../../misc/PageContent';
-import { DataTable, Flex, SearchField, Tag } from '@redpanda-data/ui';
+import { DataTable, Flex, SearchField, Tag, Text } from '@redpanda-data/ui';
 import { Statistic } from '../../misc/Statistic';
 import { Link } from 'react-router-dom';
 
@@ -189,11 +189,15 @@ class GroupList extends PageComponent {
     GroupId = (p: { group: GroupDescription }) => {
         const protocol = p.group.protocolType;
 
-        if (protocol == 'consumer') return <>{p.group.groupId}</>;
+        const groupIdEl = <Text wordBreak="break-word" whiteSpace="break-spaces" noOfLines={1}>{p.group.groupId}</Text>
+
+        if (protocol == 'consumer') {
+            return groupIdEl;
+        }
 
         return <Flex alignItems="center" gap={2}>
             <Tag>Protocol: {protocol}</Tag>
-            <span>{p.group.groupId}</span>
+            {groupIdEl}
         </Flex>;
     }
 }

--- a/frontend/src/components/pages/reassign-partitions/Step1.Partitions.tsx
+++ b/frontend/src/components/pages/reassign-partitions/Step1.Partitions.tsx
@@ -24,7 +24,7 @@ import Highlighter from 'react-highlight-words';
 import { uiSettings } from '../../../state/ui';
 import { WarningTwoTone } from '@ant-design/icons';
 import { SearchTitle } from '../../misc/KowlTable';
-import { Checkbox, DataTable, Popover } from '@redpanda-data/ui'
+import { Box, Checkbox, DataTable, Popover } from '@redpanda-data/ui'
 import { Row } from '@tanstack/react-table';
 
 export type TopicWithPartitions = Topic & { partitions: Partition[], activeReassignments: PartitionReassignmentsPartition[] };
@@ -108,13 +108,13 @@ export class StepSelectPartitions extends Component<{ partitionSelection: Partit
                                 : record.topicName;
 
                             if (this.props.throttledTopics.includes(record.topicName)) {
-                                return <div>
+                                return <Box wordBreak="break-word" whiteSpace="break-spaces" noOfLines={4}>
                                     <span>{content}</span>
                                     <WarningToolip content="Topic replication is throttled" position="top"/>
-                                </div>
+                                </Box>
                             }
 
-                            return content;
+                            return <Box wordBreak="break-word" whiteSpace="break-spaces" noOfLines={4}>{content}</Box>;
                         },
                         size: Infinity,
                     },

--- a/frontend/src/components/pages/schemas/EditCompatibility.tsx
+++ b/frontend/src/components/pages/schemas/EditCompatibility.tsx
@@ -226,7 +226,7 @@ function EditSchemaCompatibility(p: {
 
             <GridItem>
                 {(subjectName && schema) && <>
-                    <Text mt="4" fontSize="lg" fontWeight="bold">{subjectName}</Text>
+                    <Text mt="4" fontSize="lg" fontWeight="bold" wordBreak="break-word" whiteSpace="break-spaces">{subjectName}</Text>
 
                     <Text mt="8" mb="4" fontSize="lg" fontWeight="bold">Schema</Text>
                     <Box maxHeight="600px" overflow="scroll">

--- a/frontend/src/components/pages/schemas/Schema.Details.tsx
+++ b/frontend/src/components/pages/schemas/Schema.Details.tsx
@@ -89,7 +89,10 @@ class SchemaDetailsView extends PageComponent<{ subjectName: string }> {
         uiState.pageTitle = subjectNameRaw;
         uiState.pageBreadcrumbs = [];
         uiState.pageBreadcrumbs.push({ title: 'Schema Registry', linkTo: '/schema-registry' });
-        uiState.pageBreadcrumbs.push({ title: subjectNameRaw, linkTo: `/schema-registry/${encodeURIComponent(subjectNameRaw)}?version=${version}` });
+        uiState.pageBreadcrumbs.push({ title: subjectNameRaw, linkTo: `/schema-registry/${encodeURIComponent(subjectNameRaw)}?version=${version}`, options: {
+            canBeTruncated: true,
+            canBeCopied: true,
+        }});
     }
 
     refreshData(force?: boolean) {

--- a/frontend/src/components/pages/schemas/Schema.List.tsx
+++ b/frontend/src/components/pages/schemas/Schema.List.tsx
@@ -27,7 +27,7 @@ import { SmallStat } from '../../misc/SmallStat';
 import { TrashIcon } from '@heroicons/react/outline';
 import { openDeleteModal, openPermanentDeleteModal } from './modals';
 
-import { createStandaloneToast } from '@chakra-ui/react';
+import { Box, createStandaloneToast } from '@chakra-ui/react';
 import { SchemaRegistrySubject } from '../../../state/restInterfaces';
 import { Link } from 'react-router-dom';
 import { encodeURIComponentPercents } from './Schema.Details';
@@ -167,8 +167,10 @@ class SchemaList extends PageComponent<{}> {
                         sorting
                         columns={[
                             {
-                                header: 'Name', accessorKey: 'name', size: 400, cell: ({ row: { original: { name } } }) =>
-                                    <Link to={`/schema-registry/subjects/${encodeURIComponentPercents(name)}?version=latest`}>{name}</Link>
+                                header: 'Name', accessorKey: 'name', size: Infinity, cell: ({ row: { original: { name } } }) =>
+                                    <Box wordBreak="break-word" whiteSpace="break-spaces" noOfLines={4}>
+                                        <Link to={`/schema-registry/subjects/${encodeURIComponentPercents(name)}?version=latest`}>{name}</Link>
+                                    </Box>
                             },
                             { header: 'Type', cell: ({row: {original: r}}) => <SchemaTypeColumn name={r.name} />, size: 100 },
                             { header: 'Compatibility', cell: ({row: {original: r}}) => <SchemaCompatibilityColumn name={r.name} />, size: 100 },
@@ -178,7 +180,7 @@ class SchemaList extends PageComponent<{}> {
                                 id: 'actions',
                                 cell: ({row: {original: r}}) =>
                                     <Button variant="icon"
-                                            height="21px" color="gray.500"
+                                            height="16px" color="gray.500"
                                             disabledReason={api.userData?.canDeleteSchemas === false ? 'You don\'t have the \'canDeleteSchemas\' permission' : undefined}
                                             onClick={e => {
                                                 e.stopPropagation();

--- a/frontend/src/components/pages/schemas/Schema.List.tsx
+++ b/frontend/src/components/pages/schemas/Schema.List.tsx
@@ -168,7 +168,7 @@ class SchemaList extends PageComponent<{}> {
                         columns={[
                             {
                                 header: 'Name', accessorKey: 'name', size: Infinity, cell: ({ row: { original: { name } } }) =>
-                                    <Box wordBreak="break-word" whiteSpace="break-spaces" noOfLines={4}>
+                                    <Box wordBreak="break-word" whiteSpace="break-spaces" noOfLines={1}>
                                         <Link to={`/schema-registry/subjects/${encodeURIComponentPercents(name)}?version=latest`}>{name}</Link>
                                     </Box>
                             },

--- a/frontend/src/components/pages/topics/Topic.Details.tsx
+++ b/frontend/src/components/pages/topics/Topic.Details.tsx
@@ -158,7 +158,10 @@ class TopicDetails extends PageComponent<{ topicName: string }> {
 
         p.title = topicName;
         p.addBreadcrumb('Topics', '/topics');
-        p.addBreadcrumb(topicName, '/topics/' + topicName);
+        p.addBreadcrumb(topicName, '/topics/' + topicName, {
+            canBeCopied: true,
+            canBeTruncated: true,
+        });
 
         // clear messages from different topic if we have some
         if (api.messagesFor != '' && api.messagesFor != topicName) {

--- a/frontend/src/components/pages/topics/Topic.List.tsx
+++ b/frontend/src/components/pages/topics/Topic.List.tsx
@@ -214,12 +214,13 @@ const TopicsTable: FC<{ topics: Topic[], onDelete: (record: Topic) => void }> = 
                 {
                     header: 'Name',
                     accessorKey: 'topicName',
-                    cell: ({row: {original: topic}}) => <Link to={`/topics/${encodeURIComponent(topic.topicName)}`}>{renderName(topic)}</Link>,
+                    cell: ({row: {original: topic}}) => <Box wordBreak="break-word" whiteSpace="break-spaces" noOfLines={4}><Link to={`/topics/${encodeURIComponent(topic.topicName)}`}>{renderName(topic)}</Link></Box>,
                     size: Infinity,
                 },
                 {
                     header: 'Partitions',
                     accessorKey: 'partitions',
+                    enableResizing: true,
                     cell: ({row: {original: topic}}) => topic.partitionCount,
                 },
                 {
@@ -310,12 +311,14 @@ const renderName = (topic: Topic) => {
     );
 
     return (
-        <Popover content={popoverContent} placement="right" closeDelay={10} size="stretch" hideCloseButton>
+        <Box wordBreak="break-word" whiteSpace="break-spaces">
+            <Popover content={popoverContent} placement="right" closeDelay={10} size="stretch" hideCloseButton>
             <span>
                 {topic.topicName}
                 {iconClosedEye}
             </span>
-        </Popover>
+            </Popover>
+        </Box>
     );
 };
 

--- a/frontend/src/components/pages/topics/Topic.List.tsx
+++ b/frontend/src/components/pages/topics/Topic.List.tsx
@@ -42,8 +42,10 @@ import {
     Box,
     Button,
     Checkbox,
+    CopyButton,
     DataTable,
     Flex,
+    Grid,
     Icon,
     Popover,
     Text,
@@ -214,7 +216,7 @@ const TopicsTable: FC<{ topics: Topic[], onDelete: (record: Topic) => void }> = 
                 {
                     header: 'Name',
                     accessorKey: 'topicName',
-                    cell: ({row: {original: topic}}) => <Box wordBreak="break-word" whiteSpace="break-spaces" noOfLines={4}><Link to={`/topics/${encodeURIComponent(topic.topicName)}`}>{renderName(topic)}</Link></Box>,
+                    cell: ({row: {original: topic}}) => <Box wordBreak="break-word" whiteSpace="break-spaces" noOfLines={1}><Link to={`/topics/${encodeURIComponent(topic.topicName)}`}>{renderName(topic)}</Link></Box>,
                     size: Infinity,
                 },
                 {
@@ -479,7 +481,7 @@ function makeCreateTopicModal(parent: TopicList) {
     return createAutoModal<void, CreateTopicModalState>({
         modalProps: {
             title: 'Create Topic',
-            style: { width: '80%', minWidth: '600px', maxWidth: '1000px', top: '50px' },
+            style: { width: '80%', minWidth: '600px', maxWidth: '1000px', top: '50px', paddingTop: '10px', paddingBottom: '10px' },
 
             okText: 'Create',
             successTitle: 'Topic created!',
@@ -551,18 +553,31 @@ function makeCreateTopicModal(parent: TopicList) {
                 configs: config.filter(x => x.name.length > 0),
             });
 
-            return <div style={{
-                display: 'grid',
-                gridTemplateColumns: 'auto auto',
-                justifyContent: 'center',
-                justifyItems: 'end',
-                columnGap: '8px',
-                rowGap: '4px'
-            }}>
-                <span>Name:</span><span style={{ justifySelf: 'start' }}>{result.topicName}</span>
-                <span>Partitions:</span><span style={{ justifySelf: 'start' }}>{String(result.partitionCount).replace('-1', '(Default)')}</span>
-                <span>Replication Factor:</span><span style={{ justifySelf: 'start' }}>{String(result.replicationFactor).replace('-1', '(Default)')}</span>
-            </div>
+            return (
+                <Grid
+                    templateColumns="auto auto"
+                    justifyContent="center"
+                    alignItems="center"
+                    justifyItems="end"
+                    columnGap={2}
+                    rowGap={1}
+                    py={2}
+                >
+                    <Text>Name:</Text>
+                    <Flex justifySelf="start" gap={2} alignItems="center">
+                        <Text wordBreak="break-word" whiteSpace="break-spaces" noOfLines={1}>{result.topicName}</Text>
+                        <CopyButton content={result.topicName} variant="ghost"/>
+                    </Flex>
+                    <Text>Partitions:</Text>
+                    <Text justifySelf="start">
+                        {String(result.partitionCount).replace('-1', '(Default)')}
+                    </Text>
+                    <Text>Replication Factor:</Text>
+                    <Text justifySelf="start">
+                        {String(result.replicationFactor).replace('-1', '(Default)')}
+                    </Text>
+                </Grid>
+            )
         },
         onSuccess: (_state, _result) => {
             parent.refreshData(true);

--- a/frontend/src/components/pages/topics/Topic.Produce.tsx
+++ b/frontend/src/components/pages/topics/Topic.Produce.tsx
@@ -15,7 +15,7 @@ import { Link as ReactRouterLink } from 'react-router-dom'
 import { PublishMessagePayloadOptions, PublishMessageRequest } from '../../../protogen/redpanda/api/console/v1alpha1/publish_messages_pb';
 import { uiSettings } from '../../../state/ui';
 import { appGlobal } from '../../../state/appGlobal';
-import { base64ToUInt8Array, isValidBase64 } from '../../../utils/utils';
+import { base64ToUInt8Array, isValidBase64, substringWithEllipsis } from '../../../utils/utils';
 import { isEmbedded } from '../../../config';
 
 type EncodingOption = {
@@ -552,7 +552,8 @@ export class TopicProducePage extends PageComponent<{ topicName: string }> {
         const topicName = this.props.topicName;
         p.title = 'Produce'
         p.addBreadcrumb('Topics', '/topics');
-        p.addBreadcrumb(topicName, '/topics/' + topicName);
+        p.addBreadcrumb(substringWithEllipsis(topicName, 50), '/topics/' + topicName);
+
         p.addBreadcrumb('Produce record', '/produce-record')
         this.refreshData(true);
         appGlobal.onRefresh = () => this.refreshData(true);
@@ -566,7 +567,9 @@ export class TopicProducePage extends PageComponent<{ topicName: string }> {
         return (
             <Box>
                 <Heading as="h1" noOfLines={1} py={2}>Produce Kafka record</Heading>
-                <Text fontSize="lg">This will produce a single record to the <strong>{this.props.topicName}</strong> topic.</Text>
+                <Text fontSize="lg">
+                    This will produce a single record to the topic.
+                </Text>
 
                 <Box my={6}>
                     <PublishTopicForm topicName={this.props.topicName} />

--- a/frontend/src/index-cloud-integration.scss
+++ b/frontend/src/index-cloud-integration.scss
@@ -28,10 +28,6 @@ div[class^="ant-"],
   opacity: 0.6 !important;
 }
 
-// Remove padding
-.pageTitle {
-  padding: 0 0 24px 0 !important;
-}
 
 .ant-page-header.has-breadcrumb {
   padding: 0;

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -1531,10 +1531,6 @@ div.ant-collapse.ant-collapse-borderless>div>div>span {
     background-color: rgba(255, 187, 0, 0.185);
 }
 
-.pageTitle {
-    /* background: rgba(255, 0, 0, 0.089); */
-}
-
 .ant-breadcrumb {
     /* don't allow wrapping */
     white-space: nowrap;

--- a/frontend/src/state/uiState.ts
+++ b/frontend/src/state/uiState.ts
@@ -14,10 +14,15 @@ import { PageDefinition } from '../components/routes';
 import { api } from './backendApi';
 import { uiSettings, TopicDetailsSettings as TopicSettings } from './ui';
 
+export interface BreadcrumbOptions {
+    canBeTruncated?: boolean;
+    canBeCopied?: boolean;
+}
 
 export interface BreadcrumbEntry {
     title: string;
     linkTo: string;
+    options?: BreadcrumbOptions;
 }
 
 

--- a/frontend/src/utils/utils.test.ts
+++ b/frontend/src/utils/utils.test.ts
@@ -1,0 +1,31 @@
+import { substringWithEllipsis } from './utils'; // Adjust the import path as needed
+
+describe('substringWithEllipsis', () => {
+    it('returns the original string if its length is less than maxLength', () => {
+        expect(substringWithEllipsis('Hello', 10)).toBe('Hello');
+    });
+
+    it('returns the original string if its length is equal to maxLength', () => {
+        expect(substringWithEllipsis('Hello', 5)).toBe('Hello');
+    });
+
+    it('handles cases where maxLength is less than 3', () => {
+        // Since effectiveLength is calculated as Math.max(maxLength - 3, 1),
+        // a maxLength of 2 would lead to an effectiveLength of 1, and thus the output should be "H..."
+        // However, given the logic, it's adjusted to ensure there's at least 1 character before the ellipsis
+        expect(substringWithEllipsis('Hello, world!', 2)).toBe('H...');
+        expect(substringWithEllipsis('Hello, world!', 1)).toBe('H...');
+    });
+
+    it('returns an empty string with ellipsis if maxLength is 0', () => {
+        // This scenario is interesting because the logic dictates a minimum effective length of 1 character.
+        // However, a maxLength of 0 logically suggests no characters should be shown.
+        // The function's logic needs to be clear on this behavior; assuming we follow the implementation, it would be:
+        expect(substringWithEllipsis('Hello, world!', 0)).toBe('H...');
+        // But if considering maxLength of 0 as a request for no output, the implementation might need adjusting.
+    });
+
+    it('correctly handles an empty input string', () => {
+        expect(substringWithEllipsis('', 5)).toBe('');
+    });
+});

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -806,3 +806,23 @@ export function retrier<T>(operation: () => Promise<T>, { attempts = Infinity, d
  * performing indexing
  */
 export type ElementOf<T> = T extends (infer E)[] ? E : T extends readonly (infer F)[] ? F : never;
+
+/**
+ * Truncates a string to a specified length and adds an ellipsis (...) if the truncation occurs.
+ *
+ * @param {string} input The string to truncate.
+ * @param {number} maxLength The maximum length of the string, including the ellipsis.
+ * @returns {string} The truncated string with ellipsis if truncation was necessary, otherwise the original string.
+ */
+export function substringWithEllipsis(input: string, maxLength: number): string {
+    // Check if the input length is greater than the maxLength
+    // Note: We account for the length of the ellipsis in the comparison
+    if (input.length > maxLength) {
+        // Subtract 3 from maxLength to accommodate the ellipsis
+        // Ensure maxLength is at least 4 to avoid negative substring lengths
+        const effectiveLength = Math.max(maxLength - 3, 1);
+        return input.substring(0, effectiveLength) + '...';
+    } else {
+        return input;
+    }
+}


### PR DESCRIPTION
1. I think having it in the breadcrumb is a good thing when it comes to consistency. We currently have the detail items there for all the pages I know of.

2. I think it's however OK to cut it when needed (we have no other choice). I've worked on a prototype that takes all the possible space and adds `...` once needed.  (Please note that the whitespace at the end is needed for the refreshing text, if we could get rid of that it could go til the end).

![Screenshot 2024-02-19 at 12 09 18 PM](https://github.com/redpanda-data/console-enterprise/assets/1083817/46c62784-c46c-4154-8a54-84fc90de0938)
![Screenshot 2024-02-19 at 12 14 57 PM](https://github.com/redpanda-data/console-enterprise/assets/1083817/286cea0f-4123-4055-86b6-cbcb0f493175)

However in this scenario we would need to add `copy to clipboard` icon so that users can copy it if it's too long. Sth like github does 
![Screenshot 2024-02-19 at 12 17 39 PM](https://github.com/redpanda-data/console-enterprise/assets/1083817/77a4b884-d72f-4e7f-9292-6140d646b9b9)


In the tables I prototyped the solution that would take `n` number of lines before it shows `...` 
![Screenshot 2024-02-19 at 12 15 37 PM](https://github.com/redpanda-data/console-enterprise/assets/1083817/bc6168e9-d41e-463f-b850-7243ddd691d2)

WDYT?


