### PR TITLE
Add tokenFilePath support for providing SASL OAuth token via file

### DIFF
--- a/backend/pkg/config/kafka_sasl_oauth.go
+++ b/backend/pkg/config/kafka_sasl_oauth.go
@@ -29,7 +29,7 @@ type KafkaSASLOAuthBearer struct {
 	TokenEndpoint string                    `yaml:"tokenEndpoint"`
 	Scope         string                    `yaml:"scope"`
 	Extensions    []KafkaSASLOAuthExtension `yaml:"extensions"`
-	TokenFilePath string                    `yaml:"tokenFilePath"`
+	TokenFilepath string                    `yaml:"tokenFilepath"`
 }
 
 // KafkaSASLOAuthExtension is the struct for the SASL OAuth extension support(custom key-value pairs)
@@ -53,7 +53,7 @@ func (c *KafkaSASLOAuthBearer) Validate() error {
 		if c.ClientID == "" || c.ClientSecret == "" {
 			return fmt.Errorf("OAuth Bearer client credentials must be set")
 		}
-	} else if c.Token == "" && c.TokenFilePath == "" {
+	} else if c.Token == "" && c.TokenFilepath == "" {
 		return fmt.Errorf("OAuth Bearer token or token file path must be set")
 	}
 

--- a/backend/pkg/config/kafka_sasl_oauth.go
+++ b/backend/pkg/config/kafka_sasl_oauth.go
@@ -29,6 +29,7 @@ type KafkaSASLOAuthBearer struct {
 	TokenEndpoint string                    `yaml:"tokenEndpoint"`
 	Scope         string                    `yaml:"scope"`
 	Extensions    []KafkaSASLOAuthExtension `yaml:"extensions"`
+	TokenFilePath string                    `yaml:"tokenFilePath"`
 }
 
 // KafkaSASLOAuthExtension is the struct for the SASL OAuth extension support(custom key-value pairs)
@@ -52,8 +53,8 @@ func (c *KafkaSASLOAuthBearer) Validate() error {
 		if c.ClientID == "" || c.ClientSecret == "" {
 			return fmt.Errorf("OAuth Bearer client credentials must be set")
 		}
-	} else if c.Token == "" {
-		return fmt.Errorf("OAuth Bearer token must be set")
+	} else if c.Token == "" && c.TokenFilePath == "" {
+		return fmt.Errorf("OAuth Bearer token or token file path must be set")
 	}
 
 	return nil

--- a/backend/pkg/factory/kafka/kafka.go
+++ b/backend/pkg/factory/kafka/kafka.go
@@ -182,9 +182,9 @@ func NewKgoConfig(cfg config.Kafka, logger *zap.Logger, metricsNamespace string)
 					Token:      cfg.SASL.OAUth.Token,
 					Extensions: kafkaSASLOAuthExtensionsToStrMap(cfg.SASL.OAUth.Extensions),
 				}.AsMechanism()
-			} else if cfg.SASL.OAUth.TokenFilePath != "" {
+			} else if cfg.SASL.OAUth.TokenFilepath != "" {
 				mechanism = oauth.Oauth(func(ctx context.Context) (oauth.Auth, error) {
-					token, err := os.ReadFile(cfg.SASL.OAUth.TokenFilePath)
+					token, err := os.ReadFile(cfg.SASL.OAUth.TokenFilepath)
 					if err != nil {
 						return oauth.Auth{}, fmt.Errorf("failed to open token file: %w", err)
 					}

--- a/backend/pkg/factory/kafka/kafka.go
+++ b/backend/pkg/factory/kafka/kafka.go
@@ -178,11 +178,6 @@ func NewKgoConfig(cfg config.Kafka, logger *zap.Logger, metricsNamespace string)
 						Extensions: kafkaSASLOAuthExtensionsToStrMap(cfg.SASL.OAUth.Extensions),
 					}, err
 				})
