### PR TITLE
Hides trial banner in case licenses failed to fetch

### DIFF
--- a/frontend/src/components/pages/overview/Overview.tsx
+++ b/frontend/src/components/pages/overview/Overview.tsx
@@ -418,7 +418,7 @@ function ClusterDetails() {
         }
       />
 
-      {!api.licenses.some(isLicenseWithEnterpriseAccess) && (
+      {api.licensesLoaded === 'loaded' && !api.licenses.some(isLicenseWithEnterpriseAccess) && (
         <>
           <GridItem />
           <GridItem colSpan={{ base: 1, lg: 2 }}>


### PR DESCRIPTION
In case license information fails to fetch (for any reason) we should assume users are already using enterprise and hide this banner. We would like to avoid showing this to upgraded users if there is e.g. network error.


Before:

<img width="580" alt="Screenshot 2024-12-02 at 22 18 41" src="https://github.com/user-attachments/assets/e0b9bc34-5b6d-4dbf-9efb-c31028fe3f8f">


After:

<img width="609" alt="Screenshot 2024-12-02 at 22 21 35" src="https://github.com/user-attachments/assets/0224cea3-fd75-4999-9671-5cecd64a3fca">
<img width="579" alt="Screenshot 2024-12-02 at 22 20 50" src="https://github.com/user-attachments/assets/cfc47971-b7be-4781-8001-19935416597a">
