### PR TITLE
backend: add slog-based logger package to replace zap

### DIFF
--- a/backend/.golangci.yaml
+++ b/backend/.golangci.yaml
@@ -80,7 +80,7 @@ linters:
       attr-only: true
       no-global: all
       context: all
-      msgstyle: lowercased
+      msg-style: lowercased
       key-naming-case: snake
       forbidden-keys:
         - time

--- a/backend/.golangci.yaml
+++ b/backend/.golangci.yaml
@@ -33,6 +33,7 @@ linters:
     - reassign
     - revive
     - rowserrcheck
+    - sloglint
     - sqlclosecheck
     - staticcheck
     - unconvert
@@ -75,6 +76,18 @@ linters:
       require-explanation: true
       require-specific: true
       allow-unused: false
+    sloglint:
+      attr-only: true
+      no-global: all
+      context: all
+      msgstyle: lowercased
+      key-naming-case: snake
+      forbidden-keys:
+        - time
+        - level
+        - msg
+        - source
+        - err # Use "error"
     revive:
       confidence: 0.7
       severity: warning
@@ -129,6 +142,8 @@ linters:
           - bodyclose
           - goconst
           - gosec
+          - noctx
+          - sloglint
           - staticcheck
         path: (.+)_test.go
       - linters:

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -155,6 +155,7 @@ require (
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/knadh/koanf/maps v0.1.2 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20250317134145-8bc96cf8fc35 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect

--- a/backend/pkg/logger/example_test.go
+++ b/backend/pkg/logger/example_test.go
@@ -1,0 +1,253 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package logger_test
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/redpanda-data/console/backend/pkg/logger"
+)
+
+type contextKey string
+
+// Example demonstrates basic usage of the logger package.
+func Example() {
+	// Create a simple logger
+	log := logger.NewSlogLogger(
+		logger.WithLevel(slog.LevelInfo),
+	)
+
+	ctx := context.Background()
+	log.InfoContext(ctx, "application started", slog.String("version", "1.0.0"))
+}
+
+// Example_withPrometheus demonstrates using the logger with Prometheus metrics.
+func Example_withPrometheus() {
+	// Create a Prometheus registry
+	registry := prometheus.NewRegistry()
+
+	// Create logger with Prometheus metrics
+	log := logger.NewSlogLogger(
+		logger.WithLevel(slog.LevelInfo),
+		logger.WithPrometheusRegistry(registry),
+	)
+
+	ctx := context.Background()
+	log.InfoContext(ctx, "server started", slog.Int("port", 8080))
+	log.ErrorContext(ctx, "connection failed", slog.String("err", "timeout"))
+
+	// The Prometheus registry now contains metrics about log messages
+}
+
+// Example_withContext demonstrates context-aware logging using structured attributes.
+func Example_withContext() {
+	// Create logger
+	log := logger.NewSlogLogger(
+		logger.WithLevel(slog.LevelInfo),
+	)
+
+	// Create context and log with structured attributes
+	ctx := context.Background()
+
+	// Log message with context-related attributes
+	log.InfoContext(ctx, "user action performed",
+		slog.String("action", "update_profile"),
+		slog.String("request_id", "req-123"),
+		slog.String("user_id", "user-456"),
+	)
+}
+
+// Example_enterprise demonstrates how to add custom handlers for enterprise features.
+func Example_enterprise() {
+	// Custom handler that adds authentication info
+	authHandler := func(next slog.Handler) slog.Handler {
+		return &customAuthHandler{next: next}
+	}
+
+	// Create logger with custom handler
+	log := logger.NewSlogLogger(
+		logger.WithLevel(slog.LevelInfo),
+		logger.WithHandler(authHandler),
+	)
+
+	ctx := context.Background()
+
+	log.InfoContext(ctx, "audit event",
+		slog.String("resource", "topic"),
+		slog.String("action", "created"),
+		slog.String("org_id", "org-789"),
+	)
+}
+
+// Example_structured demonstrates structured logging with various field types.
+func Example_structured() {
+	log := logger.NewSlogLogger()
+
+	ctx := context.Background()
+
+	// Log with various field types
+	log.InfoContext(ctx, "processing complete",
+		slog.Int("duration_ms", 250),
+		slog.Int("items_processed", 1000),
+		slog.Float64("success_rate", 0.98),
+		slog.Any("metadata", map[string]any{
+			"source":    "kafka",
+			"partition": 3,
+		}),
+		slog.Any("tags", []string{"batch", "async"}),
+	)
+}
+
+// Example_withDefaultAttrs demonstrates setting default attributes for all log entries.
+func Example_withDefaultAttrs() {
+	log := logger.NewSlogLogger(
+		logger.WithDefaultAttrs(
+			slog.String("service", "redpanda-console"),
+			slog.String("environment", "production"),
+			slog.String("region", "us-west-2"),
+		),
+	)
+
+	ctx := context.Background()
+
+	// These logs will all include the default fields
+	log.InfoContext(ctx, "cache miss", slog.String("key", "user:123"))
+	log.WarnContext(ctx, "slow query", slog.Int("duration_ms", 500))
+}
+
+// Example_withMode demonstrates different log modes.
+func Example_withMode() {
+	// JSON mode - structured output for production
+	jsonLogger := logger.NewSlogLogger(
+		logger.WithFormat(logger.FormatJSON),
+		logger.WithLevel(slog.LevelInfo),
+	)
+
+	// Text mode - human-readable output for development
+	textLogger := logger.NewSlogLogger(
+		logger.WithFormat(logger.FormatText),
+		logger.WithLevel(slog.LevelInfo),
+	)
+
+	// Auto mode - smart detection based on environment
+	autoLogger := logger.NewSlogLogger(
+		logger.WithLevel(slog.LevelInfo),
+		// Default behavior auto-detects mode based on environment
+	)
+
+	ctx := context.Background()
+
+	// JSON output: {"time":"...","level":"INFO","msg":"server started","port":8080}
+	jsonLogger.InfoContext(ctx, "server started", slog.Int("port", 8080))
+
+	// Text output: time=2023-01-01T12:00:00Z level=INFO msg="server started" port=8080
+	textLogger.InfoContext(ctx, "server started", slog.Int("port", 8080))
+
+	// Auto mode: JSON in production, text in development
+	autoLogger.InfoContext(ctx, "server started", slog.Int("port", 8080))
+}
+
+// Example_productionConfiguration demonstrates a typical production setup.
+func Example_productionConfiguration() {
+	// Production logger: JSON mode, info level, with metrics
+	registry := prometheus.NewRegistry()
+
+	log := logger.NewSlogLogger(
+		logger.WithFormat(logger.FormatJSON),
+		logger.WithLevel(slog.LevelInfo),
+		logger.WithPrometheusRegistry(registry),
+		logger.WithDefaultAttrs(
+			slog.String("service", "redpanda-console"),
+			slog.String("version", "1.0.0"),
+			slog.String("environment", "production"),
+		),
+	)
+
+	log.Info("service started successfully")
+	log.Error("connection failed", slog.String("err", "timeout"), slog.Int("retry_count", 3))
+}
+
+// Example_developmentConfiguration demonstrates a typical development setup.
+func Example_developmentConfiguration() {
+	// Development logger: text mode, debug level
+	log := logger.NewSlogLogger(
+		logger.WithFormat(logger.FormatText),
+		logger.WithLevel(slog.LevelDebug),
+		logger.WithDefaultAttrs(
+			slog.String("service", "redpanda-console"),
+			slog.String("version", "dev"),
+		),
+	)
+
+	ctx := context.Background()
+	log.DebugContext(ctx, "starting development server")
+	log.InfoContext(ctx, "connected to local kafka", slog.String("brokers", "localhost:9092"))
+	log.WarnContext(ctx, "using development configuration")
+}
+
+// Example_timestampFormats demonstrates different timestamp formatting options.
+func Example_timestampFormats() {
+	ctx := context.Background()
+
+	// RFC3339 format (ISO 8601) - using standard time package constant
+	rfc3339Logger := logger.NewSlogLogger(
+		logger.WithFormat(logger.FormatJSON),
+		logger.WithTimestampFormat(time.RFC3339),
+	)
+	rfc3339Logger.InfoContext(ctx, "Using RFC3339 format", slog.String("service", "api"))
+
+	// Human-readable datetime format - using standard time package constant
+	dateTimeLogger := logger.NewSlogLogger(
+		logger.WithFormat(logger.FormatJSON),
+		logger.WithTimestampFormat(time.DateTime),
+	)
+	dateTimeLogger.InfoContext(ctx, "Using datetime format", slog.String("service", "api"))
+
+	// Custom format - date only
+	customLogger := logger.NewSlogLogger(
+		logger.WithFormat(logger.FormatJSON),
+		logger.WithTimestampFormat("2006-01-02"),
+	)
+	customLogger.InfoContext(ctx, "Using custom format", slog.String("service", "api"))
+
+	// Output (approximate):
+	// {"time":"2023-12-25T14:30:45Z","level":"INFO","msg":"Using RFC3339 format","service":"api"}
+	// {"time":"2023-12-25 14:30:45","level":"INFO","msg":"Using datetime format","service":"api"}
+	// {"time":"2023-12-25","level":"INFO","msg":"Using custom format","service":"api"}
+}
+
+// customAuthHandler is an example of a custom handler for enterprise features
+type customAuthHandler struct {
+	next slog.Handler
+}
+
+func (h *customAuthHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.next.Enabled(ctx, level)
+}
+
+func (h *customAuthHandler) Handle(ctx context.Context, record slog.Record) error {
+	// Extract auth info from context and add to record
+	if authInfo := ctx.Value(contextKey("auth_info")); authInfo != nil {
+		record.AddAttrs(slog.Any("auth", authInfo))
+	}
+	return h.next.Handle(ctx, record)
+}
+
+func (h *customAuthHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &customAuthHandler{next: h.next.WithAttrs(attrs)}
+}
+
+func (h *customAuthHandler) WithGroup(name string) slog.Handler {
+	return &customAuthHandler{next: h.next.WithGroup(name)}
+}

