### PR TITLE
backend: fix topic deletion for Kafka API v6+ compatibility

### DIFF
--- a/backend/pkg/console/delete_topic.go
+++ b/backend/pkg/console/delete_topic.go
@@ -30,6 +30,11 @@ func (s *Service) DeleteTopic(ctx context.Context, topicName string) *rest.Error
 
 	req := kmsg.NewDeleteTopicsRequest()
 	req.TopicNames = []string{topicName}
+	req.Topics = []kmsg.DeleteTopicsRequestTopic{
+		{
+			Topic: kmsg.StringPtr(topicName),
+		},
+	}
 	req.TimeoutMillis = 30 * 1000 // 30s
 
 	res, err := req.RequestWith(ctx, cl)


### PR DESCRIPTION
## Summary
- Add Topics field to DeleteTopicsRequest for Kafka API v6+ compatibility
- Fixes "No topics set in the response" error for serverless customers
- Ensures compatibility with both v5 (TopicNames) and v6+ (Topics) formats