### PR TITLE
backend: add principal type and name to list acls operation

### DIFF
--- a/backend/pkg/console/list_acls.go
+++ b/backend/pkg/console/list_acls.go
@@ -98,21 +98,19 @@ func (s *Service) ListAllACLs(ctx context.Context, req kmsg.DescribeACLsRequest)
 				PermissionType: acl.PermissionType.String(),
 			}
 
-			p := strings.ToLower(acl.Principal)
-
 			switch {
-			case strings.HasPrefix(p, "user:"):
+			case strings.HasPrefix(acl.Principal, "User:"):
 				acls[j].PrincipalType = ACLPrincipalTypeUser
-				acls[j].PrincipalName = p[strings.IndexRune(p, ':')+1:]
-			case strings.HasPrefix(p, "group:"):
+				acls[j].PrincipalName = acl.Principal[strings.IndexRune(acl.Principal, ':')+1:]
+			case strings.HasPrefix(acl.Principal, "Group:"):
 				acls[j].PrincipalType = ACLPrincipalTypeGroup
-				acls[j].PrincipalName = p[strings.IndexRune(p, ':')+1:]
-			case strings.HasPrefix(p, "redpandarole:"):
+				acls[j].PrincipalName = acl.Principal[strings.IndexRune(acl.Principal, ':')+1:]
+			case strings.HasPrefix(acl.Principal, "RedpandaRole:"):
 				acls[j].PrincipalType = ACLPrincipalTypeRedpandaRole
-				acls[j].PrincipalName = p[strings.IndexRune(p, ':')+1:]
+				acls[j].PrincipalName = acl.Principal[strings.IndexRune(acl.Principal, ':')+1:]
 			default:
 				acls[j].PrincipalType = ACLPrincipalTypeUnknown
-				acls[j].PrincipalName = p
+				acls[j].PrincipalName = acl.Principal
 			}
 		}
 		overview.ACLs = acls

--- a/backend/pkg/console/list_acls.go
+++ b/backend/pkg/console/list_acls.go
@@ -12,9 +12,25 @@ package console
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// ACLPrincipalType is the type of principal.
+// Example "User", or "RedpandaRole".
+type ACLPrincipalType string
+
+const (
+	// ACLPrincipalTypeUnknown is the default unknown principal type.
+	ACLPrincipalTypeUnknown ACLPrincipalType = "UNKNOWN"
+	// ACLPrincipalTypeUser is the User principal type.
+	ACLPrincipalTypeUser ACLPrincipalType = "USER"
+	// ACLPrincipalTypeGroup is the Group principal type.
+	ACLPrincipalTypeGroup ACLPrincipalType = "GROUP"
+	// ACLPrincipalTypeRedpandaRole is the RedpandaRole principal type.
+	ACLPrincipalTypeRedpandaRole ACLPrincipalType = "REDPANDA_ROLE"
 )
 
 // ACLOverview contains all acl resources along with the information whether an
@@ -38,10 +54,12 @@ type ACLResource struct {
 
 // ACLRule describes a Kafka ACL rule with all it's properties.
 type ACLRule struct {
-	Principal      string `json:"principal"`
-	Host           string `json:"host"`
-	Operation      string `json:"operation"`
-	PermissionType string `json:"permissionType"`
+	Principal      string           `json:"principal"`
+	Host           string           `json:"host"`
+	Operation      string           `json:"operation"`
+	PermissionType string           `json:"permissionType"`
+	PrincipalName  string           `json:"principalName"`
+	PrincipalType  ACLPrincipalType `json:"principalType"`
 }
 
 // ListAllACLs returns a list of all stored ACLs.
@@ -78,6 +96,23 @@ func (s *Service) ListAllACLs(ctx context.Context, req kmsg.DescribeACLsRequest)
 				Host:           acl.Host,
 				Operation:      acl.Operation.String(),
 				PermissionType: acl.PermissionType.String(),
+			}
+
+			p := strings.ToLower(acl.Principal)
+
+			switch {
+			case strings.HasPrefix(p, "user:"):
+				acls[j].PrincipalType = ACLPrincipalTypeUser
+				acls[j].PrincipalName = p[strings.IndexRune(p, ':')+1:]
+			case strings.HasPrefix(p, "group:"):
+				acls[j].PrincipalType = ACLPrincipalTypeGroup
+				acls[j].PrincipalName = p[strings.IndexRune(p, ':')+1:]
+			case strings.HasPrefix(p, "redpandarole:"):
+				acls[j].PrincipalType = ACLPrincipalTypeRedpandaRole
+				acls[j].PrincipalName = p[strings.IndexRune(p, ':')+1:]
+			default:
+				acls[j].PrincipalType = ACLPrincipalTypeUnknown
+				acls[j].PrincipalName = p
 			}
 		}
 		overview.ACLs = acls

