### PR TITLE
rpcn: add description to resources

### DIFF
--- a/frontend/src/components/pages/rp-connect/Pipelines.Details.tsx
+++ b/frontend/src/components/pages/rp-connect/Pipelines.Details.tsx
@@ -381,6 +381,6 @@ export const PipelineResources = observer((p: { resources?: Pipeline_Resources }
     if (!r) return <>Not set</>
 
     return <Flex gap="4">
-        {r.cpuShares} / {r.memoryShares}
+        {r.cpuShares} CPU / {r.memoryShares} Memory
     </Flex>
 });


### PR DESCRIPTION
Currently resources display something like: `100m / 400M` which is super confusing, while we should make this better, this is a stop gap solution to at least tell the user what resources these are.