### PR TITLE
refactor: move Kafka client metrics from hooks to factory

### DIFF
--- a/backend/pkg/factory/kafka/client_hooks.go
+++ b/backend/pkg/factory/kafka/client_hooks.go
@@ -56,7 +56,6 @@ type kafkaMetrics struct {
 	requestsReceived prometheus.Counter
 	bytesReceived    prometheus.Counter
 	openConnections  *prometheus.GaugeVec
-	activeClients    prometheus.Gauge
 }
 
 func newClientHooks(logger *slog.Logger, metricsNamespace string, registry prometheus.Registerer) *clientHooks {
@@ -92,12 +91,6 @@ func newClientHooks(logger *slog.Logger, metricsNamespace string, registry prome
 				Name:      "open_connections",
 				Help:      "Number of open connections to Kafka brokers",
 			}, []string{"broker_id"}),
-			activeClients: prometheus.NewGauge(prometheus.GaugeOpts{
-				Namespace: metricsNamespace,
-				Subsystem: "kafka",
-				Name:      "active_clients",
-				Help:      "Number of active Kafka clients",
-			}),
 		}
 
 		registry.MustRegister(
@@ -106,7 +99,6 @@ func newClientHooks(logger *slog.Logger, metricsNamespace string, registry prome
 			metrics.requestsReceived,
 			metrics.bytesReceived,
 			metrics.openConnections,
-			metrics.activeClients,
 		)
 
 		registryMetrics[registry] = metrics

--- a/backend/pkg/factory/kafka/metrics.go
+++ b/backend/pkg/factory/kafka/metrics.go
@@ -1,0 +1,89 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package kafka
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// FactoryMetrics holds all Kafka client factory metrics
+type FactoryMetrics struct {
+	ActiveClientsGauge    prometheus.Gauge
+	ClientsCreatedCounter prometheus.Counter
+	ClientsClosedCounter  prometheus.Counter
+}
+
+var (
+	factoryMetricsRegistry = make(map[string]*FactoryMetrics)
+	factoryMetricsMu       sync.RWMutex
+)
+
+// NewFactoryMetrics creates and registers factory metrics for client tracking
+func NewFactoryMetrics(metricsNamespace string, clientType string, registry prometheus.Registerer) *FactoryMetrics {
+	factoryMetricsMu.Lock()
+	defer factoryMetricsMu.Unlock()
+
+	if metrics, exists := factoryMetricsRegistry[clientType]; exists {
+		return metrics
+	}
+
+	metrics := &FactoryMetrics{
+		ActiveClientsGauge: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "kafka_client",
+			Name:      "active_total",
+			Help:      "Number of active Kafka clients in factory",
+			ConstLabels: prometheus.Labels{
+				"client_type": clientType,
+			},
+		}),
+		ClientsCreatedCounter: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "kafka_client",
+			Name:      "created_total",
+			Help:      "Total number of Kafka clients created in factory",
+			ConstLabels: prometheus.Labels{
+				"client_type": clientType,
+			},
+		}),
+		ClientsClosedCounter: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "kafka_client",
+			Name:      "closed_total",
+			Help:      "Total number of Kafka clients closed in factory",
+			ConstLabels: prometheus.Labels{
+				"client_type": clientType,
+			},
+		}),
+	}
+
+	registry.MustRegister(
+		metrics.ActiveClientsGauge,
+		metrics.ClientsCreatedCounter,
+		metrics.ClientsClosedCounter,
+	)
+
+	factoryMetricsRegistry[clientType] = metrics
+	return metrics
+}
+
+// IncrementActiveClients increments the active clients counter
+func (m *FactoryMetrics) IncrementActiveClients() {
+	m.ActiveClientsGauge.Inc()
+	m.ClientsCreatedCounter.Inc()
+}
+
+// DecrementActiveClients decrements the active clients counter
+func (m *FactoryMetrics) DecrementActiveClients() {
+	m.ActiveClientsGauge.Dec()
+	m.ClientsClosedCounter.Inc()
+}


### PR DESCRIPTION
## Summary

Refactors Kafka client metrics tracking from hooks to factory level for better separation of concerns and extensibility across multiple factory types.

## Key Changes

- Add dedicated `FactoryMetrics` package for centralized client lifecycle tracking
- Move active clients metric from `client_hooks.go` to factory-level management  
- Support multiple factory types (kafka, redpanda, schema) with simplified client type keys
- Provide comprehensive metrics: `active_total`, `created_total`, `closed_total`
- Enable proper client lifecycle tracking with factory cleanup integration

## Benefits

- Better separation of concerns between transport hooks and client management
- Extensible metrics system supporting multiple factory implementations
- Consistent metrics naming with configurable `client_type` labels
- Foundation for tracking client metrics across all factory types in the system