--- a/backend/pkg/console/list_acls.go
+++ b/backend/pkg/console/list_acls.go
@@ -55,11 +55,11 @@ type ACLResource struct {
 // ACLRule describes a Kafka ACL rule with all it's properties.
 type ACLRule struct {
 	Principal      string           `json:"principal"`
+	PrincipalType  ACLPrincipalType `json:"principalType"`
+	PrincipalName  string           `json:"principalName"`
 	Host           string           `json:"host"`
 	Operation      string           `json:"operation"`
 	PermissionType string           `json:"permissionType"`
-	PrincipalName  string           `json:"principalName"`
-	PrincipalType  ACLPrincipalType `json:"principalType"`
 }
 
 // ListAllACLs returns a list of all stored ACLs.

--- a/backend/pkg/console/list_acls_integration_test.go
+++ b/backend/pkg/console/list_acls_integration_test.go
@@ -1,0 +1,125 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+//go:build integration
+
+package console
+
+import (
+	"context"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kmsg"
+	"go.uber.org/zap"
+
+	"github.com/redpanda-data/console/backend/pkg/testutil"
+)
+
+func (s *ConsoleIntegrationTestSuite) TestListACLs() {
+	ctx := context.Background()
+	t := s.T()
+	assert := assert.New(t)
+	require := require.New(t)
+
+	logCfg := zap.NewDevelopmentConfig()
+	logCfg.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
+	log, err := logCfg.Build()
+	require.NoError(err)
+
+	testTopicName := testutil.TopicNameForTest("test_list_acls_topic")
+	_, err = s.kafkaAdminClient.CreateTopic(ctx, 1, 1, nil, testTopicName)
+	require.NoError(err)
+
+	timer1 := time.NewTimer(30 * time.Millisecond)
+	<-timer1.C
+
+	defer func() {
+		s.kafkaAdminClient.DeleteTopics(ctx, testTopicName)
+	}()
+
+	aclReq := kmsg.NewCreateACLsRequestCreation()
+	aclReq.PermissionType = kmsg.ACLPermissionTypeAllow
+	aclReq.Operation = kmsg.ACLOperationAll
+	aclReq.Host = "*"
+	aclReq.Principal = "User:foo"
+	aclReq.ResourcePatternType = kmsg.ACLResourcePatternTypePrefixed
+	aclReq.ResourceName = testTopicName
+	aclReq.ResourceType = kmsg.ACLResourceTypeTopic
+
+	// aclReq2 := kmsg.NewCreateACLsRequestCreation()
+	// aclReq2.PermissionType = kmsg.ACLPermissionTypeAllow
+	// aclReq2.Operation = kmsg.ACLOperationAll
+	// aclReq2.Host = "*"
+	// aclReq2.Principal = "RedpandaRole:admin"
+	// aclReq2.ResourcePatternType = kmsg.ACLResourcePatternTypePrefixed
+	// aclReq2.ResourceName = testTopicName
+	// aclReq2.ResourceType = kmsg.ACLResourceTypeTopic
+
+	req := kmsg.NewCreateACLsRequest()
+	req.Creations = []kmsg.CreateACLsRequestCreation{aclReq}
+
+	_, err = req.RequestWith(ctx, s.kafkaClient)
+	require.NoError(err)
+
+	defer func() {
+		host := "*"
+		principal := "User:foo"
+
+		aclReq := kmsg.NewDeleteACLsRequestFilter()
+		aclReq.PermissionType = kmsg.ACLPermissionTypeAllow
+		aclReq.Operation = kmsg.ACLOperationAll
+		aclReq.Host = &host
+		aclReq.Principal = &principal
+		aclReq.ResourcePatternType = kmsg.ACLResourcePatternTypePrefixed
+		aclReq.ResourceName = &testTopicName
+		aclReq.ResourceType = kmsg.ACLResourceTypeTopic
+
+		// principal2 := "RedpandaRole:admin"
+
+		// aclReq2 := kmsg.NewDeleteACLsRequestFilter()
+		// aclReq2.PermissionType = kmsg.ACLPermissionTypeAllow
+		// aclReq2.Operation = kmsg.ACLOperationAll
+		// aclReq2.Host = &host
+		// aclReq2.Principal = &principal2
+		// aclReq2.ResourcePatternType = kmsg.ACLResourcePatternTypePrefixed
+		// aclReq2.ResourceName = &testTopicName
+		// aclReq2.ResourceType = kmsg.ACLResourceTypeTopic
+
+		delReq := kmsg.DeleteACLsRequest{
+			Filters: []kmsg.DeleteACLsRequestFilter{aclReq},
+		}
+
+		_, err = delReq.RequestWith(ctx, s.kafkaClient)
+		assert.NoError(err)
+	}()
+
+	svc := createNewTestService(t, log, "test_list_acls", s.testSeedBroker, s.registryAddr)
+
+	res, err := svc.ListAllACLs(ctx, kmsg.DescribeACLsRequest{
+		ResourceType:        kmsg.ACLResourceTypeAny,
+		ResourcePatternType: kmsg.ACLResourcePatternTypeAny,
+		Operation:           kmsg.ACLOperationAny,
+		PermissionType:      kmsg.ACLPermissionTypeAny,
+	})
+
+	require.NoError(err)
+	require.NotNil(res)
+
+	require.Len(res.ACLResources, 1)
+	require.Len(res.ACLResources[0].ACLs, 1)
+	assert.Equal("User:foo", res.ACLResources[0].ACLs[0].Principal)
+	assert.Equal(ACLPrincipalTypeUser, res.ACLResources[0].ACLs[0].PrincipalType)
+	assert.Equal("foo", res.ACLResources[0].ACLs[0].PrincipalName)
+
+	// require.Len(res.ACLResources[1].ACLs, 1)
+	// assert.Equal("RedpandaRole:admin", res.ACLResources[1].ACLs[0].Principal)
+	// assert.Equal(ACLPrincipalTypeRedpandaRole, res.ACLResources[1].ACLs[0].PrincipalType)
+}


### PR DESCRIPTION
Adds `principalType` to the response to the `GET /acl` endpoint.
The type can be one of several predefined values.
Also adds `principalName` to the response. This is just the value of the `principal` with the type prefix removed.