### PR TITLE
backend: fix nil pointer deref

### DIFF
--- a/backend/pkg/api/connect/service/console/service.go
+++ b/backend/pkg/api/connect/service/console/service.go
@@ -169,9 +169,7 @@ func (api *Service) PublishMessage(
 	canPublish, restErr := api.authHooks.CanPublishTopicRecords(ctx, msg.GetTopic())
 	if restErr != nil || !canPublish {
 		err := errors.New("you don't have permissions to publish topic records")
-		if restErr.Message != "" {
-			err = fmt.Errorf("%w: "+restErr.Message, err)
-		} else if restErr.Err != nil {
+		if restErr != nil && restErr.Err != nil {
 			err = restErr.Err
 		}
 		return nil, apierrors.NewConnectError(


### PR DESCRIPTION
This fixes a potential nil pointer derefence panic, which may happen if the permission check yields false but no restErr is given. That is an expected case and must be handled.