### PR TITLE
Properly fix cursor for buttons

### DIFF
--- a/frontend/src/globals.css
+++ b/frontend/src/globals.css
@@ -118,3 +118,10 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
+}

--- a/frontend/src/globals.scss
+++ b/frontend/src/globals.scss
@@ -32,7 +32,3 @@ h2 {
 b {
     font-weight: 600;
 }
-
-button {
-    cursor: pointer;
-}


### PR DESCRIPTION
We've changed Chakra's resetCSS and included TS Preflight.

The whole issue was caused by this 

https://tailwindcss.com/docs/upgrade-guide#buttons-use-the-default-cursor

So this fixes it properly