### PR TITLE
frontend: fix tooltip for edit kafka connector

### DIFF
--- a/frontend/src/components/pages/connect/Connector.Details.tsx
+++ b/frontend/src/components/pages/connect/Connector.Details.tsx
@@ -123,7 +123,7 @@ const KafkaConnectorMain = observer(
           {connectClusterStore.validateConnectorState(connectorName, ['RUNNING', 'PAUSED']) ? (
             <Tooltip
               placement="top"
-              isDisabled={canEdit !== true}
+              isDisabled={canEdit === true}
               label={"You don't have 'canEditConnectCluster' permissions for this connect cluster"}
               hasArrow={true}
             >
@@ -141,7 +141,7 @@ const KafkaConnectorMain = observer(
           {/* [Restart] */}
           <Tooltip
             placement="top"
-            isDisabled={canEdit !== true}
+            isDisabled={canEdit === true}
             label={"You don't have 'canEditConnectCluster' permissions for this connect cluster"}
             hasArrow={true}
           >
@@ -158,7 +158,7 @@ const KafkaConnectorMain = observer(
           {/* [Delete] */}
           <Tooltip
             placement="top"
-            isDisabled={canEdit !== true}
+            isDisabled={canEdit === true}
             label={"You don't have 'canEditConnectCluster' permissions for this connect cluster"}
             hasArrow={true}
           >
@@ -204,7 +204,7 @@ const KafkaConnectorMain = observer(
                   <Flex m={4} mb={6}>
                     <Tooltip
                       placement="top"
-                      isDisabled={canEdit !== true}
+                      isDisabled={canEdit === true}
                       label={"You don't have 'canEditConnectCluster' permissions for this connect cluster"}
                       hasArrow={true}
                     >


### PR DESCRIPTION
Fix wrong tooltip message in update kafka connector

User with permissions:
![image](https://github.com/user-attachments/assets/46adcbb7-ddd0-4237-87b5-8c4d07d210fb)
(mouse over)
User without permissions:
![image](https://github.com/user-attachments/assets/ffabaea5-e0ef-4b8a-84e6-a4fb48d223d4)
