### PR TITLE
Hotfixes KowlEditor resizing in Safari

### DIFF
--- a/frontend/src/components/misc/KowlJsonView.tsx
+++ b/frontend/src/components/misc/KowlJsonView.tsx
@@ -23,14 +23,22 @@ export const KowlJsonView = observer((props: {
         ? props.srcObj
         : JSON.stringify(props.srcObj, undefined, 4);
 
-    return <>
-        <Box
-            display="block"
-            minHeight="40"
-            maxHeight="45rem" // no chakra space equivalent exists
-            height="96"
-            style={props.style}
-        >
+    return <Box
+        display="block"
+        minHeight="40"
+        maxHeight="45rem" // no chakra space equivalent exists
+        height="96"
+        style={props.style}
+        position="relative"
+    >
+        {/*
+         We have a problem in Safari with Monaco editor, when used with automaticLayout: true, which is a default,
+         it causes an infinite loop in Safari. It recalculates in a wrong way, changes the dimensions of a parent
+         and that triggers ResizeObserver again (see the internal implementation).
+         We tried to play with overflow, boxSizing, even manually using ResizeObserver.
+         Changing the parent to absolutely positioned element works around the issue for now.
+         */}
+        <Box position="absolute" h="full" w="full">
             <KowlEditor
                 value={str}
                 language="json"
@@ -40,5 +48,5 @@ export const KowlJsonView = observer((props: {
                 }}
             />
         </Box>
-    </>
+    </Box>;
 });


### PR DESCRIPTION
https://github.com/redpanda-data/console/issues/1422

This is a hotfix that works around the issue on how sizes are calculated in Safari when using `automaticLayout: true`