### PR TITLE
Add `offset.lag.max` advanced property to MM2 guide

### DIFF
--- a/backend/pkg/connector/guide/mirror_source.go
+++ b/backend/pkg/connector/guide/mirror_source.go
@@ -57,6 +57,7 @@ func NewMirrorSourceGuide(opts ...Option) Guide {
 							"producer.override.compression.type",
 							"producer.override.max.request.size",
 							"consumer.auto.offset.reset",
+							"offset.lag.max",
 						},
 					},
 				},


### PR DESCRIPTION
Add `How out-of-sync a remote partition can be before it is resynced` to MirrorSourceConnector guide.