### PR TITLE
Hide transforms if API doesn't allow it

### DIFF
--- a/frontend/src/components/routes.tsx
+++ b/frontend/src/components/routes.tsx
@@ -280,8 +280,12 @@ export const APP_ROUTES: IRouteEntry[] = [
     MakeRoute<{ clusterName: string}>('/connect-clusters/:clusterName/create-connector', CreateConnector, 'Create Connector', undefined, undefined, routeVisibility(false)),
     MakeRoute<{ clusterName: string, connector: string }>('/connect-clusters/:clusterName/:connector', KafkaConnectorDetails, 'Connector Details'),
 
-    MakeRoute<{}>('/transforms-setup', TransformsSetup, 'Transforms', undefined, true),
-    MakeRoute<{}>('/transforms', TransformsList, 'Transforms', MdOutlineSmartToy, true),
+    MakeRoute<{}>('/transforms-setup', TransformsSetup, 'Transforms', undefined, true,
+      routeVisibility(false, [Feature.TransformsService])
+    ),
+    MakeRoute<{}>('/transforms', TransformsList, 'Transforms', MdOutlineSmartToy, true,
+      routeVisibility(false, [Feature.TransformsService])
+    ),
     MakeRoute<{ transformName: string }>('/transforms/:transformName', TransformDetails, 'Transforms'),
 
     // MakeRoute<{}>('/rp-connect', RpConnectPipelinesList, 'Redpanda Connect Pipelines', LinkIcon, true),

--- a/frontend/src/state/supportedFeatures.ts
+++ b/frontend/src/state/supportedFeatures.ts
@@ -38,6 +38,7 @@ export class Feature {
     static readonly CreateUser: FeatureEntry = { endpoint: '/api/users', method: 'POST' };
     static readonly DeleteUser: FeatureEntry = { endpoint: '/api/users', method: 'DELETE' };
     static readonly SecurityService: FeatureEntry = { endpoint: 'redpanda.api.console.v1alpha1.SecurityService', method: 'POST' };
+    static readonly TransformsService: FeatureEntry = { endpoint: 'redpanda.api.console.v1alpha1.TransformService', method: 'POST' };
 }
 
 export function isSupported(f: FeatureEntry): boolean {


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/console-enterprise/issues/429

@bojand shall we keep it visible like on the picture or hide it (current implementation)
<img width="427" alt="Screenshot 2024-07-25 at 23 06 05" src="https://github.com/user-attachments/assets/c73d1b4a-9e3a-4d97-813f-b043794d65e5">

@rikimaru0345 FYI I've hidden both `/transforms` and `/transforms-setup` 