--- a/backend/pkg/logger/logger.go
+++ b/backend/pkg/logger/logger.go
@@ -1,0 +1,123 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// Package logger provides a structured logging interface based on Go's slog package.
+// It supports Prometheus metrics integration, context-aware logging, and extensibility
+// through custom handlers.
+package logger
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"time"
+)
+
+// NewSlogLogger creates a new slog.Logger with the provided options.
+// This function configures handlers, output, level, and other settings,
+// then returns a standard slog.Logger ready for use.
+//
+// Options are applied in the order provided; later options override earlier ones.
+// For example, WithLevel(slog.LevelDebug) followed by WithLevel(slog.LevelInfo)
+// will result in a logger with Info level.
+func NewSlogLogger(opts ...Option) *slog.Logger {
+	cfg := &config{
+		level:      slog.LevelInfo,
+		output:     os.Stdout,
+		attributes: []slog.Attr{},
+		format:     FormatJSON,
+	}
+
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	// Create the appropriate handler based on format configuration
+	handler := createHandler(cfg)
+
+	// Build handler chain - handlers run in the order they were added
+	// Apply handlers in reverse order so the first added handler is the outermost
+	for i := len(cfg.handlers) - 1; i >= 0; i-- {
+		handler = cfg.handlers[i](handler)
+	}
+
+	// Add default attributes if any
+	if len(cfg.attributes) > 0 {
+		handler = handler.WithAttrs(cfg.attributes)
+	}
+
+	return slog.New(handler)
+}
+
+// Format represents the logging output format.
+type Format int8
+
+const (
+	// FormatJSON outputs structured JSON logs, ideal for production environments
+	FormatJSON Format = iota
+	// FormatText outputs human-readable text logs, ideal for development
+	FormatText
+)
+
+// HandlerFunc is a function that wraps a slog.Handler to add functionality.
+// Handlers are applied in the order they are added, so the first handler
+// added will be the first to process log records.
+//
+// This follows the middleware pattern commonly used in Go (similar to HTTP middleware).
+// Each HandlerFunc receives the next handler in the chain and returns a new handler
+// that can modify the behavior before/after calling the next handler.
+type HandlerFunc func(slog.Handler) slog.Handler
+
+// config holds the configuration for creating a new logger.
+type config struct {
+	level           slog.Level
+	output          io.Writer
+	handlers        []HandlerFunc
+	attributes      []slog.Attr
+	format          Format
+	timestampFormat string // empty means default slog format
+}
+
+// createHandler creates the appropriate slog.Handler based on the configuration.
+func createHandler(cfg *config) slog.Handler {
+	handlerOpts := &slog.HandlerOptions{
+		Level: cfg.level,
+	}
+
+	// If custom timestamp format is specified, use ReplaceAttr to customize the time field
+	if cfg.timestampFormat != "" {
+		handlerOpts.ReplaceAttr = func(_ []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey {
+				return formatTimestamp(a, cfg.timestampFormat)
+			}
+			return a
+		}
+	}
+
+	// Create handler based on format
+	switch cfg.format {
+	case FormatText:
+		return slog.NewTextHandler(cfg.output, handlerOpts)
+	case FormatJSON:
+		return slog.NewJSONHandler(cfg.output, handlerOpts)
+	default:
+		return slog.NewJSONHandler(cfg.output, handlerOpts)
+	}
+}
+
+// formatTimestamp formats a time attribute according to the specified format.
+func formatTimestamp(attr slog.Attr, format string) slog.Attr {
+	t, ok := attr.Value.Any().(time.Time)
+	if !ok {
+		return attr // Return original if not a time
+	}
+
+	// Use the format as a time layout string
+	return slog.String(slog.TimeKey, t.Format(format))
+}

