### PR TITLE
Authn rewrite decorated logger

### DIFF
--- a/backend/pkg/api/api.go
+++ b/backend/pkg/api/api.go
@@ -19,7 +19,6 @@ import (
 	"io/fs"
 	"time"
 
-	"github.com/cloudhut/common/logging"
 	"github.com/cloudhut/common/rest"
 	"go.uber.org/zap"
 	"golang.org/x/net/http2"
@@ -34,6 +33,7 @@ import (
 	schemafactory "github.com/redpanda-data/console/backend/pkg/factory/schema"
 	"github.com/redpanda-data/console/backend/pkg/git"
 	"github.com/redpanda-data/console/backend/pkg/license"
+	"github.com/redpanda-data/console/backend/pkg/logging"
 	"github.com/redpanda-data/console/backend/pkg/version"
 )
 

--- a/backend/pkg/api/connect/interceptor/error_log.go
+++ b/backend/pkg/api/connect/interceptor/error_log.go
@@ -28,8 +28,7 @@ var _ connect.Interceptor = &ErrorLogInterceptor{}
 // are written before the interceptors would be called, such as:
 // - Authentication errors (enterprise HTTP middleware)
 // - JSON Unmarshalling errors of request body (happens prior calling interceptors)
-type ErrorLogInterceptor struct {
-}
+type ErrorLogInterceptor struct{}
 
 // NewErrorLogInterceptor creates a new ErrorLogInterceptor.
 func NewErrorLogInterceptor() *ErrorLogInterceptor {

--- a/backend/pkg/api/connect/interceptor/error_log.go
+++ b/backend/pkg/api/connect/interceptor/error_log.go
@@ -17,6 +17,8 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/redpanda-data/console/backend/pkg/logging"
 )
 
 var _ connect.Interceptor = &ErrorLogInterceptor{}
@@ -27,14 +29,11 @@ var _ connect.Interceptor = &ErrorLogInterceptor{}
 // - Authentication errors (enterprise HTTP middleware)
 // - JSON Unmarshalling errors of request body (happens prior calling interceptors)
 type ErrorLogInterceptor struct {
-	logger *zap.Logger
 }
 
 // NewErrorLogInterceptor creates a new ErrorLogInterceptor.
-func NewErrorLogInterceptor(logger *zap.Logger) *ErrorLogInterceptor {
-	return &ErrorLogInterceptor{
-		logger: logger,
-	}
+func NewErrorLogInterceptor() *ErrorLogInterceptor {
+	return &ErrorLogInterceptor{}
 }
 
 // WrapUnary creates an interceptor to validate Connect requests.
@@ -86,8 +85,9 @@ func (in *ErrorLogInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFu
 			return response, err
 		}
 
-		// 6. Log error details
-		in.logger.Warn("",
+		// 6. Log error details with decorated logger
+		logger := logging.FromContext(ctx)
+		logger.Warn("",
 			zap.String("timestamp", start.Format(time.RFC3339)),
 			zap.String("procedure", procedure),
 			zap.String("request_duration", requestDuration.String()),

--- a/backend/pkg/api/routes.go
+++ b/backend/pkg/api/routes.go
@@ -71,7 +71,7 @@ func (api *API) setupConnectWithGRPCGateway(r chi.Router) {
 	observerInterceptor := commoninterceptor.NewObserver(apiProm.ObserverAdapter())
 	baseInterceptors := []connect.Interceptor{
 		observerInterceptor,
-		interceptor.NewErrorLogInterceptor(api.Logger.Named("error_log")),
+		interceptor.NewErrorLogInterceptor(),
 		interceptor.NewRequestValidationInterceptor(v, api.Logger.Named("validator")),
 		interceptor.NewEndpointCheckInterceptor(&api.Cfg.Console.API, api.Logger.Named("endpoint_checker")),
 	}

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 
 	"github.com/cloudhut/common/flagext"
-	"github.com/cloudhut/common/logging"
 	"github.com/knadh/koanf"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/confmap"
@@ -34,13 +33,13 @@ type Config struct {
 	MetricsNamespace string `yaml:"metricsNamespace"`
 	ServeFrontend    bool   `yaml:"serveFrontend"` // useful for local development where we want the frontend from 'npm run start'
 
-	Console        Console        `yaml:"console"`
-	Redpanda       Redpanda       `yaml:"redpanda"`
-	Connect        Connect        `yaml:"connect"`
-	REST           Server         `yaml:"server"`
-	Kafka          Kafka          `yaml:"kafka"`
-	SchemaRegistry Schema         `yaml:"schemaRegistry"`
-	Logger         logging.Config `yaml:"logger"`
+	Console        Console  `yaml:"console"`
+	Redpanda       Redpanda `yaml:"redpanda"`
+	Connect        Connect  `yaml:"connect"`
+	REST           Server   `yaml:"server"`
+	Kafka          Kafka    `yaml:"kafka"`
+	SchemaRegistry Schema   `yaml:"schemaRegistry"`
+	Logger         Logging  `yaml:"logger"`
 }
 
 // RegisterFlags for all (sub)configs

--- a/backend/pkg/config/logging.go
+++ b/backend/pkg/config/logging.go
@@ -58,6 +58,7 @@ func (l *Logging) Set(logLevel string) error {
 	return nil
 }
 
+// SetDefaults for logging config.
 func (l *Logging) SetDefaults() {
 	l.LogLevelInput = "info"
 	l.LogLevel = zap.NewAtomicLevelAt(zap.InfoLevel)

--- a/backend/pkg/config/logging.go
+++ b/backend/pkg/config/logging.go
@@ -1,0 +1,64 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package config
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"go.uber.org/zap"
+)
+
+// Logging config for a zap logger
+type Logging struct {
+	LogLevelInput string `yaml:"level"`
+	LogLevel      zap.AtomicLevel
+}
+
+// RegisterFlags adds the flags required to config the server
+func (l *Logging) RegisterFlags(f *flag.FlagSet) {
+	l.Set("info")
+	f.Var(l, "logging.level", "Only log messages with the given severity or above. Valid levels: [debug, info, warn, error]")
+}
+
+// String implements the flag.Value interface
+func (l *Logging) String() string {
+	return l.LogLevelInput
+}
+
+// Set updates the value of the allowed log level by implementing the flag.Value interface
+func (l *Logging) Set(logLevel string) error {
+	switch strings.ToLower(logLevel) {
+	case "", "info":
+		l.LogLevel = zap.NewAtomicLevelAt(zap.InfoLevel)
+	case "debug":
+		l.LogLevel = zap.NewAtomicLevelAt(zap.DebugLevel)
+	case "warn":
+		l.LogLevel = zap.NewAtomicLevelAt(zap.WarnLevel)
+	case "error":
+		l.LogLevel = zap.NewAtomicLevelAt(zap.ErrorLevel)
+	case "panic":
+		l.LogLevel = zap.NewAtomicLevelAt(zap.PanicLevel)
+	case "fatal":
+		l.LogLevel = zap.NewAtomicLevelAt(zap.FatalLevel)
+	default:
+		fmt.Printf("Invalid log level supplied: '%s'. Defaulting to info.", logLevel)
+		l.LogLevel = zap.NewAtomicLevelAt(zap.InfoLevel)
+	}
+	l.LogLevelInput = logLevel
+
+	return nil
+}
+
+func (l *Logging) SetDefaults() {
+	l.LogLevelInput = "info"
+	l.LogLevel = zap.NewAtomicLevelAt(zap.InfoLevel)
+}

--- a/backend/pkg/logging/context.go
+++ b/backend/pkg/logging/context.go
@@ -1,0 +1,37 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package logging
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
+
+type loggerKey struct{}
+
+// ContextWithLogger returns a new context containing the provided logger.
+func ContextWithLogger(ctx context.Context, logger *zap.Logger) context.Context {
+	return context.WithValue(ctx, loggerKey{}, logger)
+}
+
+// FromContext retrieves the logger stored in the context (if any). If none is
+// found, returns a new zap logger that uses the default config.
+func FromContext(ctx context.Context) *zap.Logger {
+	l, ok := ctx.Value(loggerKey{}).(*zap.Logger)
+	if ok && l != nil {
+		return l
+	}
+
+	// Use pre-initialized (or default) zapcore config.
+	core := getZapCore(zap.NewAtomicLevelAt(zap.InfoLevel), "console")
+
+	return zap.New(core)
+}

--- a/backend/pkg/logging/filter_level.go
+++ b/backend/pkg/logging/filter_level.go
@@ -1,0 +1,46 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package logging
+
+import "go.uber.org/zap/zapcore"
+
+// FilterLevel wraps an existing zap.Core but logs at a different level.
+// This function can be used to create child loggers which should print
+// only log levels at a different log level than the parent logger.
+func FilterLevel(level zapcore.Level) func(zapcore.Core) zapcore.Core {
+	return func(c zapcore.Core) zapcore.Core {
+		return newLevelFilterCore(c, level)
+	}
+}
+
+// levelFilterCore allows to change the log level on the fly. This must remain here until
+// https://github.com/uber-go/zap/pull/775 is merged and released
+type levelFilterCore struct {
+	zapcore.Core
+	level zapcore.Level
+}
+
+func newLevelFilterCore(core zapcore.Core, level zapcore.Level) zapcore.Core {
+	return &levelFilterCore{core, level}
+}
+
+// Enabled checks if the lvl is to be printed
+func (c *levelFilterCore) Enabled(lvl zapcore.Level) bool {
+	return lvl >= c.level
+}
+
+// Check determines whether the supplied Entry should be logged
+func (c *levelFilterCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if !c.Enabled(ent.Level) {
+		return ce
+	}
+
+	return c.Core.Check(ent, ce)
+}

--- a/backend/pkg/logging/logger.go
+++ b/backend/pkg/logging/logger.go
@@ -1,0 +1,95 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package logging
+
+import (
+	"os"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/redpanda-data/console/backend/pkg/config"
+)
+
+var (
+	zapCore      zapcore.Core
+	initCoreOnce sync.Once
+)
+
+// NewLogger creates a preconfigured global logger and configures the global zap logger
+func NewLogger(cfg *config.Logging, metricsNamespace string) *zap.Logger {
+	core := getZapCore(cfg.LogLevel, metricsNamespace)
+	logger := zap.New(core)
+	zap.ReplaceGlobals(logger)
+
+	if zapCore == nil {
+		setZapCore(core)
+	}
+
+	return logger
+}
+
+// prometheusHook is a hook for the zap library which exposes Prometheus counters for various log levels.
+func prometheusHook(metricsNamespace string) func(zapcore.Entry) error {
+	messageCounterVec := promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metricsNamespace,
+		Name:      "log_messages_total",
+		Help:      "Total number of log messages.",
+	}, []string{"level"})
+
+	// Pre-initialize counters for all supported log levels so that they expose 0 for each level on startup
+	supportedLevels := []zapcore.Level{
+		zapcore.DebugLevel,
+		zapcore.InfoLevel,
+		zapcore.WarnLevel,
+		zapcore.ErrorLevel,
+		// Panic and Fatal are pointless since they would always report 0
+	}
+	for _, level := range supportedLevels {
+		messageCounterVec.WithLabelValues(level.String())
+	}
+
+	return func(entry zapcore.Entry) error {
+		messageCounterVec.WithLabelValues(entry.Level.String()).Inc()
+		return nil
+	}
+}
+
+// setZapCore sets the zap core config with hooks.
+// This ensures that they are available as fallbacks when a logger is
+// not found on the context.
+func setZapCore(core zapcore.Core) {
+	initCoreOnce.Do(func() {
+		zapCore = core
+	})
+}
+
+// getZapCore retrieves the initialized zapcore config or creates a new zapcore
+// config using your provided log level and metrics namespace.
+func getZapCore(logLevel zap.AtomicLevel, metricsNamespace string) zapcore.Core {
+	if zapCore != nil {
+		return zapCore
+	}
+
+	encoderCfg := zap.NewProductionEncoderConfig()
+	encoderCfg.EncodeTime = zapcore.ISO8601TimeEncoder
+	encoderCfg.EncodeDuration = zapcore.StringDurationEncoder
+	core := zapcore.NewCore(
+		zapcore.NewJSONEncoder(encoderCfg),
+		zapcore.Lock(os.Stdout),
+		logLevel,
+	)
+	core = zapcore.RegisterHooks(core, prometheusHook(metricsNamespace))
+
+	return core
+}

--- a/backend/pkg/logging/logger.go
+++ b/backend/pkg/logging/logger.go
@@ -7,6 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+// Package logging provides functions for instructing a new logger,
+// attaching a decorated logger to the context as well as retrieving
+// a logger from the context.
 package logging
 
 import (


### PR DESCRIPTION
This allows attaching decorated loggers to the context. Only the error log interceptor will retrieve the logger from context for now, but we may change this in the future.