### PR TITLE
feat(api): add user agent tracking

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/ohler55/ojg v1.26.6
 	github.com/prometheus/client_golang v1.22.0
 	github.com/redpanda-data/benthos/v4 v4.53.0
-	github.com/redpanda-data/common-go/api v0.0.0-20250520173735-a6ab5e2bd434
+	github.com/redpanda-data/common-go/api v0.0.0-20250625225352-8eb9dea0ac01
 	github.com/redpanda-data/common-go/net v0.1.1-0.20240429123545-4da3d2b371f7
 	github.com/redpanda-data/common-go/rpadmin v0.1.14
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -517,6 +517,8 @@ github.com/redpanda-data/common-go/api v0.0.0-20241213223629-113b96483733 h1:hiJ
 github.com/redpanda-data/common-go/api v0.0.0-20241213223629-113b96483733/go.mod h1:klAmWfc8Q3hEZk8geFTMu6f2sk3VUKRS7cv/LvB05ig=
 github.com/redpanda-data/common-go/api v0.0.0-20250520173735-a6ab5e2bd434 h1:1/ndAayXoHTaL/Z2sosVTuHkX7qHkI8VG5OSNnwuSrU=
 github.com/redpanda-data/common-go/api v0.0.0-20250520173735-a6ab5e2bd434/go.mod h1:klAmWfc8Q3hEZk8geFTMu6f2sk3VUKRS7cv/LvB05ig=
+github.com/redpanda-data/common-go/api v0.0.0-20250625225352-8eb9dea0ac01 h1:akK8Urp2+4iuFkeSeHcEhA1hTIIiXtcDtpb74tyzCQ4=
+github.com/redpanda-data/common-go/api v0.0.0-20250625225352-8eb9dea0ac01/go.mod h1:wwoP8aiTYS9/nqljzjxWoIuTWCMqNAn9oakuVxlaOwM=
 github.com/redpanda-data/common-go/net v0.1.1-0.20240429123545-4da3d2b371f7 h1:MXLdjFdFjOtyuUR4TdVVsqFP8xnru2YDwzH9bJTUr1M=
 github.com/redpanda-data/common-go/net v0.1.1-0.20240429123545-4da3d2b371f7/go.mod h1:UJIi/yUxGOBYXUrfUsOkxfYxcb/ll7mZrwae/i+U2kc=
 github.com/redpanda-data/common-go/rpadmin v0.1.12 h1:po35y++/K+C+WIsga1Ps4/S5QvDBHHO4uGjGDR+X9dI=


### PR DESCRIPTION
Integrate the user agent tracking middleware from common-go library to extract and use user agent information in API requests. This adds:

- User agent middleware in HTTP request pipeline
- User agent info extraction in metrics reporting
- Update common-go/api dependency to latest version

Related to: #UX-161