### PR TITLE
Use DefaultToGlobal when retrieving schema registry subject compatibility

### DIFF
--- a/backend/pkg/console/schema_registry.go
+++ b/backend/pkg/console/schema_registry.go
@@ -231,7 +231,7 @@ func (s *Service) GetSchemaRegistrySubjectDetails(ctx context.Context, subjectNa
 
 	grp.Go(func() error {
 		// 2. Retrieve subject config (subject compatibility level)
-		compatibilityRes := srClient.Compatibility(grpCtx, subjectName)
+		compatibilityRes := srClient.Compatibility(sr.WithParams(grpCtx, sr.DefaultToGlobal), subjectName)
 		compatibility := compatibilityRes[0]
 		if err := compatibility.Err; err != nil {
 			s.logger.Warn("failed to get subject config", zap.String("subject", subjectName), zap.Error(err))


### PR DESCRIPTION
After upgrading to version 3, we are seeing excessive log warnings when schema registry subjects do not have subject-level compatibility defined. The warnings look like this:

`{"level":"warn","ts":"2025-05-16T17:41:11.073+0200","msg":"failed to get subject config","subject":"some-topic-v3-value","error":"Subject 'some-topic-v3-value' does not have subject-level compatibility configured"}
{"level":"warn","ts":"2025-05-16T17:41:11.090+0200","msg":"failed to get subject config","subject":"another-topic-v1-key","error":"Subject 'another-topic-v1-key' does not have subject-level compatibility configured"}`

In versions prior to 3, these cases were handled differently: the UI would display "DEFAULT" for such subjects. Starting with version 3, the UI elements remain empty, and these warnings are logged instead.

The schema registry API provides an optional parameter that allows the global compatibility level to be returned when no subject-level compatibility is defined: https://docs.confluent.io/platform/current/schema-registry/develop/api.html#get--config-(string-%20subject)

This pull request adds the optional parameter to the schema registry API call. With this change, the active compatibility level for a subject will be retrieved, falling back to the global compatibility level if no subject-level configuration is defined. 