### PR TITLE
feat: implement TLS certificate reloading for clients

### DIFF
--- a/backend/pkg/api/api.go
+++ b/backend/pkg/api/api.go
@@ -156,7 +156,7 @@ func setDefaultClientProviders(cfg *config.Config, logger *zap.Logger, opts *opt
 	// it will return a NotConfigured connect.Error.
 
 	if opts.schemaClientProvider == nil {
-		schemaClientProvider, err := schemafactory.NewSingleClientProvider(cfg)
+		schemaClientProvider, err := schemafactory.NewSingleClientProvider(cfg, logger.Named("schema_registry"))
 		if err != nil {
 			logger.Fatal("failed to create the schema registry client provider", zap.Error(err))
 		}

--- a/backend/pkg/console/list_messages_integration_test.go
+++ b/backend/pkg/console/list_messages_integration_test.go
@@ -789,7 +789,7 @@ func createNewTestService(t *testing.T, log *zap.Logger,
 	}
 
 	kafkaFactory := kafkafactory.NewCachedClientProvider(&cfg, log)
-	schemaFactory, _ := schema.NewSingleClientProvider(&cfg)
+	schemaFactory, _ := schema.NewSingleClientProvider(&cfg, log)
 	cacheFn := func(ctx context.Context) (string, error) { return "single/", nil }
 
 	svc, err := NewService(&cfg, log, kafkaFactory, schemaFactory, nil, cacheFn, nil)

--- a/backend/pkg/factory/redpanda/single_client.go
+++ b/backend/pkg/factory/redpanda/single_client.go
@@ -49,7 +49,7 @@ func NewSingleClientProvider(cfg *config.Config, l *zap.Logger) (ClientFactory, 
 }
 
 // GetRedpandaAPIClient returns a redpanda admin api for the given context.
-func (p *SingleClientProvider) GetRedpandaAPIClient(ctx context.Context, opts ...ClientOption) (AdminAPIClient, error) {
+func (p *SingleClientProvider) GetRedpandaAPIClient(_ context.Context, opts ...ClientOption) (AdminAPIClient, error) {
 	cfg := &ClientOptions{
 		URLs: p.cfg.URLs,
 	}
@@ -70,7 +70,6 @@ func (p *SingleClientProvider) GetRedpandaAPIClient(ctx context.Context, opts ..
 
 	// Build admin client with provided credentials with reloader
 	tlsCfg, err := p.cfg.TLS.TLSConfigWithReloader(
-		ctx,
 		p.logger,
 		hostname,
 	)

--- a/backend/pkg/serde/avro_test.go
+++ b/backend/pkg/serde/avro_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sr"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/redpanda-data/console/backend/pkg/config"
 	schemafactory "github.com/redpanda-data/console/backend/pkg/factory/schema"
@@ -126,7 +127,7 @@ func TestAvroSerde_DeserializePayload(t *testing.T) {
 			Enabled: true,
 			URLs:    []string{ts.URL},
 		},
-	})
+	}, zaptest.NewLogger(t))
 	require.NoError(t, err)
 	schemaCachedClient, err := schema.NewCachedClient(singleClientProvider, func(context.Context) (string, error) {
 		return "single/", nil
@@ -306,7 +307,7 @@ func TestAvroSerde_SerializeObject(t *testing.T) {
 			Enabled: true,
 			URLs:    []string{ts.URL},
 		},
-	})
+	}, zaptest.NewLogger(t))
 	require.NoError(t, err)
 	schemaCachedClient, err := schema.NewCachedClient(singleClientProvider, func(context.Context) (string, error) {
 		return "single/", nil

--- a/backend/pkg/serde/json_schema_test.go
+++ b/backend/pkg/serde/json_schema_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sr"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/redpanda-data/console/backend/pkg/config"
 	schemafactory "github.com/redpanda-data/console/backend/pkg/factory/schema"
@@ -271,7 +272,7 @@ func TestJsonSchemaSerde_SerializeObject(t *testing.T) {
 			Enabled: true,
 			URLs:    []string{ts.URL},
 		},
-	})
+	}, zaptest.NewLogger(t))
 	require.NoError(t, err)
 	schemaCachedClient, err := schema.NewCachedClient(singleClientProvider, func(context.Context) (string, error) {
 		return "single/", nil

--- a/backend/pkg/serde/protobuf_schema_test.go
+++ b/backend/pkg/serde/protobuf_schema_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sr"
+	"go.uber.org/zap/zaptest"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -167,7 +168,7 @@ func TestProtobufSchemaSerde_DeserializePayload(t *testing.T) {
 			Enabled: true,
 			URLs:    []string{ts.URL},
 		},
-	})
+	}, zaptest.NewLogger(t))
 	require.NoError(t, err)
 	schemaCachedClient, err := schema.NewCachedClient(singleClientProvider, func(context.Context) (string, error) {
 		return "single/", nil
@@ -359,7 +360,7 @@ func TestProtobufSchemaSerde_SerializeObject(t *testing.T) {
 			Enabled: true,
 			URLs:    []string{ts.URL},
 		},
-	})
+	}, zaptest.NewLogger(t))
 	require.NoError(t, err)
 	schemaCachedClient, err := schema.NewCachedClient(singleClientProvider, func(context.Context) (string, error) {
 		return "single/", nil

--- a/backend/pkg/serde/service_integration_test.go
+++ b/backend/pkg/serde/service_integration_test.go
@@ -162,7 +162,7 @@ func (s *SerdeIntegrationTestSuite) TestDeserializeRecord() {
 	mspPackSvc, err := ms.NewService(cfg.Serde.MessagePack)
 	require.NoError(err)
 
-	schemaClientFactory, err := schemafactory.NewSingleClientProvider(&cfg)
+	schemaClientFactory, err := schemafactory.NewSingleClientProvider(&cfg, logger)
 	require.NoError(err)
 
 	cacheNamespaceFn := func(context.Context) (string, error) {
@@ -2167,7 +2167,7 @@ func (s *SerdeIntegrationTestSuite) TestDeserializeRecord() {
 		err = protoSvc.Start()
 		require.NoError(err)
 
-		schemaClientFactory2, err := schemafactory.NewSingleClientProvider(&cfg)
+		schemaClientFactory2, err := schemafactory.NewSingleClientProvider(&cfg, logger)
 		require.NoError(err)
 
 		cacheNamespaceFn := func(context.Context) (string, error) {
@@ -2576,7 +2576,7 @@ func (s *SerdeIntegrationTestSuite) TestDeserializeRecord() {
 		mspPackSvc, err := ms.NewService(cfg.Serde.MessagePack)
 		require.NoError(err)
 
-		schemaClientFactory, err := schemafactory.NewSingleClientProvider(&cfg)
+		schemaClientFactory, err := schemafactory.NewSingleClientProvider(&cfg, logger)
 		require.NoError(err)
 
 		cacheNamespaceFn := func(context.Context) (string, error) {
@@ -2809,7 +2809,10 @@ func (s *SerdeIntegrationTestSuite) TestDeserializeRecord() {
 		disabledCfg := s.createBaseConfig()
 		disabledCfg.SchemaRegistry.Enabled = false // Key: disable schema registry!
 
-		schemaClientFactory, err := schemafactory.NewSingleClientProvider(&disabledCfg)
+		logger, err := zap.NewProduction()
+		require.NoError(err)
+
+		schemaClientFactory, err := schemafactory.NewSingleClientProvider(&disabledCfg, logger)
 		require.NoError(err)
 
 		cacheNamespaceFn := func(context.Context) (string, error) {

--- a/backend/pkg/tls/ca_test.go
+++ b/backend/pkg/tls/ca_test.go
@@ -28,7 +28,8 @@ func TestMaybeWithDynamicClientCA(t *testing.T) {
 	defer os.RemoveAll(testSetup.TmpDir)
 
 	t.Run("empty CA path returns nil", func(t *testing.T) {
-		ctx := context.Background()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		cfg := &tls.Config{}
 
 		configFunc := MaybeWithDynamicClientCA(ctx, "", "localhost", 5*time.Minute, testSetup.Logger)
@@ -37,7 +38,8 @@ func TestMaybeWithDynamicClientCA(t *testing.T) {
 	})
 
 	t.Run("valid CA path configures TLS", func(t *testing.T) {
-		ctx := context.Background()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		cfg := &tls.Config{}
 
 		configFunc := MaybeWithDynamicClientCA(ctx, testSetup.CAPath, "localhost", 5*time.Minute, testSetup.Logger)
@@ -53,7 +55,8 @@ func TestMaybeWithDynamicClientCA(t *testing.T) {
 	})
 
 	t.Run("non-existent CA path returns error", func(t *testing.T) {
-		ctx := context.Background()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		cfg := &tls.Config{}
 		nonExistentPath := filepath.Join(testSetup.TmpDir, "nonexistent.crt")
 

--- a/backend/pkg/tls/keypair_test.go
+++ b/backend/pkg/tls/keypair_test.go
@@ -28,7 +28,8 @@ func TestMaybeWithDynamicDiskKeyPair(t *testing.T) {
 	defer os.RemoveAll(testSetup.TmpDir)
 
 	t.Run("empty paths return nil", func(t *testing.T) {
-		ctx := context.Background()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		cfg := &tls.Config{}
 
 		configFunc := MaybeWithDynamicDiskKeyPair(ctx, "", "", tlscfg.ForServer, 5*time.Minute, testSetup.Logger)
@@ -40,7 +41,8 @@ func TestMaybeWithDynamicDiskKeyPair(t *testing.T) {
 	})
 
 	t.Run("server certificate is loaded", func(t *testing.T) {
-		ctx := context.Background()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		cfg := &tls.Config{}
 
 		configFunc := MaybeWithDynamicDiskKeyPair(ctx, testSetup.CertPath, testSetup.KeyPath, tlscfg.ForServer, 5*time.Minute, testSetup.Logger)
@@ -57,7 +59,8 @@ func TestMaybeWithDynamicDiskKeyPair(t *testing.T) {
 	})
 
 	t.Run("client certificate is loaded", func(t *testing.T) {
-		ctx := context.Background()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		cfg := &tls.Config{}
 
 		configFunc := MaybeWithDynamicDiskKeyPair(ctx, testSetup.CertPath, testSetup.KeyPath, tlscfg.ForClient, 5*time.Minute, testSetup.Logger)


### PR DESCRIPTION
Add automatic TLS certificate reloading capability for Kafka and Schema Registry clients. This makes clients reload certificates when they change on disk.

- Update single client providers to create clients on demand
- Add TLSConfigWithReloader usage for dynamic certificate loading
- Extract hostnames from connection URLs for proper certificate validation
- Pass logger to relevant components for certificate reload logging