### PR TITLE
frontend: enable AI agents in serverless UI 2.8

### DIFF
--- a/frontend/src/components/routes.tsx
+++ b/frontend/src/components/routes.tsx
@@ -358,7 +358,7 @@ export const APP_ROUTES: IRouteEntry[] = [
     true,
     routeVisibility(
       // Do not display agents if feature flag is disabled, or in self-hosted mode or when using Serverless console
-      () => isEmbedded() && !isServerless() && isFeatureFlagEnabled('enableAiAgentsInConsoleUi'), // Needed to pass flags to current routing solution
+      () => isEmbedded() && isFeatureFlagEnabled('enableAiAgentsInConsoleUi'), // Needed to pass flags to current routing solution
       [Feature.PipelineService],
       [],
       [],


### PR DESCRIPTION
Requested by @birdayz to enable testing in serverless

Backporting to 2.8 release, see https://github.com/redpanda-data/console/pull/1790 for 3.0