### PR TITLE
Show an error when topic deletion fails

### DIFF
--- a/frontend/src/components/pages/topics/Topic.List.tsx
+++ b/frontend/src/components/pages/topics/Topic.List.tsx
@@ -441,9 +441,15 @@ function ConfirmDeletionModal({
                 if (topicToDelete?.topicName) {
                   setDeletionPending(true);
                   api
-                    .deleteTopic(topicToDelete?.topicName) // modal is not shown when topic is null
+                    .deleteTopic(topicToDelete?.topicName)
                     .then(finish)
-                    .catch(setError)
+                    .catch((err) => {
+                      toast({
+                        title: 'Failed to delete topic',
+                        description: <Text as="span">{err.message}</Text>,
+                        status: 'error',
+                      });
+                    })
                     .finally(() => {
                       setDeletionPending(false);
                     });

--- a/frontend/src/state/backendApi.ts
+++ b/frontend/src/state/backendApi.ts
@@ -629,9 +629,10 @@ const apiStore = {
   },
 
   async deleteTopic(topicName: string) {
-    return rest(`${appConfig.restBasePath}/topics/${encodeURIComponent(topicName)}`, { method: 'DELETE' }).catch(
-      addError,
-    );
+    const response = await appConfig.fetch(`${appConfig.restBasePath}/topics/${encodeURIComponent(topicName)}`, {
+      method: 'DELETE',
+    });
+    return parseOrUnwrap<any>(response, null);
   },
 
   async deleteTopicRecords(topicName: string, offset: number, partitionId?: number) {


### PR DESCRIPTION
![Screenshot 2025-04-24 at 9 46 49](https://github.com/user-attachments/assets/62ceb740-2f89-4d89-a794-ba94fdb5ab87)


The problem was in `backendApi.ts:rest` which returns null in some error cases, making FE to believe that the request succeeded. I'll elimiated all usages of this through the app now.