### PR TITLE
Adds cursor:pointer for buttons

### DIFF
--- a/frontend/src/globals.scss
+++ b/frontend/src/globals.scss
@@ -32,3 +32,7 @@ h2 {
 b {
     font-weight: 600;
 }
+
+button {
+    cursor: pointer;
+}


### PR DESCRIPTION
I think this regression was caused when because we now do reset CSS with tailwind instead of Chakra, which we've disabled.