### PR TITLE
frontend: add visual highlighting for soft-deleted schema registry subjects

### DIFF
--- a/frontend/src/components/pages/schemas/Schema.List.scss
+++ b/frontend/src/components/pages/schemas/Schema.List.scss
@@ -14,7 +14,7 @@
 }
 
 .soft-deleted-row {
-    background-color: var(--chakra-colors-gray-50) !important;
-    color: var(--chakra-colors-gray-400) !important;
+    background-color: var(--chakra-colors-gray-50);
+    color: var(--chakra-colors-gray-400);
 }
 

--- a/frontend/src/components/pages/schemas/Schema.List.scss
+++ b/frontend/src/components/pages/schemas/Schema.List.scss
@@ -13,3 +13,8 @@
     display: none;
 }
 
+.soft-deleted-row {
+    background-color: var(--chakra-colors-gray-50) !important;
+    color: var(--chakra-colors-gray-400) !important;
+}
+

--- a/frontend/src/components/pages/schemas/Schema.List.tsx
+++ b/frontend/src/components/pages/schemas/Schema.List.tsx
@@ -283,6 +283,7 @@ class SchemaList extends PageComponent<{}> {
             data={filteredSubjects}
             pagination
             sorting
+            rowClassName={(row) => (row.original.isSoftDeleted ? 'soft-deleted-row' : '')}
             columns={[
               {
                 header: 'Name',

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -2198,7 +2198,3 @@ $borderRadius: 8px;
   user-select: none;
 }
 
-.subjectSoftDeleted {
-  background: #fafafa;
-  color: var(--chakra-colors-gray-400);
-}


### PR DESCRIPTION
## Summary
- Add visual highlighting for soft-deleted schema registry subjects in table view
- Implement conditional row styling using DataTable's rowClassName prop  
- Add CSS class with light gray background and muted text for soft-deleted subjects
- Remove unused legacy CSS class from global styles

## Changes
- `Schema.List.tsx`: Add rowClassName prop to conditionally apply 'soft-deleted-row' class
- `Schema.List.scss`: Add styling for soft-deleted subjects using Chakra UI semantic tokens
- `index.scss`: Remove unused `.subjectSoftDeleted` class

The API already provides `isSoftDeleted` boolean data, this change ensures the UI properly displays the visual separation that was previously missing.

First row is a soft-deleted subject

<img width="2900" height="1604" alt="ss-Ul6lYYcz@2x" src="https://github.com/user-attachments/assets/7c1ec084-1e16-49f5-84dc-cd4cce1920f3" />
