### PR TITLE
backend: move observer interceptor to the first place

### DIFF
--- a/backend/pkg/api/connect/integration/api_suite_test.go
+++ b/backend/pkg/api/connect/integration/api_suite_test.go
@@ -95,7 +95,7 @@ func (s *APISuite) SetupSuite() {
 		ctx,
 		[]string{"redpanda:29092"},
 		network.WithNetwork([]string{"kconnect"}, s.network),
-		testcontainers.WithImage("docker.cloudsmith.io/redpanda/connectors-unsupported/connectors:v1.0.0-44344ad"),
+		testcontainers.WithImage("docker.cloudsmith.io/redpanda/connectors-unsupported/connectors:latest"),
 	)
 	require.NoError(err)
 

--- a/backend/pkg/api/routes.go
+++ b/backend/pkg/api/routes.go
@@ -61,10 +61,10 @@ func (api *API) setupConnectWithGRPCGateway(r chi.Router) {
 	}
 	observerInterceptor := commoninterceptor.NewObserver(apiProm.ObserverAdapter())
 	baseInterceptors := []connect.Interceptor{
+		observerInterceptor,
 		interceptor.NewErrorLogInterceptor(api.Logger.Named("error_log"), api.Hooks.Console.AdditionalLogFields),
 		interceptor.NewRequestValidationInterceptor(v, api.Logger.Named("validator")),
 		interceptor.NewEndpointCheckInterceptor(&api.Cfg.Console.API, api.Logger.Named("endpoint_checker")),
-		observerInterceptor,
 	}
 	r.Use(observerInterceptor.WrapHandler)
 


### PR DESCRIPTION
If the observer interceptor intercepts requests
that are already aborted by previous interceptors
such as the validation interceptor, we will report the wrong statuses.