### PR TITLE
Fix handling of special consumer group offset values

### DIFF
--- a/backend/pkg/console/edit_consumer_group_offsets.go
+++ b/backend/pkg/console/edit_consumer_group_offsets.go
@@ -113,7 +113,7 @@ func (s *Service) EditConsumerGroupOffsets(ctx context.Context, groupID string, 
 	for i, topic := range topics {
 		substitutedPartitions := make([]kmsg.OffsetCommitRequestTopicPartition, len(topic.Partitions))
 		for j, partition := range topic.Partitions {
-			switch partition.Partition {
+			switch partition.Offset {
 			case TimestampLatest:
 				offset, exists := endOffsets.Lookup(topic.Topic, partition.Partition)
 				if !exists {


### PR DESCRIPTION
### Problem

Editing a consumer group's offset to earliest or latest does not work correctly.

### Cause

The Console API uses two special offset values:  
- `-1` for `TimestampLatest`  
- `-2` for `TimestampEarliest`

These values are sent in the request but should be replaced with actual start/end offsets by the `EditConsumerGroupOffsets` function before being committed.

However, this replacement did not happen because the code was incorrectly checking `partition.Partition` instead of `partition.Offset` in the switch-case.

### Solution

Fixed the condition to check `partition.Offset` instead.

### Jira issue

[UX-143](https://redpandadata.atlassian.net/browse/UX-143)

[UX-143]: https://redpandadata.atlassian.net/browse/UX-143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