### PR TITLE
feat: support custom Prometheus registry for Kafka metrics

### DIFF
--- a/backend/pkg/api/api.go
+++ b/backend/pkg/api/api.go
@@ -167,7 +167,7 @@ func New(cfg *config.Config, inputOpts ...Option) (*API, error) {
 // Set default client providers if none provided
 func setDefaultClientProviders(cfg *config.Config, logger *slog.Logger, opts *options) error {
 	if opts.kafkaClientProvider == nil {
-		opts.kafkaClientProvider = kafkafactory.NewCachedClientProvider(cfg, logger)
+		opts.kafkaClientProvider = kafkafactory.NewCachedClientProvider(cfg, logger, opts.prometheusRegistry)
 	}
 
 	// We can always create a factory if we don't already have one.

--- a/backend/pkg/api/routes.go
+++ b/backend/pkg/api/routes.go
@@ -23,6 +23,7 @@ import (
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	commoninterceptor "github.com/redpanda-data/common-go/api/interceptor"
 	"github.com/redpanda-data/common-go/api/metrics"
@@ -546,7 +547,7 @@ func (api *API) routes() *chi.Mux {
 		// Private routes - these should only be accessible from within Kubernetes or a protected ingress
 		router.Group(func(r chi.Router) {
 			api.Hooks.Route.ConfigInternalRouter(r)
-			r.Handle("/admin/metrics", promhttp.Handler())
+			r.Handle("/admin/metrics", promhttp.HandlerFor(api.PrometheusRegistry.(*prometheus.Registry), promhttp.HandlerOpts{}))
 			r.Handle("/admin/health", api.handleLivenessProbe())
 			r.Handle("/admin/startup", api.handleStartupProbe())
 		})

--- a/backend/pkg/console/cluster_info_integration_test.go
+++ b/backend/pkg/console/cluster_info_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"log/slog"
 	"net"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -43,7 +44,7 @@ func (s *ConsoleIntegrationTestSuite) TestGetClusterInfo() {
 	cfg.MetricsNamespace = testutil.MetricNameForTest("get_cluster_info")
 	cfg.Kafka.Brokers = []string{testSeedBroker}
 
-	kafkaProvider := kafkafactory.NewCachedClientProvider(&cfg, log)
+	kafkaProvider := kafkafactory.NewCachedClientProvider(&cfg, log, prometheus.NewRegistry())
 	svc, err := NewService(&cfg, log, kafkaProvider, nil, nil, nil, nil)
 	require.NoError(err)
 	defer svc.Stop()

--- a/backend/pkg/console/list_messages_integration_test.go
+++ b/backend/pkg/console/list_messages_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kerr"
@@ -786,7 +787,7 @@ func createNewTestService(t *testing.T, log *slog.Logger,
 		cfg.SchemaRegistry.URLs = []string{registryAddr}
 	}
 
-	kafkaFactory := kafkafactory.NewCachedClientProvider(&cfg, log)
+	kafkaFactory := kafkafactory.NewCachedClientProvider(&cfg, log, prometheus.NewRegistry())
 	schemaFactory, _ := schema.NewSingleClientProvider(&cfg)
 	cacheFn := func(ctx context.Context) (string, error) { return "single/", nil }
 

--- a/backend/pkg/console/log_dir_topic_test.go
+++ b/backend/pkg/console/log_dir_topic_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kfake"
@@ -212,7 +213,7 @@ func TestLogDirsByTopic(t *testing.T) {
 		require.NoError(t, fakeCluster.MoveTopicPartition(topicName, 2, 2))
 
 		consoleSvc := Service{
-			kafkaClientFactory: kafkafactory.NewCachedClientProvider(&kafkaCfg, slog.New(slog.NewTextHandler(nil, &slog.HandlerOptions{Level: slog.LevelError + 1}))),
+			kafkaClientFactory: kafkafactory.NewCachedClientProvider(&kafkaCfg, slog.New(slog.NewTextHandler(nil, &slog.HandlerOptions{Level: slog.LevelError + 1})), prometheus.NewRegistry()),
 			logger:             slog.New(slog.NewTextHandler(nil, &slog.HandlerOptions{Level: slog.LevelError + 1})),
 		}
 
@@ -288,7 +289,7 @@ func TestLogDirsByTopic(t *testing.T) {
 		require.NoError(t, fakeCluster.MoveTopicPartition(topicName, 2, 2))
 
 		consoleSvc := Service{
-			kafkaClientFactory: kafkafactory.NewCachedClientProvider(&kafkaCfg, slog.New(slog.NewTextHandler(nil, &slog.HandlerOptions{Level: slog.LevelError + 1}))),
+			kafkaClientFactory: kafkafactory.NewCachedClientProvider(&kafkaCfg, slog.New(slog.NewTextHandler(nil, &slog.HandlerOptions{Level: slog.LevelError + 1})), prometheus.NewRegistry()),
 			logger:             slog.New(slog.NewTextHandler(nil, &slog.HandlerOptions{Level: slog.LevelError + 1})),
 		}
 

--- a/backend/pkg/console/topic_config_integration_test.go
+++ b/backend/pkg/console/topic_config_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -44,7 +45,7 @@ func (s *ConsoleIntegrationTestSuite) TestGetTopicConfigs() {
 	cfg.MetricsNamespace = testutil.MetricNameForTest("get_topic_configs")
 	cfg.Kafka.Brokers = []string{testSeedBroker}
 
-	kafkaProvider := kafkafactory.NewCachedClientProvider(&cfg, log)
+	kafkaProvider := kafkafactory.NewCachedClientProvider(&cfg, log, prometheus.NewRegistry())
 	svc, err := NewService(&cfg, log, kafkaProvider, nil, nil, nil, nil)
 	require.NoError(err)
 

--- a/backend/pkg/factory/kafka/kafka.go
+++ b/backend/pkg/factory/kafka/kafka.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jcmturner/gokrb5/v8/client"
 	krbconfig "github.com/jcmturner/gokrb5/v8/config"
 	"github.com/jcmturner/gokrb5/v8/keytab"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sasl"
@@ -65,11 +66,12 @@ type CachedClientProvider struct {
 	cfg         *config.Config
 	logger      *slog.Logger
 	clientCache *cache.Cache[string, *kgo.Client]
+	registry    prometheus.Registerer
 }
 
 // NewCachedClientProvider creates a new CachedClientProvider with the specified
 // configuration and logger, initializing the client cache with defined settings.
-func NewCachedClientProvider(cfg *config.Config, logger *slog.Logger) *CachedClientProvider {
+func NewCachedClientProvider(cfg *config.Config, logger *slog.Logger, registry prometheus.Registerer) *CachedClientProvider {
 	cacheSettings := []cache.Opt{
 		cache.MaxAge(30 * time.Second),
 		cache.MaxErrorAge(time.Second),
@@ -79,6 +81,7 @@ func NewCachedClientProvider(cfg *config.Config, logger *slog.Logger) *CachedCli
 		cfg:         cfg,
 		logger:      logger,
 		clientCache: cache.New[string, *kgo.Client](cacheSettings...),
+		registry:    registry,
 	}
 }
 
@@ -100,7 +103,7 @@ func (f *CachedClientProvider) GetKafkaClient(context.Context) (*kgo.Client, *ka
 
 // createClient creates a Kafka client based on the provided Kafka configuration.
 func (f *CachedClientProvider) createClient() (*kgo.Client, error) {
-	kgoOpts, err := NewKgoConfig(f.cfg.Kafka, f.logger, f.cfg.MetricsNamespace)
+	kgoOpts, err := NewKgoConfig(f.cfg.Kafka, f.logger, f.cfg.MetricsNamespace, f.registry)
 	if err != nil {
 		return nil, apierrors.NewConnectError(
 			connect.CodeInternal,
@@ -109,23 +112,27 @@ func (f *CachedClientProvider) createClient() (*kgo.Client, error) {
 		)
 	}
 
-	client, err := kgo.NewClient(kgoOpts...)
+	kgoClient, err := kgo.NewClient(kgoOpts...)
 	if err != nil {
 		return nil, err
 	}
 
-	// Increment client count metric
-	promActiveClients.Inc()
+	// Increment active clients metric
+	metricsInitMu.RLock()
+	if metrics, exists := registryMetrics[f.registry]; exists {
+		metrics.activeClients.Inc()
+	}
+	metricsInitMu.RUnlock()
 
-	return client, nil
+	return kgoClient, nil
 }
 
 // NewKgoConfig creates a new Config for the Kafka Client as exposed by the franz-go library.
 // If TLS certificates can't be read an error will be returned.
 //
 //nolint:gocognit,cyclop // This function is lengthy, but it's only plumbing configurations. Seems okay to me.
-func NewKgoConfig(cfg config.Kafka, logger *slog.Logger, metricsNamespace string) ([]kgo.Opt, error) {
-	metricHooks := newClientHooks(loggerpkg.Named(logger, "kafka_client_hooks"), metricsNamespace)
+func NewKgoConfig(cfg config.Kafka, logger *slog.Logger, metricsNamespace string, registry prometheus.Registerer) ([]kgo.Opt, error) {
+	metricHooks := newClientHooks(loggerpkg.Named(logger, "kafka_client_hooks"), metricsNamespace, registry)
 
 	opts := []kgo.Opt{
 		kgo.SeedBrokers(cfg.Brokers...),


### PR DESCRIPTION
## Summary
- Enables injection of custom Prometheus registry for Kafka client metrics
- Replaces global registry usage with per-registry metric management
- Maintains all existing metrics functionality including active client tracking

## Changes
- Modified `client_hooks.go` to support per-registry metrics instead of global promauto
- Updated `CachedClientProvider` to accept and use injected Prometheus registry
- Fixed `/admin/metrics` endpoint to use injected registry
- Updated test files to pass registry parameter

This allows enterprise repos to inject their own Prometheus registry while preserving all Kafka metrics collection.