### PR TITLE
INC-640: set IncludeSourceCodeInfo to false

### DIFF
--- a/backend/pkg/proto/service.go
+++ b/backend/pkg/proto/service.go
@@ -609,7 +609,7 @@ func (s *Service) protoFileToDescriptor(files map[string]filesystem.File) ([]*de
 		ImportPaths:           []string{"."},
 		InferImportPaths:      true,
 		ValidateUnlinkedFiles: true,
-		IncludeSourceCodeInfo: true,
+		IncludeSourceCodeInfo: false,
 		ErrorReporter:         errorReporter,
 	}
 	descriptors, err := parser.ParseFiles(filePaths...)

--- a/backend/pkg/schema/service.go
+++ b/backend/pkg/schema/service.go
@@ -265,7 +265,7 @@ func (s *Service) compileProtoSchemas(schema *SchemaVersionedResponse, schemaRep
 		Accessor:              protoparse.FileContentsFromMap(schemasByPath),
 		InferImportPaths:      true,
 		ValidateUnlinkedFiles: true,
-		IncludeSourceCodeInfo: true,
+		IncludeSourceCodeInfo: false,
 		ErrorReporter:         errorReporter,
 	}
 	descriptors, err := parser.ParseFiles(schema.Subject)
@@ -494,7 +494,7 @@ func (s *Service) ValidateProtobufSchema(ctx context.Context, name string, sch S
 		Accessor:              protoparse.FileContentsFromMap(schemasByPath),
 		InferImportPaths:      true,
 		ValidateUnlinkedFiles: true,
-		IncludeSourceCodeInfo: true,
+		IncludeSourceCodeInfo: false,
 	}
 
 	_, err = parser.ParseFiles(name)


### PR DESCRIPTION
I cannot think of a technical reason why we would need the source code info for dynamic Protocol Buffer loading and dynamic compiling and record deserialization.

Turning this off provides sometimes significant improvement in memory usage.