### PR TITLE
Console 35 consumer groups rework - single partition offset edit

### DIFF
--- a/frontend/src/components/pages/consumers/Group.Details.tsx
+++ b/frontend/src/components/pages/consumers/Group.Details.tsx
@@ -57,6 +57,7 @@ import { DeleteOffsetsModal, EditOffsetsModal, type GroupOffset } from './Modals
 class GroupDetails extends PageComponent<{ groupId: string }> {
   @observable edittingOffsets: GroupOffset[] | null = null;
   @observable editedTopic: string | null = null;
+  @observable editedPartition: number | null = null;
 
   @observable deletingMode: GroupDeletingMode = 'group';
   @observable deletingOffsets: GroupOffset[] | null = null;
@@ -125,6 +126,11 @@ class GroupDetails extends PageComponent<{ groupId: string }> {
           onEditOffsets={(g) => {
             this.editGroup();
             this.editedTopic = g[0].topicName;
+            if (g.length === 1) {
+              this.editedPartition = g[0].partitionId;
+            } else {
+              this.editedPartition = null;
+            }
           }}
           quickSearch={this.quickSearch}
           onDeleteOffsets={(offsets, mode) => {
@@ -206,11 +212,12 @@ class GroupDetails extends PageComponent<{ groupId: string }> {
 
         {/* Modals */}
         <EditOffsetsModal
-          key={this.editedTopic}
+          key={`${this.editedTopic ?? ''}-${this.editedPartition ?? ''}`}
           group={group}
           offsets={this.edittingOffsets}
           onClose={() => (this.edittingOffsets = null)}
           initialTopic={this.editedTopic}
+          initialPartition={this.editedPartition}
         />
       </PageContent>
     );
@@ -231,6 +238,7 @@ class GroupDetails extends PageComponent<{ groupId: string }> {
     if (!groupOffsets) return;
 
     this.editedTopic = null;
+    this.editedPartition = null;
     this.edittingOffsets = groupOffsets;
   }
 


### PR DESCRIPTION
- Added a selector for editing single partition.
  - Clicking edit button next to the partition will preselect that partition
- Moving to step 2 (preview) will only update offsets of selected partition

<img width="635" alt="image" src="https://github.com/user-attachments/assets/fe2dd78c-cba2-464d-af68-c69c2dca6423" />
<img width="635" alt="image" src="https://github.com/user-attachments/assets/cf851134-dd68-4d58-a333-ec78c14a4595" />
