### PR TITLE
fix: resolve goconst linting issues with unknown string constant

### DIFF
--- a/backend/pkg/api/connect/service/clusterstatus/redpanda.go
+++ b/backend/pkg/api/connect/service/clusterstatus/redpanda.go
@@ -23,8 +23,7 @@ type redpandaStatusChecker struct{}
 // reports the version individually, we iterate through the list of brokers and
 // return the first reported version that contains a semVer.
 func (*redpandaStatusChecker) clusterVersionFromBrokerList(brokers []rpadmin.Broker) string {
-	//nolint:goconst // Other occurrences are unrelated
-	version := "unknown"
+	version := unknownVersion
 	for _, broker := range brokers {
 		if broker.Version != "" {
 			// Broker version may look like this: "v22.1.4 - 491e56900d2316fcbb22aa1d37e7195897878309"

--- a/backend/pkg/api/connect/service/clusterstatus/service.go
+++ b/backend/pkg/api/connect/service/clusterstatus/service.go
@@ -35,6 +35,8 @@ import (
 	"github.com/redpanda-data/console/backend/pkg/version"
 )
 
+const unknownVersion = "unknown"
+
 var _ consolev1alpha1connect.ClusterStatusServiceHandler = (*Service)(nil)
 
 // Service that implements the ClusterStatusServiceHandler interface. This includes all
@@ -99,7 +101,7 @@ func (s *Service) GetKafkaInfo(ctx context.Context, _ *connect.Request[v1alpha1.
 	})
 
 	// Fetch Kafka API version
-	clusterVersion := "unknown"
+	clusterVersion := unknownVersion
 	grp.Go(func() error {
 		var err error
 
@@ -202,7 +204,7 @@ func (s *Service) GetRedpandaInfo(ctx context.Context, _ *connect.Request[v1alph
 
 	grp, grpCtx := errgroup.WithContext(childCtx)
 
-	version := "unknown"
+	version := unknownVersion
 	grp.Go(func() error {
 		brokers, err := redpandaCl.Brokers(grpCtx)
 		if err != nil {


### PR DESCRIPTION
## Summary

This PR fixes goconst and nolintlint issues by consolidating repeated "unknown" string literals into a single constant. The change addresses linter inconsistencies between local and CI environments where nolint directives behave differently despite using identical golangci-lint versions.

## Changes

- Added `unknownVersion` constant to replace hardcoded "unknown" strings
- Updated `service.go` to use the constant in two locations (lines 104, 207)  
- Updated `redpanda.go` to use the constant and removed unused nolint directive
- Eliminates goconst violations for repeated string literals
- Resolves nolintlint warnings about unused directives

## Background

The CI was reporting linting errors that weren't appearing locally:
- `goconst: string 'unknown' has 3 occurrences, make it a constant`
- `nolintlint: directive '//nolint:goconst' is unused for linter "goconst"`

Despite both environments using golangci-lint v2.3.0, the nolint directive was working locally but not in CI. This change resolves the underlying issue by properly using a constant instead of relying on linter suppression.