### PR TITLE
frontend: Fix typo in topic page

### DIFF
--- a/frontend/src/components/pages/topics/Topic.List.tsx
+++ b/frontend/src/components/pages/topics/Topic.List.tsx
@@ -467,7 +467,7 @@ function makeCreateTopicModal(parent: TopicList) {
         if (value == undefined)
             throw new Error(`unexpected: value for retention size is 'undefined' but unit is set to ${unit}`);
 
-        if (unit == 'Bit')
+        if (unit == 'Bytes')
             return value;
         if (unit == 'KiB')
             return value * 1024;


### PR DESCRIPTION
![Screenshot 2024-03-20 at 8 28 01 PM](https://github.com/redpanda-data/console/assets/13494801/d2b2540c-23b0-407e-b1d8-d89dbc6bb59a)
![Screenshot 2024-03-20 at 8 18 35 PM](https://github.com/redpanda-data/console/assets/13494801/f2e013ce-0261-4ce9-9db5-8e5b68e3d491)

It seems like 'Bit' may be a typo of 'Bytes'.
I noticed the word "Bytes" on the "Edit retention.bytes" pop-up on the topic configuration page.