### PR TITLE
Move pipeline editting to its own route, allow changing name and description

### DIFF
--- a/frontend/src/components/pages/rp-connect/Pipelines.Edit.tsx
+++ b/frontend/src/components/pages/rp-connect/Pipelines.Edit.tsx
@@ -16,23 +16,20 @@ import { appGlobal } from '../../../state/appGlobal';
 import PageContent from '../../misc/PageContent';
 import { PageComponent, PageInitHelper } from '../Page';
 import { Box, Button, createStandaloneToast, Flex, FormField, Input } from '@redpanda-data/ui';
-import PipelinesYamlEditor from '../../misc/PipelinesYamlEditor';
 import { pipelinesApi } from '../../../state/backendApi';
 import { DefaultSkeleton } from '../../../utils/tsxUtils';
 import { Link } from 'react-router-dom';
-import Tabs from '../../misc/tabs/Tabs';
 import { PipelineCreate } from '../../../protogen/redpanda/api/dataplane/v1alpha2/pipeline_pb';
+import { PipelineEditor } from './Pipelines.Create';
 const { ToastContainer, toast } = createStandaloneToast();
 
-const exampleContent = `
-`;
 
 @observer
-class RpConnectPipelinesCreate extends PageComponent<{}> {
+class RpConnectPipelinesEdit extends PageComponent<{}> {
 
     @observable fileName = '';
     @observable description = '';
-    @observable editorContent = exampleContent;
+    @observable editorContent = '';
     @observable isCreating = false;
 
     constructor(p: any) {
@@ -72,8 +69,8 @@ class RpConnectPipelinesCreate extends PageComponent<{}> {
                             isRequired
                             value={this.fileName}
                             onChange={x => this.fileName = x.target.value}
-                  width={500}
-                />
+                            width={500}
+                        />
                     </Flex>
                 </FormField>
                 <FormField label="Description">
@@ -81,7 +78,7 @@ class RpConnectPipelinesCreate extends PageComponent<{}> {
                         data-testid="pipelineDescription"
                         value={this.description}
                         onChange={x => this.description = x.target.value}
-                width={500}
+                        width={500}
                     />
                 </FormField>
 
@@ -137,37 +134,7 @@ class RpConnectPipelinesCreate extends PageComponent<{}> {
     }
 }
 
-export default RpConnectPipelinesCreate;
+export default RpConnectPipelinesEdit;
 
 
-export const PipelineEditor = observer((p: {
-    yaml: string,
-    onChange: (newYaml: string) => void
-}) => {
 
-    return <Tabs tabs={[
-        {
-            key: 'config', title: 'Configuration',
-            content: () => <Box>
-                {/* yaml editor */}
-                <Flex height="400px" maxWidth="800px">
-                    <PipelinesYamlEditor
-                        defaultPath="config.yaml"
-                        path="config.yaml"
-                        value={p.yaml}
-                        onChange={e => {
-                            if (e)
-                                p.onChange(e);
-                        }}
-                        language="yaml"
-                    />
-                </Flex>
-            </Box>
-        },
-        {
-            key: 'preview', title: 'Pipeline preview',
-            content: <></>,
-            disabled: true
-        },
-    ]} />
-});

--- a/frontend/src/components/routes.tsx
+++ b/frontend/src/components/routes.tsx
@@ -54,6 +54,7 @@ import TransformDetails from './pages/transforms/Transform.Details';
 import RpConnectPipelinesDetails from './pages/rp-connect/Pipelines.Details';
 import RpConnectPipelinesCreate from './pages/rp-connect/Pipelines.Create';
 import {isServerless} from '../config';
+import RpConnectPipelinesEdit from './pages/rp-connect/Pipelines.Edit';
 
 //
 //	Route Types
@@ -314,6 +315,7 @@ export const APP_ROUTES: IRouteEntry[] = [
     // MakeRoute<{}>('/rp-connect', RpConnectPipelinesList, 'Connectors', LinkIcon, true),
     MakeRoute<{}>('/rp-connect/create', RpConnectPipelinesCreate, 'Connectors'),
     MakeRoute<{ pipelineId: string }>('/rp-connect/:pipelineId', RpConnectPipelinesDetails, 'Connectors'),
+    MakeRoute<{ pipelineId: string }>('/rp-connect/:pipelineId/edit', RpConnectPipelinesEdit, 'Connectors'),
 
     MakeRoute<{}>('/reassign-partitions', ReassignPartitions, 'Reassign Partitions', BeakerIcon, false,
         routeVisibility(true,


### PR DESCRIPTION
Moves pipeline editting to its own route instead of having it on the details page:

A success "toast" is triggered on success but is currently not visible due to a bug which will be addresses in another PR.


![image](https://github.com/user-attachments/assets/850e8a27-c7dd-4862-be11-d3102cb022c9)

https://github.com/user-attachments/assets/6ba47f83-f31f-4235-aa5d-09e254232b25


