### PR TITLE
rpcn: warn when compute units are bumped

### DIFF
--- a/frontend/src/components/pages/rp-connect/tasks.tsx
+++ b/frontend/src/components/pages/rp-connect/tasks.tsx
@@ -1,5 +1,5 @@
 export const MIN_TASKS = 1,
-  MAX_TASKS = 90;
+  MAX_TASKS = 72;
 
 const milliValueRegex = /^(\d+(\.\d+)?)(m?)$/;
 

--- a/frontend/src/state/backendApi.ts
+++ b/frontend/src/state/backendApi.ts
@@ -2215,13 +2215,13 @@ export const pipelinesApi = observable({
     const client = appConfig.pipelinesClient;
     if (!client) throw new Error('pipelines client is not initialized');
 
-    await client.createPipeline({ request: { pipeline } });
+    return await client.createPipeline({ request: { pipeline } });
   },
   async updatePipeline(id: string, pipelineUpdate: PipelineUpdate) {
     const client = appConfig.pipelinesClient;
     if (!client) throw new Error('pipelines client is not initialized');
 
-    await client.updatePipeline({
+    return await client.updatePipeline({
       request: {
         id,
         pipeline: pipelineUpdate,


### PR DESCRIPTION
Sometimes the API adapts automatically the number of compute units, for instance when using an Ollama connector or values in disallowed ranges e.g. 16-31 compute units (since they would use a little part of a dedicated big machine). This adds a warning when the backend does it.

To make it work, I had to do some hacks to have the useToast function available otherwise the local toast would disappear on page change (the "Pipeline created"/"Pipeline updated" toasts did already disappear actually). Pls advise if there's a better way.