### PR TITLE
Fix doc links

### DIFF
--- a/frontend/src/components/pages/transforms/Transforms.List.tsx
+++ b/frontend/src/components/pages/transforms/Transforms.List.tsx
@@ -110,7 +110,7 @@ class TransformsList extends PageComponent<{}> {
           Redpanda.{' '}
           <ChakraLink
             isExternal
-            href="https://docs.redpanda.com/beta/develop/data-transforms/"
+            href="https://docs.redpanda.com/current/develop/data-transforms/how-transforms-work/"
             style={{ textDecoration: 'underline solid 1px' }}
           >
             Learn more

--- a/frontend/src/components/pages/transforms/Transforms.Setup.tsx
+++ b/frontend/src/components/pages/transforms/Transforms.Setup.tsx
@@ -36,7 +36,7 @@ export class TransformsSetup extends PageComponent<{}> {
               within Redpanda.{' '}
               <ChakraLink
                 isExternal
-                href="https://docs.redpanda.com/beta/develop/data-transforms/"
+                href="https://docs.redpanda.com/current/develop/data-transforms/build/
                 style={{ textDecoration: 'underline solid 1px' }}
               >
                 Learn more


### PR DESCRIPTION
Data transforms is no longer in beta. Although we have redirects, it's best to use the GA URL.