### PR TITLE
frontend: redpanda connect and kafka connect ux improvements for serverless

### DIFF
--- a/frontend/src/components/pages/connect/Overview.tsx
+++ b/frontend/src/components/pages/connect/Overview.tsx
@@ -26,6 +26,7 @@ import SearchBar from '../../misc/SearchBar';
 import RpConnectPipelinesList from '../rp-connect/Pipelines.List';
 import { RedpandaConnectIntro } from '../rp-connect/RedpandaConnectIntro';
 import { Features } from '../../../state/supportedFeatures';
+import {isServerless} from '../../../config';
 
 @observer
 class KafkaConnectOverview extends PageComponent {
@@ -64,9 +65,18 @@ class KafkaConnectOverview extends PageComponent {
             },
         ] as Tab[];
 
+        if (isServerless())
+            tabs.removeAll(x => x.key == 'kafkaConnect');
+
         return (
             <PageContent>
-                <Tabs tabs={tabs} defaultSelectedTabKey={showPipelines ? 'redpandaConnect' : 'kafkaConnect'} />
+                {tabs.length == 1
+                    ? (typeof tabs[0].content == 'function'
+                            ? tabs[0].content()
+                            : tabs[0].content
+                    )
+                    : <Tabs tabs={tabs} defaultSelectedTabKey={showPipelines ? 'redpandaConnect' : 'kafkaConnect'} />
+                }
             </PageContent>
         );
     }

--- a/frontend/src/components/routes.tsx
+++ b/frontend/src/components/routes.tsx
@@ -53,6 +53,7 @@ import { TransformsSetup } from './pages/transforms/Transforms.Setup';
 import TransformDetails from './pages/transforms/Transform.Details';
 import RpConnectPipelinesDetails from './pages/rp-connect/Pipelines.Details';
 import RpConnectPipelinesCreate from './pages/rp-connect/Pipelines.Create';
+import {isServerless} from "../config";
 
 //
 //	Route Types
@@ -277,7 +278,9 @@ export const APP_ROUTES: IRouteEntry[] = [
         routeVisibility(true, [Feature.GetQuotas], ['canListQuotas'])
     ),
 
-    MakeRoute<{}>('/connect-clusters', KafkaConnectOverview, 'Connectors', LinkIcon, true),
+    MakeRoute<{}>('/connect-clusters', KafkaConnectOverview, 'Connectors', LinkIcon, true,
+        routeVisibility(!(!Feature.PipelineService && !api.connectConnectors?.isConfigured && isServerless()))
+    ),
     MakeRoute<{ clusterName: string }>('/connect-clusters/:clusterName', KafkaClusterDetails, 'Connect Cluster'),
     MakeRoute<{ clusterName: string}>('/connect-clusters/:clusterName/create-connector', CreateConnector, 'Create Connector', undefined, undefined, routeVisibility(false)),
     MakeRoute<{ clusterName: string, connector: string }>('/connect-clusters/:clusterName/:connector', KafkaConnectorDetails, 'Connector Details'),

--- a/frontend/src/components/routes.tsx
+++ b/frontend/src/components/routes.tsx
@@ -53,7 +53,7 @@ import { TransformsSetup } from './pages/transforms/Transforms.Setup';
 import TransformDetails from './pages/transforms/Transform.Details';
 import RpConnectPipelinesDetails from './pages/rp-connect/Pipelines.Details';
 import RpConnectPipelinesCreate from './pages/rp-connect/Pipelines.Create';
-import {isServerless} from "../config";
+import {isServerless} from '../config';
 
 //
 //	Route Types
@@ -279,7 +279,25 @@ export const APP_ROUTES: IRouteEntry[] = [
     ),
 
     MakeRoute<{}>('/connect-clusters', KafkaConnectOverview, 'Connectors', LinkIcon, true,
-        routeVisibility(!(!Feature.PipelineService && !api.connectConnectors?.isConfigured && isServerless()))
+        () => {
+            if (isServerless()) {
+                console.log('Connect clusters inside serverless checks.')
+                // We are in serverless, there is no kafka connect, so we can ignore it.
+                // Here, we only care about the pipeline service and use that to decide whether to show the entry
+                if (isSupported(Feature.PipelineService)) {
+                    console.log('Pipeline Service enabled. Showing sidebar link.')
+                    return {visible: true, disabledReasons: []};
+                }
+                // Pipeline service is not active? Hide entry
+                console.log('Pipeline Service NOT enabled. NOT showing sidebar link.')
+                return { visible: false, disabledReasons: [DisabledReasons.notSupported] };
+            } else {
+                // We are in cloud (dedicated or BYOC), or self-hosted
+                // We always show the entry, if kafka connect is not enabled, the page will show a link to the documentation
+                console.log('Pipeline Service state does not matter. Showing sidebar link.')
+                return { visible: true, disabledReasons: [] };
+            }
+        }
     ),
     MakeRoute<{ clusterName: string }>('/connect-clusters/:clusterName', KafkaClusterDetails, 'Connect Cluster'),
     MakeRoute<{ clusterName: string}>('/connect-clusters/:clusterName/create-connector', CreateConnector, 'Create Connector', undefined, undefined, routeVisibility(false)),

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -178,6 +178,7 @@ const routesIgnoredInServerless = [
     '/quotas',
     '/reassign-partitions',
     '/admin',
+    '/transforms',
 ];
 
 export const embeddedAvailableRoutesObservable = observable({

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -182,15 +182,20 @@ const routesIgnoredInServerless = [
 ];
 
 export const embeddedAvailableRoutesObservable = observable({
-
     get routes() {
         return APP_ROUTES
             .filter((x) => x.icon != null) // routes without icon are "nested", so they shouldn't be visible directly
             .filter((x) => !routesIgnoredInEmbedded.includes(x.path)) // things that should not be visible in embedded/cloud mode
             .filter(x => {
-                if (isServerless())
-                    if (routesIgnoredInServerless.includes(x.path))
-                        return false; // remove entry
+                if (x.visibilityCheck) {
+                    const state = x.visibilityCheck();
+                    return state.visible;
+                }
+                return true;
+            })
+            .filter(x => {
+                if (isServerless() && routesIgnoredInServerless.includes(x.path))
+                    return false;
                 return true;
             });
     }


### PR DESCRIPTION
This PR implements the improvements described in https://github.com/redpanda-data/console-enterprise/issues/455

- [x] Add transforms endpoint to list of endpoints to hide in serverless 
- [x] Make connectors sidebar link inactive on serverless clusters when the PipelineService (rpconnect) feature is inactive. This covers the case between when Redpanda Connect for serverless is implemented and when it is made available to customers
- [x] Remove Kafka Connect tab from UI for serverless clusters