--- a/backend/pkg/logger/logger_test.go
+++ b/backend/pkg/logger/logger_test.go
@@ -1,0 +1,347 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package logger
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSlogLogger(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    []Option
+		wantErr bool
+	}{
+		{
+			name: "default logger",
+			opts: nil,
+		},
+		{
+			name: "with debug level",
+			opts: []Option{WithLevel(slog.LevelDebug)},
+		},
+		{
+			name: "with custom output",
+			opts: []Option{WithOutput(&bytes.Buffer{})},
+		},
+		{
+			name: "with default attributes",
+			opts: []Option{
+				WithDefaultAttrs(
+					slog.String("service", "test"),
+					slog.String("version", "1.0.0"),
+				),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := NewSlogLogger(tt.opts...)
+			assert.NotNil(t, logger)
+		})
+	}
+}
+
+func TestLoggerMethods(t *testing.T) {
+	tests := []struct {
+		name     string
+		logFunc  func(*slog.Logger, context.Context, string, ...any)
+		level    string
+		expected string
+	}{
+		{
+			name:     "debug",
+			logFunc:  (*slog.Logger).DebugContext,
+			level:    "debug",
+			expected: "DEBUG",
+		},
+		{
+			name:     "info",
+			logFunc:  (*slog.Logger).InfoContext,
+			level:    "info",
+			expected: "INFO",
+		},
+		{
+			name:     "warn",
+			logFunc:  (*slog.Logger).WarnContext,
+			level:    "warn",
+			expected: "WARN",
+		},
+		{
+			name:     "error",
+			logFunc:  (*slog.Logger).ErrorContext,
+			level:    "error",
+			expected: "ERROR",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := NewSlogLogger(
+				WithOutput(&buf),
+				WithFormat(FormatJSON),     // Explicitly use JSON mode for predictable output
+				WithLevel(slog.LevelDebug), // Set to debug to capture all levels
+			)
+
+			tt.logFunc(logger, t.Context(), "test message", slog.String("key", "value"))
+
+			output := buf.String()
+			assert.Contains(t, output, "test message")
+			assert.Contains(t, output, `"key":"value"`)
+			assert.Contains(t, output, tt.expected)
+		})
+	}
+}
+
+func TestWithLevel(t *testing.T) {
+	tests := []struct {
+		name      string
+		level     slog.Level
+		shouldLog map[string]bool
+	}{
+		{
+			name:  "debug level logs all",
+			level: slog.LevelDebug,
+			shouldLog: map[string]bool{
+				"debug": true,
+				"info":  true,
+				"warn":  true,
+				"error": true,
+			},
+		},
+		{
+			name:  "info level",
+			level: slog.LevelInfo,
+			shouldLog: map[string]bool{
+				"debug": false,
+				"info":  true,
+				"warn":  true,
+				"error": true,
+			},
+		},
+		{
+			name:  "warn level",
+			level: slog.LevelWarn,
+			shouldLog: map[string]bool{
+				"debug": false,
+				"info":  false,
+				"warn":  true,
+				"error": true,
+			},
+		},
+		{
+			name:  "error level",
+			level: slog.LevelError,
+			shouldLog: map[string]bool{
+				"debug": false,
+				"info":  false,
+				"warn":  false,
+				"error": true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := NewSlogLogger(
+				WithOutput(&buf),
+				WithLevel(tt.level),
+			)
+
+			// Test each log level
+			logger.DebugContext(t.Context(), "debug message")
+			debugLogged := strings.Contains(buf.String(), "debug message")
+			assert.Equal(t, tt.shouldLog["debug"], debugLogged, "debug level mismatch")
+			buf.Reset()
+
+			logger.Info("info message")
+			infoLogged := strings.Contains(buf.String(), "info message")
+			assert.Equal(t, tt.shouldLog["info"], infoLogged, "info level mismatch")
+			buf.Reset()
+
+			logger.Warn("warn message")
+			warnLogged := strings.Contains(buf.String(), "warn message")
+			assert.Equal(t, tt.shouldLog["warn"], warnLogged, "warn level mismatch")
+			buf.Reset()
+
+			logger.Error("error message")
+			errorLogged := strings.Contains(buf.String(), "error message")
+			assert.Equal(t, tt.shouldLog["error"], errorLogged, "error level mismatch")
+		})
+	}
+}
+
+func TestLoggerWith(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewSlogLogger(
+		WithOutput(&buf),
+		WithFormat(FormatJSON), // Explicitly use JSON mode for predictable output
+	)
+
+	// Create a child logger with additional fields
+	childLogger := logger.With(slog.String("request_id", "123"), slog.String("user", "test-user"))
+
+	childLogger.Info("child logger message")
+
+	output := buf.String()
+	assert.Contains(t, output, `"request_id":"123"`)
+	assert.Contains(t, output, `"user":"test-user"`)
+	assert.Contains(t, output, "child logger message")
+}
+
+func TestStructuredLogging(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewSlogLogger(
+		WithOutput(&buf),
+		WithFormat(FormatJSON), // Explicitly use JSON mode for predictable output
+	)
+
+	logger.Info("structured log",
+		slog.String("string", "value"),
+		slog.Int("int", 42),
+		slog.Float64("float", 3.14),
+		slog.Bool("bool", true),
+		slog.Any("nested", map[string]any{
+			"key": "value",
+		}),
+	)
+
+	// Parse the JSON output
+	var logEntry map[string]any
+	err := json.Unmarshal(buf.Bytes(), &logEntry)
+	require.NoError(t, err)
+
+	assert.Equal(t, "structured log", logEntry["msg"])
+	assert.Equal(t, "value", logEntry["string"])
+	assert.Equal(t, float64(42), logEntry["int"]) // JSON numbers are float64
+	assert.Equal(t, 3.14, logEntry["float"])
+	assert.Equal(t, true, logEntry["bool"])
+}
+
+func TestWithFormat(t *testing.T) {
+	tests := []struct {
+		name      string
+		format    Format
+		message   string
+		checkJSON bool
+	}{
+		{
+			name:      "explicit json format",
+			format:    FormatJSON,
+			message:   "test message",
+			checkJSON: true,
+		},
+		{
+			name:      "explicit text format",
+			format:    FormatText,
+			message:   "test message",
+			checkJSON: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := NewSlogLogger(
+				WithOutput(&buf),
+				WithFormat(tt.format),
+			)
+
+			logger.Info(tt.message, slog.String("key", "value"))
+
+			output := buf.String()
+			require.NotEmpty(t, output)
+			assert.Contains(t, output, tt.message)
+
+			if tt.checkJSON {
+				// JSON format should contain quotes around keys and values
+				assert.Contains(t, output, `"msg":"test message"`)
+				assert.Contains(t, output, `"key":"value"`)
+			} else {
+				// Text format should be more human-readable
+				assert.Contains(t, output, "test message")
+				assert.Contains(t, output, "key=value")
+			}
+		})
+	}
+}
+
+func TestDefaultFormat(t *testing.T) {
+	// Test that the default logger uses JSON format
+	var buf bytes.Buffer
+	logger := NewSlogLogger(
+		WithOutput(&buf),
+	)
+
+	logger.Info("test message", slog.String("key", "value"))
+
+	output := buf.String()
+	require.NotEmpty(t, output)
+
+	// Default should be JSON format
+	assert.Contains(t, output, `"msg":"test message"`)
+	assert.Contains(t, output, `"key":"value"`)
+}
+
+func TestFormatOverride(t *testing.T) {
+	tests := []struct {
+		name           string
+		format         Format
+		expectedFormat string
+		description    string
+	}{
+		{
+			name:           "explicit JSON mode",
+			format:         FormatJSON,
+			expectedFormat: "json",
+			description:    "should use JSON format when explicitly set",
+		},
+		{
+			name:           "explicit text mode",
+			format:         FormatText,
+			expectedFormat: "text",
+			description:    "should use text format when explicitly set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := NewSlogLogger(
+				WithOutput(&buf),
+				WithFormat(tt.format),
+			)
+
+			logger.Info("test message", slog.String("key", "value"))
+
+			output := buf.String()
+			require.NotEmpty(t, output)
+
+			if tt.expectedFormat == "json" {
+				assert.Contains(t, output, `"msg":"test message"`)
+				assert.Contains(t, output, `"key":"value"`)
+			} else {
+				assert.Contains(t, output, "test message")
+				assert.Contains(t, output, "key=value")
+			}
+		})
+	}
+}

