### PR TITLE
fix: still render the UI if failed to refresh schema types

### DIFF
--- a/frontend/src/state/backendApi.ts
+++ b/frontend/src/state/backendApi.ts
@@ -924,7 +924,11 @@ const apiStore = {
                 if (types.schemaTypes) {
                     this.schemaTypes = types.schemaTypes;
                 }
-            }, addError);
+            })
+            .catch((err) => {
+                this.schemaTypes = undefined;
+                console.warn('failed to request schema type', err)
+            });
     },
 
     refreshSchemaDetails(subjectName: string, force?: boolean) {


### PR DESCRIPTION
This fixes UI rendering if schema types endpoint doesn't exist in schema registry (mostly old registries)

```
{"level":"error","ts":"2024-05-08T17:03:08.003Z","msg":"Sending REST error","route":"/api/schema-registry/schemas/types","method":"GET","status_code":502,"remote_address":"10.3.1.11","public_error":"Failed to retrieve schema registry types from the schema registry: get schema types failed: Status code 404","error":"get schema types failed: Status code 404"}
```

![CleanShot 2024-05-08 at 18 11 18@2x](https://github.com/redpanda-data/console/assets/503380/077afd2f-1f29-47fe-886e-5de720dc2952)

Very similar PR to [this](https://github.com/redpanda-data/console/pull/1154).