### PR TITLE
Only render deebug button for redpanda clusters

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -87,7 +87,7 @@ const AppPageHeader = observer(() => {
         </Flex>
         <Flex alignItems="center" gap={2}>
           {
-            !isEmbedded() && (
+            (!isEmbedded() && api.isRedpanda) && (
               <Button
                 as={ReactRouterLink}
                 to={api.userData?.canViewDebugBundle ? '/debug-bundle' : undefined}


### PR DESCRIPTION
### Problem
The `Debug bundle` feature should be present only in standalone (non-cloud) mode and not in self-hosted (red panda) mode.

###
Solution

Add the isRedpanda condition to hide the button in self-hosted mode.