### PR TITLE
frontend: enable quotas sidebar in embedded mode

### DIFF
--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -268,7 +268,7 @@ export function isServerless() {
   return config.isServerless;
 }
 
-const routesIgnoredInEmbedded = ['/overview', '/quotas', '/reassign-partitions', '/admin'];
+const routesIgnoredInEmbedded = ['/overview', '/reassign-partitions', '/admin'];
 
 const routesIgnoredInServerless = ['/overview', '/quotas', '/reassign-partitions', '/admin', '/transforms'];
 


### PR DESCRIPTION
Remove /quotas from routesIgnoredInEmbedded to make the quotas page accessible via sidebar when Console runs in cloud/embedded mode.