### PR TITLE
backend: fix nil pointer dereference in Avro deserialization

### DIFF
--- a/backend/.golangci.yaml
+++ b/backend/.golangci.yaml
@@ -28,6 +28,7 @@ linters:
     - misspell
     - nakedret
     - nilerr
+    - nilnesserr
     - noctx
     - nolintlint
     - reassign

--- a/backend/pkg/console/consumer_group_delete.go
+++ b/backend/pkg/console/consumer_group_delete.go
@@ -26,7 +26,7 @@ func (s *Service) DeleteConsumerGroup(ctx context.Context, groupID string) error
 		return fmt.Errorf("failed to delete group: %w", err)
 	}
 	if res.Err != nil {
-		return fmt.Errorf("failed to delete group: %w", err)
+		return fmt.Errorf("failed to delete group: %w", res.Err)
 	}
 
 	return nil

--- a/backend/pkg/console/service.go
+++ b/backend/pkg/console/service.go
@@ -43,7 +43,7 @@ type Service struct {
 	redpandaClientFactory redpandafactory.ClientFactory
 	gitSvc                *git.Service // Git service can be nil if not configured
 	connectSvc            *connect.Service
-	cachedSchemaClient    *schemacache.CachedClient
+	cachedSchemaClient    schemacache.Client
 	serdeSvc              *serde.Service
 	protoSvc              *proto.Service
 	logger                *zap.Logger
@@ -96,7 +96,7 @@ func NewService(
 		}
 	}
 
-	var cachedSchemaClient *schemacache.CachedClient
+	var cachedSchemaClient schemacache.Client
 	if cfg.SchemaRegistry.Enabled {
 		cachedSchemaClient, err = schemacache.NewCachedClient(schemaClientFactory, cacheNamespaceFn)
 		if err != nil {

--- a/backend/pkg/schema/client.go
+++ b/backend/pkg/schema/client.go
@@ -69,6 +69,7 @@ type Client interface {
 	ParseJSONSchema(ctx context.Context, sch sr.Schema) (*jsonschema.Schema, error)
 	SchemaByID(ctx context.Context, id int) (sr.Schema, error)
 	SchemaByVersion(ctx context.Context, subject string, id int) (sr.SubjectSchema, error)
+	CompileProtoSchemaWithReferences(ctx context.Context, schema sr.Schema, accessorMap map[string]string) (linker.Files, error)
 }
 
 // Ensure CachedClient implements the Client interface.


### PR DESCRIPTION
## Summary

Fixes a critical panic that occurs when attempting to deserialize Avro messages while schema registry is disabled. The issue was caused by a nil interface dereference in the serde service when no schema client was available.

- Fix schema client interface to prevent nil interface access when schema registry disabled
- Add comprehensive integration test reproducing the original panic scenario
- Enable nilnesserr linter to catch similar nil interface issues in the future
- Fix unrelated bug in consumer group deletion error handling

## Related Issue

Fixes #1842 - Users reported "invalid memory address or nil pointer dereference" panic when viewing messages from topics containing Avro data while schema registry was disabled.