### PR TITLE
proto: add module name to buf.yaml

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -2,6 +2,7 @@ version: v2
 
 modules:
   - path: proto
+    name: buf.build/redpandadata/dataplane
 
 deps:
   - buf.build/bufbuild/protovalidate


### PR DESCRIPTION
The module name is required to push to buf