### PR TITLE
Fix setting of custom BASE_URL in index.html

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -34,13 +34,12 @@
                 return window.location;
             };
             let l = window.__getLocation();
-            let base = document.createElement('base');
+            let base = document.querySelector("base");
             if (!basePath.startsWith('__BASE')) {
                 base.href = l.protocol + '//' + l.hostname + (l.port ? (':' + l.port) : '') + basePath;
             } else {
                 base.href = l.protocol + '//' + l.hostname + (l.port ? (':' + l.port) : '') + '/';
             }
-            document.head.appendChild(base);
         }
     </script>
 

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -34,7 +34,7 @@
                 return window.location;
             };
             let l = window.__getLocation();
-            let base = document.querySelector("base");
+            let base = document.querySelector('base');
             if (!basePath.startsWith('__BASE')) {
                 base.href = l.protocol + '//' + l.hostname + (l.port ? (':' + l.port) : '') + basePath;
             } else {


### PR DESCRIPTION
Since a default base tag was added to the index.html, the mechanism for setting a custom BASE_URL is broken. When multiple base tags are present in a html file, only the first tag is used (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base#multiple_base_elements). Therefore, we need to adapt the existing base tag and not append a newly created one.