### PR TITLE
rpcn: rename tasks to compute units

### DIFF
--- a/frontend/src/components/pages/rp-connect/Pipelines.Create.tsx
+++ b/frontend/src/components/pages/rp-connect/Pipelines.Create.tsx
@@ -126,8 +126,8 @@ class RpConnectPipelinesCreate extends PageComponent<{}> {
             />
           </FormField>
           <FormField
-            label="Tasks"
-            description="One task is equivalent to 0.1 CPU and 400 MB of memory. This is enough to experiment with low-volume pipelines. For pipelines that include the AI Ollama components, one task is equivalent to 1 GPU. This can have cost implications."
+            label="Compute Units"
+            description="One compute unit is equivalent to 0.1 CPU and 400 MB of memory. This is enough to experiment with low-volume pipelines. For pipelines that include the AI Ollama components, one AI compute unit is equivalent to 1 GPU. This can have cost implications."
             w={500}
           >
             <NumberInput

--- a/frontend/src/components/pages/rp-connect/Pipelines.Details.tsx
+++ b/frontend/src/components/pages/rp-connect/Pipelines.Details.tsx
@@ -430,7 +430,7 @@ export const PipelineResources = observer((p: { resources?: Pipeline_Resources }
   const tasks = cpuToTasks(r.cpuShares);
   return (
     <Flex gap="4">
-      {tasks || '-'} Tasks ({r.cpuShares} CPU / {r.memoryShares} Memory)
+      {tasks || '-'} Compute Units ({r.cpuShares} CPU / {r.memoryShares} Memory)
     </Flex>
   );
 });

--- a/frontend/src/components/pages/rp-connect/Pipelines.Edit.tsx
+++ b/frontend/src/components/pages/rp-connect/Pipelines.Edit.tsx
@@ -116,7 +116,7 @@ class RpConnectPipelinesEdit extends PageComponent<{ pipelineId: string }> {
             width={500}
           />
         </FormField>
-        <FormField label="Tasks">
+        <FormField label="Compute Units">
           <NumberInput
             value={this.tasks}
             onChange={(e) => (this.tasks = Number(e ?? MIN_TASKS))}


### PR DESCRIPTION
We're using a new term for sizing.