### PR TITLE
backend: improve panic logging in message worker

### DIFF
--- a/backend/pkg/console/list_messages.go
+++ b/backend/pkg/console/list_messages.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -551,7 +552,10 @@ func (s *Service) startMessageWorker(ctx context.Context, wg *sync.WaitGroup,
 	defer wg.Done()
 	defer func() {
 		if r := recover(); r != nil {
-			s.logger.Error("recovered from panic in message worker", zap.Any("error", r))
+			s.logger.Error("recovered from panic in message worker",
+				zap.Any("error", r),
+				zap.String("stack_trace", string(debug.Stack())),
+				zap.String("topic", consumeReq.TopicName))
 		}
 	}()
 


### PR DESCRIPTION
## Summary

Add stack trace and topic information to panic recovery logging in the message worker to aid in debugging.

- Add stack trace using `debug.Stack()` for better panic debugging
- Include topic name in panic log to identify which topic caused the issue  
- Import `runtime/debug` package for stack trace functionality

This improves observability when message processing encounters unexpected panics during consumption.

Relates to: https://github.com/redpanda-data/console/issues/1842