### PR TITLE
Migrates buttons on login screen to Chakra

### DIFF
--- a/frontend/src/components/misc/login.tsx
+++ b/frontend/src/components/misc/login.tsx
@@ -16,7 +16,8 @@ import SvgLogo from '../../assets/logos/redpanda-text-color.svg';
 import { uiState } from '../../state/uiState';
 import { GoogleOutlined, GithubOutlined } from '@ant-design/icons';
 import OktaLogo from '../../utils/svg/OktaLogo';
-import { Box, Button, FormLabel, Input, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, ModalOverlay, Spinner, Stack, Text } from '@redpanda-data/ui';
+import { Box, Button,
+  Flex, FormLabel, Input, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, ModalOverlay, Spinner, Stack, Text } from '@redpanda-data/ui';
 import { appGlobal } from '../../state/appGlobal';
 import { toJson } from '../../utils/jsonUtils';
 import AzureADLogo from '../../utils/svg/AzureADLogo';
@@ -120,20 +121,19 @@ class Login extends Component {
 
             <div className="loginContainer">
               <div className="loginLeft">
-                <div
+                <Flex
                   className="loginLogo"
-                  style={{
-                    height: '60px',
-                    marginTop: '2rem',
-                    marginBottom: '4rem',
-                  }}
+                  placeItems="center"
+                  height={15}
+                  mt={8}
+                  mb={16}
                 >
                   <img
                     src={SvgLogo}
                     style={{ height: '36px' }}
                     alt="Redpanda Console Logo"
                   />
-                </div>
+                </Flex>
 
                 <Stack spacing="2">
                   <Text fontSize="18px" fontWeight="600" >{this.providersResponse?.loginTitle ?? 'Howdy!'}</Text>
@@ -147,7 +147,7 @@ class Login extends Component {
                     <div style={{ fontSize: '18px', fontWeight: 600 }}>
                       <span>Sign in to Redpanda Console</span>
                     </div>
-                    <div className="loginButtonList">
+                    <Flex placeContent="center" placeItems="center" mt={4} gap={2}>
                       {providerButtons?.map((p) => (
                         <LoginProviderButton key={p.displayName} provider={p} />
                       )) ||
@@ -166,7 +166,7 @@ class Login extends Component {
                             Retreiving login method from backend...
                           </div>
                         )}
-                    </div>
+                    </Flex>
                   </div>
 
                   <PlainLoginBox provider={plainLoginProvider} />
@@ -187,10 +187,22 @@ export default Login;
 function LoginProviderButton(props: { provider: Provider }): JSX.Element {
     const p = props.provider;
 
-    return <div key={p.displayName} className="loginButton2" onClick={() => window.location.replace(p.url)}>
-        {iconMap.get(p.displayName.toLowerCase())}
-        <span>{p.displayName}</span>
-    </div>
+  return (
+    <Button
+      colorScheme="brand"
+      key={p.displayName}
+      width={130}
+      height={85}
+      display="flex"
+      placeContent="center"
+      placeItems="center"
+      flexDirection="column"
+      onClick={() => window.location.replace(p.url)}
+    >
+      {iconMap.get(p.displayName.toLowerCase())}
+      <span>{p.displayName}</span>
+    </Button>
+  );
 }
 
 function ProvidersError(p: { error: string }) {

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -639,60 +639,6 @@ td.ant-table-column-sort {
     z-index: -1;
 }
 
-.loginLogo {
-    color: #f5f5f5;
-    font-size: 2rem;
-    font-weight: 600;
-    display: flex;
-    place-items: center;
-}
-
-.loginButtonList {
-    display: flex;
-    place-content: center;
-    place-items: center;
-    margin-top: 1rem;
-}
-
-.loginSeperator {
-    margin: 0rem 2rem;
-    width: 1px;
-    min-height: 100px;
-    background: rgba(255, 255, 255, 0.287);
-}
-
-.loginButton2 {
-    cursor: pointer;
-    width: 130px;
-    height: 85px;
-    font-size: 1.5em;
-    font-weight: bold;
-    color: rgb(255, 255, 255);
-    background: $color-brand-secondary;
-    border-radius: 2px;
-    display: flex;
-    place-content: center;
-    place-items: center;
-    flex-direction: column;
-}
-
-.loginButton2 i {
-    font-size: 28px;
-    transition: all 0.3s ease;
-}
-
-.loginButton2:hover {
-    color: #fff;
-    background: $color-brand-secondary-hover;
-    transition: all 0.3s ease;
-}
-
-.loginButton2:hover i {
-    font-size: 45px;
-    color: #fff;
-    transition: all 0.3s ease;
-}
-
 ul.ant-menu.ant-menu-root.ant-menu-inline-collapsed {
     font-family: 'Poppins', sans-serif;
     color: #828080;

--- a/frontend/src/variables.scss
+++ b/frontend/src/variables.scss
@@ -25,11 +25,11 @@
     In our own components we want to use the same colors that ant-design uses.
     So we define our own css variables and copy the antd values.
 */
-$color-brand-secondary: var(--ant-primary-color);
-$color-brand-secondary-hover: var(--ant-primary-color-hover);
+$color-brand-secondary: rgb(225, 66, 38);
+$color-brand-secondary-hover: #ed6b4e;
 
-$color-reload-spinner: var(--ant-primary-6);
-$color-reload-spinner-bg: var(--ant-primary-1);
+$color-reload-spinner: #e14226;
+$color-reload-spinner-bg: #fff5f0;
 
 $color-light-background: #F6F6F6;
 


### PR DESCRIPTION
Basic view:

![Screenshot 2024-07-12 at 10 54 37](https://github.com/user-attachments/assets/97a96868-e862-4365-b6d0-905e15651150)

Hover:

![Screenshot 2024-07-12 at 10 54 09](https://github.com/user-attachments/assets/654bb547-6a80-4edc-950b-f931690ee8c2)

OAuth
![Screenshot 2024-07-12 at 10 54 05](https://github.com/user-attachments/assets/7cc6fa76-405e-46bf-8ae4-df510a7ec599)


- We've migrated content to Chakra to be consistent
- Added backup replacements for `--ant-primary-color` and a few other colors until we completely remove all occurencies of `$color-brand-secondary`
- Added spacing between OAuth buttons

Fixes https://github.com/redpanda-data/console-enterprise/issues/268