### PR TITLE
CONSOLE-191: add show deleted flag to schema registry client calls

### DIFF
--- a/backend/pkg/console/schema_registry.go
+++ b/backend/pkg/console/schema_registry.go
@@ -247,7 +247,7 @@ func (s *Service) GetSchemaRegistrySubjectDetails(ctx context.Context, subjectNa
 	switch version {
 	case SchemaVersionsAll:
 		grp.Go(func() error {
-			subjectSchemas, err := srClient.Schemas(ctx, subjectName)
+			subjectSchemas, err := srClient.Schemas(sr.WithParams(ctx, sr.ShowDeleted), subjectName)
 			if err != nil {
 				return fmt.Errorf("failed to retrieve all sch versions for subject %q: %w", subjectName, err)
 			}
@@ -265,7 +265,7 @@ func (s *Service) GetSchemaRegistrySubjectDetails(ctx context.Context, subjectNa
 			if err != nil {
 				return fmt.Errorf("failed to parse version %q: %w", version, err)
 			}
-			subjectSchema, err := srClient.SchemaByVersion(ctx, subjectName, versionInt)
+			subjectSchema, err := srClient.SchemaByVersion(sr.WithParams(ctx, sr.ShowDeleted), subjectName, versionInt)
 			if err != nil {
 				return fmt.Errorf("failed to retrieve schema by version %q: %w", subjectName, err)
 			}
@@ -443,7 +443,7 @@ func (s *Service) GetSchemaRegistrySchemaReferencedBy(ctx context.Context, subje
 		return nil, err
 	}
 
-	schemaRefs, err := srClient.SchemaReferences(ctx, subjectName, version)
+	schemaRefs, err := srClient.SchemaReferences(sr.WithParams(ctx, sr.ShowDeleted), subjectName, version)
 	if err != nil {
 		return nil, err
 	}
@@ -454,7 +454,7 @@ func (s *Service) GetSchemaRegistrySchemaReferencedBy(ctx context.Context, subje
 	for _, subjectSchema := range schemaRefs {
 		schemaIDCpy := subjectSchema.ID
 		grp.Go(func() error {
-			subjectVersions, err := srClient.SchemaUsagesByID(grpCtx, schemaIDCpy)
+			subjectVersions, err := srClient.SchemaUsagesByID(sr.WithParams(grpCtx, sr.ShowDeleted), schemaIDCpy)
 			if err != nil {
 				ch <- SchemaReference{
 					Error: err.Error(),


### PR DESCRIPTION
https://redpandadata.atlassian.net/browse/CONSOLE-185
https://redpandadata.atlassian.net/browse/CONSOLE-191

When we have a single subject and version, then gets deleted the main screen shows errors. This PR fixes it.
I think there is still some issues with SR pages, like in the main view, or the referenced by view. But this improves the situation. I need to investigate further.