### PR TITLE
Fixes long names in PrincipalGroupEditor

### DIFF
--- a/frontend/src/components/pages/acls/PrincipalGroupEditor.tsx
+++ b/frontend/src/components/pages/acls/PrincipalGroupEditor.tsx
@@ -291,7 +291,7 @@ export const ResourceACLsEditor = observer((p: {
             boxShadow="0px 1px 2px 0px #0000000F"
         >
             <Flex
-                flexDirection="row"
+                flexDirection="column"
                 flexGrow={1}
                 gap={10}
                 p={6}
@@ -299,7 +299,7 @@ export const ResourceACLsEditor = observer((p: {
                 {isCluster ? (
                     <Text fontWeight={600} whiteSpace="nowrap">Applies to whole cluster</Text>
                 ) : (
-                        <FormField label={`Selector (${resourceName} Name)`} errorText={errorText} isInvalid={isInvalid} width="300px">
+                        <FormField label={`Selector (${resourceName} Name)`} errorText={errorText} isInvalid={isInvalid}>
                             <InputGroup zIndex={1}>
                                 <InputLeftAddon padding="0px" width="124px">
                                     <SingleSelect<'Any' | 'Literal' | 'Prefixed'>


### PR DESCRIPTION
<img width="1475" alt="Screenshot 2024-07-03 at 20 00 14" src="https://github.com/redpanda-data/console/assets/1083817/79f4bc62-437b-4ae5-912e-e69ece77a753">

Fixes https://github.com/redpanda-data/console-enterprise/issues/399

I've extended it but as @rikimaru0345 pointed out it might still not be enough to read all text, it really depends on a selector. @ivpanda in that case I guess we will need a different UX solution, but we should learn about how long the data is first.