-			case cfg.SASL.OAUth.Token != "":
-				mechanism = oauth.Auth{
-					Token:      cfg.SASL.OAUth.Token,
-					Extensions: kafkaSASLOAuthExtensionsToStrMap(cfg.SASL.OAUth.Extensions),
-				}.AsMechanism()
 			case cfg.SASL.OAUth.TokenFilepath != "":
 				mechanism = oauth.Oauth(func(_ context.Context) (oauth.Auth, error) {
 					token, err := os.ReadFile(cfg.SASL.OAUth.TokenFilepath)
@@ -193,6 +188,11 @@ func NewKgoConfig(cfg config.Kafka, logger *zap.Logger, metricsNamespace string)
 						Token: strings.TrimSpace(string(token)),
 					}, nil
 				})
+			default:
+				mechanism = oauth.Auth{
+					Token:      cfg.SASL.OAUth.Token,
+					Extensions: kafkaSASLOAuthExtensionsToStrMap(cfg.SASL.OAUth.Extensions),
+				}.AsMechanism()
 			}
 			opts = append(opts, kgo.SASL(mechanism))
 		}

--- a/backend/pkg/factory/kafka/kafka.go
+++ b/backend/pkg/factory/kafka/kafka.go
@@ -169,7 +169,8 @@ func NewKgoConfig(cfg config.Kafka, logger *zap.Logger, metricsNamespace string)
 		// OAuth Bearer
 		if cfg.SASL.Mechanism == config.SASLMechanismOAuthBearer {
 			var mechanism sasl.Mechanism
-			if cfg.SASL.OAUth.TokenEndpoint != "" {
+			switch {
+			case cfg.SASL.OAUth.TokenEndpoint != "":
 				mechanism = oauth.Oauth(func(ctx context.Context) (oauth.Auth, error) {
 					shortToken, err := cfg.SASL.OAUth.AcquireToken(ctx)
 					return oauth.Auth{
@@ -177,13 +178,13 @@ func NewKgoConfig(cfg config.Kafka, logger *zap.Logger, metricsNamespace string)
 						Extensions: kafkaSASLOAuthExtensionsToStrMap(cfg.SASL.OAUth.Extensions),
 					}, err
 				})
-			} else if cfg.SASL.OAUth.Token != "" {
+			case cfg.SASL.OAUth.Token != "":
 				mechanism = oauth.Auth{
 					Token:      cfg.SASL.OAUth.Token,
 					Extensions: kafkaSASLOAuthExtensionsToStrMap(cfg.SASL.OAUth.Extensions),
 				}.AsMechanism()
-			} else if cfg.SASL.OAUth.TokenFilepath != "" {
-				mechanism = oauth.Oauth(func(ctx context.Context) (oauth.Auth, error) {
+			case cfg.SASL.OAUth.TokenFilepath != "":
+				mechanism = oauth.Oauth(func(_ context.Context) (oauth.Auth, error) {
 					token, err := os.ReadFile(cfg.SASL.OAUth.TokenFilepath)
 					if err != nil {
 						return oauth.Auth{}, fmt.Errorf("failed to open token file: %w", err)

--- a/docs/config/console.yaml
+++ b/docs/config/console.yaml
@@ -53,6 +53,7 @@ kafka:
       # clientSecret: "example-client-secret"
       # tokenEndpoint: "https://accounts.google.com/token"
       # scope: "openid"
+      # tokenFilePath: "/path/to/token/file"
     # Example for basic authentication (uncomment to use):
     # username: "your-username"
     # password: "your-password"

--- a/docs/config/console.yaml
+++ b/docs/config/console.yaml
@@ -53,7 +53,7 @@ kafka:
       # clientSecret: "example-client-secret"
       # tokenEndpoint: "https://accounts.google.com/token"
       # scope: "openid"
-      # tokenFilePath: "/path/to/token/file"
+      # tokenFilepath: "/path/to/token/file"
     # Example for basic authentication (uncomment to use):
     # username: "your-username"
     # password: "your-password"


### PR DESCRIPTION
Hi, currently I have use case where I use kubernetes JWT token stored in `/var/run/secrets/kafka/serviceaccount/token` in k8s pod as token to authenticate to kafka. This token is a mounted file and it is gets renewed periodically.  However, the current available options on the console is by using OIDC token endpoint or by providing token value configured via `KAFKA_SASL_OAUTH_TOKEN` env var. 

So, I am thinking to add additional optional configuration to the token file path and read the file to get the content of the content.

Please let me know what you think.

Thanks.

