### PR TITLE
frontend: still render schema pages if mode request errors

### DIFF
--- a/frontend/src/state/backendApi.ts
+++ b/frontend/src/state/backendApi.ts
@@ -838,7 +838,10 @@ const apiStore = {
                     this.schemaMode = r.mode;
                 }
             })
-            .catch(addError);
+            .catch((err) => {
+                this.schemaMode = 'Unknown'
+                console.warn('failed to request schema mode', err)
+            });
     },
 
     refreshSchemaCompatibilityConfig(force?: boolean) {


### PR DESCRIPTION
SchemaRegistries such as apicurio or karapace do not support the /mode endpoint. When opening the schema registry pages they failed to load because this request failed. The response to this request should not be mandatory. This is changed with this PR.