### PR TITLE
backend: add startup options to redpanda admin api config

### DIFF
--- a/backend/pkg/backoff/backoff.go
+++ b/backend/pkg/backoff/backoff.go
@@ -7,7 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-package kafka
+// Package backoff is a small utility package for providing backoff functionality.
+package backoff
 
 import (
 	"math"

--- a/backend/pkg/backoff/backoff_test.go
+++ b/backend/pkg/backoff/backoff_test.go
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-package kafka
+package backoff
 
 import (
 	"fmt"

--- a/backend/pkg/config/kafka_startup.go
+++ b/backend/pkg/config/kafka_startup.go
@@ -9,48 +9,27 @@
 
 package config
 
-import (
-	"fmt"
-	"math"
-	"time"
-)
-
 // KafkaStartup is a configuration block to specify how often and with what delays
 // we should try to connect to the Kafka service. If all attempts have failed the
 // application will exit with code 1.
 type KafkaStartup struct {
+	ServiceStartupAttemptsOptions
+
 	// EstablishConnectionEagerly determines whether the Kafka connection should
 	// be tested when it is created. This is handy to ensure the Kafka connection
 	// is working before issuing any further requests, but it requires some extra
 	// latency as requests are sent and awaited.
-	EstablishConnectionEagerly bool          `yaml:"establishConnectionEagerly"`
-	MaxRetries                 int           `yaml:"maxRetries"`
-	RetryInterval              time.Duration `yaml:"retryInterval"`
-	MaxRetryInterval           time.Duration `yaml:"maxRetryInterval"`
-	BackoffMultiplier          float64       `yaml:"backoffMultiplier"`
+	EstablishConnectionEagerly bool `yaml:"establishConnectionEagerly"`
 }
 
 // SetDefaults for Kafka startup configuration.
 func (k *KafkaStartup) SetDefaults() {
 	k.EstablishConnectionEagerly = true
-	k.MaxRetries = 5
-	k.RetryInterval = time.Second
-	k.MaxRetryInterval = 60 * time.Second
-	k.BackoffMultiplier = 2
+
+	k.ServiceStartupAttemptsOptions.SetDefaults()
 }
 
 // Validate startup config.
 func (k *KafkaStartup) Validate() error {
-	if k.MaxRetries < 0 {
-		return fmt.Errorf("max retries must be 0 for unlimited retries or a positive integer")
-	}
-	if k.MaxRetries == 0 {
-		k.MaxRetries = math.MaxInt
-	}
-
-	if k.BackoffMultiplier <= 0 {
-		return fmt.Errorf("the backoff multiplier must be greater than 0")
-	}
-
-	return nil
+	return k.ServiceStartupAttemptsOptions.Validate()
 }

--- a/backend/pkg/config/redpanda_admin_api.go
+++ b/backend/pkg/config/redpanda_admin_api.go
@@ -27,6 +27,10 @@ type RedpandaAdminAPI struct {
 
 	// TLS Config
 	TLS RedpandaAdminAPITLS `yaml:"tls"`
+
+	// Startup contains relevant configurations such as connection max retries
+	// for the initial Kafka service creation.
+	Startup ServiceStartupAttemptsOptions `yaml:"startup"`
 }
 
 // RegisterFlags for sensitive Admin API configurations.
@@ -37,6 +41,8 @@ func (c *RedpandaAdminAPI) RegisterFlags(flags *flag.FlagSet) {
 // SetDefaults for Admin API configuration.
 func (c *RedpandaAdminAPI) SetDefaults() {
 	c.Enabled = false
+
+	c.Startup.SetDefaults()
 }
 
 // Validate Admin API configuration.
@@ -70,6 +76,11 @@ func (c *RedpandaAdminAPI) Validate() error {
 
 	if err := c.TLS.Validate(); err != nil {
 		return fmt.Errorf("invalid TLS config: %w", err)
+	}
+
+	err := c.Startup.Validate()
+	if err != nil {
+		return fmt.Errorf("failed to validate startup config: %w", err)
 	}
 
 	return nil

--- a/backend/pkg/config/startup.go
+++ b/backend/pkg/config/startup.go
@@ -1,0 +1,50 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package config
+
+import (
+	"fmt"
+	"math"
+	"time"
+)
+
+// ServiceStartupAttemptsOptions is a configuration block to specify how often and with what delays
+// we should try to connect to a service. If all attempts have failed the
+// application will exit with code 1.
+type ServiceStartupAttemptsOptions struct {
+	MaxRetries        int           `yaml:"maxRetries"`
+	RetryInterval     time.Duration `yaml:"retryInterval"`
+	MaxRetryInterval  time.Duration `yaml:"maxRetryInterval"`
+	BackoffMultiplier float64       `yaml:"backoffMultiplier"`
+}
+
+// SetDefaults for service startup configuration.
+func (k *ServiceStartupAttemptsOptions) SetDefaults() {
+	k.MaxRetries = 5
+	k.RetryInterval = time.Second
+	k.MaxRetryInterval = 60 * time.Second
+	k.BackoffMultiplier = 2
+}
+
+// Validate startup config.
+func (k *ServiceStartupAttemptsOptions) Validate() error {
+	if k.MaxRetries < 0 {
+		return fmt.Errorf("max retries must be 0 for unlimited retries or a positive integer")
+	}
+	if k.MaxRetries == 0 {
+		k.MaxRetries = math.MaxInt
+	}
+
+	if k.BackoffMultiplier <= 0 {
+		return fmt.Errorf("the backoff multiplier must be greater than 0")
+	}
+
+	return nil
+}

--- a/backend/pkg/kafka/service.go
+++ b/backend/pkg/kafka/service.go
@@ -21,6 +21,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kversion"
 	"go.uber.org/zap"
 
+	"github.com/redpanda-data/console/backend/pkg/backoff"
 	"github.com/redpanda-data/console/backend/pkg/config"
 	"github.com/redpanda-data/console/backend/pkg/msgpack"
 	"github.com/redpanda-data/console/backend/pkg/proto"
@@ -61,7 +62,7 @@ func NewService(cfg *config.Config, logger *zap.Logger, metricsNamespace string)
 	// Ensure Kafka connection works, otherwise fail fast. Allow up to 5 retries with exponentially increasing backoff.
 	// Retries with backoff is very helpful in environments where Console concurrently starts with the Kafka target,
 	// such as a docker-compose demo.
-	eb := ExponentialBackoff{
+	eb := backoff.ExponentialBackoff{
 		BaseInterval: cfg.Kafka.Startup.RetryInterval,
 		MaxInterval:  cfg.Kafka.Startup.MaxRetryInterval,
 		Multiplier:   cfg.Kafka.Startup.BackoffMultiplier,


### PR DESCRIPTION
Addresses https://github.com/redpanda-data/console/issues/1222.

This adds similar startup options to Redpanda Admin API config, allowing to specify backoff.

Since we need cluster version there is no EstablishConnectionEagerly option to turn off connection test. That means if Admin API is enabled, we require the test to succeed at some point. Here's a filing scenario:

```sh
{"level":"info","ts":"2024-06-19T15:25:09.888-0300","msg":"started Redpanda Console","version":"development","built_at":"<not set>"}
{"level":"info","ts":"2024-06-19T15:25:09.888-0300","msg":"testing admin client connectivity","urls":["http://localhost:19634"]}
{"level":"warn","ts":"2024-06-19T15:25:12.992-0300","msg":"Failed to test Redpanda Admin connection, going to retry in 1s","remaining_retries":5}
{"level":"info","ts":"2024-06-19T15:25:13.993-0300","msg":"testing admin client connectivity","urls":["http://localhost:19634"]}
{"level":"warn","ts":"2024-06-19T15:25:17.136-0300","msg":"Failed to test Redpanda Admin connection, going to retry in 2s","remaining_retries":4}
{"level":"info","ts":"2024-06-19T15:25:19.136-0300","msg":"testing admin client connectivity","urls":["http://localhost:19634"]}
{"level":"warn","ts":"2024-06-19T15:25:22.226-0300","msg":"Failed to test Redpanda Admin connection, going to retry in 4s","remaining_retries":3}
{"level":"info","ts":"2024-06-19T15:25:26.227-0300","msg":"testing admin client connectivity","urls":["http://localhost:19634"]}
{"level":"warn","ts":"2024-06-19T15:25:29.353-0300","msg":"Failed to test Redpanda Admin connection, going to retry in 8s","remaining_retries":2}
{"level":"info","ts":"2024-06-19T15:25:37.354-0300","msg":"testing admin client connectivity","urls":["http://localhost:19634"]}
{"level":"warn","ts":"2024-06-19T15:25:40.500-0300","msg":"Failed to test Redpanda Admin connection, going to retry in 16s","remaining_retries":1}
{"level":"fatal","ts":"2024-06-19T15:25:56.502-0300","msg":"failed to create Redpanda service","error":"failed to test kafka connection: failed to test admin client connectivity: Get \"http://localhost:19634/v1/brokers\": dial tcp 127.0.0.1:19634: connect: connection refused"}
```