### PR TITLE
backend (sr): fix subject compat deletion

### DIFF
--- a/backend/pkg/api/handle_schema_registry.go
+++ b/backend/pkg/api/handle_schema_registry.go
@@ -328,7 +328,7 @@ func (api *API) handleDeleteSchemaRegistrySubjectConfig() http.HandlerFunc {
 		subjectName := getSubjectFromRequestPath(r)
 
 		// 2. Set subject compatibility level
-		res, err := api.ConsoleSvc.DeleteSchemaRegistrySubjectConfig(r.Context(), subjectName)
+		err := api.ConsoleSvc.DeleteSchemaRegistrySubjectConfig(r.Context(), subjectName)
 		if err != nil {
 			var schemaError *schema.RestError
 			if errors.As(err, &schemaError) && schemaError.ErrorCode == schema.CodeSubjectNotFound {
@@ -349,7 +349,7 @@ func (api *API) handleDeleteSchemaRegistrySubjectConfig() http.HandlerFunc {
 			})
 			return
 		}
-		rest.SendResponse(w, r, api.Logger, http.StatusOK, res)
+		rest.SendResponse(w, r, api.Logger, http.StatusOK, nil)
 	}
 }
 

--- a/backend/pkg/console/schema_registry.go
+++ b/backend/pkg/console/schema_registry.go
@@ -78,12 +78,9 @@ func (s *Service) PutSchemaRegistrySubjectConfig(ctx context.Context, subject st
 }
 
 // DeleteSchemaRegistrySubjectConfig deletes the subject's compatibility level.
-func (s *Service) DeleteSchemaRegistrySubjectConfig(ctx context.Context, subject string) (*SchemaRegistryConfig, error) {
-	config, err := s.kafkaSvc.SchemaService.DeleteSubjectConfig(ctx, subject)
-	if err != nil {
-		return nil, err
-	}
-	return &SchemaRegistryConfig{Compatibility: config.Compatibility}, nil
+func (s *Service) DeleteSchemaRegistrySubjectConfig(ctx context.Context, subject string) error {
+	_, err := s.kafkaSvc.SchemaService.DeleteSubjectConfig(ctx, subject)
+	return err
 }
 
 // GetSchemaRegistrySubjects returns a list of all register subjects. The list includes

--- a/backend/pkg/console/servicer.go
+++ b/backend/pkg/console/servicer.go
@@ -58,7 +58,7 @@ type Servicer interface {
 	GetSchemaRegistryConfig(ctx context.Context) (*SchemaRegistryConfig, error)
 	PutSchemaRegistryConfig(ctx context.Context, compatLevel schema.CompatibilityLevel) (*SchemaRegistryConfig, error)
 	PutSchemaRegistrySubjectConfig(ctx context.Context, subject string, compatLevel schema.CompatibilityLevel) (*SchemaRegistryConfig, error)
-	DeleteSchemaRegistrySubjectConfig(ctx context.Context, subject string) (*SchemaRegistryConfig, error)
+	DeleteSchemaRegistrySubjectConfig(ctx context.Context, subject string) error
 	GetSchemaRegistrySubjects(ctx context.Context) ([]SchemaRegistrySubject, error)
 	GetSchemaRegistrySubjectDetails(ctx context.Context, subjectName string, version string) (*SchemaRegistrySubjectDetails, error)
 	GetSchemaRegistrySchemaReferencedBy(ctx context.Context, subjectName, version string) ([]SchemaReference, error)


### PR DESCRIPTION
There's not much to return when we delete the subject compatibility. Previously it used to fail because there's no enum type for "NoCompat"and then serialization of that failed. The simple fix was to just remove the response as it didn't provide any value anyways.