### PR TITLE
workflows: fix buf workflow delete event handling

### DIFF
--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -50,6 +50,7 @@ jobs:
           lint: true
           format: true
           breaking: true
+          push: false  # Only validate, don't push to registry
           # Compare against the default branch so the whole PR is checked
           breaking_against: https://github.com/redpanda-data/console.git#branch=master
 

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -2,9 +2,9 @@
 # ---------------------------------------------------------------------------
 # Buf CI
 # ---------------------------------------------------------------------------
-# 1. push -> full lint / format / breaking / push to the Buf registry
-# 2. pull_request -> lint + breaking checks (no secrets, safe for forks)
-# 3. delete -> archive the corresponding label in the registry when a branch or tag is deleted
+# 1. validate -> lint + format + breaking checks (runs on both push & pull_request)
+# 2. push-to-registry -> push to Buf registry only (runs after validation passes)
+# 3. archive-label -> archive label in registry when branch/tag deleted (with error handling)
 # ---------------------------------------------------------------------------
 name: Buf CI
 
@@ -36,32 +36,33 @@ permissions:
   id-token: write         # OIDC to assume AWS role (push job)
 
 # ===========================================================================
-# Job: lint-and-breaking (pull_request only)
+# Job: validate (both push and pull_request - comprehensive validation)
 # ===========================================================================
 jobs:
-  lint-and-breaking:
-    if: github.event_name == 'pull_request'
+  validate:
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Buf – lint & breaking
+      - name: Buf – lint, format & breaking
         uses: bufbuild/buf-action@v1
         with:
           lint: true
+          format: true
           breaking: true
           # Compare against the default branch so the whole PR is checked
           breaking_against: https://github.com/redpanda-data/console.git#branch=master
 
   # ===========================================================================
-  # Job: push-module (push & delete in canonical repo)
+  # Job: push-to-registry (push events only - registry operations only)
   # ===========================================================================
-  push-module:
+  push-to-registry:
     if: |
-      github.event_name != 'pull_request' &&
+      github.event_name == 'push' &&
       github.repository == 'redpanda-data/console'
+    needs: validate  # Only run after validation passes
     runs-on: ubuntu-latest
     steps:
-      # AWS credentials (only needed here because this job pushes)
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
@@ -75,17 +76,44 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Buf – lint, format, breaking, push / archive
+      - name: Buf – push to registry
         uses: bufbuild/buf-action@v1
         with:
-          # By default, breaking checks against the previous commit in the same branch.
-          # If this is the first commit of a new branch, we'll skip the breaking check.
-          #
-          # Push event: lint, format, breaking, push
-          # Push event (create): lint, format, push
-          # Delete event: Push (archive)
-          lint: ${{ github.event_name == 'push' }}
-          format: ${{ github.event_name == 'push' }}
-          breaking: ${{ github.event_name == 'push' && github.event.created == false }}
+          # No validation - already done in validate job
+          lint: false
+          format: false
+          breaking: false
+          # Only push to registry
           push: true
           token: ${{ env.BUF_TOKEN }}
+
+  # ===========================================================================
+  # Job: archive-label (delete events only - with error handling)
+  # ===========================================================================
+  archive-label:
+    if: |
+      github.event_name == 'delete' &&
+      github.repository == 'redpanda-data/console'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ,sdlc/prod/github/buf_token
+          parse-json-secrets: true
+
+      - uses: actions/checkout@v4
+
+      - name: Buf – archive label (ignore if not found)
+        uses: bufbuild/buf-action@v1
+        with:
+          # Only archive - no other operations
+          push: true
+          token: ${{ env.BUF_TOKEN }}
+        # Don't fail the workflow if label doesn't exist
+        continue-on-error: true


### PR DESCRIPTION
## Summary
- Restructure buf workflow to eliminate redundant validation
- Fix delete event failures when archiving non-existent labels
- Add error handling for archive operations with continue-on-error
- Split validation and registry operations into focused jobs

## Root Cause
Auto-deleted branches triggered delete events that tried to archive buf labels that were never created (e.g., frontend-only changes), causing workflow failures.

## Changes
- `validate` job: runs on both push and pull_request events
- `push-to-registry` job: only handles registry push after validation passes
- `archive-label` job: handles delete events with graceful error handling
- Eliminates redundant linting between PR and push workflows