### PR TITLE
chore: fix linter warning

### DIFF
--- a/backend/pkg/serde/protobuf.go
+++ b/backend/pkg/serde/protobuf.go
@@ -16,7 +16,7 @@ import (
 	"errors"
 	"fmt"
 
-	v1proto "github.com/golang/protobuf/proto"
+	v1proto "github.com/golang/protobuf/proto" //nolint:staticcheck // deprecated, still needed, we will migrate away from it soon.
 	"github.com/jhump/protoreflect/dynamic"
 	"github.com/twmb/franz-go/pkg/kgo"
 	v2proto "google.golang.org/protobuf/proto"


### PR DESCRIPTION
We will migrate this to the new buf proto package
soon. For now we ignore this deprecation warning.