### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/backend/pkg/backoff/backoff.go
+++ b/backend/pkg/backoff/backoff.go
@@ -28,9 +28,6 @@ type ExponentialBackoff struct {
 // Each successive call increases the wait time exponentially.
 func (e *ExponentialBackoff) Backoff(attempts int) time.Duration {
 	multiplied := math.Pow(e.Multiplier, float64(attempts))
-	wait := time.Duration(float64(e.BaseInterval) * multiplied)
-	if wait > e.MaxInterval {
-		wait = e.MaxInterval
-	}
+	wait := min(time.Duration(float64(e.BaseInterval)*multiplied), e.MaxInterval)
 	return wait
 }


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.