### PR TITLE
build: run buf action only on triggers from within the repo

### DIFF
--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -3,18 +3,20 @@ name: Buf CI
 on:
   push:
     paths:
+      - .github/workflows/buf.yml
       - proto/**.proto
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - proto/**.proto
   delete:
-permissions:
-  id-token: write
-  contents: read
-  pull-requests: write
 jobs:
   push-module:
+    if: github.repository == 'redpanda-data/console'
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
+      - .github/workflows/buf.yml
       - proto/**.proto
   delete:
 jobs:

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -12,7 +12,7 @@ on:
   delete:
 jobs:
   push-module:
-    if: github.repository == 'redpanda-data/console'
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'redpanda-data/console' }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Substitute for https://github.com/redpanda-data/console/pull/1425.

Currently the this action fails on PRs from forks due to `aws-actions/configure-aws-credentials` workflow which does not have access to secrets and vars in that context. 

This PR makes the GH Action conditional to only run on PRs from within branches, along with push to master.
This should cover most cases since normally the Console team should be updating the protos.
Exceptions are docs updates by docs team, or external contributions. But we can work around those cases or offer manual fixes.