--- a/backend/pkg/logger/options.go
+++ b/backend/pkg/logger/options.go
@@ -1,0 +1,88 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package logger
+
+import (
+	"io"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Option is a function that configures a logger.
+type Option func(*config)
+
+// WithLevel sets the minimum log level using slog.Level directly.
+// This provides type safety and avoids string parsing.
+func WithLevel(level slog.Level) Option {
+	return func(c *config) {
+		c.level = level
+	}
+}
+
+// WithOutput sets the output writer for the logger.
+// Common use cases:
+//   - Testing: WithOutput(&bytes.Buffer{}) to capture logs
+//   - File logging: WithOutput(file) to write to a file
+//   - Custom writers: WithOutput(customWriter) for external systems
+func WithOutput(w io.Writer) Option {
+	return func(c *config) {
+		c.output = w
+	}
+}
+
+// WithPrometheusRegistry configures the logger to emit metrics to the provided registry.
+func WithPrometheusRegistry(reg prometheus.Registerer) Option {
+	return func(c *config) {
+		// Create and add the Prometheus handler
+		promHandler := NewPrometheusHandler(reg)
+		c.handlers = append(c.handlers, promHandler)
+	}
+}
+
+// WithHandler adds a custom handler to the handler chain.
+// Handlers are applied in the order they are added.
+func WithHandler(handler HandlerFunc) Option {
+	return func(c *config) {
+		c.handlers = append(c.handlers, handler)
+	}
+}
+
+// WithDefaultAttrs sets default attributes that will be included in all log entries.
+func WithDefaultAttrs(attrs ...slog.Attr) Option {
+	return func(c *config) {
+		c.attributes = append(c.attributes, attrs...)
+	}
+}
+
+// WithFormat sets the log output format.
+// - FormatJSON: Structured JSON output
+// - FormatText: Human-readable text format
+func WithFormat(format Format) Option {
+	return func(c *config) {
+		c.format = format
+	}
+}
+
+// WithTimestampFormat sets a custom timestamp format for log entries.
+// Use Go's standard time package constants (time.RFC3339, time.DateTime, etc.)
+// or provide a custom Go time layout string.
+//
+// Examples:
+//   - WithTimestampFormat(time.RFC3339) - ISO 8601 format (recommended)
+//   - WithTimestampFormat(time.DateTime) - Human-readable format
+//   - WithTimestampFormat(time.RFC3339Nano) - ISO 8601 with nanoseconds
+//   - WithTimestampFormat("2006-01-02 15:04:05.000") - Custom with milliseconds
+//   - WithTimestampFormat("2006-01-02") - Custom date-only format
+func WithTimestampFormat(format string) Option {
+	return func(c *config) {
+		c.timestampFormat = format
+	}
+}

--- a/backend/pkg/logger/prometheus.go
+++ b/backend/pkg/logger/prometheus.go
@@ -1,0 +1,97 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package logger
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// PrometheusHandler wraps another slog.Handler and counts log messages by level.
+type PrometheusHandler struct {
+	slog.Handler
+	messageCounterVec *prometheus.CounterVec
+}
+
+// Ensure PrometheusHandler implements slog.Handler at compile time
+var _ slog.Handler = (*PrometheusHandler)(nil)
+
+// NewPrometheusHandler creates a handler that emits Prometheus metrics for log messages.
+// It pre-initializes counters for all log levels to ensure they start at 0.
+func NewPrometheusHandler(reg prometheus.Registerer) HandlerFunc {
+	return func(next slog.Handler) slog.Handler {
+		messageCounterVec := prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "log_messages_total",
+			Help: "Total number of log messages, labeled by level.",
+		}, []string{"level"})
+
+		// Register the counter vector safely
+		if err := reg.Register(messageCounterVec); err != nil {
+			var alreadyRegisteredError prometheus.AlreadyRegisteredError
+			if !errors.As(err, &alreadyRegisteredError) {
+				// Log unexpected registration errors for debugging
+				// Use slog.Default() to respect any global slog configuration
+				//nolint:sloglint,noctx // Using global logger is intentional here to avoid circular dependency
+				slog.Default().Warn("logger: failed to register prometheus metrics", slog.Any("error", err))
+			}
+		}
+
+		// Pre-initialize counters for all supported log levels so that they expose 0 for each level on startup
+		supportedLevels := []slog.Level{
+			slog.LevelDebug,
+			slog.LevelInfo,
+			slog.LevelWarn,
+			slog.LevelError,
+		}
+		for _, level := range supportedLevels {
+			messageCounterVec.WithLabelValues(level.String()).Add(0)
+		}
+
+		return &PrometheusHandler{
+			Handler:           next,
+			messageCounterVec: messageCounterVec,
+		}
+	}
+}
+
+// Handle increments the appropriate counter and passes the record to the next handler.
+func (h *PrometheusHandler) Handle(ctx context.Context, record slog.Record) error {
+	// Increment the counter for this log level
+	h.messageCounterVec.WithLabelValues(record.Level.String()).Inc()
+
+	// Pass the record to the next handler in the chain
+	return h.Handler.Handle(ctx, record)
+}
+
+// Enabled delegates to the wrapped handler.
+func (h *PrometheusHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.Handler.Enabled(ctx, level)
+}
+
+// WithAttrs returns a new PrometheusHandler that includes the given attributes.
+// This ensures the Prometheus counting is preserved when attributes are added.
+func (h *PrometheusHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &PrometheusHandler{
+		Handler:           h.Handler.WithAttrs(attrs),
+		messageCounterVec: h.messageCounterVec, // keep the same counter
+	}
+}
+
+// WithGroup returns a new PrometheusHandler that includes the given group.
+// This ensures the Prometheus counting is preserved when groups are added.
+func (h *PrometheusHandler) WithGroup(name string) slog.Handler {
+	return &PrometheusHandler{
+		Handler:           h.Handler.WithGroup(name),
+		messageCounterVec: h.messageCounterVec, // keep the same counter
+	}
+}

