### PR TITLE
Fix infinite render in SearchBar component

### DIFF
--- a/frontend/src/components/misc/SearchBar.tsx
+++ b/frontend/src/components/misc/SearchBar.tsx
@@ -10,7 +10,7 @@
  */
 
 import { SearchField } from '@redpanda-data/ui';
-import { type IReactionDisposer, autorun } from 'mobx';
+import { type IReactionDisposer, reaction } from 'mobx';
 import { observer } from 'mobx-react';
 import React, { Component } from 'react';
 import { AnimatePresence, MotionSpan, animProps_span_searchResult } from '../../utils/animationProps';
@@ -28,7 +28,7 @@ class SearchBar<TItem> extends Component<{
   placeholderText?: string;
 }> {
   private filteredSource = {} as FilterableDataSource<TItem>;
-  autorunDisposer: IReactionDisposer | undefined = undefined;
+  reactionDisposer: IReactionDisposer | undefined = undefined;
 
   /*
         todo: autocomplete:
@@ -45,9 +45,13 @@ class SearchBar<TItem> extends Component<{
   }
 
   componentDidMount() {
-    this.autorunDisposer = autorun(() => {
-      this.props.onFilteredDataChanged(this.filteredSource.data);
-    });
+    this.reactionDisposer = reaction(
+      // Track the filtered data
+      () => this.filteredSource.data,
+      (filteredData) => {
+        this.props.onFilteredDataChanged(filteredData);
+      }
+    );
   }
 
   onChange(text: string) {
@@ -57,7 +61,7 @@ class SearchBar<TItem> extends Component<{
 
   componentWillUnmount() {
     this.filteredSource.dispose();
-    if (this.autorunDisposer) this.autorunDisposer();
+    if (this.reactionDisposer) this.reactionDisposer();
   }
 
   render() {

--- a/frontend/src/components/routes.tsx
+++ b/frontend/src/components/routes.tsx
@@ -257,7 +257,7 @@ function MakeRoute<TRouteParams>(
   const routeElement = (
     <Route
       path={`${path}${exact ? '' : '/*'}`}
-      key={title}
+      key={path}
       element={
         <ProtectedRoute path={path}>
           <RouteRenderer route={route} />


### PR DESCRIPTION
### Issue
The route /connected-clusters/redpanda contained infinite render loop

To reproduce:
 - run cloudv2 on port 3000
 - Go to http://localhost:3000/clusters/d0e8lbgpojcjpdtep250/connect-clusters/redpanda (or other cluster with connector)
 
### Cause
Caused by issue in the `SearchBar` component - it was reacting to any observable in the reactive context - some other observable being updated probably caused the issue (unsure which one exactly)
 
### Solution
Replaced the mobx's `autorun` in the `SearchBar` component by `reaction` - it does the same but is only triggered when the specified observable changes.