### PR TITLE
Propagate dynamic error messages

### DIFF
--- a/backend/pkg/console/alter_configs.go
+++ b/backend/pkg/console/alter_configs.go
@@ -15,7 +15,6 @@ import (
 	"net/http"
 
 	"github.com/cloudhut/common/rest"
-	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
@@ -47,8 +46,8 @@ func (s *Service) IncrementalAlterConfigs(ctx context.Context,
 	patchedConfigs := make([]IncrementalAlterConfigsResourceResponse, len(configRes.Resources))
 	for i, res := range configRes.Resources {
 		errMessage := ""
-		err := kerr.ErrorForCode(res.ErrorCode)
-		if err != nil {
+		kafkaErr := newKafkaErrorWithDynamicMessage(res.ErrorCode, res.ErrorMessage)
+		if kafkaErr != nil {
 			errMessage = err.Error()
 		}
 		patchedConfigs[i] = IncrementalAlterConfigsResourceResponse{

--- a/backend/pkg/console/broker_config.go
+++ b/backend/pkg/console/broker_config.go
@@ -15,7 +15,6 @@ import (
 	"net/http"
 
 	"github.com/cloudhut/common/rest"
-	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"go.uber.org/zap"
 )
@@ -99,7 +98,7 @@ func (s *Service) GetBrokerConfig(ctx context.Context, brokerID int32) ([]Broker
 
 	// Resources should always be of length = 1
 	for _, resource := range res.Resources {
-		err := kerr.TypedErrorForCode(resource.ErrorCode)
+		err := newKafkaErrorWithDynamicMessage(resource.ErrorCode, resource.ErrorMessage)
 		if err != nil {
 			return nil, &rest.Error{
 				Err:      err,

--- a/backend/pkg/console/create_topic.go
+++ b/backend/pkg/console/create_topic.go
@@ -15,7 +15,6 @@ import (
 	"net/http"
 
 	"github.com/cloudhut/common/rest"
-	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -70,12 +69,12 @@ func (s *Service) CreateTopic(ctx context.Context, createTopicReq kmsg.CreateTop
 	}
 
 	createTopicRes := createRes.Topics[0]
-	err = kerr.ErrorForCode(createTopicRes.ErrorCode)
-	if err != nil {
+	kafkaErr := newKafkaErrorWithDynamicMessage(createTopicRes.ErrorCode, createTopicRes.ErrorMessage)
+	if kafkaErr != nil {
 		return CreateTopicResponse{}, &rest.Error{
-			Err:          fmt.Errorf("failed to create topic, inner kafka error: %w", err),
+			Err:          fmt.Errorf("failed to create topic, inner kafka error: %w", kafkaErr),
 			Status:       http.StatusServiceUnavailable,
-			Message:      fmt.Sprintf("Failed to create topic, kafka responded with the following error: %v", err.Error()),
+			Message:      fmt.Sprintf("Failed to create topic, kafka responded with the following error: %v", kafkaErr.Error()),
 			InternalLogs: internalLogs,
 			IsSilent:     false,
 		}

--- a/backend/pkg/console/delete_acls.go
+++ b/backend/pkg/console/delete_acls.go
@@ -15,7 +15,6 @@ import (
 	"net/http"
 
 	"github.com/cloudhut/common/rest"
-	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -50,7 +49,7 @@ func (s *Service) DeleteACLs(ctx context.Context, filter kmsg.DeleteACLsRequestF
 		DeletedACLs:   0,
 	}
 	for _, aclRes := range res.Results {
-		err = kerr.ErrorForCode(aclRes.ErrorCode)
+		err := newKafkaErrorWithDynamicMessage(aclRes.ErrorCode, aclRes.ErrorMessage)
 		if err != nil {
 			return DeleteACLsResponse{}, &rest.Error{
 				Err:          err,
@@ -63,7 +62,7 @@ func (s *Service) DeleteACLs(ctx context.Context, filter kmsg.DeleteACLsRequestF
 
 		for _, item := range aclRes.MatchingACLs {
 			deleteAclsRes.MatchedACLs++
-			err = kerr.ErrorForCode(item.ErrorCode)
+			err := newKafkaErrorWithDynamicMessage(item.ErrorCode, item.ErrorMessage)
 			if err != nil {
 				deleteAclsRes.ErrorMessages = append(deleteAclsRes.ErrorMessages, err.Error())
 				continue

--- a/backend/pkg/console/delete_topic.go
+++ b/backend/pkg/console/delete_topic.go
@@ -49,8 +49,7 @@ func (s *Service) DeleteTopic(ctx context.Context, topicName string) *rest.Error
 	}
 
 	topicRes := res.Topics[0]
-	err = kerr.ErrorForCode(topicRes.ErrorCode)
-	if err != nil {
+	if err := newKafkaErrorWithDynamicMessage(topicRes.ErrorCode, topicRes.ErrorMessage); err != nil {
 		return &rest.Error{
 			Err:          err,
 			Status:       http.StatusServiceUnavailable,

--- a/backend/pkg/console/errors.go
+++ b/backend/pkg/console/errors.go
@@ -15,12 +15,16 @@ import (
 	"github.com/twmb/franz-go/pkg/kerr"
 )
 
-type KafkaErrorWithDynamicMessage struct {
+// KerrWithDynamicMessageError wraps the franz-go Kafka error and can be used to construct
+// errors that both contain the kerr.Err as well as an optional dynamic server message
+// that further describes the error.
+type KerrWithDynamicMessageError struct {
 	Static               *kerr.Error
 	DynamicServerMessage *string
 }
 
-func (e *KafkaErrorWithDynamicMessage) Error() string {
+// Error returns the error in a string presentation.
+func (e *KerrWithDynamicMessageError) Error() string {
 	if e.DynamicServerMessage == nil {
 		return e.Static.Error()
 	}
@@ -28,7 +32,7 @@ func (e *KafkaErrorWithDynamicMessage) Error() string {
 }
 
 // Unwrap returns the original error so that it can be matched using errors.Is().
-func (e *KafkaErrorWithDynamicMessage) Unwrap() error {
+func (e *KerrWithDynamicMessageError) Unwrap() error {
 	return e.Static
 }
 
@@ -37,5 +41,5 @@ func newKafkaErrorWithDynamicMessage(code int16, msg *string) error {
 	if kafkaErr == nil {
 		return nil
 	}
-	return &KafkaErrorWithDynamicMessage{Static: kafkaErr, DynamicServerMessage: msg}
+	return &KerrWithDynamicMessageError{Static: kafkaErr, DynamicServerMessage: msg}
 }

--- a/backend/pkg/console/errors_test.go
+++ b/backend/pkg/console/errors_test.go
@@ -1,0 +1,69 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package console
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+func TestNewKafkaErrorWithDynamicMessage(t *testing.T) {
+	tests := []struct {
+		name       string
+		code       int16
+		msg        *string
+		validateFn func(*testing.T, error)
+	}{
+		{
+			name: "Code 0 with nil message",
+			code: 0,
+			msg:  nil,
+			validateFn: func(t *testing.T, err error) {
+				assert.Nil(t, err)
+			},
+		},
+		{
+			name: "INVALID_PARTITIONS error with dynamic error message",
+			code: kerr.InvalidPartitions.Code,
+			msg:  kmsg.StringPtr("unable to create topic with 100000 partitions due to hardware constraints"),
+			validateFn: func(t *testing.T, err error) {
+				require.NotNil(t, err)
+				expectedErrMsg := fmt.Sprintf("%s: unable to create topic with 100000 partitions due to hardware constraints", kerr.InvalidPartitions.Message)
+				assert.Equal(t, expectedErrMsg, err.Error())
+				assert.True(t, errors.Is(err, kerr.InvalidPartitions))
+				assert.False(t, errors.Is(err, kerr.ReplicaNotAvailable))
+			},
+		},
+		{
+			name: "INVALID_PARTITIONS error without dynamic error message",
+			code: kerr.InvalidPartitions.Code,
+			msg:  nil,
+			validateFn: func(t *testing.T, err error) {
+				require.NotNil(t, err)
+				assert.Equal(t, kerr.InvalidPartitions.Error(), err.Error())
+				assert.True(t, errors.Is(err, kerr.InvalidPartitions))
+				assert.False(t, errors.Is(err, kerr.ReplicaNotAvailable))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := newKafkaErrorWithDynamicMessage(tt.code, tt.msg)
+			tt.validateFn(t, err)
+		})
+	}
+}


### PR DESCRIPTION
To date we do not propagate the dynamic server error message in case it's part of the Kafka response. For the new Connect API we already do so, but not for the legacy REST API.