### PR TITLE
frontend: fix remote MCP tool calling

### DIFF
--- a/frontend/src/components/pages/remote-mcp/details/inspector/remote-mcp-inspector-parameters.tsx
+++ b/frontend/src/components/pages/remote-mcp/details/inspector/remote-mcp-inspector-parameters.tsx
@@ -94,7 +94,7 @@ export const RemoteMCPInspectorParameters = ({
   onParameterChange,
 }: RemoteMCPInspectorParametersProps) => {
   return (
-    <Card>
+    <Card className="max-w-full">
       <CardHeader className="pb-3">
         <CardTitle className="text-base">Parameters</CardTitle>
       </CardHeader>

--- a/frontend/src/components/pages/remote-mcp/list/remote-mcp-list-page.tsx
+++ b/frontend/src/components/pages/remote-mcp/list/remote-mcp-list-page.tsx
@@ -444,8 +444,7 @@ export const RemoteMCPListPage = () => {
             Create new MCP Server
           </Button>
         </div>
-        <div className="rounded-md border">
-          <Table>
+        <Table>
             <TableHeader>
               {table.getHeaderGroups().map((headerGroup) => (
                 <TableRow key={headerGroup.id}>
@@ -500,7 +499,6 @@ export const RemoteMCPListPage = () => {
               )}
             </TableBody>
           </Table>
-        </div>
         <DataTablePagination table={table} />
       </div>
     </TooltipProvider>

--- a/frontend/src/state/supportedFeatures.ts
+++ b/frontend/src/state/supportedFeatures.ts
@@ -63,6 +63,10 @@ export class Feature {
     endpoint: 'redpanda.api.console.v1alpha1.SecretService',
     method: 'POST',
   };
+  static readonly RemoteMcpService: FeatureEntry = {
+    endpoint: 'redpanda.api.dataplane.v1alpha3.MCPServerService',
+    method: 'POST',
+  };
 }
 
 export function isSupported(f: FeatureEntry): boolean {
@@ -133,6 +137,9 @@ class SupportedFeatures {
   }
   @computed get rpcnSecretsApi(): boolean {
     return isSupported(Feature.SecretService);
+  }
+  @computed get remoteMcpApi(): boolean {
+    return isSupported(Feature.RemoteMcpService);
   }
 }
 


### PR DESCRIPTION
Fix for [AI-112](https://redpandadata.atlassian.net/browse/AI-112).

We first needed the `/initialize` step before we are able to call the MCP tools with the correct `Mcp-Session-Id` header, which we get from the response. Thanks @birdayz for making me realize it 😓 

In the future we can move to a proper MCP client setup instead of just doing the `fetch()` API if we feel like it's better.

@birdayz is setting up the `access-control-expose-headers` so that the response headers are exposed to the frontend.
<img width="418" height="195" alt="Screenshot 2025-08-25 at 17 30 12" src="https://github.com/user-attachments/assets/02f2ed30-989d-4540-8779-533f7d5033b2" />

The code snippets still need updating, we can do it in another PR.

[AI-112]: https://redpandadata.atlassian.net/browse/AI-112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