### PR TITLE
Fix/debezium snapshot mode

### DIFF
--- a/frontend/src/state/connect/state.ts
+++ b/frontend/src/state/connect/state.ts
@@ -503,13 +503,15 @@ export class ConnectorPropertiesStore {
       for (const p of g.properties) {
         if (!p.entry.definition.required) {
           if (p.value === p.entry.definition.default_value) {
+            // Prevent sending configs set to default when the user has not modified them.
+
             // let's ignore the default variable if the value is the same as initially rendered
             // otherwise, user might want to set it back to default
             if (p.value === p.entry.value.value) {
               continue;
             }
-            // let's ignore the variable if the original value is null
-            if (p.entry.value.value === null) {
+            // let's ignore the variable if the original value is null and the config is not present in current set configs values.
+            if (p.entry.value.value === null && !config[p.name]) {
               continue;
             }
           }


### PR DESCRIPTION
This fixes a bug in state.ts:getConfigObject() where default values weren't properly applied
when updating Kafka Connect connector configs.

The issue occurs when:

When the user attempts to reset a property to its default value (e.g., snapshot.mode: always → initial)

When the /validate response from Kafka Connect returns null for the current value of a property

Our logic checks whether the new value is:

Different from the current value (from /validate)

The same as the default value (from config definitions)

However, some properties returned by the /validate endpoint do not include a value field
(or it's explicitly null), even though the connector internally uses a default. As a result,
we incorrectly ignore the update and don't apply the intended default value to the connector.

This commit adjusts the logic to handle missing or null value fields correctly, ensuring the
default is set as expected, by checking if the config with default values is already present
in current memory kafka connect console object


Bug:

https://github.com/user-attachments/assets/c2d9e9ef-b791-4308-a8f7-bbce54ddfa99


Fix:

https://github.com/user-attachments/assets/f5caeef1-52af-4ccb-8025-78a8588b17b2

