### PR TITLE
fix: Resolve Avro Schema Reference caching

### DIFF
--- a/backend/pkg/schema/client.go
+++ b/backend/pkg/schema/client.go
@@ -278,7 +278,7 @@ func (c *CachedClient) CompileProtoSchemaWithReferences(
 // error will be returned.
 func (c *CachedClient) ParseAvroSchemaWithReferences(ctx context.Context, schema sr.Schema, schemaCache *avro.SchemaCache) (avro.Schema, error) {
 	if len(schema.References) == 0 {
-		return avro.Parse(schema.Schema)
+		return avro.ParseWithCache(schema.Schema, "", schemaCache)
 	}
 
 	// Fetch and parse all schema references recursively. All schemas that have


### PR DESCRIPTION
The Avro parser was failing to resolve schema references because the recursive parsing function was not using the shared cache for schemas that had no references themselves. When a schema with no reference was checked, it would use Parse, which would not use the existing cache, but create a temp new one. Using the ParseWithCache resolved this by making sure it was using the existing cache even if the schema it was parsing had no references itself.
