### PR TITLE
build: update rpadmin module to latest tag

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/redpanda-data/benthos/v4 v4.35.0
 	github.com/redpanda-data/common-go/api v0.0.0-20240918135346-6c838a508d64
 	github.com/redpanda-data/common-go/net v0.1.1-0.20240429123545-4da3d2b371f7
-	github.com/redpanda-data/common-go/rpadmin v0.1.7-0.20240921114754-0b4b663276c0
+	github.com/redpanda-data/common-go/rpadmin v0.1.8
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.32.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -555,8 +555,8 @@ github.com/redpanda-data/common-go/api v0.0.0-20240918135346-6c838a508d64 h1:qkz
 github.com/redpanda-data/common-go/api v0.0.0-20240918135346-6c838a508d64/go.mod h1:klAmWfc8Q3hEZk8geFTMu6f2sk3VUKRS7cv/LvB05ig=
 github.com/redpanda-data/common-go/net v0.1.1-0.20240429123545-4da3d2b371f7 h1:MXLdjFdFjOtyuUR4TdVVsqFP8xnru2YDwzH9bJTUr1M=
 github.com/redpanda-data/common-go/net v0.1.1-0.20240429123545-4da3d2b371f7/go.mod h1:UJIi/yUxGOBYXUrfUsOkxfYxcb/ll7mZrwae/i+U2kc=
-github.com/redpanda-data/common-go/rpadmin v0.1.7-0.20240921114754-0b4b663276c0 h1:RhXINGtcNKqegIUuWbm+7J9fI7YHde0vvGTP4KlipyY=
-github.com/redpanda-data/common-go/rpadmin v0.1.7-0.20240921114754-0b4b663276c0/go.mod h1:I7umqhnMhIOSEnIA3fvLtdQU7QO/SbWGCwFfFDs3De4=
+github.com/redpanda-data/common-go/rpadmin v0.1.8 h1:nb8brhdpMhlwx4nUtn/k0UVwI8++aQN+pGb/tvICLUk=
+github.com/redpanda-data/common-go/rpadmin v0.1.8/go.mod h1:I7umqhnMhIOSEnIA3fvLtdQU7QO/SbWGCwFfFDs3De4=
 github.com/rhnvrm/simples3 v0.6.1/go.mod h1:Y+3vYm2V7Y4VijFoJHHTrja6OgPrJ2cBti8dPGkC3sA=
 github.com/rickb777/period v1.0.6 h1:f4TcHBtL/4qa4D44eqgxs7785/kfLKUjRI7XYI2HCvk=
 github.com/rickb777/period v1.0.6/go.mod h1:TKkPHI/WSyjjVdeVCyqwBoQg0Cdb/jRvnc8FFdq2cgw=


### PR DESCRIPTION
Somewhere go mod seems to have broken and the rpadmin module specified doesn't seem valid:

```
github.com/redpanda-data/common-go/rpadmin@v0.1.7-0.20240921114754-0b4b663276c0 invalid version: unknown revision 0b4b663276c0
```

I tagged a new version of the module and added it to go mod.