### PR TITLE
fix: implement fault-tolerant protobuf schema compilation

### DIFF
--- a/.github/workflows/backend-lint-test.yml
+++ b/.github/workflows/backend-lint-test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60
+          version: v1.64.8
           working-directory: backend
           args: --timeout=10m --config=.golangci.yaml
       - name: Install Task

--- a/backend/.golangci.yaml
+++ b/backend/.golangci.yaml
@@ -207,3 +207,5 @@ linters-settings:
         disabled: true
       - name: var-naming
         disabled: true
+      - name: use-errors-new
+        disabled: true

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,8 @@
 module github.com/redpanda-data/console/backend
 
-go 1.23.0
+go 1.23.8
+
+toolchain go1.24.5
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.35.2-20241127180247-a33202765966.1
@@ -48,7 +50,7 @@ require (
 	github.com/twmb/franz-go/pkg/kfake v0.0.0-20241202133023-293b7c4c56bb
 	github.com/twmb/franz-go/pkg/kmsg v1.9.0
 	github.com/twmb/franz-go/pkg/sasl/kerberos v1.1.0
-	github.com/twmb/franz-go/pkg/sr v1.2.0
+	github.com/twmb/franz-go/pkg/sr v1.5.0
 	github.com/twmb/franz-go/plugin/kzap v1.1.2
 	github.com/twmb/go-cache v1.2.1
 	github.com/twmb/tlscfg v1.2.1

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -236,8 +236,6 @@ github.com/gofrs/uuid v4.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRx
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
-github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
 github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -651,8 +649,8 @@ github.com/twmb/franz-go/pkg/kmsg v1.9.0 h1:JojYUph2TKAau6SBtErXpXGC7E3gg4vGZMv9
 github.com/twmb/franz-go/pkg/kmsg v1.9.0/go.mod h1:CMbfazviCyY6HM0SXuG5t9vOwYDHRCSrJJyBAe5paqg=
 github.com/twmb/franz-go/pkg/sasl/kerberos v1.1.0 h1:alKdbddkPw3rDh+AwmUEwh6HNYgTvDSFIe/GWYRR9RM=
 github.com/twmb/franz-go/pkg/sasl/kerberos v1.1.0/go.mod h1:k8BoBjyUbFj34f0rRbn+Ky12sZFAPbmShrg0karAIMo=
-github.com/twmb/franz-go/pkg/sr v1.2.0 h1:zYr0Ly7KLFfeCGaSr8teN6LvAVeYVrZoUsyyPHTYB+M=
-github.com/twmb/franz-go/pkg/sr v1.2.0/go.mod h1:gpd2Xl5/prkj3gyugcL+rVzagjaxFqMgvKMYcUlrpDw=
+github.com/twmb/franz-go/pkg/sr v1.5.0 h1:KQH8veHxKyAjT4U4/rziJnSEfafuluznLoxhrp0yJfo=
+github.com/twmb/franz-go/pkg/sr v1.5.0/go.mod h1:O4o4mUMNfmyEt2HcuM+qZdc6KrcStvjgxWR6Cfvmukw=
 github.com/twmb/franz-go/plugin/kzap v1.1.2 h1:0arX5xJ0soUPX1LlDay6ZZoxuWkWk1lggQ5M/IgRXAE=
 github.com/twmb/franz-go/plugin/kzap v1.1.2/go.mod h1:53Cl9Uz1pbdOPDvUISIxLrZIWSa2jCuY1bTMauRMBmo=
 github.com/twmb/go-cache v1.2.1 h1:yUkLutow4S2x5NMbqFW24o14OsucoFI5Fzmlb6uBinM=

--- a/backend/pkg/connect/get_connectors.go
+++ b/backend/pkg/connect/get_connectors.go
@@ -414,7 +414,7 @@ type holisticConnectorState struct {
 	Errors []ClusterConnectorInfoError
 }
 
-//nolint:cyclop // lots of inspection of state and tasks to determine status and errors
+//nolint:cyclop,gocognit // lots of inspection of state and tasks to determine status and errors
 func getHolisticStateFromConnector(status con.ConnectorStateInfo, aggregatedTasksStatus aggregatedConnectorTasksStatus) holisticConnectorState {
 	// LOGIC:
 	// HEALTHY: Connector is in running state, > 0 tasks, all of them in running state.

--- a/backend/pkg/schema/service.go
+++ b/backend/pkg/schema/service.go
@@ -11,7 +11,6 @@ package schema
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"maps"
 	"strconv"

--- a/taskfiles/backend.yaml
+++ b/taskfiles/backend.yaml
@@ -17,7 +17,7 @@ tasks:
   install-golangci-lint:
     desc: install golangci linter
     vars:
-      GO_LINT_VERSION: 1.60.3
+      GO_LINT_VERSION: 1.64.8
     cmds:
       - mkdir -p {{ .BUILD_ROOT}}/bin
       - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "{{ .BUILD_ROOT }}"/bin/go v{{ .GO_LINT_VERSION }}


### PR DESCRIPTION
## Summary

Fixes an issue where users experienced compilation errors of their protobuf schemas that resulted in all schemas not being compiled. The problem occurred when some schemas had broken references (e.g., to soft-deleted dependencies in the schema registry).

## Changes

- **Fault-tolerant compilation**: Replace all-or-nothing approach with best-effort schema compilation
- **Graceful error handling**: Skip problematic schemas instead of aborting entire refresh
- **Enhanced logging**: Warn about failed schemas and provide success/failure metrics
- **Integration test**: Add test case that reproduces and validates the fix

## Technical Details

The issue manifested when Console encountered protobuf schemas referencing non-existent or soft-deleted schemas. Previously, this would cause the entire schema compilation process to abort, leaving users unable to deserialize any protobuf messages.

With this fix:
- Valid schemas are compiled successfully
- Broken schemas are logged as warnings and skipped
- Only fails if zero schemas can be compiled
- Provides clear metrics on compilation success/failure rates

## Impact

Users with mixed schema environments (some valid, some with broken references) will now be able to use Console's protobuf deserialization for working schemas instead of losing all functionality.