### PR TITLE
Update the name of the redpanda image in the example docker-compose file

### DIFF
--- a/docs/local/docker-compose.yaml
+++ b/docs/local/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   redpanda:
-    image: vectorized/redpanda:v23.2.17
+    image: redpandadata/redpanda:v23.2.17
     command:
       - redpanda start
       - --smp 1


### PR DESCRIPTION
### Problem
The `docker-compose.yaml` is not working because the name of the redpanda image is wrong.

```
 ✘ redpanda Error pull access denied for vect...                 1.5s
Error response from daemon: pull access denied for vectorized/redpanda, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```

### Cause

The organization name in the Docker Hub was renamed from `vectorized` to `redpandadata` some time ago.

### Solution

Updated the image name in the `docker-compose.yaml`

