### PR TITLE
front-end: disable edit name in kafka connectors

### DIFF
--- a/frontend/src/components/pages/connect/dynamic-ui/ConnectorStep.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/ConnectorStep.tsx
@@ -14,6 +14,7 @@ import { observer } from 'mobx-react';
 import type { PropertyGroup } from '../../../../state/connect/state';
 import type { ConnectorStep } from '../../../../state/restInterfaces';
 import { PropertyGroupComponent } from './PropertyGroup';
+import { ConfigPageProps } from './components';
 
 export const ConnectorStepComponent = observer(
   (props: {
@@ -22,6 +23,7 @@ export const ConnectorStepComponent = observer(
     allGroups: PropertyGroup[];
     showAdvancedOptions: boolean;
     connectorType: 'sink' | 'source';
+    context: ConfigPageProps['context'];
   }) => {
     const step = props.step;
     const groups = props.groups;
@@ -48,6 +50,7 @@ export const ConnectorStepComponent = observer(
             allGroups={props.allGroups}
             showAdvancedOptions={props.showAdvancedOptions}
             connectorType={props.connectorType}
+            context={props.context}
           />
         ))}
       </Box>

--- a/frontend/src/components/pages/connect/dynamic-ui/PropertyComponent.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/PropertyComponent.tsx
@@ -74,6 +74,7 @@ export const PropertyComponent = observer((props: { property: Property }) => {
             onChange={(e) => (p.value = e.target.value)}
             defaultValue={def.default_value ?? undefined}
             spellCheck={false}
+            isDisabled={props.property.isDisabled}
           />
         );
       }

--- a/frontend/src/components/pages/connect/dynamic-ui/PropertyGroup.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/PropertyGroup.tsx
@@ -13,6 +13,7 @@ import { Accordion, Box, Divider, Flex, Heading, Link, Text } from '@redpanda-da
 import { observer } from 'mobx-react';
 import type { PropertyGroup } from '../../../../state/connect/state';
 import { PropertyComponent } from './PropertyComponent';
+import { ConfigPageProps } from './components';
 import { TopicInput } from './forms/TopicInput';
 
 const topicsFields = ['topics', 'topics.regex'];
@@ -23,6 +24,7 @@ export const PropertyGroupComponent = observer(
     allGroups: PropertyGroup[];
     showAdvancedOptions: boolean;
     connectorType: 'sink' | 'source';
+    context: ConfigPageProps['context'];
   }) => {
     const g = props.group;
 
@@ -62,6 +64,7 @@ export const PropertyGroupComponent = observer(
                     allGroups={props.allGroups}
                     showAdvancedOptions={props.showAdvancedOptions}
                     connectorType={props.connectorType}
+                    context={props.context}
                   />
                 ),
               }))}
@@ -101,9 +104,12 @@ export const PropertyGroupComponent = observer(
             }
             {filteredProperties
               .filter((p) => topicsFields.every((v) => v !== p.name))
-              .map((p) => (
-                <PropertyComponent key={p.name} property={p} />
-              ))}
+              .map((p) => {
+                if (p.name === 'name' && props.context === 'EDIT') {
+                  p.isDisabled = true;
+                }
+                return <PropertyComponent key={p.name} property={p} />;
+              })}
           </div>
           <Divider my={10} />
         </Box>

--- a/frontend/src/components/pages/connect/dynamic-ui/components.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/components.tsx
@@ -85,6 +85,7 @@ export const ConfigPage: React.FC<ConfigPageProps> = observer(({ connectorStore,
                 allGroups={connectorStore.allGroups}
                 showAdvancedOptions={connectorStore.showAdvancedOptions}
                 connectorType={connectorStore.connectorType}
+                context={context}
               />
             );
           })}

--- a/frontend/src/state/connect/state.ts
+++ b/frontend/src/state/connect/state.ts
@@ -766,6 +766,7 @@ export class ConnectorPropertiesStore {
           lastErrorValue: undefined as any,
           propertyGroup: undefined as any,
           crud: this.crud,
+          isDisabled: undefined,
         });
 
         if (this.appliedConfig?.[name]) property.value = sanitizeValue(this.appliedConfig[name], definitionType);
@@ -820,4 +821,5 @@ export interface Property {
 
   propertyGroup: PropertyGroup;
   crud: 'create' | 'update';
+  isDisabled: boolean | undefined;
 }


### PR DESCRIPTION
Disable change name in edit kafka connect

![image](https://github.com/user-attachments/assets/31cee6e9-437b-46ae-ad1f-dfa7d0c5ab70)
