### PR TITLE
frontend: Fix AI agent pipeline filtering

### DIFF
--- a/frontend/src/react-query/api/agent.tsx
+++ b/frontend/src/react-query/api/agent.tsx
@@ -169,16 +169,26 @@ export const useListAgentsQuery = (
     refetchInterval?: number | false;
   },
 ) => {
+  // Ensure name contains is only used if a string is provided. It has to match the agent name exactly.
+  // We cannot use nameContains for filtering pipeline name because the name of the agent is stored as a tag, not pipeline name.
+  // TODO: Once dedicated "agent service" exists, we can use agentName for that endpoint to filter by agent name.
+  const agentName = input?.filter?.nameContains;
+
+  const listPipelinesRequestFilter = create(ListPipelinesRequest_FilterSchema, {
+    tags: agentName
+      ? {
+          __redpanda_cloud_pipeline_type: 'agent',
+          __redpanda_cloud_agent_name: agentName,
+        }
+      : {
+          __redpanda_cloud_pipeline_type: 'agent',
+        },
+  });
+
   const listPipelinesRequestDataPlane = create(ListPipelinesRequestSchemaDataPlane, {
     pageSize: MAX_PAGE_SIZE,
     pageToken: '',
-    filter: create(ListPipelinesRequest_FilterSchema, {
-      tags: {
-        __redpanda_cloud_pipeline_type: 'agent',
-        // TODO: Ensure this tag can do partial matching of the name
-        __redpanda_cloud_agent_name: input?.filter?.nameContains ?? '',
-      },
-    }),
+    filter: listPipelinesRequestFilter,
   });
 
   const listPipelinesRequest = create(ListPipelinesRequestSchema, {
@@ -201,13 +211,8 @@ export const useListAgentsQuery = (
 
   const allRetrievedPipelines = listAgentsResult?.data?.pages?.flatMap(({ response }) => response?.pipelines);
 
-  // TODO: Remove once tags are properly used for filtering
   const filteredAgentPipelines = allRetrievedPipelines?.filter(
-    (agent) =>
-      agent?.tags?.__redpanda_cloud_pipeline_type === 'agent' &&
-      agent?.tags?.__redpanda_cloud_agent_name
-        ?.toLowerCase()
-        .includes(input?.filter?.nameContains?.toLowerCase() ?? ''),
+    (agent) => agent?.tags?.__redpanda_cloud_pipeline_type === 'agent',
   );
 
   const uniqueAgentIds = [


### PR DESCRIPTION
We were passing the filter with empty string value - previously it did nothing but it was actually meant to be `undefined`.

We cannot filter by name partially because the tags can only be filtered by exact match and the agent name is stored as a tag, not a real pipeline name due to the abstraction living on the frontend. Once we have a dedicated agent service this problem will go away.

This resulted in people seeing this when they created an AI agent.
<img width="1872" alt="Screenshot 2025-05-15 at 19 37 47" src="https://github.com/user-attachments/assets/a06cc1f1-bf82-437d-98fb-c30ade29d1a5" />

Recording with fix
https://github.com/user-attachments/assets/623cba21-5834-4eae-aef4-5e9a96ff8d8b

