### PR TITLE
feat: hide throttle button for Redpanda clusters

### DIFF
--- a/frontend/src/components/pages/reassign-partitions/components/ActiveReassignments.tsx
+++ b/frontend/src/components/pages/reassign-partitions/components/ActiveReassignments.tsx
@@ -95,14 +95,18 @@ export class ActiveReassignments extends Component<{
         <div className="currentReassignments" style={{ display: 'flex', placeItems: 'center', marginBottom: '.5em' }}>
           <span className="title">Current Reassignments</span>
 
-          <Button
-            variant="link"
-            size="sm"
-            style={{ fontSize: 'smaller', padding: '0px 8px' }}
-            onClick={() => (this.showThrottleDialog = true)}
-          >
-            {throttleText}
-          </Button>
+          {
+            // RedPand cluster throttles as needed, the api does not support setting the throttle manually
+            !api.isRedpanda && (
+              <Button
+                variant="link"
+                size="sm"
+                style={{ fontSize: 'smaller', padding: '0px 8px' }}
+                onClick={() => (this.showThrottleDialog = true)}
+            >
+              {throttleText}
+            </Button>
+          )}
         </div>
 
         {/* Table */}


### PR DESCRIPTION
## Problem

Throttling cannot be used for Redpanda because Redpanda auto-throttles as needed. If someone tries to configure throttling the requests will fail. We need to adapt the page and remove the settings if we are running on a Redpanda cluster.

## Solution

Hide the `Throttle` setting button when the cluster is RedPanda