### PR TITLE
Preserve path encoded subjects in middleware

### DIFF
--- a/backend/pkg/api/middlewares.go
+++ b/backend/pkg/api/middlewares.go
@@ -75,11 +75,12 @@ func (b *basePathMiddleware) Wrap(next http.Handler) http.Handler {
 		// Strip prefix from the request url
 		var path string
 		rctx := chi.RouteContext(r.Context())
-		if rctx.RoutePath != "" {
+		switch {
+		case rctx.RoutePath != "":
 			path = rctx.RoutePath
-		} else if r.URL.RawPath != "" {
+		case r.URL.RawPath != "":
 			path = r.URL.RawPath
-		} else {
+		default:
 			path = r.URL.Path
 		}
 

--- a/backend/pkg/api/middlewares.go
+++ b/backend/pkg/api/middlewares.go
@@ -77,6 +77,8 @@ func (b *basePathMiddleware) Wrap(next http.Handler) http.Handler {
 		rctx := chi.RouteContext(r.Context())
 		if rctx.RoutePath != "" {
 			path = rctx.RoutePath
+		} else if r.URL.RawPath != "" {
+			path = r.URL.RawPath
 		} else {
 			path = r.URL.Path
 		}
@@ -89,6 +91,11 @@ func (b *basePathMiddleware) Wrap(next http.Handler) http.Handler {
 		// URL.path
 		if strings.HasPrefix(r.URL.Path, prefix) {
 			r.URL.Path = "/" + strings.TrimPrefix(r.URL.Path, prefix)
+		}
+
+		// URL.RawPath
+		if strings.HasPrefix(r.URL.RawPath, prefix) {
+			r.URL.RawPath = "/" + strings.TrimPrefix(r.URL.RawPath, prefix)
 		}
 
 		// requestURI


### PR DESCRIPTION
Update basePathMiddleware to use `RawPath` (if present) over `Path` to ensure that URL path encoded subjects are preserved when routing requests.

Update the middleware to also remove the prefix from `RawPath` for consistency.

Fixes #1525.