### PR TITLE
endpoints: add ACL service for Schema Registry

### DIFF
--- a/backend/pkg/console/redpanda_feature.go
+++ b/backend/pkg/console/redpanda_feature.go
@@ -31,6 +31,9 @@ const (
 
 	// redpandaFeatureDebugBundle represents debug bundle Admin API feature.
 	redpandaFeatureDebugBundle redpandaFeature = "redpanda_feature_debug_bundle"
+
+	// redpandaFeatureSchemaRegistryACL represents Schema Registry ACL feature.
+	redpandaFeatureSchemaRegistryACL redpandaFeature = "redpanda_feature_schema_registry_acl"
 )
 
 // checkRedpandaFeature checks whether redpanda has the specified feature in the specified state.

--- a/backend/pkg/serde/protobuf.go
+++ b/backend/pkg/serde/protobuf.go
@@ -16,7 +16,7 @@ import (
 	"errors"
 	"fmt"
 
-	v1proto "github.com/golang/protobuf/proto" //nolint:staticcheck // intentional import of old module
+	v1proto "github.com/golang/protobuf/proto"
 	"github.com/jhump/protoreflect/dynamic"
 	"github.com/twmb/franz-go/pkg/kgo"
 	v2proto "google.golang.org/protobuf/proto"


### PR DESCRIPTION
This one is a compromise: as the ACL service is
always present, we are adding the service to this
list, but assuming is the Schema Registry feature.

So, now, the frontend could query /endpoints to
determine whether to render the schema registry
components on the ACL page.

```
GET /api/console/endpoints


            {
                "endpoint": "redpanda.api.dataplane.v1.ACLService",
                "method": "POST",
                "isSupported": true
            },


OR

            {
                "endpoint": "redpanda.api.dataplane.v1.ACLService",
                "method": "POST",
                "isSupported": false
            },
```