### PR TITLE
frontend: add feature flag for remote MCP

### DIFF
--- a/frontend/src/components/constants.ts
+++ b/frontend/src/components/constants.ts
@@ -6,4 +6,5 @@ export const FEATURE_FLAGS = {
   enableAiAgentsInConsoleUi: false,
   enableAiAgentsInConsoleUiPreview: false,
   enableKnowledgeBaseInConsoleUi: false,
+  enableRemoteMcpInConsole: false,
 };

--- a/frontend/src/components/constants.ts
+++ b/frontend/src/components/constants.ts
@@ -7,4 +7,5 @@ export const FEATURE_FLAGS = {
   enableAiAgentsInConsoleUiPreview: false,
   enableKnowledgeBaseInConsoleUi: false,
   enableRemoteMcpInConsole: false,
+  enableRemoteMcpInspectorInConsole: false,
 };

--- a/frontend/src/components/pages/remote-mcp/details/remote-mcp-details-page.tsx
+++ b/frontend/src/components/pages/remote-mcp/details/remote-mcp-details-page.tsx
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
+import { isFeatureFlagEnabled } from 'config';
 import { AlertCircle, Loader2 } from 'lucide-react';
 import { runInAction } from 'mobx';
 import { useEffect } from 'react';
@@ -33,6 +34,8 @@ export const updatePageTitle = (serverName?: string) => {
 };
 
 export const RemoteMCPDetailsPage = () => {
+  const isRemoteMcpInspectorFeatureEnabled = isFeatureFlagEnabled('enableRemoteMcpInspectorInConsole');
+
   const { id } = useParams<{ id: string }>();
 
   const { data: mcpServerData, isLoading, error } = useGetMCPServerQuery({ id: id || '' }, { enabled: !!id });
@@ -78,14 +81,14 @@ export const RemoteMCPDetailsPage = () => {
           <TabsTrigger value="configuration">Configuration</TabsTrigger>
           <TabsTrigger value="connection">Connection</TabsTrigger>
           <TabsTrigger value="logs">Logs</TabsTrigger>
-          <TabsTrigger value="inspector">MCP Inspector</TabsTrigger>
+          {isRemoteMcpInspectorFeatureEnabled && <TabsTrigger value="inspector">MCP Inspector</TabsTrigger>}
         </TabsList>
 
         <TabsContentWrapper variant="contained">
           <RemoteMCPConfigurationTab value="configuration" />
           <RemoteMCPConnectionTab value="connection" />
           <RemoteMCPLogsTab value="logs" />
-          <RemoteMCPInspectorTab value="inspector" />
+          {isRemoteMcpInspectorFeatureEnabled && <RemoteMCPInspectorTab value="inspector" />}
         </TabsContentWrapper>
       </Tabs>
     </div>

--- a/frontend/src/components/routes.tsx
+++ b/frontend/src/components/routes.tsx
@@ -233,6 +233,7 @@ const RouteRenderer: FunctionComponent<{ route: PageDefinition<any> }> = ({ rout
 const ProtectedRoute: FunctionComponent<{ children: React.ReactNode; path: string }> = ({ children, path }) => {
   const isAgentFeatureEnabled = isFeatureFlagEnabled('enableAiAgentsInConsoleUi');
   const isKnowledgeBaseFeatureEnabled = isFeatureFlagEnabled('enableKnowledgeBaseInConsoleUi');
+  const isRemoteMcpFeatureEnabled = isFeatureFlagEnabled('enableRemoteMcpInConsole');
   const location = useLocation();
 
   useEffect(() => {
@@ -244,7 +245,11 @@ const ProtectedRoute: FunctionComponent<{ children: React.ReactNode; path: strin
       appGlobal.historyPush('/overview');
       window.location.reload(); // Required because we want to load Cloud UI's overview, not Console UI.
     }
-  }, [isAgentFeatureEnabled, isKnowledgeBaseFeatureEnabled, path, location.pathname]);
+    if (!isRemoteMcpFeatureEnabled && path.includes('/remote-mcp') && location.pathname !== '/overview') {
+      appGlobal.historyPush('/overview');
+      window.location.reload(); // Required because we want to load Cloud UI's overview, not Console UI.
+    }
+  }, [isAgentFeatureEnabled, isKnowledgeBaseFeatureEnabled, isRemoteMcpFeatureEnabled, path, location.pathname]);
 
   return children;
 };
@@ -543,7 +548,7 @@ export const APP_ROUTES: IRouteEntry[] = [
     'Remote MCP',
     MCPIcon,
     true,
-    routeVisibility(() => isEmbedded() && !isServerless()), // show only in embedded mode and only for BYOC/Dedicated
+    routeVisibility(() => isEmbedded() && !isServerless() && isFeatureFlagEnabled('enableRemoteMcpInConsole')), // show only in embedded mode and only for BYOC/Dedicated with feature flag
   ),
   MakeRoute<{}>('/remote-mcp/create', RemoteMCPCreatePage, 'Create Remote MCP Server'),
   MakeRoute<{ id: string }>('/remote-mcp/:id', RemoteMCPDetailsPage, 'Remote MCP Details'),


### PR DESCRIPTION
Adds 2 feature flags:
- `enableRemoteMcpInConsole` decides whether to show the Remote MCP page.
- `enableRemoteMcpInspectorInConsole` decides whether to show the "Inspector" tab in the details view.