### PR TITLE
backend: add hooks for init router to enable better logging

### DIFF
--- a/backend/pkg/api/connect/integration/api_suite_test.go
+++ b/backend/pkg/api/connect/integration/api_suite_test.go
@@ -70,7 +70,7 @@ func (s *APISuite) SetupSuite() {
 
 	// 2. Start Redpanda Docker container
 	container, err := redpanda.RunContainer(ctx,
-		testcontainers.WithImage("redpandadata/redpanda:v23.3.5"),
+		testcontainers.WithImage("redpandadata/redpanda:v24.1.1"),
 		redpanda.WithEnableWasmTransform(),
 		network.WithNetwork([]string{"redpanda"}, s.network),
 		redpanda.WithListener("redpanda:29092"),

--- a/backend/pkg/api/connect/integration/api_suite_test.go
+++ b/backend/pkg/api/connect/integration/api_suite_test.go
@@ -70,7 +70,7 @@ func (s *APISuite) SetupSuite() {
 
 	// 2. Start Redpanda Docker container
 	container, err := redpanda.RunContainer(ctx,
-		testcontainers.WithImage("redpandadata/redpanda:v24.1.1"),
+		testcontainers.WithImage("redpandadata/redpanda:v23.3.5"),
 		redpanda.WithEnableWasmTransform(),
 		network.WithNetwork([]string{"redpanda"}, s.network),
 		redpanda.WithListener("redpanda:29092"),

--- a/backend/pkg/api/connect/interceptor/error_log.go
+++ b/backend/pkg/api/connect/interceptor/error_log.go
@@ -111,21 +111,18 @@ func (*ErrorLogInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFu
 }
 
 func (*ErrorLogInterceptor) statusCode(protocol string, serverErr error) string {
-	grpcProtocol := "grpc"
-	grpcwebProtocol := "grpc_web"
-	connectProtocol := "connect_rpc"
 	httpProtocol := "http"
 
 	// Following the respective specifications, use integers and "status_code" for
 	// gRPC codes in contrast to strings and "error_code" for Connect codes.
 	// TODO: Check protocol case for gRPC gateway
 	switch protocol {
-	case grpcProtocol, grpcwebProtocol, httpProtocol:
+	case connect.ProtocolGRPC, connect.ProtocolGRPCWeb, httpProtocol:
 		if serverErr != nil {
 			return connect.CodeOf(serverErr).String()
 		}
 		return "ok"
-	case connectProtocol:
+	case connect.ProtocolConnect:
 		if connect.IsNotModifiedError(serverErr) {
 			// A "not modified" error is special: it's code is technically "unknown" but
 			// it would be misleading to label it as an unknown error since it's not really

--- a/backend/pkg/api/hooks.go
+++ b/backend/pkg/api/hooks.go
@@ -90,6 +90,9 @@ type RouteHooks interface {
 	// The hook can modify the interceptors slice, i.e. adding new interceptors, removing some, re-ordering, and return it in ConnectConfig.
 	// The hook can return additional connect services that shall be mounted by OSS.
 	ConfigConnectRPC(ConfigConnectRPCRequest) ConfigConnectRPCResponse
+
+	// InitConnectRPCRouter is used to initialize the ConnectRPC router with any top level middleware.
+	InitConnectRPCRouter(router chi.Router)
 }
 
 // AuthorizationHooks include all functions which allow you to intercept the requests at various
@@ -210,6 +213,7 @@ func (*defaultHooks) ConfigAPIRouterPostRegistration(_ chi.Router) {}
 func (*defaultHooks) ConfigInternalRouter(_ chi.Router)            {}
 func (*defaultHooks) ConfigRouter(_ chi.Router)                    {}
 func (*defaultHooks) ConfigGRPCGateway(_ *runtime.ServeMux)        {}
+func (*defaultHooks) InitConnectRPCRouter(_ chi.Router)            {}
 func (*defaultHooks) ConfigConnectRPC(req ConfigConnectRPCRequest) ConfigConnectRPCResponse {
 	return ConfigConnectRPCResponse{
 		Interceptors:       req.BaseInterceptors,

--- a/backend/pkg/api/hooks/hooks.go
+++ b/backend/pkg/api/hooks/hooks.go
@@ -72,6 +72,9 @@ type RouteHooks interface {
 	// The hook can modify the interceptors slice, i.e. adding new interceptors, removing some, re-ordering, and return it in ConnectConfig.
 	// The hook can return additional connect services that shall be mounted by OSS.
 	ConfigConnectRPC(ConfigConnectRPCRequest) ConfigConnectRPCResponse
+
+	// InitConnectRPCRouter is used to initialize the ConnectRPC router with any top level middleware.
+	InitConnectRPCRouter(router chi.Router)
 }
 
 // AuthorizationHooks include all functions which allow you to intercept the requests at various

--- a/backend/pkg/api/routes.go
+++ b/backend/pkg/api/routes.go
@@ -66,6 +66,9 @@ func (api *API) setupConnectWithGRPCGateway(r chi.Router) {
 		interceptor.NewRequestValidationInterceptor(v, api.Logger.Named("validator")),
 		interceptor.NewEndpointCheckInterceptor(&api.Cfg.Console.API, api.Logger.Named("endpoint_checker")),
 	}
+
+	api.Hooks.Route.InitConnectRPCRouter(r)
+
 	r.Use(observerInterceptor.WrapHandler)
 
 	// Setup gRPC-Gateway


### PR DESCRIPTION
Adds `InitConnectRPCRouter` hook that goes at the start of the connect routes to be able to properly wrap all the middleware and routes that come afterwards.