### PR TITLE
backend: add endpoint compatibility check for wasm transforms

### DIFF
--- a/backend/pkg/console/endpoint_compatibility.go
+++ b/backend/pkg/console/endpoint_compatibility.go
@@ -125,6 +125,12 @@ func (s *Service) GetEndpointCompatibility(ctx context.Context) (EndpointCompati
 			HasRedpandaAPI:  true,
 			RedpandaFeature: "role_based_access_control",
 		},
+		{
+			URL:             consolev1alpha1connect.TransformServiceName,
+			Method:          "POST",
+			HasRedpandaAPI:  true,
+			RedpandaFeature: "wasm_transforms",
+		},
 	}
 
 	endpoints := make([]EndpointCompatibilityEndpoint, 0, len(endpointRequirements))

--- a/backend/pkg/console/endpoint_compatibility.go
+++ b/backend/pkg/console/endpoint_compatibility.go
@@ -13,11 +13,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/redpanda-data/common-go/rpadmin"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"github.com/twmb/franz-go/pkg/kversion"
 
 	"github.com/redpanda-data/console/backend/pkg/protogen/redpanda/api/console/v1alpha1/consolev1alpha1connect"
+	"github.com/redpanda-data/console/backend/pkg/redpanda"
 )
 
 // EndpointCompatibility describes what Console endpoints can be offered to the frontend,
@@ -53,7 +53,7 @@ func (s *Service) GetEndpointCompatibility(ctx context.Context) (EndpointCompati
 		Method          string
 		Requests        []kmsg.Request
 		HasRedpandaAPI  bool
-		RedpandaFeature string
+		RedpandaFeature redpanda.RedpandaFeature
 	}
 	endpointRequirements := []endpoint{
 		{
@@ -123,13 +123,13 @@ func (s *Service) GetEndpointCompatibility(ctx context.Context) (EndpointCompati
 			URL:             consolev1alpha1connect.SecurityServiceName,
 			Method:          "POST",
 			HasRedpandaAPI:  true,
-			RedpandaFeature: "role_based_access_control",
+			RedpandaFeature: redpanda.RedpandaFeatureRBAC,
 		},
 		{
 			URL:             consolev1alpha1connect.TransformServiceName,
 			Method:          "POST",
 			HasRedpandaAPI:  true,
-			RedpandaFeature: "wasm_transforms",
+			RedpandaFeature: redpanda.RedpandaFeatureWASMDataTransforms,
 		},
 	}
 
@@ -158,14 +158,10 @@ func (s *Service) GetEndpointCompatibility(ctx context.Context) (EndpointCompati
 		if endpointReq.HasRedpandaAPI && s.redpandaSvc != nil {
 			endpointSupported = true
 
+			// If we have an actual feature defined that we can check explicitly
+			// lets check that specific feature.
 			if endpointReq.RedpandaFeature != "" {
-				enabled, err := s.redpandaSvc.CheckFeature(ctx,
-					endpointReq.RedpandaFeature,
-					[]rpadmin.FeatureState{rpadmin.FeatureStateActive})
-				// only use result if no error
-				if err == nil {
-					endpointSupported = enabled
-				}
+				endpointSupported = s.redpandaSvc.CheckFeature(ctx, endpointReq.RedpandaFeature)
 			}
 		}
 


### PR DESCRIPTION
When no WASM transforms (ex. Redpanda 22.3.25):

```json
{
  "endpoint": "redpanda.api.console.v1alpha1.TransformService",
  "method": "POST",
  "isSupported": false
}
```

When we do have WASM transform capability (Redpanda 24.2.1-rc3):

```json
{
  "endpoint": "redpanda.api.console.v1alpha1.TransformService",
  "method": "POST",
  "isSupported": true
}
```