### PR TITLE
feat: add Kafka connection and client metrics

### DIFF
--- a/backend/pkg/factory/kafka/client_hooks.go
+++ b/backend/pkg/factory/kafka/client_hooks.go
@@ -160,7 +160,7 @@ func IncrementClientCount() {
 	}
 }
 
-// DecrementClientCount decrements the active client count metric  
+// DecrementClientCount decrements the active client count metric
 func DecrementClientCount() {
 	if promActiveClients != nil {
 		promActiveClients.Dec()

--- a/backend/pkg/factory/kafka/kafka.go
+++ b/backend/pkg/factory/kafka/kafka.go
@@ -115,7 +115,7 @@ func (f *CachedClientProvider) createClient() (*kgo.Client, error) {
 	}
 
 	// Increment client count metric
-	IncrementClientCount()
+	promActiveClients.Inc()
 
 	return client, nil
 }

--- a/backend/pkg/factory/kafka/kafka.go
+++ b/backend/pkg/factory/kafka/kafka.go
@@ -109,7 +109,15 @@ func (f *CachedClientProvider) createClient() (*kgo.Client, error) {
 		)
 	}
 
-	return kgo.NewClient(kgoOpts...)
+	client, err := kgo.NewClient(kgoOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Increment client count metric
+	IncrementClientCount()
+
+	return client, nil
 }
 
 // NewKgoConfig creates a new Config for the Kafka Client as exposed by the franz-go library.


### PR DESCRIPTION
## Summary
Adds Prometheus metrics to monitor Kafka broker connections and active client instances for improved observability.

## Key Changes
- **New metrics**: `kafka_open_connections` gauge tracks broker connections
- **New metrics**: `kafka_active_clients` gauge tracks client instances  
- **Connection tracking**: Automatic increment/decrement via broker connect/disconnect hooks
- **Client tracking**: Exported functions for client lifecycle management
- **Error handling**: Enhanced client creation with proper error propagation

This provides better visibility into Kafka connection health and resource usage patterns.