### PR TITLE
frontend: adjust requiredVersion to allow react 18 + 19

### DIFF
--- a/frontend/module-federation.js
+++ b/frontend/module-federation.js
@@ -1,5 +1,3 @@
-const deps = require('./package.json').dependencies;
-
 module.exports = {
   filename: 'embedded.js',
   name: 'rp_console',
@@ -13,13 +11,11 @@ module.exports = {
   shared: {
     react: {
       singleton: true,
+      requiredVersion: '>=18.0.0 <20.0.0',
     },
     'react-dom': {
       singleton: true,
-    },
-    '@redpanda-data/ui': {
-      singleton: true,
-      requiredVersion: deps['@redpanda-data/ui'],
+      requiredVersion: '>=18.0.0 <20.0.0',
     },
   },
 };


### PR DESCRIPTION
We want to make console less strict and allow for both react 18 and 19.

https://www.angulararchitects.io/en/blog/getting-out-of-version-mismatch-hell-with-module-federation/