### PR TITLE
Provide default values in the init for a connector

### DIFF
--- a/frontend/src/state/connect/state.ts
+++ b/frontend/src/state/connect/state.ts
@@ -453,6 +453,7 @@ export class ConnectorPropertiesStore {
     getConfigObject(): object {
         const config = {
             'connector.class': this.pluginClassName,
+            ...this.appliedConfig,
         } as any;
 
         if (this.viewMode == 'json') {


### PR DESCRIPTION
`// PUT "/kafka-connect/clusters/{clusterName}/connector-plugins/{pluginClassName}/config/validate"` 

seems to ignore some of the properties which are then not stored in a local state.

Ideal solution would be for this call to return all received properties instead of ignoring them, alternatively this fix should hopefully solve the problem that the properties unsupported in the UI are stripped.

This needs proper testing before merging. So far I've tested my self and it works.

FYI: The reason why it worked in the Create mode is that if the user chooses the JSON view, all validations are ignored and plain JSON is sent to the backend.

fixes https://github.com/redpanda-data/console-enterprise/issues/350