### PR TITLE
fix: ratio input initialization and UI for topic config

### DIFF
--- a/frontend/src/components/license/licenseUtils.tsx
+++ b/frontend/src/components/license/licenseUtils.tsx
@@ -246,7 +246,7 @@ export const isLicenseWithEnterpriseAccess = (license: License): boolean =>
 
 /**
  * Gets the license with the latest expiration time from a list of licenses.
- * 
+ *
  * @param licenses - An array of License objects to evaluate.
  * @returns The license with the latest expiration time, or undefined if the array is empty.
  */
@@ -254,7 +254,7 @@ export const getLatestExpiringLicense = (licenses: License[]): License | undefin
   if (licenses.length === 0) {
     return undefined;
   }
-  
+
   return licenses.reduce((latest, current) => {
     const latestExpiration = Number(latest.expiresAt);
     const currentExpiration = Number(current.expiresAt);

--- a/frontend/src/components/pages/topics/CreateTopicModal/CreateTopicModal.tsx
+++ b/frontend/src/components/pages/topics/CreateTopicModal/CreateTopicModal.tsx
@@ -16,12 +16,12 @@ import {
   isSingleValue,
   Select,
 } from '@redpanda-data/ui';
-import { Slider as UISlider } from '../../../redpanda-ui/components/slider';
-import { Input as UIInput } from '../../../redpanda-ui/components/input';
-import { Label as UILabel } from '../../../redpanda-ui/components/label';
 import { isServerless } from '../../../../config';
 import { api } from '../../../../state/backendApi';
 import { SingleSelect } from '../../../misc/Select';
+import { Input as UIInput } from '../../../redpanda-ui/components/input';
+import { Label as UILabel } from '../../../redpanda-ui/components/label';
+import { Slider as UISlider } from '../../../redpanda-ui/components/slider';
 import type { CleanupPolicyType } from '../types';
 
 type CreateTopicModalState = {
@@ -656,7 +656,7 @@ export function RatioInput(p: { value: number; onChange: (ratio: number) => void
       return;
     }
     const numericValue = Number(inputValue);
-    if (!isNaN(numericValue) && numericValue >= 0 && numericValue <= 100) {
+    if (!Number.isNaN(numericValue) && numericValue >= 0 && numericValue <= 100) {
       p.onChange(numericValue / 100);
     }
   };
@@ -664,9 +664,7 @@ export function RatioInput(p: { value: number; onChange: (ratio: number) => void
   return (
     <div className="space-y-3">
       <div className="space-y-2">
-        <UILabel className="text-sm font-medium text-muted-foreground">
-          Percentage ({percentageValue}%)
-        </UILabel>
+        <UILabel className="text-sm font-medium text-muted-foreground">Percentage ({percentageValue}%)</UILabel>
         <UISlider
           min={0}
           max={100}

--- a/frontend/src/components/pages/topics/CreateTopicModal/CreateTopicModal.tsx
+++ b/frontend/src/components/pages/topics/CreateTopicModal/CreateTopicModal.tsx
@@ -1,7 +1,7 @@
 import { PlusIcon, XIcon } from '@primer/octicons-react';
 import { makeObservable, observable } from 'mobx';
 import { observer } from 'mobx-react';
-import { Component, useEffect, useState } from 'react';
+import React, { Component, useEffect, useState } from 'react';
 import type { TopicConfigEntry } from '../../../../state/restInterfaces';
 import { Label } from '../../../../utils/tsxUtils';
 import { prettyBytes, prettyMilliseconds, titleCase } from '../../../../utils/utils';
@@ -9,19 +9,16 @@ import './CreateTopicModal.scss';
 import {
   Box,
   Button,
-  Flex,
   Input,
   InputGroup,
   InputLeftAddon,
   InputRightAddon,
   isSingleValue,
-  NumberInput,
   Select,
-  Slider,
-  SliderFilledTrack,
-  SliderThumb,
-  SliderTrack,
 } from '@redpanda-data/ui';
+import { Slider as UISlider } from '../../../redpanda-ui/components/slider';
+import { Input as UIInput } from '../../../redpanda-ui/components/input';
+import { Label as UILabel } from '../../../redpanda-ui/components/label';
 import { isServerless } from '../../../../config';
 import { api } from '../../../../state/backendApi';
 import { SingleSelect } from '../../../misc/Select';
@@ -647,26 +644,59 @@ export function DurationSelect(p: {
 }
 
 export function RatioInput(p: { value: number; onChange: (ratio: number) => void }) {
+  const percentageValue = Math.round(p.value * 100);
+
+  const handleSliderChange = (values: number[]) => {
+    p.onChange(values[0] / 100);
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const inputValue = e.target.value;
+    if (inputValue === '') {
+      return;
+    }
+    const numericValue = Number(inputValue);
+    if (!isNaN(numericValue) && numericValue >= 0 && numericValue <= 100) {
+      p.onChange(numericValue / 100);
+    }
+  };
+
   return (
-    <Flex alignItems="center" gap={2}>
-      <Slider min={0} max={100} step={1} onChange={(x) => p.onChange(x / 100)} value={Math.round(p.value * 100)}>
-        <SliderTrack>
-          <SliderFilledTrack />
-        </SliderTrack>
-        <SliderThumb />
-      </Slider>
-      <NumberInput
-        min={0}
-        max={100}
-        value={`${Math.round(p.value * 100)}%`}
-        onChange={(x) => {
-          if (x === null) {
-            return;
-          }
-          p.onChange(Number(x) / 100);
-        }}
-        size="small"
-      />
-    </Flex>
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <UILabel className="text-sm font-medium text-muted-foreground">
+          Percentage ({percentageValue}%)
+        </UILabel>
+        <UISlider
+          min={0}
+          max={100}
+          step={1}
+          value={[percentageValue]}
+          onValueChange={handleSliderChange}
+          className="w-full"
+          aria-label="Percentage slider"
+        />
+      </div>
+      <div className="flex items-center gap-2">
+        <UILabel htmlFor="ratio-input" className="text-sm font-medium whitespace-nowrap">
+          Precise value:
+        </UILabel>
+        <div className="relative flex-shrink-0">
+          <UIInput
+            id="ratio-input"
+            type="number"
+            min={0}
+            max={100}
+            value={percentageValue}
+            onChange={handleInputChange}
+            className="w-20 pr-6 text-right"
+            aria-label="Percentage input"
+          />
+          <span className="absolute right-2 top-1/2 -translate-y-1/2 text-sm text-muted-foreground pointer-events-none">
+            %
+          </span>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/frontend/src/components/pages/topics/TopicConfiguration.tsx
+++ b/frontend/src/components/pages/topics/TopicConfiguration.tsx
@@ -449,7 +449,7 @@ export const ConfigEntryEditorController = <T extends string | number>(p: {
       return <PasswordInput value={value ?? ''} onChange={(x) => onChange(x.target.value as T)} />;
 
     case 'RATIO':
-      return <RatioInput value={Number(value)} onChange={(x) => onChange(x as T)} />;
+      return <RatioInput value={Number(value || entry.value)} onChange={(x) => onChange(x as T)} />;
 
     case 'INTEGER':
       return <NumInput value={Number(value)} onChange={(e) => onChange(Math.round(e ?? 0) as T)} />;

--- a/frontend/src/components/redpanda-ui/components/slider.tsx
+++ b/frontend/src/components/redpanda-ui/components/slider.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { Slider as SliderPrimitive } from 'radix-ui';
+import React from 'react';
+
+import { cn } from '../lib/utils';
+
+function Slider({
+  className,
+  defaultValue,
+  value,
+  min = 0,
+  max = 100,
+  testId,
+  ...props
+}: React.ComponentProps<typeof SliderPrimitive.Root> & { testId?: string }) {
+  const _values = React.useMemo(
+    () => (Array.isArray(value) ? value : Array.isArray(defaultValue) ? defaultValue : [min, max]),
+    [value, defaultValue, min, max],
+  );
+
+  return (
+    <SliderPrimitive.Root
+      data-slot="slider"
+      data-testid={testId}
+      defaultValue={defaultValue}
+      value={value}
+      min={min}
+      max={max}
+      className={cn(
+        'relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col',
+        className,
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        data-slot="slider-track"
+        className={cn(
+          'bg-muted relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5',
+        )}
+      >
+        <SliderPrimitive.Range
+          data-slot="slider-range"
+          className={cn('bg-selected absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full')}
+        />
+      </SliderPrimitive.Track>
+      {Array.from({ length: _values.length }, (_, index) => (
+        <SliderPrimitive.Thumb
+          data-slot="slider-thumb"
+          // biome-ignore lint/suspicious/noArrayIndexKey: part of slider implementation
+          key={index}
+          className="border-selected bg-background ring-selected/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+        />
+      ))}
+    </SliderPrimitive.Root>
+  );
+}
+
+export { Slider };

--- a/frontend/src/state/backendApi.ts
+++ b/frontend/src/state/backendApi.ts
@@ -15,6 +15,13 @@ import { create, type Registry } from '@bufbuild/protobuf';
 import type { ConnectError } from '@connectrpc/connect';
 import { Code } from '@connectrpc/connect';
 import { createStandaloneToast, redpandaTheme, redpandaToastOptions } from '@redpanda-data/ui';
+import {
+  consoleHasEnterpriseFeature,
+  getLatestExpiringLicense,
+  getMillisecondsToExpiration,
+  isBakedInTrial,
+  prettyLicenseType,
+} from 'components/license/licenseUtils';
 import { comparer, computed, observable, runInAction, transaction } from 'mobx';
 import { ListMessagesRequestSchema } from 'protogen/redpanda/api/console/v1alpha1/list_messages_pb';
 import type { TransformMetadata } from 'protogen/redpanda/api/dataplane/v1/transform_pb';
@@ -171,7 +178,6 @@ import {
 import { Features } from './supportedFeatures';
 import { PartitionOffsetOrigin } from './ui';
 import { uiState } from './uiState';
-import { consoleHasEnterpriseFeature, getExpirationDate, getLatestExpiringLicense, getMillisecondsToExpiration, getPrettyExpirationDate, isBakedInTrial, prettyLicenseType } from 'components/license/licenseUtils';
 
 const REST_TIMEOUT_SEC = 25;
 export const REST_CACHE_DURATION_SEC = 20;
@@ -574,13 +580,14 @@ const apiStore = {
         } else {
           appGlobal.historyPush('/login');
         }
-      }).finally(() => {
+      })
+      .finally(() => {
         addHeapEventProperties({
-          "Product Name": "Console",
-          Platform: api.isRedpanda ? "Redpanda" : "Kafka",
-          "Cluster Version": api.clusterOverview?.kafka?.version,
+          'Product Name': 'Console',
+          Platform: api.isRedpanda ? 'Redpanda' : 'Kafka',
+          'Cluster Version': api.clusterOverview?.kafka?.version,
           Version: process.env.REACT_APP_CONSOLE_PLATFORM_VERSION,
-          "Build Date": getBuildDate(),
+          'Build Date': getBuildDate(),
         });
       });
   },
@@ -1958,10 +1965,10 @@ const apiStore = {
           return err;
         }),
     ]);
-  
-    if(this.licenses.length > 0) {
+
+    if (this.licenses.length > 0) {
       const license = getLatestExpiringLicense(this.licenses);
-      if(license !== undefined) {
+      if (license !== undefined) {
         addHeapEventProperties({
           BakedInTrial: isBakedInTrial(license),
           LicenseType: prettyLicenseType(license),
@@ -1970,8 +1977,8 @@ const apiStore = {
       }
     }
     addHeapEventProperties({
-        'SSOEnabled': consoleHasEnterpriseFeature('SINGLE_SIGN_ON'),
-    })
+      SSOEnabled: consoleHasEnterpriseFeature('SINGLE_SIGN_ON'),
+    });
   },
 
   async refreshClusterHealth() {


### PR DESCRIPTION
## Summary
Fixes broken ratio input component for topic configuration (min.cleanable.dirty.ratio).

## Problem
- Ratio inputs initialized to 0% instead of showing current default value (20%)
- Validation errors with "Please match the format requested" tooltip
- Poor UX with unclear percentage indication

## Solution
- Fix initialization logic to use actual current values instead of empty strings
- Migrate to Redpanda UI Registry components (UISlider, UIInput, UILabel) since we couldn't show % as part of the original slider input
- Add clear percentage labeling with dynamic feedback
- Improve accessibility with proper aria-labels