### PR TITLE
frontend: use v1 data types for requests in frontend

### DIFF
--- a/frontend/src/components/pages/rp-connect/Pipelines.Edit.tsx
+++ b/frontend/src/components/pages/rp-connect/Pipelines.Edit.tsx
@@ -14,7 +14,7 @@ import { Link as ChLink } from '@redpanda-data/ui';
 import { action, makeObservable, observable } from 'mobx';
 import { observer } from 'mobx-react';
 import { Link } from 'react-router-dom';
-import { PipelineUpdate } from '../../../protogen/redpanda/api/dataplane/v1alpha2/pipeline_pb';
+import { PipelineUpdate } from '../../../protogen/redpanda/api/dataplane/v1/pipeline_pb';
 import { appGlobal } from '../../../state/appGlobal';
 import { pipelinesApi, rpcnSecretManagerApi } from '../../../state/backendApi';
 import { DefaultSkeleton } from '../../../utils/tsxUtils';
@@ -157,6 +157,7 @@ class RpConnectPipelinesEdit extends PageComponent<{ pipelineId: string }> {
         pipelineId,
         new PipelineUpdate({
           displayName: this.displayName,
+          tags: {},
           configYaml: this.editorContent,
           description: this.description,
           resources: {

--- a/frontend/src/state/backendApi.ts
+++ b/frontend/src/state/backendApi.ts
@@ -150,7 +150,7 @@ import {
   type Pipeline,
   type PipelineCreate,
   type PipelineUpdate,
-} from '../protogen/redpanda/api/dataplane/v1alpha2/pipeline_pb';
+} from '../protogen/redpanda/api/dataplane/v1/pipeline_pb';
 import {
   type CreateSecretRequest,
   type DeleteSecretRequest,
@@ -159,7 +159,7 @@ import {
   Scope,
   type Secret,
   type UpdateSecretRequest,
-} from '../protogen/redpanda/api/dataplane/v1alpha2/secret_pb';
+} from '../protogen/redpanda/api/dataplane/v1/secret_pb';
 import type { TransformMetadata } from '../protogen/redpanda/api/dataplane/v1alpha2/transform_pb';
 import { Features } from './supportedFeatures';
 import { PartitionOffsetOrigin } from './ui';


### PR DESCRIPTION
Bringing in this commit into master.
https://github.com/redpanda-data/console/commit/e9ce83d85bd0b73b45260b3d62b4f3f1925c8f5e

We should generally review and change dataplane `v1alpha2` usage throughout frontend 