### PR TITLE
Feature/enable RPCN secret by scope

### DIFF
--- a/frontend/src/components/pages/rp-connect/secrets/Secrets.Create.tsx
+++ b/frontend/src/components/pages/rp-connect/secrets/Secrets.Create.tsx
@@ -26,9 +26,9 @@ class RpConnectSecretCreate extends PageComponent {
   }
 
   initPage(p: PageInitHelper) {
-    p.title = 'Create Secret';
+    p.title = 'Create secret';
     p.addBreadcrumb('Redpanda Connect Secret Manager', '/rp-connect/secrets/create');
-    p.addBreadcrumb('Create Secret', '');
+    p.addBreadcrumb('Create secret', '');
 
     this.refreshData(true);
     appGlobal.onRefresh = () => this.refreshData(true);
@@ -145,7 +145,7 @@ class RpConnectSecretCreate extends PageComponent {
               isDisabled={isIdEmpty || isSecretEmpty || Boolean(this.isNameValid)}
               onClick={action(() => this.createSecret())}
             >
-              Create Secret
+              Create secret
             </Button>
             <Button variant="link" disabled={this.isCreating} onClick={action(() => this.cancel())}>
               Cancel

--- a/frontend/src/components/pages/rp-connect/secrets/Secrets.Create.tsx
+++ b/frontend/src/components/pages/rp-connect/secrets/Secrets.Create.tsx
@@ -46,7 +46,7 @@ class RpConnectSecretCreate extends PageComponent {
 
   async createSecret() {
     this.isCreating = true;
-
+    this.id = this.id.toUpperCase();
     rpcnSecretManagerApi
       .create(
         new CreateSecretRequest({
@@ -88,8 +88,8 @@ class RpConnectSecretCreate extends PageComponent {
     if (this.id === '') {
       return '';
     }
-    if (!/^[A-Z][A-Z0-9_]*$/.test(this.id)) {
-      return 'The name you entered is invalid. It must start with an uppercase letter (A–Z) and can only contain uppercase letters (A–Z), digits (0–9), and underscores (_).';
+    if (!/^[A-Za-z][A-Za-z0-9_]*$/.test(this.id)) {
+      return 'The name you entered is invalid. It must start with an letter (A–Z) and can only contain letters (A–Z), digits (0–9), and underscores (_).';
     }
     if (this.id.length > 255) {
       return 'The secret name must be fewer than 255 characters.';
@@ -107,7 +107,12 @@ class RpConnectSecretCreate extends PageComponent {
       <PageContent>
         <ToastContainer />
         <Flex flexDirection="column" gap={5}>
-          <FormField label="Secret name" isInvalid={Boolean(this.isNameValid)} errorText={this.isNameValid}>
+          <FormField
+            label="Secret name"
+            isInvalid={Boolean(this.isNameValid)}
+            errorText={this.isNameValid}
+            description={'This secret name will be stored in upper case.'}
+          >
             <Flex alignItems="center" gap="2">
               <Input
                 placeholder="Enter a secret name..."
@@ -117,7 +122,7 @@ class RpConnectSecretCreate extends PageComponent {
                 max={255}
                 isRequired
                 value={this.id}
-                onChange={(x) => (this.id = x.target.value.toUpperCase())}
+                onChange={(x) => (this.id = x.target.value)}
                 width={500}
                 disabled={this.isCreating}
               />

--- a/frontend/src/components/pages/rp-connect/secrets/Secrets.List.tsx
+++ b/frontend/src/components/pages/rp-connect/secrets/Secrets.List.tsx
@@ -16,7 +16,7 @@ import {
 } from '@redpanda-data/ui';
 import { observer } from 'mobx-react';
 import { Link as ReactRouterLink } from 'react-router-dom';
-import EmptyConnectors from '../../../../assets/redpanda/EmptyConnectors.svg';
+import SittingPanda from '../../../../assets/redpanda/SittingPanda.svg';
 import { DeleteSecretRequest, type Secret } from '../../../../protogen/redpanda/api/dataplane/v1alpha2/secret_pb';
 import { appGlobal } from '../../../../state/appGlobal';
 import { rpcnSecretManagerApi } from '../../../../state/backendApi';
@@ -41,7 +41,7 @@ const CreateSecretButton = () => {
 const EmptyPlaceholder = () => {
   return (
     <Flex alignItems="center" justifyContent="center" flexDirection="column" gap="4" mb="4">
-      <Image src={EmptyConnectors} />
+      <Image src={SittingPanda} width={200} />
       <Box>You have no Redpanda Connect secrets.</Box>
       <CreateSecretButton />
     </Flex>

--- a/frontend/src/components/pages/rp-connect/secrets/Secrets.Update.tsx
+++ b/frontend/src/components/pages/rp-connect/secrets/Secrets.Update.tsx
@@ -25,9 +25,9 @@ class RpConnectSecretUpdate extends PageComponent<{ secretId: string }> {
   }
 
   initPage(p: PageInitHelper) {
-    p.title = 'Update Secret';
+    p.title = 'Update secret';
     p.addBreadcrumb('Redpanda Connect Secret Manager', '/rp-connect/secrets/update');
-    p.addBreadcrumb('Update Secret', '');
+    p.addBreadcrumb('Update secret', '');
 
     this.refreshData(true);
     appGlobal.onRefresh = () => this.refreshData(true);
@@ -119,7 +119,7 @@ class RpConnectSecretUpdate extends PageComponent<{ secretId: string }> {
 
           <ButtonGroup>
             <Button isLoading={this.isUpdating} isDisabled={isSecretEmpty} onClick={action(() => this.updateSecret())}>
-              Update Secret
+              Update secret
             </Button>
             <Button variant="link" disabled={this.isUpdating} onClick={action(() => this.cancel())}>
               Cancel

--- a/frontend/src/state/backendApi.ts
+++ b/frontend/src/state/backendApi.ts
@@ -140,7 +140,9 @@ import type { Pipeline, PipelineCreate, PipelineUpdate } from '../protogen/redpa
 import {
   type CreateSecretRequest,
   type DeleteSecretRequest,
+  type ListSecretScopesRequest,
   ListSecretsRequest,
+  Scope,
   type Secret,
   type UpdateSecretRequest,
 } from '../protogen/redpanda/api/dataplane/v1alpha2/secret_pb';
@@ -2067,6 +2069,7 @@ export const pipelinesApi = observable({
 
 export const rpcnSecretManagerApi = observable({
   secrets: undefined as undefined | Secret[],
+  isEnable: true,
 
   async refreshSecrets(_force: boolean): Promise<void> {
     const client = appConfig.rpcnSecretsClient;
@@ -2112,6 +2115,15 @@ export const rpcnSecretManagerApi = observable({
     if (!client) throw new Error('redpanda connect secret client is not initialized');
 
     await client.updateSecret(updateSecretRequest);
+  },
+  async checkScope(listSecretScopesRequest: ListSecretScopesRequest) {
+    const client = appConfig.rpcnSecretsClient;
+    if (!client) throw new Error('redpanda connect secret client is not initialized');
+
+    const scopes = await client.listSecretScopes(listSecretScopesRequest);
+    const isEnable = scopes.scopes.some((scope) => scope === Scope.REDPANDA_CONNECT);
+    this.isEnable = isEnable;
+    return isEnable;
   },
 });
 


### PR DESCRIPTION
Secret manager will be disabled if `REDPANDA_CONNECT` is not present in secret scopes.

## Disabled
<img width="1472" alt="Screenshot 2024-12-04 at 3 41 12 PM" src="https://github.com/user-attachments/assets/c6d913f4-9e2b-4e42-8de9-ca37dafd4d80">

## Lowercase in create secrets 

<img width="460" alt="image" src="https://github.com/user-attachments/assets/6deb1dec-9626-493e-8b3d-ae893c7fbd46">

