### PR TITLE
frontend: fix it's/its typo

### DIFF
--- a/frontend/src/components/pages/consumers/Group.Details.tsx
+++ b/frontend/src/components/pages/consumers/Group.Details.tsx
@@ -508,7 +508,7 @@ const makeStateEntry = (iconName: string, displayName: string, description: stri
     </div>
 ];
 
-const consumerGroupStateTable = QuickTable([makeStateEntry('stable', 'Stable', 'Consumer group has members which have been assigned partitions'), makeStateEntry('completingrebalance', 'Completing Rebalance', 'Kafka is assigning partitions to group members'), makeStateEntry('preparingrebalance', 'Preparing Rebalance', 'A reassignment of partitions is required, members have been asked to stop consuming'), makeStateEntry('empty', 'Empty', 'Consumer group exists, but does not have any members'), makeStateEntry('dead', 'Dead', 'Consumer group does not have any members and it\'s metadata has been removed'), makeStateEntry('unknown', 'Unknown', 'Group state is not known')], {
+const consumerGroupStateTable = QuickTable([makeStateEntry('stable', 'Stable', 'Consumer group has members which have been assigned partitions'), makeStateEntry('completingrebalance', 'Completing Rebalance', 'Kafka is assigning partitions to group members'), makeStateEntry('preparingrebalance', 'Preparing Rebalance', 'A reassignment of partitions is required, members have been asked to stop consuming'), makeStateEntry('empty', 'Empty', 'Consumer group exists, but does not have any members'), makeStateEntry('dead', 'Dead', 'Consumer group does not have any members and its metadata has been removed'), makeStateEntry('unknown', 'Unknown', 'Group state is not known')], {
     gapHeight: '.5em',
     gapWidth: '.5em',
     keyStyle: { verticalAlign: 'top' }


### PR DESCRIPTION
This PR fixes a typo (it's --> its) on the consumer groups page.

# Before
The red rectangle annotation was added to the screenshot to illustrate the change.

![image](https://github.com/user-attachments/assets/822f5ce3-599b-43c6-bead-055f1dccadff)

# After
![image](https://github.com/user-attachments/assets/9249ec0a-0458-4b96-a6ab-6dff7b5efae1)
