### PR TITLE
backend: add debug bundle endpoint compatibility support

### DIFF
--- a/backend/pkg/console/endpoint_compatibility.go
+++ b/backend/pkg/console/endpoint_compatibility.go
@@ -125,6 +125,12 @@ func (s *Service) GetEndpointCompatibility(ctx context.Context) (EndpointCompati
 			HasRedpandaAPI:  true,
 			RedpandaFeature: redpanda.RedpandaFeatureWASMDataTransforms,
 		},
+		{
+			URL:             consolev1alpha1connect.DebugBundleServiceName,
+			Method:          "POST",
+			HasRedpandaAPI:  true,
+			RedpandaFeature: redpanda.RedpandaFeatureDebugBundle,
+		},
 	}
 
 	endpoints := make([]EndpointCompatibilityEndpoint, 0, len(endpointRequirements))


### PR DESCRIPTION
When not supported (ex, old version):

```sh
❯ http http://localhost:9090/api/console/endpoints
HTTP/1.1 200 OK
App-Build-Timestamp: 1731510626
Content-Type: application/json
Vary: Origin
Date: Wed, 13 Nov 2024 15:11:02 GMT
Content-Length: 1315

{
    "distribution": "redpanda",
    "endpointCompatibility": {
        "kafkaVersion": "unknown custom version at least v0.11.0",
        "endpoints": [
          ...
          {
                "endpoint": "redpanda.api.console.v1alpha1.DebugBundleService",
                "method": "POST",
                "isSupported": false
           },
           ...
        ]
    }
}
```

When is supported:

```sh
❯ http http://localhost:9090/api/console/endpoints
HTTP/1.1 200 OK
App-Build-Timestamp: 1731510626
Content-Type: application/json
Vary: Origin
Date: Wed, 13 Nov 2024 15:10:28 GMT
Content-Length: 1314

{
    "distribution": "redpanda",
    "endpointCompatibility": {
        "kafkaVersion": "unknown custom version at least v0.11.0",
        "endpoints": [
            ...
            {
                "endpoint": "redpanda.api.console.v1alpha1.DebugBundleService",
                "method": "POST",
                "isSupported": true
            },
            ...
        ]
    }
}
```