### PR TITLE
Hide debug bundle button in embedded mode

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -86,17 +86,21 @@ const AppPageHeader = observer(() => {
           {showRefresh && <DataRefreshButton />}
         </Flex>
         <Flex alignItems="center" gap={2}>
-          <Button
-            as={ReactRouterLink}
-            to={api.userData?.canViewDebugBundle ? '/debug-bundle' : undefined}
-            variant="ghost"
-            isDisabled={!api.userData?.canViewDebugBundle}
-            tooltip={
-              !api.userData?.canViewDebugBundle ? 'You need RedpandaCapability.MANAGE_DEBUG_BUNDLE permission' : null
-            }
-          >
-            Debug bundle
-          </Button>
+          {
+            !isEmbedded() && (
+              <Button
+                as={ReactRouterLink}
+                to={api.userData?.canViewDebugBundle ? '/debug-bundle' : undefined}
+                variant="ghost"
+                isDisabled={!api.userData?.canViewDebugBundle}
+                tooltip={
+                  !api.userData?.canViewDebugBundle ? 'You need RedpandaCapability.MANAGE_DEBUG_BUNDLE permission' : null
+                }
+                >
+                  Debug bundle
+                </Button>
+            )
+          }
           <UserPreferencesButton />
           {IsDev && !isEmbedded() && <ColorModeSwitch m={0} p={0} variant="ghost" />}
         </Flex>


### PR DESCRIPTION
### Problem

The `debug bundle` button was visible when embedded in the Cloud


### Solution

Add a condition `!isEmbedded()` to only render the button in standalone mode