### PR TITLE
mcp: fix template for generate

### DIFF
--- a/frontend/src/components/pages/remote-mcp/templates/input/generate.yaml
+++ b/frontend/src/components/pages/remote-mcp/templates/input/generate.yaml
@@ -18,5 +18,4 @@ generate:
 meta:
   mcp:
     enabled: true
-    description: "Generate 10 example user event messages with realistic data"
-    properties: []
+    description: "Generate example user event messages with realistic data"


### PR DESCRIPTION
- It's only one msg
- Props are ignored for input type, so omit it to avoid confusion