--- a/backend/pkg/logger/prometheus_test.go
+++ b/backend/pkg/logger/prometheus_test.go
@@ -1,0 +1,163 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package logger
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrometheusHandler(t *testing.T) {
+	// Create a new registry for testing
+	reg := prometheus.NewRegistry()
+
+	var buf bytes.Buffer
+	logger := NewSlogLogger(
+		WithOutput(&buf),
+		WithLevel(slog.LevelDebug),
+		WithPrometheusRegistry(reg),
+	)
+
+	// Log messages at different levels
+	logger.Debug("debug message")
+	logger.Debug("another debug")
+	logger.Info("info message")
+	logger.Warn("warn message")
+	logger.Error("error message")
+	logger.Error("another error")
+	logger.Error("yet another error")
+
+	// Gather metrics
+	metrics, err := reg.Gather()
+	require.NoError(t, err)
+
+	// Find our metric
+	var logMetric *dto.MetricFamily
+	for _, m := range metrics {
+		if m.GetName() == "log_messages_total" {
+			logMetric = m
+			break
+		}
+	}
+	require.NotNil(t, logMetric, "log_messages_total metric not found")
+
+	// Check metric type and help
+	assert.Equal(t, dto.MetricType_COUNTER, *logMetric.Type)
+	assert.Equal(t, "Total number of log messages, labeled by level.", *logMetric.Help)
+
+	// Check counters
+	counters := make(map[string]float64)
+	for _, m := range logMetric.Metric {
+		for _, l := range m.Label {
+			if *l.Name == "level" {
+				counters[*l.Value] = *m.Counter.Value
+			}
+		}
+	}
+
+	// Verify counts
+	assert.Equal(t, float64(2), counters["DEBUG"], "debug count mismatch")
+	assert.Equal(t, float64(1), counters["INFO"], "info count mismatch")
+	assert.Equal(t, float64(1), counters["WARN"], "warn count mismatch")
+	assert.Equal(t, float64(3), counters["ERROR"], "error count mismatch")
+}
+
+func TestPrometheusHandlerInitialization(t *testing.T) {
+	// Create a new registry
+	reg := prometheus.NewRegistry()
+
+	// Create logger with Prometheus handler
+	var buf bytes.Buffer
+	_ = NewSlogLogger(
+		WithOutput(&buf),
+		WithPrometheusRegistry(reg),
+	)
+
+	// Check that all counters are initialized to 0
+	expectedMetrics := `
+# HELP log_messages_total Total number of log messages, labeled by level.
+# TYPE log_messages_total counter
+log_messages_total{level="DEBUG"} 0
+log_messages_total{level="ERROR"} 0
+log_messages_total{level="INFO"} 0
+log_messages_total{level="WARN"} 0
+`
+
+	err := testutil.GatherAndCompare(reg, bytes.NewBufferString(expectedMetrics), "log_messages_total")
+	assert.NoError(t, err)
+}
+
+func TestPrometheusHandlerWithGroups(t *testing.T) {
+	// Create a new registry
+	reg := prometheus.NewRegistry()
+
+	var buf bytes.Buffer
+	logger := NewSlogLogger(
+		WithOutput(&buf),
+		WithPrometheusRegistry(reg),
+	)
+
+	// Create a logger with groups
+	groupedLogger := logger.WithGroup("request").With(slog.String("id", "123"))
+
+	ctx := context.Background()
+	groupedLogger.InfoContext(ctx, "grouped message")
+
+	// The Prometheus handler should still count the message
+	metrics, err := reg.Gather()
+	require.NoError(t, err)
+
+	var logMetric *dto.MetricFamily
+	for _, m := range metrics {
+		if m.GetName() == "log_messages_total" {
+			logMetric = m
+			break
+		}
+	}
+	require.NotNil(t, logMetric)
+
+	// Find info counter
+	var infoCount float64
+	for _, m := range logMetric.Metric {
+		for _, l := range m.Label {
+			if *l.Name == "level" && *l.Value == "INFO" {
+				infoCount = *m.Counter.Value
+			}
+		}
+	}
+
+	assert.Equal(t, float64(1), infoCount)
+}
+
+func TestPrometheusHandlerRegistrationSafety(t *testing.T) {
+	// Test that registering the same metric twice doesn't panic
+	reg := prometheus.NewRegistry()
+
+	// First logger
+	_ = NewSlogLogger(
+		WithPrometheusRegistry(reg),
+	)
+
+	// Second logger with the same registry
+	// This should not panic due to AlreadyRegisteredError being handled gracefully
+	assert.NotPanics(t, func() {
+		_ = NewSlogLogger(
+			WithPrometheusRegistry(reg),
+		)
+	})
+}


### PR DESCRIPTION
## Summary
- Add new logger package based on Go's native slog to replace uber/zap
- Provides Prometheus metrics integration for log message counts by level
- Supports configurable handlers with middleware-style extensibility
- Includes JSON/text output formats and custom timestamp formatting
- Preparation for migrating existing zap-based logging to slog