### PR TITLE
Backend: git submodule support

### DIFF
--- a/backend/pkg/config/git.go
+++ b/backend/pkg/config/git.go
@@ -24,7 +24,7 @@ type Git struct {
 	AllowedFileExtensions []string `yaml:"-"`
 
 	// Max file size which will be considered. Files exceeding this size will be ignored and logged.
-	MaxFileSize int64 `yaml:"-"`
+	MaxFileSize int64 `yaml:"maxFileSize"`
 
 	// Whether or not to use the filename or the full filepath as key in the map
 	IndexByFullFilepath bool `yaml:"-"`
@@ -38,6 +38,9 @@ type Git struct {
 	// Authentication Configs
 	BasicAuth GitAuthBasicAuth `yaml:"basicAuth"`
 	SSH       GitAuthSSH       `yaml:"ssh"`
+
+	// CloneSubmodules enables shallow cloning of submodules at recursion depth of 1.
+	CloneSubmodules bool `yaml:"cloneSubmodules"`
 }
 
 // RegisterFlagsWithPrefix for all (sub)configs
@@ -53,6 +56,9 @@ func (c *Git) Validate() error {
 	}
 	if c.RefreshInterval == 0 {
 		return fmt.Errorf("git config is enabled but refresh interval is set to 0 (disabled)")
+	}
+	if c.MaxFileSize <= 0 {
+		return fmt.Errorf("git config is enabled but file max size is <= 0")
 	}
 
 	return c.Repository.Validate()

--- a/backend/pkg/git/service.go
+++ b/backend/pkg/git/service.go
@@ -109,12 +109,18 @@ func (c *Service) CloneRepository(ctx context.Context) error {
 		referenceName = plumbing.NewBranchReferenceName(c.Cfg.Repository.Branch)
 	}
 	c.logger.Info("cloning git repository", zap.String("url", c.Cfg.Repository.URL))
-	repo, err := git.CloneContext(ctx, memory.NewStorage(), fs, &git.CloneOptions{
-		RecurseSubmodules: 1,
-		URL:               c.Cfg.Repository.URL,
-		Auth:              c.auth,
-		ReferenceName:     referenceName,
-	})
+	cloneOptions := &git.CloneOptions{
+		URL:           c.Cfg.Repository.URL,
+		Auth:          c.auth,
+		ReferenceName: referenceName,
+	}
+
+	if c.Cfg.CloneSubmodules {
+		cloneOptions.RecurseSubmodules = 1
+		cloneOptions.ShallowSubmodules = true
+	}
+
+	repo, err := git.CloneContext(ctx, memory.NewStorage(), fs, cloneOptions)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/git/service.go
+++ b/backend/pkg/git/service.go
@@ -110,9 +110,10 @@ func (c *Service) CloneRepository(ctx context.Context) error {
 	}
 	c.logger.Info("cloning git repository", zap.String("url", c.Cfg.Repository.URL))
 	repo, err := git.CloneContext(ctx, memory.NewStorage(), fs, &git.CloneOptions{
-		URL:           c.Cfg.Repository.URL,
-		Auth:          c.auth,
-		ReferenceName: referenceName,
+		RecurseSubmodules: 1,
+		URL:               c.Cfg.Repository.URL,
+		Auth:              c.auth,
+		ReferenceName:     referenceName,
 	})
 	if err != nil {
 		return err

--- a/backend/pkg/git/util.go
+++ b/backend/pkg/git/util.go
@@ -27,7 +27,7 @@ func readFile(fileName string, fs billy.Filesystem, maxSize int64) ([]byte, erro
 	}
 	fileSize := fileInfo.Size()
 	if fileSize > maxSize {
-		return nil, fmt.Errorf("file size is larger than the expected maxSize of '%d' bytes", maxSize)
+		return nil, fmt.Errorf("file size of '%d' bytes is larger than the expected max size of '%d' bytes", fileSize, maxSize)
 	}
 
 	file, err := fs.Open(fileName)

--- a/backend/pkg/proto/service.go
+++ b/backend/pkg/proto/service.go
@@ -457,23 +457,9 @@ func (s *Service) createProtoRegistry(ctx context.Context) error {
 			zap.Int("fetched_proto_files", len(files)))
 	}
 
-	for fn := range files {
-		if !strings.Contains(fn, "google") {
-			fmt.Println(fn)
-		}
-	}
-
 	fileDescriptors, err := s.protoFileToDescriptor(files)
 	if err != nil {
 		return fmt.Errorf("failed to compile proto files to descriptors: %w", err)
-	}
-
-	fmt.Println("fileDescriptors:", len(fileDescriptors))
-	for _, fd := range fileDescriptors {
-		fqn := fd.GetFullyQualifiedName()
-		if !strings.Contains(fqn, "google") {
-			fmt.Println(fqn)
-		}
 	}
 
 	// Merge proto descriptors from schema registry into the existing proto descriptors
@@ -595,12 +581,9 @@ func (s *Service) protoFileToDescriptor(files map[string]filesystem.File) ([]*de
 		return nil
 	}
 
-	parserImportPaths := []string{"."}
-	parserImportPaths = append(parserImportPaths, s.cfg.ImportPaths...)
-
 	parser := protoparse.Parser{
 		Accessor:              protoparse.FileContentsFromMap(filesStr),
-		ImportPaths:           parserImportPaths,
+		ImportPaths:           []string{"."},
 		InferImportPaths:      true,
 		ValidateUnlinkedFiles: true,
 		IncludeSourceCodeInfo: true,


### PR DESCRIPTION
Adds support for cloning submodules. By default clone does not clone submodule content. If git repository configured contains submodule this could result in problematic scenarios where protos do not work properly.

Adds a new single boolean config property `cloneSubmodules`, that when enabled, we perform a shallow clone of recursive depth of `1`.

Also adds config property for max size, as users might need to change this.

Example usage.

Repo: https://github.com/bojand/pbgsmt
This repo has a submodule linking https://github.com/googleapis/googleapis and protos in the repo import proto messages within the submodule.

Example config:

```yaml
  protobuf:
    enabled: true
    schemaRegistry:
      enabled: true
      refreshInterval: 5m
    importPaths: ["proto/thirdparty/", "proto"]
    git:
      enabled: true
      refreshInterval: 5m
      cloneSubmodules: true
      maxFileSize: 3000000
      repository:
        url: https://github.com/bojand/pbgsmt.git
    mappings:
    - topicName: "test-pbgsmt"
      valueProtoType: "models.v1.Package"
```

Listing of messages:

<img width="1082" alt="image" src="https://github.com/redpanda-data/console/assets/2081100/b19584bf-8e28-45c3-ac4d-1d592db1772e">
