### PR TITLE
Ms/support debug bundle adminapi

### DIFF
--- a/backend/pkg/factory/redpanda/disabled.go
+++ b/backend/pkg/factory/redpanda/disabled.go
@@ -23,6 +23,6 @@ var _ ClientFactory = (*DisabledClientProvider)(nil)
 type DisabledClientProvider struct{}
 
 // GetRedpandaAPIClient returns a not configured error when invoked.
-func (*DisabledClientProvider) GetRedpandaAPIClient(context.Context) (AdminAPIClient, error) {
+func (*DisabledClientProvider) GetRedpandaAPIClient(context.Context, ...ClientOption) (AdminAPIClient, error) {
 	return nil, apierrors.NewRedpandaAdminAPINotConfiguredError()
 }

--- a/backend/pkg/factory/redpanda/redpanda.go
+++ b/backend/pkg/factory/redpanda/redpanda.go
@@ -14,7 +14,9 @@ package redpanda
 
 import (
 	"context"
+	"errors"
 	"io"
+	"net/http"
 
 	"github.com/redpanda-data/common-go/rpadmin"
 )
@@ -102,10 +104,6 @@ type AdminAPIClient interface {
 	// true, Redpanda will delete ACLs bound to the role.
 	DeleteRole(ctx context.Context, name string, deleteACL bool) error
 
-	// GetDebugBundleStatus gets the current debug bundle process status on the specified broker node.
-	// This should be called using Host client to issue a request against a specific broker node.
-	GetDebugBundleStatus(ctx context.Context) (rpadmin.DebugBundleStatus, error)
-
 	// MountTopics mounts topics according to the provided configuration.
 	MountTopics(ctx context.Context, config rpadmin.MountConfiguration) (rpadmin.MigrationInfo, error)
 
@@ -142,4 +140,29 @@ type AdminAPIClient interface {
 
 	// GetEnterpriseFeatures reports enterprise features in use as well as the license status.
 	GetEnterpriseFeatures(ctx context.Context) (rpadmin.EnterpriseFeaturesResponse, error)
+
+	// CreateDebugBundle starts the debug bundle process. This should be called using
+	// the host client to issue a request against a specific broker node. jobID is
+	// the user-specified job UUID.
+	CreateDebugBundle(ctx context.Context, jobID string, opts ...rpadmin.DebugBundleOption) (rpadmin.DebugBundleStartResponse, error)
+
+	// GetDebugBundleStatus gets the current debug bundle process status on the
+	// specified broker node. This should be called using the host client to issue a
+	// request against a specific broker node.
+	GetDebugBundleStatus(ctx context.Context) (rpadmin.DebugBundleStatus, error)
+
+	// CancelDebugBundleProcess cancels the specific debug bundle process that's
+	// running. This should be called using the host client to issue a request against a
+	// specific broker node.
+	CancelDebugBundleProcess(ctx context.Context, jobID string) error
+
+	// DeleteDebugBundleFile deletes the specific debug bundle file on the specified
+	// broker node. This should be called using the host client to issue a request
+	// against a specific broker node.
+	DeleteDebugBundleFile(ctx context.Context, filename string) error
+
+	// DownloadDebugBundleFile gets the specific debug bundle file on the specified
+	// broker node. The caller must call close on the response returned as it does
+	// not yet have its body read.
+	DownloadDebugBundleFile(ctx context.Context, filename string) (*http.Response, error)
 }

--- a/backend/pkg/factory/redpanda/redpanda.go
+++ b/backend/pkg/factory/redpanda/redpanda.go
@@ -22,7 +22,28 @@ import (
 // ClientFactory defines the interface for creating and retrieving Redpanda API clients.
 type ClientFactory interface {
 	// GetRedpandaAPIClient retrieves a Redpanda admin API client based on the context.
-	GetRedpandaAPIClient(ctx context.Context) (AdminAPIClient, error)
+	GetRedpandaAPIClient(ctx context.Context, opts ...ClientOption) (AdminAPIClient, error)
+}
+
+// ClientOption is a function that configures ClientOptions.
+// It may return an error if the option is invalid.
+type ClientOption func(*ClientOptions) error
+
+// ClientOptions holds all configurable parameters for constructing an AdminAPIClient.
+type ClientOptions struct {
+	URLs []string
+}
+
+// WithURLs lets the caller override the URLs that the client will use.
+// It requires at least one URL; otherwise it returns an error immediately.
+func WithURLs(urls ...string) ClientOption {
+	return func(_ *ClientOptions) error {
+		if len(urls) == 0 {
+			return errors.New("WithURLs: at least one URL must be provided")
+		}
+
+		return nil
+	}
 }
 
 // AdminAPIClient defines an interface for the rpadmin.AdminAPI struct, so that

--- a/backend/pkg/factory/redpanda/redpanda.go
+++ b/backend/pkg/factory/redpanda/redpanda.go
@@ -39,11 +39,11 @@ type ClientOptions struct {
 // WithURLs lets the caller override the URLs that the client will use.
 // It requires at least one URL; otherwise it returns an error immediately.
 func WithURLs(urls ...string) ClientOption {
-	return func(_ *ClientOptions) error {
+	return func(o *ClientOptions) error {
 		if len(urls) == 0 {
 			return errors.New("WithURLs: at least one URL must be provided")
 		}
-
+		o.URLs = urls
 		return nil
 	}
 }


### PR DESCRIPTION
This PR contains 2 changes:

1. For the admin api client factory it adds the ability to provide client options, initially only the ability to override the broker urls
2. It extends the admin api interface by debug bundle methods

Jira: https://redpandadata.atlassian.net/browse/CONSOLE-183