### PR TITLE
Add redpanda connect secret manager to console

### DIFF
--- a/frontend/src/components/pages/rp-connect/Pipelines.List.tsx
+++ b/frontend/src/components/pages/rp-connect/Pipelines.List.tsx
@@ -37,7 +37,7 @@ const { ToastContainer, toast } = createStandaloneToast();
 
 const CreatePipelineButton = () => {
     return (<Box style={{ display: 'flex', marginBottom: '.5em' }}>
-        <Link to={'/rp-connect/create'}><Button variant="outline" colorScheme="brand">Create Pipeline</Button></Link>
+        <Link to={'/rp-connect/create'}><Button>Create pipeline</Button></Link>
     </Box>)
 }
 
@@ -134,14 +134,17 @@ class RpConnectPipelinesList extends PageComponent<{}> {
                     <ToastContainer />
                     {/* Pipeline List */}
 
-                    <Flex my={5} flexDir={'row'} gap={2}>
-                        <SearchField width="350px"
-                                     searchText={uiSettings.pipelinesList.quickSearch}
-                                     setSearchText={x => uiSettings.pipelinesList.quickSearch = x}
-                                     placeholderText="Enter search term / regex..."
-                        />
-                        <CreatePipelineButton/>
-                    </Flex>
+                    {pipelinesApi.pipelines.length != 0 && (
+                        <Flex my={5} flexDir={'row'} gap={2}>
+                            <CreatePipelineButton/>
+                            <SearchField width="350px"
+                                         searchText={uiSettings.pipelinesList.quickSearch}
+                                         setSearchText={x => uiSettings.pipelinesList.quickSearch = x}
+                                         placeholderText="Enter search term / regex..."
+                            />
+                        </Flex>
+                    )}
+
 
 
                     {(pipelinesApi.pipelines ?? []).length == 0

--- a/frontend/src/components/pages/rp-connect/Pipelines.List.tsx
+++ b/frontend/src/components/pages/rp-connect/Pipelines.List.tsx
@@ -35,6 +35,19 @@ import { HiX } from 'react-icons/hi';
 
 const { ToastContainer, toast } = createStandaloneToast();
 
+const CreatePipelineButton = () => {
+    return (<Box style={{ display: 'flex', marginBottom: '.5em' }}>
+        <Link to={'/rp-connect/create'}><Button variant="outline" colorScheme="brand">Create Pipeline</Button></Link>
+    </Box>)
+}
+
+const EmptyPlaceholder = () => {
+    return <Flex alignItems="center" justifyContent="center" flexDirection="column" gap="4" mb="4">
+        <Image src={EmptyConnectors} />
+        <Box>You have no Redpanda Connect pipelines.</Box>
+        <CreatePipelineButton/>
+    </Flex>
+};
 
 export const PipelineStatus = observer((p: { status: Pipeline_State }) => {
     switch (p.status) {
@@ -121,17 +134,15 @@ class RpConnectPipelinesList extends PageComponent<{}> {
                     <ToastContainer />
                     {/* Pipeline List */}
 
-                    <div style={{ display: 'flex', marginBottom: '.5em' }}>
-                        <Link to={'/rp-connect/create'}><Button variant="solid" colorScheme="brand">Create pipeline</Button></Link>
-                    </div>
-
-                    <Box my={5}>
+                    <Flex my={5} flexDir={'row'} gap={2}>
                         <SearchField width="350px"
-                            searchText={uiSettings.pipelinesList.quickSearch}
-                            setSearchText={x => uiSettings.pipelinesList.quickSearch = x}
-                            placeholderText="Enter search term / regex..."
+                                     searchText={uiSettings.pipelinesList.quickSearch}
+                                     setSearchText={x => uiSettings.pipelinesList.quickSearch = x}
+                                     placeholderText="Enter search term / regex..."
                         />
-                    </Box>
+                        <CreatePipelineButton/>
+                    </Flex>
+
 
                     {(pipelinesApi.pipelines ?? []).length == 0
                         ? <EmptyPlaceholder />
@@ -226,13 +237,3 @@ class RpConnectPipelinesList extends PageComponent<{}> {
 }
 
 export default RpConnectPipelinesList;
-
-const EmptyPlaceholder = () => {
-    return <Flex alignItems="center" justifyContent="center" flexDirection="column" gap="4" mb="4">
-        <Image src={EmptyConnectors} />
-        <Box>You have no Redpanda Connect pipelines.</Box>
-        <Link to="/rp-connect/create">
-            <Button variant="solid">Create pipeline</Button>
-        </Link>
-    </Flex>
-};

--- a/frontend/src/components/pages/rp-connect/Pipelines.List.tsx
+++ b/frontend/src/components/pages/rp-connect/Pipelines.List.tsx
@@ -135,7 +135,7 @@ class RpConnectPipelinesList extends PageComponent<{}> {
                     {/* Pipeline List */}
 
                     {pipelinesApi.pipelines.length != 0 && (
-                        <Flex my={5} flexDir={'row'} gap={2}>
+                        <Flex my={5} flexDir={'column'} gap={2}>
                             <CreatePipelineButton/>
                             <SearchField width="350px"
                                          searchText={uiSettings.pipelinesList.quickSearch}

--- a/frontend/src/components/pages/rp-connect/secrets/Secrets.Create.tsx
+++ b/frontend/src/components/pages/rp-connect/secrets/Secrets.Create.tsx
@@ -11,6 +11,9 @@ import {CreateSecretRequest, Scope} from '../../../../protogen/redpanda/api/data
 
 const {ToastContainer, toast} = createStandaloneToast();
 
+const returnSecretTab = '/connect-clusters?defaultTab=redpanda-connect-secret'
+
+
 @observer
 class RpConnectSecretCreate extends PageComponent {
 
@@ -39,7 +42,7 @@ class RpConnectSecretCreate extends PageComponent {
     cancel() {
         this.secret = '';
         this.id = '';
-        appGlobal.history.push('/connect-clusters/redpanda-connect-secret');
+        appGlobal.history.push(returnSecretTab);
     }
 
     async createSecret() {
@@ -61,15 +64,15 @@ class RpConnectSecretCreate extends PageComponent {
             .then(async () => {
                 toast({
                     status: 'success', duration: 4000, isClosable: false,
-                    title: 'Pipeline created'
+                    title: 'Secret created'
                 });
                 await pipelinesApi.refreshPipelines(true);
-                appGlobal.history.push('/connect-clusters/redpanda-connect-secret');
+                appGlobal.history.push(returnSecretTab);
             })
             .catch(err => {
                 toast({
                     status: 'error', duration: null, isClosable: true,
-                    title: 'Failed to create pipeline',
+                    title: 'Failed to create secret',
                     description: formatPipelineError(err),
                 })
             })

--- a/frontend/src/components/pages/rp-connect/secrets/Secrets.Create.tsx
+++ b/frontend/src/components/pages/rp-connect/secrets/Secrets.Create.tsx
@@ -29,15 +29,15 @@ class RpConnectSecretCreate extends PageComponent {
 
     initPage(p: PageInitHelper) {
         p.title = 'Create Secret';
-        p.addBreadcrumb('Redpanda Connect Secret Manager', '/rp-connect/secret/create');
+        p.addBreadcrumb('Redpanda Connect Secret Manager', '/rp-connect/secrets/create');
         p.addBreadcrumb('Create Secret', '');
 
         this.refreshData(true);
         appGlobal.onRefresh = () => this.refreshData(true);
     }
 
-    refreshData(_force: boolean) {
-        rpcnSecretManagerApi.refreshSecrets(_force);
+    refreshData(force: boolean) {
+        rpcnSecretManagerApi.refreshSecrets(force);
     }
 
     cancel() {
@@ -77,9 +77,9 @@ class RpConnectSecretCreate extends PageComponent {
     render() {
         if (!rpcnSecretManagerApi.secrets) return DefaultSkeleton;
 
-        const alreadyExists = (rpcnSecretManagerApi.secrets || []).any(x => x.id == this.id);
-        const isIdEmpty = this.id.trim().length == 0;
-        const isSecretEmpty = this.secret.trim().length == 0;
+        const alreadyExists = (rpcnSecretManagerApi.secrets || []).any(x => x.id === this.id);
+        const isIdEmpty = this.id.trim().length === 0;
+        const isSecretEmpty = this.secret.trim().length === 0;
 
         return (
             <PageContent>

--- a/frontend/src/components/pages/rp-connect/secrets/Secrets.Create.tsx
+++ b/frontend/src/components/pages/rp-connect/secrets/Secrets.Create.tsx
@@ -1,0 +1,139 @@
+import {Button, ButtonGroup, createStandaloneToast, Flex, FormField, Input} from '@redpanda-data/ui';
+import {PageComponent, PageInitHelper} from '../../Page';
+import {observer} from 'mobx-react';
+import {appGlobal} from '../../../../state/appGlobal';
+import {pipelinesApi, rpcnSecretManagerApi} from '../../../../state/backendApi';
+import PageContent from '../../../misc/PageContent';
+import {action, makeObservable, observable} from 'mobx';
+import {DefaultSkeleton} from '../../../../utils/tsxUtils';
+import {formatPipelineError} from '../errors';
+import {CreateSecretRequest, Scope} from '../../../../protogen/redpanda/api/dataplane/v1alpha2/secret_pb';
+
+const {ToastContainer, toast} = createStandaloneToast();
+
+@observer
+class RpConnectSecretCreate extends PageComponent {
+
+    @observable id = '';
+    @observable secret = '';
+    @observable isCreating = false;
+
+    constructor(p: any) {
+        super(p);
+        makeObservable(this, undefined, {autoBind: true});
+    }
+
+    initPage(p: PageInitHelper) {
+        p.title = 'Create Secret';
+        p.addBreadcrumb('Redpanda Connect Secret Manager', '/rp-connect/secret/create');
+        p.addBreadcrumb('Create Secret', '');
+
+        this.refreshData(true);
+        appGlobal.onRefresh = () => this.refreshData(true);
+    }
+
+    refreshData(_force: boolean) {
+        rpcnSecretManagerApi.refreshSecrets(_force);
+    }
+
+    cancel() {
+        this.secret = '';
+        this.id = '';
+        appGlobal.history.push('/connect-clusters/redpanda-connect-secret');
+    }
+
+    async createSecret() {
+        this.isCreating = true;
+
+        //create function given string return base64 encoded Uint8Array
+        function base64Encode(str: string): Uint8Array {
+            const encodedString = btoa(str);
+            const charList = encodedString.split('').map(char => char.charCodeAt(0));
+            return new Uint8Array(charList);
+        }
+
+
+        rpcnSecretManagerApi.create(new CreateSecretRequest({
+            id: this.id,
+            secretData: base64Encode(this.secret),
+            scopes: [Scope.REDPANDA_CONNECT]
+        }))
+            .then(async () => {
+                toast({
+                    status: 'success', duration: 4000, isClosable: false,
+                    title: 'Pipeline created'
+                });
+                await pipelinesApi.refreshPipelines(true);
+                appGlobal.history.push('/connect-clusters/redpanda-connect-secret');
+            })
+            .catch(err => {
+                toast({
+                    status: 'error', duration: null, isClosable: true,
+                    title: 'Failed to create pipeline',
+                    description: formatPipelineError(err),
+                })
+            })
+            .finally(() => {
+                this.isCreating = false;
+            });
+    }
+
+    render() {
+        if (!rpcnSecretManagerApi.secrets) return DefaultSkeleton;
+
+        const alreadyExists = (rpcnSecretManagerApi.secrets || []).any(x => x.id == this.id);
+        const isIdEmpty = this.id.trim().length == 0;
+        const isSecretEmpty = this.secret.trim().length == 0;
+
+        return (
+            <PageContent>
+                <ToastContainer/>
+                <Flex flexDirection="column" gap={5}>
+                    <FormField label="Secret name" isInvalid={alreadyExists} errorText="Secret name is already in use">
+                        <Flex alignItems="center" gap="2">
+                            <Input
+                                placeholder="Enter a secret name..."
+                                data-testid="secretId"
+                                pattern="^[A-Z][A-Z0-9_]*$"
+                                min={1}
+                                max={255}
+                                isRequired
+                                value={this.id}
+                                onChange={x => this.id = x.target.value.toUpperCase()}
+                                width={500}
+                                disabled={this.isCreating}
+                            />
+                        </Flex>
+                    </FormField>
+
+                    <FormField label="Secret value">
+                        <Flex alignItems="center" gap="2">
+                            <Input
+                                placeholder="Enter a secret value..."
+                                data-testid="secretValue"
+                                isRequired
+                                value={this.secret}
+                                onChange={x => this.secret = x.target.value}
+                                width={500}
+                                type="password"
+                                disabled={this.isCreating}
+                            />
+                        </Flex>
+                    </FormField>
+
+                    <ButtonGroup>
+                        <Button isLoading={this.isCreating} isDisabled={isIdEmpty || isSecretEmpty || alreadyExists} onClick={action(() => this.createSecret())}>
+                            Create Secret
+                        </Button>
+                        <Button variant="link" disabled={this.isCreating} onClick={action(() => this.cancel())}>
+                            Cancel
+                        </Button>
+                    </ButtonGroup>
+                </Flex>
+            </PageContent>
+        );
+
+    }
+}
+
+export default RpConnectSecretCreate;

--- a/frontend/src/components/pages/rp-connect/secrets/Secrets.Create.tsx
+++ b/frontend/src/components/pages/rp-connect/secrets/Secrets.Create.tsx
@@ -1,4 +1,4 @@
-import {Button, ButtonGroup, createStandaloneToast, Flex, FormField, Input} from '@redpanda-data/ui';
+import {Button, ButtonGroup, createStandaloneToast, Flex, FormField, Input, PasswordInput} from '@redpanda-data/ui';
 import {PageComponent, PageInitHelper} from '../../Page';
 import {observer} from 'mobx-react';
 import {appGlobal} from '../../../../state/appGlobal';
@@ -110,8 +110,8 @@ class RpConnectSecretCreate extends PageComponent {
                     </FormField>
 
                     <FormField label="Secret value">
-                        <Flex alignItems="center" gap="2">
-                            <Input
+                        <Flex alignItems="center" width={500}>
+                            <PasswordInput
                                 placeholder="Enter a secret value..."
                                 data-testid="secretValue"
                                 isRequired
@@ -119,7 +119,7 @@ class RpConnectSecretCreate extends PageComponent {
                                 onChange={x => this.secret = x.target.value}
                                 width={500}
                                 type="password"
-                                disabled={this.isCreating}
+                                isDisabled={this.isCreating}
                             />
                         </Flex>
                     </FormField>

--- a/frontend/src/components/pages/rp-connect/secrets/Secrets.Create.tsx
+++ b/frontend/src/components/pages/rp-connect/secrets/Secrets.Create.tsx
@@ -8,6 +8,7 @@ import {action, makeObservable, observable} from 'mobx';
 import {DefaultSkeleton} from '../../../../utils/tsxUtils';
 import {formatPipelineError} from '../errors';
 import {CreateSecretRequest, Scope} from '../../../../protogen/redpanda/api/dataplane/v1alpha2/secret_pb';
+import {base64ToUInt8Array, encodeBase64} from '../../../../utils/utils';
 
 const {ToastContainer, toast} = createStandaloneToast();
 
@@ -48,17 +49,9 @@ class RpConnectSecretCreate extends PageComponent {
     async createSecret() {
         this.isCreating = true;
 
-        //create function given string return base64 encoded Uint8Array
-        function base64Encode(str: string): Uint8Array {
-            const encodedString = btoa(str);
-            const charList = encodedString.split('').map(char => char.charCodeAt(0));
-            return new Uint8Array(charList);
-        }
-
-
         rpcnSecretManagerApi.create(new CreateSecretRequest({
             id: this.id,
-            secretData: base64Encode(this.secret),
+            secretData: base64ToUInt8Array(encodeBase64(this.secret)),
             scopes: [Scope.REDPANDA_CONNECT]
         }))
             .then(async () => {

--- a/frontend/src/components/pages/rp-connect/secrets/Secrets.List.tsx
+++ b/frontend/src/components/pages/rp-connect/secrets/Secrets.List.tsx
@@ -147,7 +147,7 @@ class RpConnectSecretsList extends PageComponent {
                                                         onClick={e => {
                                                             e.stopPropagation();
                                                             e.preventDefault();
-                                                            appGlobal.history.push(`/rp-connect/secret/${r.id}/edit`);
+                                                            appGlobal.history.push(`/rp-connect/secrets/${r.id}/edit`);
                                                         }}>
                                                     <PencilIcon/>
                                                 </Button>

--- a/frontend/src/components/pages/rp-connect/secrets/Secrets.List.tsx
+++ b/frontend/src/components/pages/rp-connect/secrets/Secrets.List.tsx
@@ -17,7 +17,7 @@ const {ToastContainer, toast} = createStandaloneToast();
 
 const CreateSecretButton = () => {
     return (<Box style={{display: 'flex', marginBottom: '.5em'}}>
-        <Link to={'/rp-connect/secret/create'}><Button variant="outline" colorScheme="brand">Create Secret</Button></Link>
+        <Link to={'/rp-connect/secret/create'}><Button>Create secret</Button></Link>
     </Box>)
 }
 
@@ -88,14 +88,16 @@ class RpConnectSecretsList extends PageComponent {
                 <Section>
                     <ToastContainer/>
 
-                    <Flex my={5} flexDir={'row'} gap={2}>
-                        <SearchField width="350px"
-                                     searchText={uiSettings.rpncSecretList.quickSearch}
-                                     setSearchText={x => uiSettings.rpncSecretList.quickSearch = x}
-                                     placeholderText="Enter search term / regex..."
-                        />
-                        <CreateSecretButton/>
-                    </Flex>
+                    {rpcnSecretManagerApi.secrets?.length != 0 && (
+                        <Flex my={5} flexDir={'row'} gap={2}>
+                            <CreateSecretButton/>
+                            <SearchField width="350px"
+                                         searchText={uiSettings.rpncSecretList.quickSearch}
+                                         setSearchText={x => uiSettings.rpncSecretList.quickSearch = x}
+                                         placeholderText="Enter search term / regex..."
+                            />
+                        </Flex>
+                    )}
 
                     {(rpcnSecretManagerApi.secrets ?? []).length == 0
                         ? <EmptyPlaceholder/>
@@ -112,7 +114,7 @@ class RpConnectSecretsList extends PageComponent {
                                 },
                                 {
                                     header: 'Secret notation',
-                                    cell: ({row: {original}}) => <Text wordBreak="break-word" whiteSpace="break-spaces">{`$(secrets.${original.id})`}</Text>,
+                                    cell: ({row: {original}}) => <Code><Text wordBreak="break-word" whiteSpace="break-spaces">{`$(secrets.${original.id})`}</Text></Code>,
                                     size: 400
                                 },
                                 // let use this on next phase
@@ -127,34 +129,40 @@ class RpConnectSecretsList extends PageComponent {
                                     header: '',
                                     id: 'actions',
                                     cell: ({row: {original: r}}) =>
-                                        <ButtonGroup>
-                                            <Button variant="icon"
-                                                    height="16px" color="gray.500"
-                                                    onClick={e => {
-                                                        e.stopPropagation();
-                                                        e.preventDefault();
-                                                        appGlobal.history.push(`/rp-connect/secret/${r.id}/edit`);
-                                                    }}>
-                                                <PencilIcon/>
-                                            </Button>
-                                            <ConfirmItemDeleteModal
-                                                trigger={
-                                                    <Button variant="icon"
-                                                            height="16px"
-                                                            color="gray.500"
-                                                    >
-                                                        <TrashIcon/>
-                                                    </Button>} itemType={'Secret'}
-                                                onConfirm={
-                                                    async (dismiss) => {
-                                                        await this.deleteSecret(r.id)
-                                                        dismiss();
+                                        <Flex justifyContent={'flex-end'}>
+                                            <ButtonGroup>
+                                                <Button variant="icon"
+                                                        height="16px" color="gray.500"
+                                                        onClick={e => {
+                                                            e.stopPropagation();
+                                                            e.preventDefault();
+                                                            appGlobal.history.push(`/rp-connect/secret/${r.id}/edit`);
+                                                        }}>
+                                                    <PencilIcon/>
+                                                </Button>
+                                                <ConfirmItemDeleteModal
+                                                    trigger={
+                                                        <Button variant="icon"
+                                                                height="16px"
+                                                                color="gray.500"
+                                                        >
+                                                            <TrashIcon/>
+                                                        </Button>} itemType={'Secret'}
+                                                    onConfirm={
+                                                        async (dismiss) => {
+                                                            await this.deleteSecret(r.id)
+                                                            dismiss();
+                                                        }
                                                     }
-                                                }>
-                                                <Text>Deleting this secret may disrupt the functionality of pipelines that depend on it. Are you sure you want to delete the secret <Code>{r.id}</Code>?</Text>
-                                            </ConfirmItemDeleteModal>
+                                                    inputMatchText={r.id}>
+                                                    <Flex flexDirection={'column'}>
+                                                        <Text>Deleting this secret may disrupt the functionality of pipelines that depend on it. Are you sure?</Text>
+                                                        <Text>To confirm, type <Code>{r.id}</Code> in the confirmation box below.</Text>
+                                                    </Flex>
+                                                </ConfirmItemDeleteModal>
 
-                                        </ButtonGroup>
+                                            </ButtonGroup>
+                                        </Flex>
                                     ,
                                     size: 10
                                 },

--- a/frontend/src/components/pages/rp-connect/secrets/Secrets.List.tsx
+++ b/frontend/src/components/pages/rp-connect/secrets/Secrets.List.tsx
@@ -71,7 +71,7 @@ class RpConnectSecretsList extends PageComponent {
 
         const filteredSecrets = (rpcnSecretManagerApi.secrets ?? [])
             .filter(u => {
-                const filter = uiSettings.rpncSecretList.quickSearch;
+                const filter = uiSettings.rpcnSecretList.quickSearch;
                 if (!filter) return true;
                 try {
                     const quickSearchRegExp = new RegExp(filter, 'i');
@@ -92,8 +92,8 @@ class RpConnectSecretsList extends PageComponent {
                         <Flex my={5} flexDir={'column'} gap={2}>
                             <CreateSecretButton/>
                             <SearchField width="350px"
-                                         searchText={uiSettings.rpncSecretList.quickSearch}
-                                         setSearchText={x => uiSettings.rpncSecretList.quickSearch = x}
+                                         searchText={uiSettings.rpcnSecretList.quickSearch}
+                                         setSearchText={x => uiSettings.rpcnSecretList.quickSearch = x}
                                          placeholderText="Enter search term / regex..."
                             />
                         </Flex>

--- a/frontend/src/components/pages/rp-connect/secrets/Secrets.List.tsx
+++ b/frontend/src/components/pages/rp-connect/secrets/Secrets.List.tsx
@@ -9,7 +9,6 @@ import Section from '../../../misc/Section';
 import PageContent from '../../../misc/PageContent';
 import {uiSettings} from '../../../../state/ui';
 import {Link} from 'react-router-dom';
-import {encodeURIComponentPercents} from '../../../../utils/utils';
 import {PencilIcon, TrashIcon} from '@heroicons/react/outline';
 import EmptyConnectors from '../../../../assets/redpanda/EmptyConnectors.svg';
 import {DeleteSecretRequest, Secret} from '../../../../protogen/redpanda/api/dataplane/v1alpha2/secret_pb';
@@ -108,20 +107,12 @@ class RpConnectSecretsList extends PageComponent {
                             columns={[
                                 {
                                     header: 'Secret name',
-                                    cell: ({row: {original}}) => (
-                                        <Link to={`/rp-connect/${encodeURIComponentPercents(original.id)}`}>
-                                            <Text>{original.id}</Text>
-                                        </Link>
-                                    ),
+                                    cell: ({row: {original}}) => <Text>{original.id}</Text>,
                                     size: 200,
                                 },
                                 {
                                     header: 'Secret notation',
-                                    cell: ({row: {original}}) => (
-                                        <Link to={`/rp-connect/${encodeURIComponentPercents(original.id)}`}>
-                                            <Text wordBreak="break-word" whiteSpace="break-spaces">{`$(secrets.${original.id})`}</Text>
-                                        </Link>
-                                    ),
+                                    cell: ({row: {original}}) => <Text wordBreak="break-word" whiteSpace="break-spaces">{`$(secrets.${original.id})`}</Text>,
                                     size: 400
                                 },
                                 // let use this on next phase

--- a/frontend/src/components/pages/rp-connect/secrets/Secrets.List.tsx
+++ b/frontend/src/components/pages/rp-connect/secrets/Secrets.List.tsx
@@ -8,7 +8,7 @@ import {Box, Button, ButtonGroup, Code, ConfirmItemDeleteModal, CopyButton, crea
 import Section from '../../../misc/Section';
 import PageContent from '../../../misc/PageContent';
 import {uiSettings} from '../../../../state/ui';
-import {Link} from 'react-router-dom';
+import {Link as ReactRouterLink} from 'react-router-dom';
 import {PencilIcon, TrashIcon} from '@heroicons/react/outline';
 import EmptyConnectors from '../../../../assets/redpanda/EmptyConnectors.svg';
 import {DeleteSecretRequest, Secret} from '../../../../protogen/redpanda/api/dataplane/v1alpha2/secret_pb';
@@ -16,9 +16,9 @@ import {DeleteSecretRequest, Secret} from '../../../../protogen/redpanda/api/dat
 const {ToastContainer, toast} = createStandaloneToast();
 
 const CreateSecretButton = () => {
-    return (<Box style={{display: 'flex', marginBottom: '.5em'}}>
-        <Link to={'/rp-connect/secret/create'}><Button>Create secret</Button></Link>
-    </Box>)
+    return (<Flex marginBottom={'.5em'}>
+        <Button as={ReactRouterLink} to={'/rp-connect/secrets/create'}>Create secret</Button>
+    </Flex>)
 }
 
 const EmptyPlaceholder = () => {

--- a/frontend/src/components/pages/rp-connect/secrets/Secrets.List.tsx
+++ b/frontend/src/components/pages/rp-connect/secrets/Secrets.List.tsx
@@ -4,7 +4,7 @@ import {observer} from 'mobx-react';
 import {appGlobal} from '../../../../state/appGlobal';
 import {rpcnSecretManagerApi} from '../../../../state/backendApi';
 import {Features} from '../../../../state/supportedFeatures';
-import {Box, Button, ButtonGroup, Code, ConfirmItemDeleteModal, createStandaloneToast, DataTable, Flex, Image, SearchField, Text} from '@redpanda-data/ui';
+import {Box, Button, ButtonGroup, Code, ConfirmItemDeleteModal, CopyButton, createStandaloneToast, DataTable, Flex, Image, SearchField, Text, Tooltip} from '@redpanda-data/ui';
 import Section from '../../../misc/Section';
 import PageContent from '../../../misc/PageContent';
 import {uiSettings} from '../../../../state/ui';
@@ -89,7 +89,7 @@ class RpConnectSecretsList extends PageComponent {
                     <ToastContainer/>
 
                     {rpcnSecretManagerApi.secrets?.length != 0 && (
-                        <Flex my={5} flexDir={'row'} gap={2}>
+                        <Flex my={5} flexDir={'column'} gap={2}>
                             <CreateSecretButton/>
                             <SearchField width="350px"
                                          searchText={uiSettings.rpncSecretList.quickSearch}
@@ -114,7 +114,18 @@ class RpConnectSecretsList extends PageComponent {
                                 },
                                 {
                                     header: 'Secret notation',
-                                    cell: ({row: {original}}) => <Code><Text wordBreak="break-word" whiteSpace="break-spaces">{`$(secrets.${original.id})`}</Text></Code>,
+                                    cell: ({row: {original}}) => (
+                                        <Box>
+                                            <Code><Text wordBreak="break-word" whiteSpace="break-spaces">{`$\{secrets.${original.id}}`}</Text></Code>
+                                            <Tooltip label="Copy" hasArrow>
+                                                <CopyButton
+                                                    content={`$\{secrets.${original.id}}`}
+                                                    variant="ghost"
+                                                    colorScheme="gray"
+                                                    size="sm"
+                                                />
+                                            </Tooltip>
+                                        </Box>),
                                     size: 400
                                 },
                                 // let use this on next phase

--- a/frontend/src/components/pages/rp-connect/secrets/Secrets.List.tsx
+++ b/frontend/src/components/pages/rp-connect/secrets/Secrets.List.tsx
@@ -1,0 +1,181 @@
+import React from 'react';
+import {PageComponent, PageInitHelper} from '../../Page';
+import {observer} from 'mobx-react';
+import {appGlobal} from '../../../../state/appGlobal';
+import {rpcnSecretManagerApi} from '../../../../state/backendApi';
+import {Features} from '../../../../state/supportedFeatures';
+import {Box, Button, ButtonGroup, Code, ConfirmItemDeleteModal, createStandaloneToast, DataTable, Flex, Image, SearchField, Text} from '@redpanda-data/ui';
+import Section from '../../../misc/Section';
+import PageContent from '../../../misc/PageContent';
+import {uiSettings} from '../../../../state/ui';
+import {Link} from 'react-router-dom';
+import {encodeURIComponentPercents} from '../../../../utils/utils';
+import {PencilIcon, TrashIcon} from '@heroicons/react/outline';
+import EmptyConnectors from '../../../../assets/redpanda/EmptyConnectors.svg';
+import {DeleteSecretRequest, Secret} from '../../../../protogen/redpanda/api/dataplane/v1alpha2/secret_pb';
+
+const {ToastContainer, toast} = createStandaloneToast();
+
+const CreateSecretButton = () => {
+    return (<Box style={{display: 'flex', marginBottom: '.5em'}}>
+        <Link to={'/rp-connect/secret/create'}><Button variant="outline" colorScheme="brand">Create Secret</Button></Link>
+    </Box>)
+}
+
+const EmptyPlaceholder = () => {
+    return <Flex alignItems="center" justifyContent="center" flexDirection="column" gap="4" mb="4">
+        <Image src={EmptyConnectors}/>
+        <Box>You have no Redpanda Connect secrets.</Box>
+        <CreateSecretButton/>
+    </Flex>
+};
+
+@observer
+class RpConnectSecretsList extends PageComponent {
+
+    initPage(p: PageInitHelper) {
+        p.addBreadcrumb('Redpanda Connect Secret Manager', '/rp-connect/secrets');
+        this.refreshData(true);
+        appGlobal.onRefresh = () => this.refreshData(true);
+    }
+
+    refreshData(force: boolean) {
+        if (!Features.pipelinesApi) return;
+
+        rpcnSecretManagerApi.refreshSecrets(force)
+            .catch((err) => {
+                if (String(err).includes('404')) {
+                    // Hacky special handling for OSS version, it is possible for the /endpoints request to not complete in time for this to render
+                    // so in this case there would be an error shown because we were too fast (with rendering, or the req was too slow)
+                    // We don't want to show an error in that case
+                    return;
+                }
+
+                if (Features.pipelinesApi) {
+                    toast({
+                        status: 'error', duration: null, isClosable: true,
+                        title: 'Failed to load pipelines',
+                        description: String(err),
+                    });
+                }
+            })
+    }
+
+    async deleteSecret(id: string) {
+        await rpcnSecretManagerApi.delete(new DeleteSecretRequest({
+            id
+        }))
+        this.refreshData(true);
+    }
+
+    render() {
+
+        const filteredSecrets = (rpcnSecretManagerApi.secrets ?? [])
+            .filter(u => {
+                const filter = uiSettings.rpncSecretList.quickSearch;
+                if (!filter) return true;
+                try {
+                    const quickSearchRegExp = new RegExp(filter, 'i');
+                    if (u.id.match(quickSearchRegExp))
+                        return true;
+                    return false;
+                } catch {
+                    return false;
+                }
+            });
+
+        return (
+            <PageContent>
+                <Section>
+                    <ToastContainer/>
+
+                    <Flex my={5} flexDir={'row'} gap={2}>
+                        <SearchField width="350px"
+                                     searchText={uiSettings.rpncSecretList.quickSearch}
+                                     setSearchText={x => uiSettings.rpncSecretList.quickSearch = x}
+                                     placeholderText="Enter search term / regex..."
+                        />
+                        <CreateSecretButton/>
+                    </Flex>
+
+                    {(rpcnSecretManagerApi.secrets ?? []).length == 0
+                        ? <EmptyPlaceholder/>
+                        : <DataTable<Secret>
+                            data={filteredSecrets}
+                            pagination
+                            defaultPageSize={10}
+                            sorting
+                            columns={[
+                                {
+                                    header: 'Secret name',
+                                    cell: ({row: {original}}) => (
+                                        <Link to={`/rp-connect/${encodeURIComponentPercents(original.id)}`}>
+                                            <Text>{original.id}</Text>
+                                        </Link>
+                                    ),
+                                    size: 200,
+                                },
+                                {
+                                    header: 'Secret notation',
+                                    cell: ({row: {original}}) => (
+                                        <Link to={`/rp-connect/${encodeURIComponentPercents(original.id)}`}>
+                                            <Text wordBreak="break-word" whiteSpace="break-spaces">{`$(secrets.${original.id})`}</Text>
+                                        </Link>
+                                    ),
+                                    size: 400
+                                },
+                                // let use this on next phase
+                                // {
+                                //     header: 'Pipelines',
+                                //     cell: (_) => (
+                                //         <Text wordBreak="break-word" whiteSpace="break-spaces">TODO</Text>
+                                //     ),
+                                //     size: 400,
+                                // },
+                                {
+                                    header: '',
+                                    id: 'actions',
+                                    cell: ({row: {original: r}}) =>
+                                        <ButtonGroup>
+                                            <Button variant="icon"
+                                                    height="16px" color="gray.500"
+                                                    onClick={e => {
+                                                        e.stopPropagation();
+                                                        e.preventDefault();
+                                                        appGlobal.history.push(`/rp-connect/secret/${r.id}/edit`);
+                                                    }}>
+                                                <PencilIcon/>
+                                            </Button>
+                                            <ConfirmItemDeleteModal
+                                                trigger={
+                                                    <Button variant="icon"
+                                                            height="16px"
+                                                            color="gray.500"
+                                                    >
+                                                        <TrashIcon/>
+                                                    </Button>} itemType={'Secret'}
+                                                onConfirm={
+                                                    async (dismiss) => {
+                                                        await this.deleteSecret(r.id)
+                                                        dismiss();
+                                                    }
+                                                }>
+                                                <Text>Deleting this secret may disrupt the functionality of pipelines that depend on it. Are you sure you want to delete the secret <Code>{r.id}</Code>?</Text>
+                                            </ConfirmItemDeleteModal>
+
+                                        </ButtonGroup>
+                                    ,
+                                    size: 10
+                                },
+                            ]}
+                            emptyText=""
+                        />
+                    }
+
+                </Section>
+            </PageContent>
+        )
+    }
+}
+
+export default RpConnectSecretsList;

--- a/frontend/src/components/pages/rp-connect/secrets/Secrets.Update.tsx
+++ b/frontend/src/components/pages/rp-connect/secrets/Secrets.Update.tsx
@@ -1,4 +1,4 @@
-import {Button, ButtonGroup, createStandaloneToast, Flex, FormField, Input} from '@redpanda-data/ui';
+import {Button, ButtonGroup, createStandaloneToast, Flex, FormField, Input, PasswordInput} from '@redpanda-data/ui';
 import {PageComponent, PageInitHelper} from '../../Page';
 import {observer} from 'mobx-react';
 import {appGlobal} from '../../../../state/appGlobal';
@@ -91,7 +91,7 @@ class RpConnectSecretUpdate extends PageComponent<{ secretId: string }> {
                             <Input
                                 placeholder="Enter a secret name..."
                                 data-testid="secretId"
-                                pattern="[a-zA-Z0-9_\-]+"
+                                pattern="^[A-Z][A-Z0-9_]*$"
                                 isRequired
                                 disabled={true}
                                 value={this.props.secretId}
@@ -101,8 +101,8 @@ class RpConnectSecretUpdate extends PageComponent<{ secretId: string }> {
                     </FormField>
 
                     <FormField label="Secret value">
-                        <Flex alignItems="center" gap="2">
-                            <Input
+                        <Flex alignItems="center" gap="2" width={500}>
+                            <PasswordInput
                                 placeholder="Enter a new secret value..."
                                 data-testid="secretValue"
                                 isRequired
@@ -110,6 +110,7 @@ class RpConnectSecretUpdate extends PageComponent<{ secretId: string }> {
                                 onChange={x => this.secret = x.target.value}
                                 width={500}
                                 type="password"
+                                isDisabled={this.isUpdating}
                             />
                         </Flex>
                     </FormField>

--- a/frontend/src/components/pages/rp-connect/secrets/Secrets.Update.tsx
+++ b/frontend/src/components/pages/rp-connect/secrets/Secrets.Update.tsx
@@ -25,7 +25,7 @@ class RpConnectSecretUpdate extends PageComponent<{ secretId: string }> {
 
     initPage(p: PageInitHelper) {
         p.title = 'Update Secret';
-        p.addBreadcrumb('Redpanda Connect Secret Manager', '/rp-connect/secret/update');
+        p.addBreadcrumb('Redpanda Connect Secret Manager', '/rp-connect/secrets/update');
         p.addBreadcrumb('Update Secret', '');
 
         this.refreshData(true);

--- a/frontend/src/components/pages/rp-connect/secrets/Secrets.Update.tsx
+++ b/frontend/src/components/pages/rp-connect/secrets/Secrets.Update.tsx
@@ -11,6 +11,8 @@ import {Scope, UpdateSecretRequest} from '../../../../protogen/redpanda/api/data
 
 const {ToastContainer, toast} = createStandaloneToast();
 
+const returnSecretTab = '/connect-clusters?defaultTab=redpanda-connect-secret'
+
 @observer
 class RpConnectSecretUpdate extends PageComponent<{ secretId: string }> {
     @observable secret = '';
@@ -36,7 +38,7 @@ class RpConnectSecretUpdate extends PageComponent<{ secretId: string }> {
 
     cancel() {
         this.secret = '';
-        appGlobal.history.push('/connect-clusters/redpanda-connect-secret');
+        appGlobal.history.push(returnSecretTab);
     }
 
     async updateSecret() {
@@ -61,7 +63,7 @@ class RpConnectSecretUpdate extends PageComponent<{ secretId: string }> {
                     title: 'Secret updated'
                 });
                 await pipelinesApi.refreshPipelines(true);
-                appGlobal.history.push('/connect-clusters/redpanda-connect-secret');
+                appGlobal.history.push(returnSecretTab);
             })
             .catch(err => {
                 toast({

--- a/frontend/src/components/pages/rp-connect/secrets/Secrets.Update.tsx
+++ b/frontend/src/components/pages/rp-connect/secrets/Secrets.Update.tsx
@@ -1,0 +1,132 @@
+import {Button, ButtonGroup, createStandaloneToast, Flex, FormField, Input} from '@redpanda-data/ui';
+import {PageComponent, PageInitHelper} from '../../Page';
+import {observer} from 'mobx-react';
+import {appGlobal} from '../../../../state/appGlobal';
+import {pipelinesApi, rpcnSecretManagerApi} from '../../../../state/backendApi';
+import PageContent from '../../../misc/PageContent';
+import {action, makeObservable, observable} from 'mobx';
+import {DefaultSkeleton} from '../../../../utils/tsxUtils';
+import {formatPipelineError} from '../errors';
+import {Scope, UpdateSecretRequest} from '../../../../protogen/redpanda/api/dataplane/v1alpha2/secret_pb';
+
+const {ToastContainer, toast} = createStandaloneToast();
+
+@observer
+class RpConnectSecretUpdate extends PageComponent<{ secretId: string }> {
+    @observable secret = '';
+    @observable isUpdating = false;
+
+    constructor(p: any) {
+        super(p);
+        makeObservable(this, undefined, {autoBind: true});
+    }
+
+    initPage(p: PageInitHelper) {
+        p.title = 'Update Secret';
+        p.addBreadcrumb('Redpanda Connect Secret Manager', '/rp-connect/secret/update');
+        p.addBreadcrumb('Update Secret', '');
+
+        this.refreshData(true);
+        appGlobal.onRefresh = () => this.refreshData(true);
+    }
+
+    refreshData(_force: boolean) {
+        rpcnSecretManagerApi.refreshSecrets(_force);
+    }
+
+    cancel() {
+        this.secret = '';
+        appGlobal.history.push('/connect-clusters/redpanda-connect-secret');
+    }
+
+    async updateSecret() {
+        this.isUpdating = true;
+
+        //create function given string return base64 encoded Uint8Array
+        function base64Encode(str: string): Uint8Array {
+            const encodedString = btoa(str);
+            const charList = encodedString.split('').map(char => char.charCodeAt(0));
+            return new Uint8Array(charList);
+        }
+
+
+        rpcnSecretManagerApi.update(this.props.secretId, new UpdateSecretRequest({
+            id: this.props.secretId,
+            secretData: base64Encode(this.secret),
+            scopes: [Scope.REDPANDA_CONNECT]
+        }))
+            .then(async () => {
+                toast({
+                    status: 'success', duration: 4000, isClosable: false,
+                    title: 'Secret updated'
+                });
+                await pipelinesApi.refreshPipelines(true);
+                appGlobal.history.push('/connect-clusters/redpanda-connect-secret');
+            })
+            .catch(err => {
+                toast({
+                    status: 'error', duration: null, isClosable: true,
+                    title: 'Failed to update secret',
+                    description: formatPipelineError(err),
+                })
+            })
+            .finally(() => {
+                this.isUpdating = false;
+            });
+    }
+
+    render() {
+        if (!rpcnSecretManagerApi.secrets) return DefaultSkeleton;
+
+        const isSecretEmpty = this.secret.trim().length == 0;
+
+        return (
+            <PageContent>
+                <ToastContainer/>
+                <Flex flexDirection="column" gap={5}>
+                    <FormField label="Secret name">
+                        <Flex alignItems="center" gap="2">
+                            <Input
+                                placeholder="Enter a secret name..."
+                                data-testid="secretId"
+                                pattern="[a-zA-Z0-9_\-]+"
+                                isRequired
+                                disabled={true}
+                                value={this.props.secretId}
+                                width={500}
+                            />
+                        </Flex>
+                    </FormField>
+
+                    <FormField label="Secret value">
+                        <Flex alignItems="center" gap="2">
+                            <Input
+                                placeholder="Enter a new secret value..."
+                                data-testid="secretValue"
+                                isRequired
+                                value={this.secret}
+                                onChange={x => this.secret = x.target.value}
+                                width={500}
+                                type="password"
+                            />
+                        </Flex>
+                    </FormField>
+
+                    <ButtonGroup>
+                        <Button isLoading={this.isUpdating} isDisabled={isSecretEmpty}
+                                onClick={action(() => this.updateSecret())}
+                        >
+                            Update Secret
+                        </Button>
+                        <Button variant="link" disabled={this.isUpdating} onClick={action(() => this.cancel())}>
+                            Cancel
+                        </Button>
+                    </ButtonGroup>
+                </Flex>
+            </PageContent>
+        );
+
+    }
+}
+
+export default RpConnectSecretUpdate;

--- a/frontend/src/components/routes.tsx
+++ b/frontend/src/components/routes.tsx
@@ -9,7 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
-import React from 'react';
+import React, {FunctionComponent} from 'react';
 import { Switch } from 'react-router-dom';
 import { Section } from './misc/common';
 import { Route, Redirect } from 'react-router';
@@ -68,7 +68,7 @@ type IRouteEntry = PageDefinition<any>;
 export interface PageDefinition<TRouteParams = {}> {
     title: string;
     path: string;
-    pageType: PageComponentType<TRouteParams>;
+    pageType: PageComponentType<TRouteParams> | FunctionComponent<TRouteParams>;
     routeJsx: JSX.Element;
     icon?: (props: React.ComponentProps<'svg'>) => JSX.Element;
     menuItemKey?: string; // set by 'CreateRouteMenuItems'
@@ -157,7 +157,7 @@ interface MenuItemState {
 
 function MakeRoute<TRouteParams>(
     path: string,
-    page: PageComponentType<TRouteParams>,
+    page: PageComponentType<TRouteParams> | FunctionComponent<TRouteParams>,
     title: string,
     icon?: (props: React.ComponentProps<'svg'>) => JSX.Element,
     exact: boolean = true, showCallback?: () => MenuItemState): PageDefinition<TRouteParams> {
@@ -283,8 +283,7 @@ export const APP_ROUTES: IRouteEntry[] = [
         routeVisibility(true, [Feature.GetQuotas], ['canListQuotas'])
     ),
 
-    // defaultView difines the default tab to show when the user navigates to the page
-    MakeRoute<{defaultView: string}>('/connect-clusters/:defaultView?', KafkaConnectOverview, 'Connect', LinkIcon, true,
+    MakeRoute<{matchedPath: string}>('/connect-clusters', KafkaConnectOverview, 'Connect', LinkIcon, true,
         () => {
             if (isServerless()) {
                 console.log('Connect clusters inside serverless checks.')

--- a/frontend/src/components/routes.tsx
+++ b/frontend/src/components/routes.tsx
@@ -317,11 +317,11 @@ export const APP_ROUTES: IRouteEntry[] = [
     MakeRoute<{ transformName: string }>('/transforms/:transformName', TransformDetails, 'Transforms'),
 
     // MakeRoute<{}>('/rp-connect', RpConnectPipelinesList, 'Connectors', LinkIcon, true),
-    MakeRoute<{}>('/rp-connect/secret/create', RpConnectSecretCreate, 'Connector-Secrets'),
+    MakeRoute<{}>('/rp-connect/secrets/create', RpConnectSecretCreate, 'Connector-Secrets'),
     MakeRoute<{}>('/rp-connect/create', RpConnectPipelinesCreate, 'Connectors'),
     MakeRoute<{ pipelineId: string }>('/rp-connect/:pipelineId', RpConnectPipelinesDetails, 'Connectors'),
     MakeRoute<{ pipelineId: string }>('/rp-connect/:pipelineId/edit', RpConnectPipelinesEdit, 'Connectors'),
-    MakeRoute<{ secretId: string }>('/rp-connect/secret/:secretId/edit', RpConnectSecretUpdate, 'Connector-Secrets'),
+    MakeRoute<{ secretId: string }>('/rp-connect/secrets/:secretId/edit', RpConnectSecretUpdate, 'Connector-Secrets'),
 
     MakeRoute<{}>('/reassign-partitions', ReassignPartitions, 'Reassign Partitions', BeakerIcon, false,
         routeVisibility(true,

--- a/frontend/src/components/routes.tsx
+++ b/frontend/src/components/routes.tsx
@@ -57,6 +57,8 @@ import {isServerless} from '../config';
 import UploadLicensePage from './pages/admin/UploadLicensePage';
 import RpConnectPipelinesEdit from './pages/rp-connect/Pipelines.Edit';
 import AdminPageDebugBundleProgress from './pages/admin/Admin.DebugBundleProgress';
+import RpConnectSecretCreate from './pages/rp-connect/secrets/Secrets.Create';
+import RpConnectSecretUpdate from './pages/rp-connect/secrets/Secrets.Update';
 
 //
 //	Route Types
@@ -281,7 +283,8 @@ export const APP_ROUTES: IRouteEntry[] = [
         routeVisibility(true, [Feature.GetQuotas], ['canListQuotas'])
     ),
 
-    MakeRoute<{}>('/connect-clusters', KafkaConnectOverview, 'Connect', LinkIcon, true,
+    // defaultView difines the default tab to show when the user navigates to the page
+    MakeRoute<{defaultView: string}>('/connect-clusters/:defaultView?', KafkaConnectOverview, 'Connect', LinkIcon, true,
         () => {
             if (isServerless()) {
                 console.log('Connect clusters inside serverless checks.')
@@ -315,9 +318,11 @@ export const APP_ROUTES: IRouteEntry[] = [
     MakeRoute<{ transformName: string }>('/transforms/:transformName', TransformDetails, 'Transforms'),
 
     // MakeRoute<{}>('/rp-connect', RpConnectPipelinesList, 'Connectors', LinkIcon, true),
+    MakeRoute<{}>('/rp-connect/secret/create', RpConnectSecretCreate, 'Connector-Secrets'),
     MakeRoute<{}>('/rp-connect/create', RpConnectPipelinesCreate, 'Connectors'),
     MakeRoute<{ pipelineId: string }>('/rp-connect/:pipelineId', RpConnectPipelinesDetails, 'Connectors'),
     MakeRoute<{ pipelineId: string }>('/rp-connect/:pipelineId/edit', RpConnectPipelinesEdit, 'Connectors'),
+    MakeRoute<{ secretId: string }>('/rp-connect/secret/:secretId/edit', RpConnectSecretUpdate, 'Connector-Secrets'),
 
     MakeRoute<{}>('/reassign-partitions', ReassignPartitions, 'Reassign Partitions', BeakerIcon, false,
         routeVisibility(true,

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -19,7 +19,7 @@ import { Interceptor as ConnectRpcInterceptor, StreamRequest, UnaryRequest, crea
 import { createConnectTransport } from '@connectrpc/connect-web';
 import { ConsoleService } from './protogen/redpanda/api/console/v1alpha1/console_service_connect';
 import { SecurityService } from './protogen/redpanda/api/console/v1alpha1/security_connect';
-// import { RedpandaConnectService } from './protogen/redpanda/api/console/v1alpha1/rp_connect_connect';
+import { SecretService as RPCNSecretService } from './protogen/redpanda/api/dataplane/v1alpha2/secret_connect';
 import { PipelineService } from './protogen/redpanda/api/console/v1alpha1/pipeline_connect';
 import { TransformService } from './protogen/redpanda/api/console/v1alpha1/transform_connect';
 import { configureMonacoYaml } from 'monaco-yaml';
@@ -76,6 +76,7 @@ interface Config {
     debugBundleClient?: PromiseClient<typeof DebugBundleService>;
     securityClient?: PromiseClient<typeof SecurityService>;
     pipelinesClient?: PromiseClient<typeof PipelineService>;
+    rpcnSecretsClient?: PromiseClient<typeof RPCNSecretService>;
     transformsClient?: PromiseClient<typeof TransformService>;
     fetch: WindowOrWorkerGlobalScope['fetch'];
     assetsPath: string;
@@ -113,6 +114,7 @@ const setConfig = ({ fetch, urlOverride, jwt, isServerless, ...args }: SetConfig
     const debugBundleGrpcClient = createPromiseClient(DebugBundleService, transport);
     const securityGrpcClient = createPromiseClient(SecurityService, transport);
     const pipelinesGrpcClient = createPromiseClient(PipelineService, transport);
+    const secretGrpcClient = createPromiseClient(RPCNSecretService, transport);
     const transformClient = createPromiseClient(TransformService, transport);
     Object.assign(config, {
         jwt,
@@ -126,6 +128,7 @@ const setConfig = ({ fetch, urlOverride, jwt, isServerless, ...args }: SetConfig
         securityClient: securityGrpcClient,
         pipelinesClient: pipelinesGrpcClient,
         transformsClient: transformClient,
+        rpcnSecretsClient: secretGrpcClient,
         ...args,
     });
     return config;
@@ -140,7 +143,7 @@ export const setMonacoTheme = (_editor: monaco.editor.IStandaloneCodeEditor, mon
             'editorGutter.background': '#00000018',
             'editor.lineHighlightBackground': '#aaaaaa20',
             'editor.lineHighlightBorder': '#00000000',
-            'editorLineNumber.foreground': '#8c98a8',            
+            'editorLineNumber.foreground': '#8c98a8',
             'editorOverviewRuler.background': '#606060',
         },
         rules: []

--- a/frontend/src/state/backendApi.ts
+++ b/frontend/src/state/backendApi.ts
@@ -120,6 +120,7 @@ import { PartitionOffsetOrigin } from './ui';
 import { Features } from './supportedFeatures';
 import { TransformMetadata } from '../protogen/redpanda/api/dataplane/v1alpha1/transform_pb';
 import { Pipeline, PipelineCreate, PipelineUpdate } from '../protogen/redpanda/api/dataplane/v1alpha2/pipeline_pb';
+import { CreateSecretRequest, DeleteSecretRequest, ListSecretsRequest, Secret, UpdateSecretRequest } from '../protogen/redpanda/api/dataplane/v1alpha2/secret_pb';
 import { License, ListEnterpriseFeaturesResponse_Feature, SetLicenseRequest, SetLicenseResponse } from '../protogen/redpanda/api/console/v1alpha1/license_pb';
 import { CreateDebugBundleRequest, CreateDebugBundleResponse, DebugBundleStatus, DebugBundleStatus_Status, GetClusterHealthResponse, GetDebugBundleStatusResponse_DebugBundleBrokerStatus } from '../protogen/redpanda/api/console/v1alpha1/debug_bundle_pb';
 
@@ -1851,6 +1852,57 @@ export const pipelinesApi = observable({
         if (!client) throw new Error('pipelines client is not initialized');
 
         await client.stopPipeline({ request: { id } });
+    },
+});
+
+export const rpcnSecretManagerApi = observable({
+    secrets: undefined as undefined | Secret[],
+
+    async refreshSecrets(_force: boolean): Promise<void> {
+
+        const client = appConfig.rpcnSecretsClient;
+        if (!client) throw new Error('redpanda connect secret client is not initialized');
+
+        const secrets = [];
+
+        let nextPageToken = '';
+        while (true) {
+
+            const res = await client.listSecrets(new ListSecretsRequest({
+                pageToken: nextPageToken,
+                pageSize: 100
+            }));
+
+            const response = res.secrets;
+            if (!response) break;
+
+            secrets.push(...response);
+
+            if (!res || res.nextPageToken.length == 0)
+                break;
+            nextPageToken = res.nextPageToken;
+        }
+
+        this.secrets = secrets;
+    },
+
+    async delete(secret: DeleteSecretRequest) {
+        const client = appConfig.rpcnSecretsClient;
+        if (!client) throw new Error('redpanda connect secret client is not initialized');
+
+        await client.deleteSecret(secret);
+    },
+    async create(secret: CreateSecretRequest) {
+        const client = appConfig.rpcnSecretsClient;
+        if (!client) throw new Error('redpanda connect secret client is not initialized');
+
+        await client.createSecret(secret);
+    },
+    async update(id: string, updateSecretRequest: UpdateSecretRequest) {
+        const client = appConfig.rpcnSecretsClient;
+        if (!client) throw new Error('redpanda connect secret client is not initialized');
+
+        await client.updateSecret(updateSecretRequest);
     },
 });
 

--- a/frontend/src/state/ui.ts
+++ b/frontend/src/state/ui.ts
@@ -234,6 +234,10 @@ const defaultUiSettings = {
         quickSearch: ''
     },
 
+    rpncSecretList: {
+        quickSearch: ''
+    },
+
     pipelinesDetails: {
         logsQuickSearch: '',
         sorting: [] as SortingState,

--- a/frontend/src/state/ui.ts
+++ b/frontend/src/state/ui.ts
@@ -234,7 +234,7 @@ const defaultUiSettings = {
         quickSearch: ''
     },
 
-    rpncSecretList: {
+    rpcnSecretList: {
         quickSearch: ''
     },
 


### PR DESCRIPTION
This PR introduces a new tab for Redpanda Connect

Features:
- Create secrets
- Edit secrets
- Delete secrets
- Update secrets
- Secret autocomplete on pipeline RPCN editor
- Choose which connect tab is showing as default based on query param `defaultTab`

Pending:

- [x] Handle BYOC, Serverless and Hosted cluster
- [x] Avoid duplications auto complete secrets in the pipeline editor **-- disable autocomplete**
- [ ] Disable buttons in the "Update Secret" form while an update request is in progress.

## Dedicated integration cluster

https://github.com/user-attachments/assets/88c0ab66-3efe-4091-b821-3436e19109b8

## Serverless integration cluster

https://github.com/user-attachments/assets/ef115086-2ec2-44fd-b014-43b7c69008a5

### Before:
![image](https://github.com/user-attachments/assets/e5960096-ddfe-4fb2-b2cb-62e754343b2d)


## Enterprice self-hosted

https://github.com/user-attachments/assets/f1987f9e-16e5-464c-99ec-872a17a797c1



