### PR TITLE
frontend: show pipeline service in sidebar for serverless

### DIFF
--- a/frontend/src/components/routes.tsx
+++ b/frontend/src/components/routes.tsx
@@ -277,7 +277,9 @@ export const APP_ROUTES: IRouteEntry[] = [
         routeVisibility(true, [Feature.GetQuotas], ['canListQuotas'])
     ),
 
-    MakeRoute<{}>('/connect-clusters', KafkaConnectOverview, 'Connectors', LinkIcon, true),
+    MakeRoute<{}>('/connect-clusters', KafkaConnectOverview, 'Connectors', LinkIcon, true,
+        routeVisibility(true, [Feature.PipelineService])
+    ),
     MakeRoute<{ clusterName: string }>('/connect-clusters/:clusterName', KafkaClusterDetails, 'Connect Cluster'),
     MakeRoute<{ clusterName: string}>('/connect-clusters/:clusterName/create-connector', CreateConnector, 'Create Connector', undefined, undefined, routeVisibility(false)),
     MakeRoute<{ clusterName: string, connector: string }>('/connect-clusters/:clusterName/:connector', KafkaConnectorDetails, 'Connector Details'),

--- a/frontend/src/components/routes.tsx
+++ b/frontend/src/components/routes.tsx
@@ -277,9 +277,7 @@ export const APP_ROUTES: IRouteEntry[] = [
         routeVisibility(true, [Feature.GetQuotas], ['canListQuotas'])
     ),
 
-    MakeRoute<{}>('/connect-clusters', KafkaConnectOverview, 'Connectors', LinkIcon, true,
-        routeVisibility(true, [Feature.PipelineService])
-    ),
+    MakeRoute<{}>('/connect-clusters', KafkaConnectOverview, 'Connectors', LinkIcon, true),
     MakeRoute<{ clusterName: string }>('/connect-clusters/:clusterName', KafkaClusterDetails, 'Connect Cluster'),
     MakeRoute<{ clusterName: string}>('/connect-clusters/:clusterName/create-connector', CreateConnector, 'Create Connector', undefined, undefined, routeVisibility(false)),
     MakeRoute<{ clusterName: string, connector: string }>('/connect-clusters/:clusterName/:connector', KafkaConnectorDetails, 'Connector Details'),

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -176,7 +176,6 @@ const routesIgnoredInServerless = [
     '/quotas',
     '/reassign-partitions',
     '/admin',
-    '/connect-clusters',
 ];
 
 export const embeddedAvailableRoutesObservable = observable({


### PR DESCRIPTION
Attempt to show pipeline service in the sidebar for serverless clusters. ~~It doesn't quite work so I'll ask for some help from console team to fix it.~~ Works now but let me know if this is the right/best way.

related to: https://github.com/redpanda-data/console-enterprise/pull/435