### PR TITLE
schema-registry: enable sidebar in serverless mode

### DIFF
--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -172,7 +172,6 @@ const routesIgnoredInEmbedded = [
 
 const routesIgnoredInServerless = [
     '/overview',
-    '/schema-registry',
     '/quotas',
     '/reassign-partitions',
     '/admin',


### PR DESCRIPTION
This should make sure we don't hide the schema registry sidebar link in serverless embedded mode.