### PR TITLE
Fix/long names 2

### DIFF
--- a/frontend/src/components/misc/ConfigList.tsx
+++ b/frontend/src/components/misc/ConfigList.tsx
@@ -18,7 +18,7 @@ import { equalsIgnoreCase } from '../../utils/utils';
 
 import styles from './ConfigList.module.scss';
 
-import { DataTable, Flex, Tooltip } from '@redpanda-data/ui';
+import { DataTable, Flex, Tooltip, Text } from '@redpanda-data/ui';
 import { ColumnDef } from '@tanstack/react-table';
 
 export function ConfigList({ configEntries, valueDisplay, renderTooltip }: { configEntries: ConfigEntry[]; valueDisplay: ValueDisplay; renderTooltip?: (e: ConfigEntry, content: JSX.Element) => JSX.Element }) {
@@ -53,8 +53,10 @@ export function ConfigList({ configEntries, valueDisplay, renderTooltip }: { con
         {
             header: 'Value',
             accessorKey: 'value',
-            cell: ({row: {original: record}}) => <span
-                className={styles.value}>{formatConfigValue(record.name, record.value, valueDisplay)}</span>
+            size: Infinity,
+            cell: ({row: {original: record}}) => <Text
+                wordBreak="break-all" whiteSpace="break-spaces" noOfLines={4}
+                className={styles.value}>{formatConfigValue(record.name, record.value, valueDisplay)}</Text>
         },
     ]
 

--- a/frontend/src/components/pages/topics/TopicConfiguration.scss
+++ b/frontend/src/components/pages/topics/TopicConfiguration.scss
@@ -2,18 +2,18 @@
     width: 100%;
 
     display: grid;
-    /* columns:            name + value, isEdited, buttons  */
-    grid-template-columns: minmax(500px, auto) auto 1fr;
+    /* columns:            name, value, isEdited, buttons  */
+    grid-template-columns: minmax(300px, auto) auto auto 1fr;
     align-items: center;
     gap: 12px;
 
     .searchBar {
-        grid-column-start: span 5;
+        grid-column-start: span 4;
         margin-bottom: 1em;
     }
 
     .configGroupSpacer {
-        grid-column-start: span 3;
+        grid-column-start: span 4;
         margin: 1em 0em;
         height: 1px;
         background: hsl(0deg, 0%, 80%);
@@ -24,7 +24,7 @@
     }
 
     .configGroupTitle {
-        grid-column-start: span 3;
+        grid-column-start: span 4;
         font-size: 1.5em;
         font-weight: 600;
     }

--- a/frontend/src/components/pages/topics/TopicConfiguration.scss
+++ b/frontend/src/components/pages/topics/TopicConfiguration.scss
@@ -1,12 +1,11 @@
 .configGroupTable {
-    width: max(500px, 50%);
+    width: 100%;
 
     display: grid;
-    /* columns:            name, value, isEditted, <space>, buttons  */
-    grid-template-columns:
-        minmax(200px, auto) minmax(250px, auto) auto 1fr auto;
+    /* columns:            name + value, isEdited, buttons  */
+    grid-template-columns: minmax(500px, auto) auto 1fr;
     align-items: center;
-    gap: 11px 8px;
+    gap: 12px;
 
     .searchBar {
         grid-column-start: span 5;
@@ -14,7 +13,7 @@
     }
 
     .configGroupSpacer {
-        grid-column-start: span 5;
+        grid-column-start: span 3;
         margin: 1em 0em;
         height: 1px;
         background: hsl(0deg, 0%, 80%);
@@ -25,32 +24,15 @@
     }
 
     .configGroupTitle {
-        grid-column-start: span 5;
+        grid-column-start: span 3;
         font-size: 1.5em;
         font-weight: 600;
     }
 
-    .configName {
-        display: flex;
-        align-items: center;
-        align-self: flex-start;
-        padding-right: 1em;
-
-        font-weight: 500;
-    }
-
-    .configValue {
-        padding-left: 12px;
-        margin-right: auto;
-
-        .ant-select {
-            min-width: 12em;
-        }
-    }
-
     .isEditted {
         opacity: .5;
-        margin-right: 3em;
+        margin-left: 20px;
+        margin-right: 20px;
     }
 
     .configButtons {

--- a/frontend/src/components/pages/topics/TopicConfiguration.tsx
+++ b/frontend/src/components/pages/topics/TopicConfiguration.tsx
@@ -244,10 +244,11 @@ const ConfigEntry = observer((p: { onEditEntry: (configEntry: ConfigEntryExtende
                 <Text fontWeight="600">
                     {p.entry.name}
                 </Text>
-                <Text>
-                    {friendlyValue}
-                </Text>
             </Flex>
+
+            <Text>
+                {friendlyValue}
+            </Text>
 
             <span className="isEditted">{entry.isExplicitlySet && 'Custom'}</span>
 

--- a/frontend/src/components/pages/topics/TopicConfiguration.tsx
+++ b/frontend/src/components/pages/topics/TopicConfiguration.tsx
@@ -240,13 +240,16 @@ const ConfigEntry = observer((p: { onEditEntry: (configEntry: ConfigEntryExtende
 
     return (
         <>
-            <span className="configName">{p.entry.name}</span>
-
-            <span className="configValue">{friendlyValue}</span>
+            <Flex direction="column">
+                <Text fontWeight="600">
+                    {p.entry.name}
+                </Text>
+                <Text>
+                    {friendlyValue}
+                </Text>
+            </Flex>
 
             <span className="isEditted">{entry.isExplicitlySet && 'Custom'}</span>
-
-            <span className="spacer"></span>
 
             <span className="configButtons">
                 <Tooltip label={nonEdittableReason} placement="left" isDisabled={canEdit} hasArrow>


### PR DESCRIPTION
Fixes

- Spacing in the Broker table
- Spacing in a Message Configration
  - We've made the table a bit wider
  - We widen it to 100% in case the keys are long, if it's not enough, they'll break (in this case we don't use ...)



![Screenshot 2024-03-04 at 16 18 11](https://github.com/redpanda-data/console/assets/1083817/a7e862d0-72c7-4ce4-badc-9c51ab1c680c)
![Screenshot 2024-03-04 at 16 18 39](https://github.com/redpanda-data/console/assets/1083817/32e8cfbc-0c4a-4b83-84b1-1b0b542db1ff)
