### PR TITLE
backend: OAuth SASL extensions support

### DIFF
--- a/backend/pkg/config/kafka_sasl_oauth.go
+++ b/backend/pkg/config/kafka_sasl_oauth.go
@@ -28,6 +28,7 @@ type KafkaSASLOAuthBearer struct {
 	ClientSecret  string `yaml:"clientSecret"`
 	TokenEndpoint string `yaml:"tokenEndpoint"`
 	Scope         string `yaml:"scope"`
+	Extensions    string `yaml:"extensions"`
 }
 
 // RegisterFlags registers all sensitive Kerberos settings as flag
@@ -37,6 +38,7 @@ func (c *KafkaSASLOAuthBearer) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&c.ClientSecret, "kafka.sasl.oauth.clientSecret", "", "OAuth Bearer Client Secret")
 	f.StringVar(&c.TokenEndpoint, "kafka.sasl.oauth.tokenEndpoint", "", "OAuth Bearer Token Endpoint")
 	f.StringVar(&c.Scope, "kafka.sasl.oauth.scope", "", "OAuth Bearer Scope")
+	f.StringVar(&c.Extensions, "kafka.sasl.oauth.extensions", "", "OAuth SASL extensions")
 }
 
 // Validate Kafka SASL OAuth configurations.

--- a/backend/pkg/config/kafka_sasl_oauth.go
+++ b/backend/pkg/config/kafka_sasl_oauth.go
@@ -31,6 +31,7 @@ type KafkaSASLOAuthBearer struct {
 	Extensions    []KafkaSASLOAuthExtension `yaml:"extensions"`
 }
 
+// KafkaSASLOAuthExtension is the struct for the SASL OAuth extension support(custom key-value pairs)
 type KafkaSASLOAuthExtension struct {
 	Key   string `yaml:"key"`
 	Value string `yaml:"value"`

--- a/backend/pkg/config/kafka_sasl_oauth.go
+++ b/backend/pkg/config/kafka_sasl_oauth.go
@@ -23,12 +23,17 @@ import (
 
 // KafkaSASLOAuthBearer is the config struct for the SASL OAuthBearer mechanism
 type KafkaSASLOAuthBearer struct {
-	Token         string `yaml:"token"`
-	ClientID      string `yaml:"clientId"`
-	ClientSecret  string `yaml:"clientSecret"`
-	TokenEndpoint string `yaml:"tokenEndpoint"`
-	Scope         string `yaml:"scope"`
-	Extensions    string `yaml:"extensions"`
+	Token         string                    `yaml:"token"`
+	ClientID      string                    `yaml:"clientId"`
+	ClientSecret  string                    `yaml:"clientSecret"`
+	TokenEndpoint string                    `yaml:"tokenEndpoint"`
+	Scope         string                    `yaml:"scope"`
+	Extensions    []KafkaSASLOAuthExtension `yaml:"extensions"`
+}
+
+type KafkaSASLOAuthExtension struct {
+	Key   string `yaml:"key"`
+	Value string `yaml:"value"`
 }
 
 // RegisterFlags registers all sensitive Kerberos settings as flag
@@ -38,7 +43,6 @@ func (c *KafkaSASLOAuthBearer) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&c.ClientSecret, "kafka.sasl.oauth.clientSecret", "", "OAuth Bearer Client Secret")
 	f.StringVar(&c.TokenEndpoint, "kafka.sasl.oauth.tokenEndpoint", "", "OAuth Bearer Token Endpoint")
 	f.StringVar(&c.Scope, "kafka.sasl.oauth.scope", "", "OAuth Bearer Scope")
-	f.StringVar(&c.Extensions, "kafka.sasl.oauth.extensions", "", "OAuth SASL extensions")
 }
 
 // Validate Kafka SASL OAuth configurations.

--- a/docs/config/console.yaml
+++ b/docs/config/console.yaml
@@ -51,6 +51,7 @@ kafka:
   #     clientSecret: # can be set via the --kafka.sasl.oauth.clientSecret flag as well
   #     tokenEndpoint: # can be set via the --kafka.sasl.oauth.tokenEndpoint flag as well. Will be used to fetch a short living token if specified
   #     scope: # can be set via the --kafka.sasl.oauth.scope flag as well
+  #     extensions: # can be set via the --kafka.sasl.oauth.extensions flag as well. Extensions are key value pairs to add to the authentication request
   #   awsMskIam: # either set both accessKey and secretKey or leave both empty to use default AWS configuration in your environment
   #     accessKey:
   #     secretKey: # can be set via the --kafka.sasl.aws-msk-iam.secret-key flag as well

--- a/docs/config/console.yaml
+++ b/docs/config/console.yaml
@@ -51,7 +51,9 @@ kafka:
   #     clientSecret: # can be set via the --kafka.sasl.oauth.clientSecret flag as well
   #     tokenEndpoint: # can be set via the --kafka.sasl.oauth.tokenEndpoint flag as well. Will be used to fetch a short living token if specified
   #     scope: # can be set via the --kafka.sasl.oauth.scope flag as well
-  #     extensions: # can be set via the --kafka.sasl.oauth.extensions flag as well. Extensions are key value pairs to add to the authentication request
+  #     extensions: # Extensions are key value pairs to add to the authentication request
+  #       - key:
+  #         value:
   #   awsMskIam: # either set both accessKey and secretKey or leave both empty to use default AWS configuration in your environment
   #     accessKey:
   #     secretKey: # can be set via the --kafka.sasl.aws-msk-iam.secret-key flag as well


### PR DESCRIPTION
Kafka SASL OAuth supports sending extensions(custom key-value pairs) during OAuth authentication. These extensions are also supported by franz-go(https://pkg.go.dev/github.com/twmb/franz-go/pkg/sasl/oauth).
So this PR adds a support for these custom properties