### PR TITLE
backend: add jsonpath config pkg

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/knadh/koanf v1.5.0
 	github.com/linkedin/goavro v2.1.0+incompatible
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/ohler55/ojg v1.26.4
 	github.com/prometheus/client_golang v1.20.5
 	github.com/redpanda-data/benthos/v4 v4.42.0
 	github.com/redpanda-data/common-go/api v0.0.0-20241213223629-113b96483733

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -497,6 +497,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/npillmayer/nestext v0.1.3/go.mod h1:h2lrijH8jpicr25dFY+oAJLyzlya6jhnuG+zWp9L0Uk=
 github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1 h1:dOYG7LS/WK00RWZc8XGgcUTlTxpp3mKhdR2Q9z9HbXM=
 github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1/go.mod h1:mpRZBD8SJ55OIICQ3iWH0Yz3cjzA61JdqMLoWXeB2+8=
+github.com/ohler55/ojg v1.26.4 h1:DTatWge/oPYVw7p7movCviCbVqe+s+iNkaGwo1HN6Jc=
+github.com/ohler55/ojg v1.26.4/go.mod h1:/Y5dGWkekv9ocnUixuETqiL58f+5pAsUfg5P8e7Pa2o=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=

--- a/backend/pkg/config/jsonpath/jsonpath.go
+++ b/backend/pkg/config/jsonpath/jsonpath.go
@@ -1,0 +1,283 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// Package jsonpath implements JSONPath or JSONPath-similar types that can be
+// used in configs.
+package jsonpath
+
+import (
+	"encoding"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/ohler55/ojg/jp"
+)
+
+// Interface assertions.
+var (
+	_ encoding.TextUnmarshaler = (*MappedJSONPath)(nil)
+	_ encoding.TextMarshaler   = (*MappedJSONPath)(nil)
+)
+
+// MappedJSONPath is a custom type that combines JSONPath expressions with regex-based
+// transformations to extract and manipulate data from JSON documents. It's particularly
+// useful for extracting and transforming identifiers from structured data like JWT tokens.
+// Features:
+//
+// 1. JSONPath Extraction: Use standard JSONPath syntax to query JSON documents
+// 2. Regex Filtering: Filter string results through regex patterns
+// 3. Regex Capture and Replacement: Transform extracted strings with regex capture groups
+// 4. Case Transformation: Apply uppercase or lowercase transformations to results
+//
+// - The path (segments) is evaluated with ojg/jp.
+// - If the optional mapping is present, each string result is:
+//  1. filtered through the regex (non-matches are discarded),
+//  2. replaced using $-captures,
+//  3. lower-cased (flag 'L') or upper-cased (flag 'U').
+//
+// This JSON Path type is generic, any subsystem can embed it wherever a
+// JSONPath and optional regex-transform is useful.
+//
+// Example:
+//   - "$.user_info.email/([^@]+)@.*/$1/L" - Extract username from email and lowercase it
+type MappedJSONPath struct {
+	raw string  // original rule text, preserved for logging and round-tripping
+	exp jp.Expr // compiled JSONPath expression
+
+	// mapping section (set only when rule contains “/regex/…”)
+	hasMapping bool
+	re         *regexp.Regexp
+	repl       string
+	lower      bool
+	upper      bool
+}
+
+// NewMappedJSONPath creates a new MappedJSONPath from a string rule.
+// It returns an error if the rule is invalid.
+//
+// Example:
+// path, err := NewMappedJSONPath("$.user_info.email/([^@]+)@.*/$1/L")
+func NewMappedJSONPath(rule string) (MappedJSONPath, error) {
+	var m MappedJSONPath
+	if err := m.UnmarshalText([]byte(rule)); err != nil {
+		return MappedJSONPath{}, err
+	}
+	return m, nil
+}
+
+// MustNewMappedJSONPath creates a new MappedJSONPath from a string rule.
+// It panics if the rule is invalid.
+//
+// Example:
+// path := MustNewMappedJSONPath("$.user_info.email/([^@]+)@.*/$1/L")
+func MustNewMappedJSONPath(rule string) MappedJSONPath {
+	m, err := NewMappedJSONPath(rule)
+	if err != nil {
+		panic(err)
+	}
+	return m
+}
+
+// UnmarshalText parses a rule from configuration data.
+func (m *MappedJSONPath) UnmarshalText(b []byte) error {
+	if len(b) == 0 {
+		return errors.New("empty string is not a valid JSON path")
+	}
+
+	m.raw = string(b)
+
+	pathPart, mapPart, err := splitRule(m.raw)
+	if err != nil {
+		return err
+	}
+
+	exp, err := jp.Parse([]byte(pathPart))
+	if err != nil {
+		return fmt.Errorf("invalid JSONPath: %w", err)
+	}
+	m.exp = exp
+
+	if mapPart != "" {
+		re, repl, lower, upper, err := parseMapping(mapPart)
+		if err != nil {
+			return fmt.Errorf("invalid mapping %q: %w", mapPart, err)
+		}
+		m.hasMapping, m.re, m.repl, m.lower, m.upper = true, re, repl, lower, upper
+	}
+	return nil
+}
+
+// MarshalText returns the original rule text.
+func (m MappedJSONPath) MarshalText() ([]byte, error) { return []byte(m.raw), nil }
+
+// Eval applies the rule to a JSON document.
+//
+// Non-string matches are skipped; values that fail the regex (when present)
+// are discarded.
+func (m MappedJSONPath) Eval(doc any) []string {
+	raw := m.exp.Get(doc)
+	out := make([]string, 0, len(raw))
+
+	for _, v := range raw {
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+
+		if m.hasMapping {
+			if !m.re.MatchString(s) {
+				continue
+			}
+			s = m.re.ReplaceAllString(s, m.repl)
+			switch {
+			case m.lower:
+				s = strings.ToLower(s)
+			case m.upper:
+				s = strings.ToUpper(s)
+			}
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// String returns the original rule text.
+func (m MappedJSONPath) String() string {
+	return m.raw
+}
+
+// splitRule divides the rule into the pure-JSONPath part and the mapping suffix.
+// It scans for the first unescaped slash. If none is found, the mapping part is
+// empty.
+func splitRule(s string) (jsonPath string, regexMapping string, err error) {
+	if !strings.HasPrefix(s, "$") {
+		return "", "", errors.New(`rule must start with "$"`)
+	}
+
+	// Allow either dot notation ($.field) or bracket notation ($["field"])
+	if !(strings.HasPrefix(s, "$.") || strings.HasPrefix(s, "$[")) {
+		return "", "", errors.New(`rule must start with "$." or "$["`)
+	}
+
+	escape := false
+	for i, r := range s {
+		switch {
+		case escape:
+			escape = false
+		case r == '\\':
+			escape = true
+		case r == '/':
+			return s[:i], s[i:], nil // path, mapping
+		}
+	}
+	return s, "", nil // entire string is the path
+}
+
+// parseMapping validates and decomposes a mapping suffix of the form
+// "/regex/replacement/flags".
+//
+// Escaped slashes (`\/`) and backslashes (`\\`) inside `regex` and
+// "replacement" are honored.
+//
+// Return values are:
+//
+// 1. compiled regular expression (`*regexp.Regexp`)
+// 2. replacement string (after unescaping)
+// 3. `true` if the `L` flag is present, force lower-case
+// 4. `true` if the `U` flag is present, force upper-case
+// 5. error, if any component is syntactically invalid
+func parseMapping(m string) (expr *regexp.Regexp, replacementString string, isLower bool, isUpper bool, err error) {
+	if m == "" || m[0] != '/' {
+		return nil, "", false, false, errors.New("mapping must start with '/'")
+	}
+
+	parts, err := splitMappingParts(m)
+	if err != nil {
+		return nil, "", false, false, err
+	}
+
+	if len(parts) < 2 || len(parts) > 3 {
+		return nil, "", false, false, fmt.Errorf("mapping requires pattern and replacement, got %d parts", len(parts))
+	}
+
+	pattern := parts[0]
+	replacement := parts[1]
+
+	// Process flags if present
+	var lower, upper bool
+	if len(parts) == 3 {
+		switch parts[2] {
+		case "L":
+			lower = true
+		case "U":
+			upper = true
+		default:
+			return nil, "", false, false, fmt.Errorf("unknown flag %q, expected 'L' or 'U'", parts[2])
+		}
+	}
+
+	// Compile the regex
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, "", false, false, fmt.Errorf("invalid regex %q: %w", pattern, err)
+	}
+
+	return re, replacement, lower, upper, nil
+}
+
+// splitMappingParts splits a mapping string by unescaped '/' delimiters.
+// For example: "/abc\/def/ghi/L" -> ["abc\/def", "ghi", "L"]
+func splitMappingParts(s string) ([]string, error) {
+	if s == "" || s[0] != '/' {
+		return nil, errors.New("mapping must start with '/'")
+	}
+
+	var parts []string
+	var current strings.Builder
+
+	// Skip the leading '/'
+	s = s[1:]
+
+	escape := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+
+		if escape {
+			current.WriteByte(c)
+			escape = false
+			continue
+		}
+
+		if c == '\\' {
+			escape = true
+			continue
+		}
+
+		if c == '/' {
+			parts = append(parts, current.String())
+			current.Reset()
+			continue
+		}
+
+		current.WriteByte(c)
+	}
+
+	// Add the last part if there's content
+	if current.Len() > 0 {
+		parts = append(parts, current.String())
+	}
+
+	if escape {
+		return nil, errors.New("invalid escape sequence at end of string")
+	}
+
+	return parts, nil
+}

--- a/backend/pkg/config/jsonpath/jsonpath_test.go
+++ b/backend/pkg/config/jsonpath/jsonpath_test.go
@@ -1,0 +1,677 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package jsonpath
+
+import (
+	"encoding/json"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitRule(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		expectedPath string
+		expectedMap  string
+		validateFunc func(t *testing.T, path, mapping string, err error)
+	}{
+		{
+			name:         "basic path without mapping",
+			input:        "$.field",
+			expectedPath: "$.field",
+			expectedMap:  "",
+			validateFunc: func(t *testing.T, path, mapping string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "$.field", path)
+				assert.Empty(t, mapping)
+			},
+		},
+		{
+			name:         "nested path without mapping",
+			input:        "$.field.subfield",
+			expectedPath: "$.field.subfield",
+			expectedMap:  "",
+			validateFunc: func(t *testing.T, path, mapping string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "$.field.subfield", path)
+				assert.Empty(t, mapping)
+			},
+		},
+		{
+			name:         "path with mapping",
+			input:        "$.field/regex/repl/",
+			expectedPath: "$.field",
+			expectedMap:  "/regex/repl/",
+			validateFunc: func(t *testing.T, path, mapping string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "$.field", path)
+				assert.Equal(t, "/regex/repl/", mapping)
+			},
+		},
+		{
+			name:         "path with escaped slash",
+			input:        "$.field\\/subfield",
+			expectedPath: "$.field\\/subfield",
+			expectedMap:  "",
+			validateFunc: func(t *testing.T, path, mapping string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "$.field\\/subfield", path)
+				assert.Empty(t, mapping)
+			},
+		},
+		{
+			name:         "path with escaped slash and mapping",
+			input:        "$.field\\/subfield/regex/repl/",
+			expectedPath: "$.field\\/subfield",
+			expectedMap:  "/regex/repl/",
+			validateFunc: func(t *testing.T, path, mapping string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "$.field\\/subfield", path)
+				assert.Equal(t, "/regex/repl/", mapping)
+			},
+		},
+		{
+			name:  "invalid path - no prefix",
+			input: "field",
+			validateFunc: func(t *testing.T, _, _ string, err error) {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "must start with")
+			},
+		},
+		{
+			name:  "invalid path - wrong prefix",
+			input: "$field",
+			validateFunc: func(t *testing.T, _, _ string, err error) {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "must start with")
+			},
+		},
+		{
+			name:         "path with bracket notation",
+			input:        `$["field"]`,
+			expectedPath: `$["field"]`,
+			expectedMap:  "",
+			validateFunc: func(t *testing.T, path, mapping string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, `$["field"]`, path)
+				assert.Empty(t, mapping)
+			},
+		},
+		{
+			name:         "path with bracket notation and dots",
+			input:        `$["field.with.dots"]`,
+			expectedPath: `$["field.with.dots"]`,
+			expectedMap:  "",
+			validateFunc: func(t *testing.T, path, mapping string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, `$["field.with.dots"]`, path)
+				assert.Empty(t, mapping)
+			},
+		},
+		{
+			name:         "path with bracket notation and mapping",
+			input:        `$["field.with.dots"]/regex/repl/`,
+			expectedPath: `$["field.with.dots"]`,
+			expectedMap:  "/regex/repl/",
+			validateFunc: func(t *testing.T, path, mapping string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, `$["field.with.dots"]`, path)
+				assert.Equal(t, "/regex/repl/", mapping)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path, mapping, err := splitRule(tc.input)
+			tc.validateFunc(t, path, mapping, err)
+		})
+	}
+}
+
+func TestSplitMappingParts(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		expected     []string
+		validateFunc func(t *testing.T, parts []string, err error)
+	}{
+		{
+			name:     "simple two part mapping",
+			input:    "/regex/replacement",
+			expected: []string{"regex", "replacement"},
+			validateFunc: func(t *testing.T, parts []string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, []string{"regex", "replacement"}, parts)
+			},
+		},
+		{
+			name:     "mapping with flag",
+			input:    "/regex/replacement/L",
+			expected: []string{"regex", "replacement", "L"},
+			validateFunc: func(t *testing.T, parts []string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, []string{"regex", "replacement", "L"}, parts)
+			},
+		},
+		{
+			name:     "mapping with escaped slashes",
+			input:    "/reg\\/ex/re\\/placement",
+			expected: []string{"reg/ex", "re/placement"},
+			validateFunc: func(t *testing.T, parts []string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, []string{"reg/ex", "re/placement"}, parts)
+			},
+		},
+		{
+			name:     "mapping with escaped backslashes",
+			input:    "/reg\\\\ex/replacement",
+			expected: []string{"reg\\ex", "replacement"},
+			validateFunc: func(t *testing.T, parts []string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, []string{"reg\\ex", "replacement"}, parts)
+			},
+		},
+		{
+			name:  "invalid mapping - no leading slash",
+			input: "regex/replacement",
+			validateFunc: func(t *testing.T, _ []string, err error) {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "must start with '/'")
+			},
+		},
+		{
+			name:  "invalid mapping - trailing escape",
+			input: "/regex\\",
+			validateFunc: func(t *testing.T, _ []string, err error) {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid escape sequence")
+			},
+		},
+		{
+			name:  "empty mapping",
+			input: "",
+			validateFunc: func(t *testing.T, _ []string, err error) {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "must start with '/'")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			parts, err := splitMappingParts(tc.input)
+			tc.validateFunc(t, parts, err)
+		})
+	}
+}
+
+func TestParseMapping(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		validateFunc func(t *testing.T, re *regexp.Regexp, repl string, lower, upper bool, err error)
+	}{
+		{
+			name:  "valid mapping without flags",
+			input: "/([^@]+)@.*/replacement",
+			validateFunc: func(t *testing.T, re *regexp.Regexp, repl string, lower, upper bool, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, re)
+				assert.Equal(t, "replacement", repl)
+				assert.False(t, lower)
+				assert.False(t, upper)
+
+				// Verify the regex works
+				match := re.FindStringSubmatch("user@example.com")
+				assert.Equal(t, []string{"user@example.com", "user"}, match)
+			},
+		},
+		{
+			name:  "valid mapping with lowercase flag",
+			input: "/([^@]+)@.*/replacement/L",
+			validateFunc: func(t *testing.T, re *regexp.Regexp, repl string, lower, upper bool, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, re)
+				assert.Equal(t, "replacement", repl)
+				assert.True(t, lower)
+				assert.False(t, upper)
+			},
+		},
+		{
+			name:  "valid mapping with uppercase flag",
+			input: "/([^@]+)@.*/replacement/U",
+			validateFunc: func(t *testing.T, re *regexp.Regexp, repl string, lower, upper bool, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, re)
+				assert.Equal(t, "replacement", repl)
+				assert.False(t, lower)
+				assert.True(t, upper)
+			},
+		},
+		{
+			name:  "valid mapping with capture replacement",
+			input: "/([^@]+)@.*/$1",
+			validateFunc: func(t *testing.T, re *regexp.Regexp, repl string, lower, upper bool, err error) {
+				assert.NoError(t, err)
+				assert.NotNil(t, re)
+				assert.Equal(t, "$1", repl)
+				assert.False(t, lower)
+				assert.False(t, upper)
+			},
+		},
+		{
+			name:  "invalid mapping - no leading slash",
+			input: "regex/replacement",
+			validateFunc: func(t *testing.T, re *regexp.Regexp, _ string, _, _ bool, err error) {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "must start with '/'")
+				assert.Nil(t, re)
+			},
+		},
+		{
+			name:  "invalid mapping - invalid regex",
+			input: "/[unclosed/replacement",
+			validateFunc: func(t *testing.T, re *regexp.Regexp, _ string, _, _ bool, err error) {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid regex")
+				assert.Nil(t, re)
+			},
+		},
+		{
+			name:  "invalid mapping - missing parts",
+			input: "/regex",
+			validateFunc: func(t *testing.T, re *regexp.Regexp, _ string, _, _ bool, err error) {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "mapping requires pattern and replacement")
+				assert.Nil(t, re)
+			},
+		},
+		{
+			name:  "invalid mapping - unknown flag",
+			input: "/regex/replacement/X",
+			validateFunc: func(t *testing.T, re *regexp.Regexp, _ string, _, _ bool, err error) {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "unknown flag")
+				assert.Nil(t, re)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			re, repl, lower, upper, err := parseMapping(tc.input)
+			tc.validateFunc(t, re, repl, lower, upper, err)
+		})
+	}
+}
+
+func TestMappedJSONPath_UnmarshalText(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		validateFunc func(t *testing.T, m *MappedJSONPath, err error)
+	}{
+		{
+			name:  "valid path without mapping",
+			input: "$.field",
+			validateFunc: func(t *testing.T, m *MappedJSONPath, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "$.field", m.raw)
+				assert.NotNil(t, m.exp)
+				assert.False(t, m.hasMapping)
+			},
+		},
+		{
+			name:  "valid path with mapping",
+			input: "$.field/([^@]+)@.*/$1/L",
+			validateFunc: func(t *testing.T, m *MappedJSONPath, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "$.field/([^@]+)@.*/$1/L", m.raw)
+				assert.NotNil(t, m.exp)
+				assert.True(t, m.hasMapping)
+				assert.NotNil(t, m.re)
+				assert.Equal(t, "$1", m.repl)
+				assert.True(t, m.lower)
+				assert.False(t, m.upper)
+			},
+		},
+		{
+			name:  "invalid path",
+			input: "field",
+			validateFunc: func(t *testing.T, _ *MappedJSONPath, err error) {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "must start with")
+			},
+		},
+		{
+			name:  "invalid JSONPath",
+			input: "$.[invalid",
+			validateFunc: func(t *testing.T, _ *MappedJSONPath, err error) {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid JSONPath")
+			},
+		},
+		{
+			name:  "invalid mapping",
+			input: "$.field/[unclosed/replacement",
+			validateFunc: func(t *testing.T, _ *MappedJSONPath, err error) {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid mapping")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var m MappedJSONPath
+			err := m.UnmarshalText([]byte(tc.input))
+			tc.validateFunc(t, &m, err)
+		})
+	}
+}
+
+func TestMappedJSONPath_MarshalText(t *testing.T) {
+	tests := []struct {
+		name         string
+		mappedPath   MappedJSONPath
+		validateFunc func(t *testing.T, text []byte, err error)
+	}{
+		{
+			name: "marshal path without mapping",
+			mappedPath: MappedJSONPath{
+				raw: "$.field",
+			},
+			validateFunc: func(t *testing.T, text []byte, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "$.field", string(text))
+			},
+		},
+		{
+			name: "marshal path with mapping",
+			mappedPath: MappedJSONPath{
+				raw: "$.field/regex/repl/L",
+			},
+			validateFunc: func(t *testing.T, text []byte, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "$.field/regex/repl/L", string(text))
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			text, err := tc.mappedPath.MarshalText()
+			tc.validateFunc(t, text, err)
+		})
+	}
+}
+
+func TestMappedJSONPath_Eval(t *testing.T) {
+	tests := []struct {
+		name         string
+		rule         string
+		doc          string
+		validateFunc func(t *testing.T, result []string)
+	}{
+		{
+			name: "simple path extraction",
+			rule: "$.sub",
+			doc:  `{"sub": "user", "other": "value"}`,
+			validateFunc: func(t *testing.T, result []string) {
+				assert.Equal(t, []string{"user"}, result)
+			},
+		},
+		{
+			name: "nested path extraction",
+			rule: "$.user_info.email",
+			doc:  `{"sub": "user", "user_info": {"name": "User", "email": "user@example.com"}}`,
+			validateFunc: func(t *testing.T, result []string) {
+				assert.Equal(t, []string{"user@example.com"}, result)
+			},
+		},
+		{
+			name: "path with mapping - extract username from email",
+			rule: "$.user_info.email/([^@]+)@.*/$1",
+			doc:  `{"sub": "user", "user_info": {"name": "User", "email": "user@example.com"}}`,
+			validateFunc: func(t *testing.T, result []string) {
+				assert.Equal(t, []string{"user"}, result)
+			},
+		},
+		{
+			name: "path with mapping and lowercase",
+			rule: "$.user_info.email/([^@]+)@.*/$1/L",
+			doc:  `{"sub": "user", "user_info": {"name": "User", "email": "USER@example.com"}}`,
+			validateFunc: func(t *testing.T, result []string) {
+				assert.Equal(t, []string{"user"}, result)
+			},
+		},
+		{
+			name: "path with mapping and uppercase",
+			rule: "$.user_info.email/([^@]+)@.*/$1/U",
+			doc:  `{"sub": "user", "user_info": {"name": "User", "email": "user@example.com"}}`,
+			validateFunc: func(t *testing.T, result []string) {
+				assert.Equal(t, []string{"USER"}, result)
+			},
+		},
+		{
+			name: "path with domain validation - matching domain",
+			rule: "$.user_info.email/([^@]+)@example\\.com/$1/L",
+			doc:  `{"sub": "user", "user_info": {"name": "User", "email": "user@example.com"}}`,
+			validateFunc: func(t *testing.T, result []string) {
+				assert.Equal(t, []string{"user"}, result)
+			},
+		},
+		{
+			name: "path with domain validation - non-matching domain",
+			rule: "$.user_info.email/([^@]+)@example\\.com/$1/L",
+			doc:  `{"sub": "user", "user_info": {"name": "User", "email": "user@other.com"}}`,
+			validateFunc: func(t *testing.T, result []string) {
+				assert.Empty(t, result)
+			},
+		},
+		{
+			name: "path with non-string value",
+			rule: "$.age",
+			doc:  `{"sub": "user", "age": 30}`,
+			validateFunc: func(t *testing.T, result []string) {
+				assert.Empty(t, result)
+			},
+		},
+		{
+			name: "multiple matches",
+			rule: "$.emails[*]",
+			doc:  `{"sub": "user", "emails": ["user@example.com", "user@other.com"]}`,
+			validateFunc: func(t *testing.T, result []string) {
+				assert.Equal(t, []string{"user@example.com", "user@other.com"}, result)
+			},
+		},
+		{
+			name: "multiple matches with mapping",
+			rule: "$.emails[*]/([^@]+)@.*/$1",
+			doc:  `{"sub": "user", "emails": ["user1@example.com", "user2@other.com"]}`,
+			validateFunc: func(t *testing.T, result []string) {
+				assert.Equal(t, []string{"user1", "user2"}, result)
+			},
+		},
+		{
+			name: "path not found",
+			rule: "$.missing",
+			doc:  `{"sub": "user", "user_info": {"name": "User"}}`,
+			validateFunc: func(t *testing.T, result []string) {
+				assert.Empty(t, result)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var m MappedJSONPath
+			err := m.UnmarshalText([]byte(tc.rule))
+			require.NoError(t, err, "Failed to unmarshal rule")
+
+			var doc any
+			err = json.Unmarshal([]byte(tc.doc), &doc)
+			require.NoError(t, err, "Failed to unmarshal document")
+
+			result := m.Eval(doc)
+			tc.validateFunc(t, result)
+		})
+	}
+}
+
+func TestMappedJSONPath_E2E_WithRealWorldExamples(t *testing.T) {
+	// Example from the documentation
+	jwtPayload := `{
+		"sub": "user",
+		"user_info": {
+			"name": "User",
+			"email": "user@example.com"
+		}
+	}`
+
+	tests := []struct {
+		name         string
+		rule         string
+		validateFunc func(t *testing.T, result []string)
+	}{
+		{
+			name: "default rule",
+			rule: "$.sub",
+			validateFunc: func(t *testing.T, result []string) {
+				assert.Equal(t, []string{"user"}, result)
+			},
+		},
+		{
+			name: "extract from email",
+			rule: "$.user_info.email/([^@]+)@.*/$1/L",
+			validateFunc: func(t *testing.T, result []string) {
+				assert.Equal(t, []string{"user"}, result)
+			},
+		},
+		{
+			name: "extract with domain validation",
+			rule: "$.user_info.email/([^@]+)@example\\.com/$1/L",
+			validateFunc: func(t *testing.T, result []string) {
+				assert.Equal(t, []string{"user"}, result)
+			},
+		},
+	}
+
+	var doc any
+	err := json.Unmarshal([]byte(jwtPayload), &doc)
+	require.NoError(t, err, "Failed to unmarshal JWT payload")
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var m MappedJSONPath
+			err := m.UnmarshalText([]byte(tc.rule))
+			require.NoError(t, err, "Failed to unmarshal rule")
+
+			result := m.Eval(doc)
+			tc.validateFunc(t, result)
+		})
+	}
+}
+
+func TestMappedJSONPath_E2E_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name         string
+		rule         string
+		doc          string
+		validateFunc func(t *testing.T, result []string, err error)
+	}{
+		{
+			name: "path with dots in field name",
+			rule: `$["field.with.dots"]`, // Using bracket notation instead of escaped dots
+			doc:  `{"field.with.dots": "value"}`,
+			validateFunc: func(t *testing.T, result []string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, []string{"value"}, result)
+			},
+		},
+		{
+			name: "complex nested array path",
+			rule: `$.users[*].contacts[?(@.type=="email")].value`,
+			doc:  `{"users":[{"name":"User1","contacts":[{"type":"email","value":"user1@example.com"},{"type":"phone","value":"123456"}]},{"name":"User2","contacts":[{"type":"email","value":"user2@example.com"}]}]}`,
+			validateFunc: func(t *testing.T, result []string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, []string{"user1@example.com", "user2@example.com"}, result)
+			},
+		},
+		{
+			name: "empty JSON document",
+			rule: "$.field",
+			doc:  `{}`,
+			validateFunc: func(t *testing.T, result []string, err error) {
+				assert.NoError(t, err)
+				assert.Empty(t, result)
+			},
+		},
+		{
+			name: "empty rule",
+			rule: "",
+			doc:  `{"email": "user+alias@example.com"}`,
+			validateFunc: func(t *testing.T, result []string, err error) {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, "empty string is not a valid JSON path")
+				assert.Empty(t, result)
+			},
+		},
+		{
+			name: "null JSON value",
+			rule: "$.nullable",
+			doc:  `{"nullable": null}`,
+			validateFunc: func(t *testing.T, result []string, err error) {
+				assert.NoError(t, err)
+				assert.Empty(t, result)
+			},
+		},
+		{
+			name: "mapping with special regex characters",
+			rule: `$.email/([^@]+)@.*/$1/L`,
+			doc:  `{"email": "user+alias@example.com"}`,
+			validateFunc: func(t *testing.T, result []string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, []string{"user+alias"}, result)
+			},
+		},
+		{
+			name: "regex with plus character as literal",
+			rule: `$.email/user\\+([^@]+)@.*/$1/L`,
+			doc:  `{"email": "user+alias@example.com"}`,
+			validateFunc: func(t *testing.T, result []string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, []string{"alias"}, result)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := NewMappedJSONPath(tc.rule)
+
+			var doc any
+			if err == nil {
+				err = json.Unmarshal([]byte(tc.doc), &doc)
+				require.NoError(t, err, "Failed to unmarshal document")
+
+				result := m.Eval(doc)
+				tc.validateFunc(t, result, err)
+			} else {
+				tc.validateFunc(t, nil, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a new package for a specific JSON path type, that is supposed to match the type used for `oidc_principal_mapping` in Redpanda core. This is a custom implementation on top of JSON path which allows a transform regex as a suffix. 

This is meant to be used for authentication, but may be valid to be used for other usecases as well. If helpful for other applications such as rpk we can move this type/pkg to the common-go repository.

Jira: CONSOLE-175