### PR TITLE
ci: skip lint/format/breaking on delete runs

### DIFF
--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -78,11 +78,14 @@ jobs:
       - name: Buf – lint, format, breaking, push / archive
         uses: bufbuild/buf-action@v1
         with:
-          # Lint & breaking: PRs only
-          # Format (writes files): push only
-          # Push (publishes / archives): push and delete
+          # By default, breaking checks against the previous commit in the same branch.
+          # If this is the first commit of a new branch, we'll skip the breaking check.
+          #
+          # Push event: lint, format, breaking, push
+          # Push event (create): lint, format, push
+          # Delete event: Push (archive)
           lint: ${{ github.event_name == 'push' }}
           format: ${{ github.event_name == 'push' }}
-          breaking: ${{ github.event_name == 'push' }}
+          breaking: ${{ github.event_name == 'push' && github.event.created == false }}
           push: true
           token: ${{ env.BUF_TOKEN }}


### PR DESCRIPTION
Buf needs a comparison target for breaking; on a
delete event there is no checkout, so the step fails.