### PR TITLE
Edit Consumer Group modal improvements

### DIFF
--- a/frontend/src/components/pages/consumers/Group.Details.tsx
+++ b/frontend/src/components/pages/consumers/Group.Details.tsx
@@ -154,7 +154,11 @@ class GroupDetails extends PageComponent<{ groupId: string }> {
     return (
       <PageContent className="groupDetails">
         <Flex gap={2}>
-          <Button variant="outline" onClick={() => this.editGroup()}>
+          <Button
+            variant="outline"
+            onClick={() => this.editGroup()}
+            disabledReason={cannotEditGroupReason(group)}
+          >
             Edit Group
           </Button>
           <DeleteOffsetsModal

--- a/frontend/src/components/pages/consumers/Modals.tsx
+++ b/frontend/src/components/pages/consumers/Modals.tsx
@@ -110,6 +110,8 @@ export class EditOffsetsModal extends Component<{
   @observable selectedPartition: number | null = null;
   @observable timestampUtcMs: number = new Date().valueOf();
   @observable offsetShiftByValue = 0;
+  @observable offsetShiftByValueAsString = '0';
+
 
   @observable otherConsumerGroups: GroupDescription[] = [];
   @observable selectedGroup: string | undefined = undefined;
@@ -276,8 +278,21 @@ export class EditOffsetsModal extends Component<{
           <Box mt={2}>
             <FormLabel>Shift by</FormLabel>
             <NumberInput
-              value={this.customOffsetValue}
-              onChange={(_, valueAsNumber) => (this.customOffsetValue = valueAsNumber)}
+              value={this.offsetShiftByValueAsString}
+              onChange={(valueAsString, valueAsNumber) => {
+                // entering '-' or '.' without any digits will set the value to -Number.MAX_SAFE_INTEGER
+                // we want to prevent this and set the value to 0 instead in onBlur
+                if (valueAsNumber !== -Number.MAX_SAFE_INTEGER) {
+                  this.offsetShiftByValueAsString = valueAsString;
+                  this.offsetShiftByValue = valueAsNumber;
+                }
+              }}
+              onBlur={() => {
+                if (Number.isNaN(this.offsetShiftByValue)) {
+                  this.offsetShiftByValueAsString = '0';
+                  this.offsetShiftByValue = 0;
+                }
+              }}
             />
           </Box>
         )}

--- a/frontend/src/components/pages/consumers/Modals.tsx
+++ b/frontend/src/components/pages/consumers/Modals.tsx
@@ -109,7 +109,7 @@ export class EditOffsetsModal extends Component<{
   @observable selectedTopic: string | null = null;
   @observable selectedPartition: number | null = null;
   @observable timestampUtcMs: number = new Date().valueOf();
-  @observable customOffsetValue = 0;
+  @observable offsetShiftByValue = 0;
 
   @observable otherConsumerGroups: GroupDescription[] = [];
   @observable selectedGroup: string | undefined = undefined;
@@ -274,7 +274,7 @@ export class EditOffsetsModal extends Component<{
 
         {this.selectedOption === 'shiftBy' && (
           <Box mt={2}>
-            <FormLabel>Custom offset value</FormLabel>
+            <FormLabel>Shift by</FormLabel>
             <NumberInput
               value={this.customOffsetValue}
               onChange={(_, valueAsNumber) => (this.customOffsetValue = valueAsNumber)}
@@ -438,7 +438,7 @@ export class EditOffsetsModal extends Component<{
       } else if (op === 'shiftBy') {
         for (const x of selectedOffsets) {
           if (x.offset) {
-            x.newOffset = x.offset + this.customOffsetValue;
+            x.newOffset = x.offset + this.offsetShiftByValue;
           }
         }
       } else if (op === 'time') {


### PR DESCRIPTION
### Problem 1:
<img width="1173" alt="image" src="https://github.com/user-attachments/assets/8c3da625-5144-4a64-9827-fc2c86c512d4" />


#### Cause:

The group can not be editable when in use.

#### Solution:

Disable the edit button when the group is in use by adding the `disabledReason={cannotEditGroupReason(group)}`

### Problem 2:

The label for the input `Custom offset value` was confusing, since the user is supposed to select a difference to which the offset should be shifted by, and not the offset itself.

#### Solution:
Change the label to  just `Shift by`

### Problem 3:

The shift by number input UIX is not good.
- Impossible to enter negative number by keyboard unless entering the digits first
- Deleting the text shows `NaN`

#### Cause:
The state of the field was driven only by value of type number, so the input always had to show a number and not an incomplete text input (like `""` or `"-"`)

#### Solution:
Use string value for handling state of the field.

### Problem 4:
Entering only negative sign `-` without completing the number would automatically change the value to `-9007199254740991` (`-Number.MAX_SAFE_INTEGER`) on blur.

#### Cause:

Implementation of the UI library.

#### Solution:
Add a condition to handle this special case and change the value to `0` on blur


