### PR TITLE
be: replace franz-go/sr fork

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,9 +1,6 @@
 module github.com/redpanda-data/console/backend
 
-go 1.24.1
-
-// Use fork until https://github.com/twmb/franz-go/pull/1062 is merged and released.
-replace github.com/twmb/franz-go/pkg/sr v1.4.0 => github.com/weeco/franz-go/pkg/sr v0.0.0-20250716104819-91f6bce0597a
+go 1.24.3
 
 toolchain go1.24.4
 
@@ -44,6 +41,7 @@ require (
 	github.com/linkedin/goavro v2.1.0+incompatible
 	github.com/ohler55/ojg v1.26.6
 	github.com/prometheus/client_golang v1.22.0
+	github.com/prometheus/client_model v0.6.2
 	github.com/redpanda-data/benthos/v4 v4.53.0
 	github.com/redpanda-data/common-go/api v0.0.0-20250701102610-07660e078862
 	github.com/redpanda-data/common-go/net v0.1.1-0.20240429123545-4da3d2b371f7
@@ -57,7 +55,7 @@ require (
 	github.com/twmb/franz-go/pkg/kfake v0.0.0-20250620172413-c17130ef7765
 	github.com/twmb/franz-go/pkg/kmsg v1.11.2
 	github.com/twmb/franz-go/pkg/sasl/kerberos v1.1.0
-	github.com/twmb/franz-go/pkg/sr v1.4.0
+	github.com/twmb/franz-go/pkg/sr v1.5.0
 	github.com/twmb/franz-go/plugin/kzap v1.1.2
 	github.com/twmb/go-cache v1.2.1
 	github.com/twmb/tlscfg v1.2.1
@@ -188,7 +186,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.65.0 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -464,6 +464,8 @@ github.com/twmb/franz-go/pkg/kmsg v1.11.2 h1:hIw75FpwcAjgeyfIGFqivAvwC5uNIOWRGvQ
 github.com/twmb/franz-go/pkg/kmsg v1.11.2/go.mod h1:CFfkkLysDNmukPYhGzuUcDtf46gQSqCZHMW1T4Z+wDE=
 github.com/twmb/franz-go/pkg/sasl/kerberos v1.1.0 h1:alKdbddkPw3rDh+AwmUEwh6HNYgTvDSFIe/GWYRR9RM=
 github.com/twmb/franz-go/pkg/sasl/kerberos v1.1.0/go.mod h1:k8BoBjyUbFj34f0rRbn+Ky12sZFAPbmShrg0karAIMo=
+github.com/twmb/franz-go/pkg/sr v1.5.0 h1:KQH8veHxKyAjT4U4/rziJnSEfafuluznLoxhrp0yJfo=
+github.com/twmb/franz-go/pkg/sr v1.5.0/go.mod h1:O4o4mUMNfmyEt2HcuM+qZdc6KrcStvjgxWR6Cfvmukw=
 github.com/twmb/franz-go/plugin/kzap v1.1.2 h1:0arX5xJ0soUPX1LlDay6ZZoxuWkWk1lggQ5M/IgRXAE=
 github.com/twmb/franz-go/plugin/kzap v1.1.2/go.mod h1:53Cl9Uz1pbdOPDvUISIxLrZIWSa2jCuY1bTMauRMBmo=
 github.com/twmb/go-cache v1.2.1 h1:yUkLutow4S2x5NMbqFW24o14OsucoFI5Fzmlb6uBinM=
@@ -478,8 +480,6 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/weeco/franz-go/pkg/sr v0.0.0-20250716104819-91f6bce0597a h1:C+j/xPi5Cc10fGQRuYa+Z/E4ZHD2W4QmSLOJ/EB6aGM=
-github.com/weeco/franz-go/pkg/sr v0.0.0-20250716104819-91f6bce0597a/go.mod h1:O4o4mUMNfmyEt2HcuM+qZdc6KrcStvjgxWR6Cfvmukw=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=

--- a/backend/pkg/schema/client_test.go
+++ b/backend/pkg/schema/client_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hamba/avro/v2"
 	"github.com/stretchr/testify/suite"
 	"github.com/twmb/franz-go/pkg/sr"
-	"github.com/twmb/franz-go/pkg/sr/mock"
+	"github.com/twmb/franz-go/pkg/sr/srfake"
 
 	"github.com/redpanda-data/console/backend/pkg/factory/schema"
 )
@@ -40,7 +40,7 @@ func (f *testSchemaClientFactory) GetSchemaRegistryClient(context.Context) (*sr.
 // TestCachedClientSuite contains essential tests for CachedClient
 type TestCachedClientSuite struct {
 	suite.Suite
-	mockRegistry  *mock.Registry
+	mockRegistry  *srfake.Registry
 	srClient      *sr.Client
 	clientFactory *testSchemaClientFactory
 	cachedClient  *CachedClient
@@ -59,7 +59,7 @@ func getTenantContext(tenantID string) context.Context {
 
 // SetupSuite runs once before all tests
 func (s *TestCachedClientSuite) SetupSuite() {
-	s.mockRegistry = mock.New()
+	s.mockRegistry = srfake.New()
 	s.Require().NotNil(s.mockRegistry)
 
 	var err error


### PR DESCRIPTION
Now it's released in the latest version, but it's called srfake.