### PR TITLE
backend: fix schema registry error handling and UI improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
 - [BUGFIX] Fix missing cache for JSON schema compilation, causing repeated compilation overhead.
 - [BUGFIX] Fix incorrect caching scope for Avro schemas in multi-tenant environments.
 - [BUGFIX] Fix circular reference detection in Avro schema parsing to prevent infinite recursion.
+- [BUGFIX] Fix schema registry compatibility configuration error handling to gracefully handle unconfigured subjects.
 - [IMPROVEMENT] Add comprehensive schema registry test suite with mock package to prevent regressions.
+- [IMPROVEMENT] Add visual indicators for soft-deleted schema registry subjects with archive icons and tooltips.
+- [IMPROVEMENT] Add colored badges for schema types (AVRO, PROTOBUF, JSON) in schema registry list view.
 
 ## v2.8.7 / 2025-06-27
 


### PR DESCRIPTION
## Summary

Fixes error handling issues in schema registry compatibility configuration and improves UI visual indicators for better user experience.

## Changes

### Backend
- Fix handling of schema registry subject compatibility configuration errors
- Handle 40408 error code (subject compatibility not configured) by returning "DEFAULT"
- Return "UNKNOWN" for other errors instead of failing the entire request
- Change compatibility field from pointer to string for consistency

### Frontend  
- Add archive icon with tooltip for soft-deleted subjects
- Add colored badges for schema types (AVRO=blue, PROTOBUF=teal, JSON=orange)
- Show "None" instead of empty space for subjects with no active versions
- Import required icons and UI components

## Related Issues

This addresses potential bugs in schema registry client usage that could cause degraded user experience when subjects have non-standard compatibility configurations.

<img width="2928" height="1520" alt="ss-DSDpk6N7@2x" src="https://github.com/user-attachments/assets/2c2334e2-885f-4582-9588-1c83a3cc2679" />
