### PR TITLE
Fixes grammar in a license notification banner

### DIFF
--- a/frontend/src/components/license/LicenseNotification.tsx
+++ b/frontend/src/components/license/LicenseNotification.tsx
@@ -52,7 +52,7 @@ export const LicenseNotification = observer(() => {
                     </Box>}
 
                     {showEnterpriseFeaturesWarning && <Text>
-                        You're using Enterprise {activeEnterpriseFeatures.length === 1 ? 'feature' : 'features'} <strong>{activeEnterpriseFeatures.map(x => x.name).join(', ')}</strong> in your connected Redpanda cluster. {activeEnterpriseFeatures.length === 1 ? 'This feature requires a license' : 'These features require a license'}.
+                        You're using {activeEnterpriseFeatures.length === 1 ? 'an enterprise feature' : 'enterprise features'} <strong>{activeEnterpriseFeatures.map(x => x.name).join(', ')}</strong> in your connected Redpanda cluster. {activeEnterpriseFeatures.length === 1 ? 'This feature requires a license' : 'These features require a license'}.
                     </Text>}
 
                     <Flex gap={2} my={2}>


### PR DESCRIPTION
<img width="956" alt="Screenshot 2024-11-15 at 19 34 45" src="https://github.com/user-attachments/assets/60335582-d0b9-4043-94c8-c63718ae5095">
