### PR TITLE
frontend: Remove React requiredVersion

### DIFF
--- a/frontend/module-federation.js
+++ b/frontend/module-federation.js
@@ -8,22 +8,18 @@ module.exports = {
     './EmbeddedApp': './src/EmbeddedApp.tsx',
     './injectApp': './src/injectApp.tsx',
     './config': './src/config.ts',
-    './newReact': require.resolve('react'),
-    './newReactDOM': require.resolve('react-dom'),
   },
 
-  shared: [
-    'react-dom',
-    {
-      react: {
-        import: 'react', // the "react" package will be used a provided and fallback module
-        shareKey: 'newReact', // under this name the shared module will be placed in the share scope
-        shareScope: 'modern', // share scope with this name will be used
-        singleton: true, // only a single version of the shared module is allowed
-      },
-      '@redpanda-data/ui': {
-        import: '@redpanda-data/ui',
-      },
+  shared: {
+    react: {
+      singleton: true,
     },
-  ],
+    'react-dom': {
+      singleton: true,
+    },
+    '@redpanda-data/ui': {
+      singleton: true,
+      requiredVersion: deps['@redpanda-data/ui'],
+    },
+  },
 };


### PR DESCRIPTION
Required for React 19 upgrade to have smooth transition. This way we should be able to use both React 18 and 19 at the same time across Cloud + Console and different clusters (serverless installpack vs regular)

Similar to https://github.com/redpanda-data/cloudv2/pull/22639