### PR TITLE
backend: prevent panic on IncrementalAlterConfigs

### DIFF
--- a/backend/pkg/console/alter_configs.go
+++ b/backend/pkg/console/alter_configs.go
@@ -54,7 +54,7 @@ func (s *Service) IncrementalAlterConfigs(ctx context.Context,
 		errMessage := ""
 		kafkaErr := newKafkaErrorWithDynamicMessage(res.ErrorCode, res.ErrorMessage)
 		if kafkaErr != nil {
-			errMessage = err.Error()
+			errMessage = kafkaErr.Error()
 		}
 		patchedConfigs[i] = IncrementalAlterConfigsResourceResponse{
 			Error:        errMessage,


### PR DESCRIPTION
If the patch failed on one of the resources, we
were failing to use the proper error message
causing an unexpected panic.

Fixes CONSOLE-181