### PR TITLE
Adds NullFallbackBoundary around license banners

### DIFF
--- a/frontend/src/components/layout/Content.tsx
+++ b/frontend/src/components/layout/Content.tsx
@@ -17,11 +17,14 @@ import { LicenseNotification } from '../license/LicenseNotification';
 import { ErrorDisplay } from '../misc/ErrorDisplay';
 import { renderErrorModals } from '../misc/ErrorModal';
 import { RouteView } from '../routes';
+import { NullFallbackBoundary } from '../misc/NullFallbackBoundary';
 
 export const AppContent = observer(() => (
   <div id="mainLayout">
     {/* Page */}
-    <LicenseNotification />
+    <NullFallbackBoundary>
+      <LicenseNotification />
+    </NullFallbackBoundary>
     <ModalContainer />
     <AppPageHeader />
 

--- a/frontend/src/components/misc/NullFallbackBoundary.tsx
+++ b/frontend/src/components/misc/NullFallbackBoundary.tsx
@@ -1,0 +1,37 @@
+import React, { ReactNode, ErrorInfo } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+class NullFallbackBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(_: Error): ErrorBoundaryState {
+    // Update state to indicate an error has occurred
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    // Log the error to an error reporting service, if needed
+    console.error('NullFallbackBoundary caught an error', error, errorInfo);
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      // Render nothing in case of an error
+      return null;
+    }
+
+    return this.props.children;
+  }
+}
+
+export { NullFallbackBoundary };

--- a/frontend/src/components/pages/acls/Acl.List.tsx
+++ b/frontend/src/components/pages/acls/Acl.List.tsx
@@ -68,6 +68,7 @@ import { AclPrincipalGroupEditor } from './PrincipalGroupEditor';
 
 import { FeatureLicenseNotification } from '../../license/FeatureLicenseNotification';
 import { UserRoleTags } from './UserPermissionAssignments';
+import { NullFallbackBoundary } from '../../misc/NullFallbackBoundary';
 
 // TODO - once AclList is migrated to FC, we could should move this code to use useToast()
 const { ToastContainer, toast } = createStandaloneToast({
@@ -442,7 +443,9 @@ const RolesTab = observer(() => {
     <Flex flexDirection="column" gap="4">
       <Box>Roles are groups of ACLs abstracted under a single name. Roles can be assigned to principals.</Box>
 
-      <FeatureLicenseNotification featureName="rbac" />
+      <NullFallbackBoundary>
+        <FeatureLicenseNotification featureName="rbac" />
+      </NullFallbackBoundary>
 
       <SearchField
         width="300px"

--- a/frontend/src/components/pages/overview/Overview.tsx
+++ b/frontend/src/components/pages/overview/Overview.tsx
@@ -48,6 +48,7 @@ import {
 } from '../../license/licenseUtils';
 import { Statistic } from '../../misc/Statistic';
 import ClusterHealthOverview from './ClusterHealthOverview';
+import { NullFallbackBoundary } from '../../misc/NullFallbackBoundary';
 
 @observer
 class Overview extends PageComponent {
@@ -109,7 +110,10 @@ class Overview extends PageComponent {
 
     return (
       <Box>
-        <OverviewLicenseNotification />
+        <NullFallbackBoundary>
+          <OverviewLicenseNotification />
+        </NullFallbackBoundary>
+
         <PageContent className="overviewGrid">
           <Section py={5} my={4}>
             <Flex>

--- a/frontend/src/components/pages/reassign-partitions/ReassignPartitions.tsx
+++ b/frontend/src/components/pages/reassign-partitions/ReassignPartitions.tsx
@@ -67,6 +67,7 @@ import {
   partitionSelectionToTopicPartitions,
   topicAssignmentsToReassignmentRequest,
 } from './logic/utils';
+import { NullFallbackBoundary } from '../../misc/NullFallbackBoundary';
 
 export interface PartitionSelection {
   // Which partitions are selected?
@@ -215,7 +216,9 @@ class ReassignPartitions extends PageComponent {
         <ToastContainer />
         <div className="reassignPartitions" style={{ paddingBottom: '12em' }}>
           <PageContent>
-            <FeatureLicenseNotification featureName="reassignPartitions" />
+            <NullFallbackBoundary>
+              <FeatureLicenseNotification featureName="reassignPartitions" />
+            </NullFallbackBoundary>
 
             {/* Statistics */}
             <Section py={4}>


### PR DESCRIPTION
Introduced `NullFallbackBoundary` for silently failing, we shouldn't affect the functionality in case there would be some problem with the code