### PR TITLE
frontend: rpk cloud mcp proxy flag fixes

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -31,7 +31,7 @@ The dev server proxies API requests to `http://localhost:9090` for `/api`, `/red
 ### Testing
 
 ```bash
-bun run test             # Run unit and integration tests (Bun's built-in test runner)
+bun run test             # Run unit and integration tests (Vitest)
 bun run e2e-test         # Run E2E tests with Playwright
 bun run e2e-test:ui      # Run E2E tests with Playwright (UI mode)
 bun run install:chromium # Install Chromium for Playwright
@@ -39,7 +39,7 @@ bun run install:chromium # Install Chromium for Playwright
 
 **Testing Strategy:**
 
-1. **Bun Tests** (Unit + Integration) - Fast, cheap to run
+1. **Vitest Tests** (Unit + Integration) - Fast, cheap to run
    - Test CRUD operations and business logic
    - Verify gRPC Connect transport endpoints are called correctly
    - Test data fetching, mutations, and state management
@@ -58,7 +58,7 @@ bun run install:chromium # Install Chromium for Playwright
 
 **What to Test:**
 
-✅ **Integration Tests (Bun):**
+✅ **Integration Tests (Vitest):**
 - API calls are made with correct parameters
 - gRPC Connect transport endpoints are invoked
 - Data transformations and business logic
@@ -102,7 +102,7 @@ bun run analyze          # Build with bundle analyzer (RSDOCTOR=true)
 - **Class components** - Old React pattern
 - **Decorator pattern** - Old TypeScript pattern (`@observable`, `@action`, etc.)
 - **Yup** - Old validation library, use Zod or protovalidate-es instead
-- **Vitest/Jest** - Old test runner
+- **Jest** - Old test runner
 
 #### ✅ MODERN (Use for All New Code)
 
@@ -111,7 +111,7 @@ bun run analyze          # Build with bundle analyzer (RSDOCTOR=true)
 - **Functional components** - React 18.3 hooks pattern
 - **Local state** - `useState`, `useReducer` for component state
 - **Zustand** - For global state management (when needed)
-- **Bun test** - For unit and integration tests (CRUD, API calls)
+- **Vitest** - For unit and integration tests (CRUD, API calls)
 - **Playwright** - For E2E tests (complex browser scenarios)
 - **React Hook Form** - For form management (complex forms)
 - **AutoForm** - For simple forms without custom components
@@ -431,7 +431,7 @@ export const MCPServerPage = () => {
 4. **Minimize className usage** - delegate styling to UI components and layouts
 5. Add route definition in `src/components/routes.tsx`
 6. For state: use local state or Zustand (not MobX)
-7. Write integration tests with Bun (focus on CRUD and API calls, not component rendering)
+7. Write integration tests with Vitest (focus on CRUD and API calls, not component rendering)
 8. Write E2E tests with Playwright for complex user journeys
 
 **Example Structure:**
@@ -488,12 +488,12 @@ const { data, isLoading, error } = useQuery({
 
 **Testing:**
 ```tsx
-// ✅ GOOD - Integration test for API calls and business logic (Bun test)
-import { describe, test, expect, mock } from 'bun:test';
+// ✅ GOOD - Integration test for API calls and business logic (Vitest)
+import { describe, test, expect, vi } from 'vitest';
 
 describe('MCP Server CRUD', () => {
   test('should create MCP server with correct transport call', async () => {
-    const mockTransport = mock(() => Promise.resolve({ id: '123', name: 'test' }));
+    const mockTransport = vi.fn(() => Promise.resolve({ id: '123', name: 'test' }));
 
     const result = await createMCPServer({ name: 'test', url: 'http://example.com' });
 
@@ -506,7 +506,7 @@ describe('MCP Server CRUD', () => {
   });
 
   test('should handle server creation errors', async () => {
-    const mockTransport = mock(() => Promise.reject(new Error('Network error')));
+    const mockTransport = vi.fn(() => Promise.reject(new Error('Network error')));
 
     await expect(createMCPServer({ name: 'test' })).rejects.toThrow('Network error');
   });
@@ -663,7 +663,7 @@ Frontend config via `REACT_APP_` prefixed environment variables:
 - ✅ Use Redpanda UI registry components (Tailwind-based, NOT `@redpanda-data/ui`)
 - ✅ Use functional components with React hooks
 - ✅ Use local state or Zustand for state management
-- ✅ Use Bun test for unit and integration tests (CRUD, API calls, business logic)
+- ✅ Use Vitest for unit and integration tests (CRUD, API calls, business logic)
 - ✅ Focus integration tests on gRPC Connect transport calls, not component rendering
 - ✅ Use Playwright for E2E tests (complex browser scenarios and user journeys)
 - ✅ Use AutoForm for simple forms (no custom components)
@@ -679,7 +679,7 @@ Frontend config via `REACT_APP_` prefixed environment variables:
 - ❌ Create new class components
 - ❌ Use decorator pattern (`@observable`, `@action`, etc.)
 - ❌ Use Yup for validation
-- ❌ Use Vitest/Jest for tests
+- ❌ Use Jest for tests
 - ❌ Write tests that extensively test component rendering (tested in UI registry)
 - ❌ Test UI component behavior in integration tests (use Playwright for UI flows)
 - ❌ Expand legacy patterns in new code

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/__snapshots__/utils.test.ts.snap
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/__snapshots__/utils.test.ts.snap
@@ -1,0 +1,904 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`createMCPConfig > Integration with Cursor > creates config for Cursor with serverless cluster 1`] = `
+{
+  "args": [
+    "cloud",
+    "mcp",
+    "proxy",
+    "--serverless-cluster-id",
+    "serverless-456",
+    "--mcp-server-id",
+    "mcp-999",
+  ],
+  "command": "rpk",
+  "name": "cursor-serverless",
+}
+`;
+
+exports[`createMCPConfig > Integration with Cursor > creates config object compatible with Cursor IDE 1`] = `
+{
+  "args": [
+    "cloud",
+    "mcp",
+    "proxy",
+    "--cluster-id",
+    "cursor-cluster-123",
+    "--mcp-server-id",
+    "cursor-mcp-456",
+  ],
+  "command": "rpk",
+  "name": "cursor-test-server",
+}
+`;
+
+exports[`createMCPConfig > Integration with VSCode > creates config for VSCode with serverless cluster 1`] = `
+{
+  "args": [
+    "cloud",
+    "mcp",
+    "proxy",
+    "--serverless-cluster-id",
+    "serverless-123",
+    "--mcp-server-id",
+    "mcp-789",
+  ],
+  "command": "rpk",
+  "name": "vscode-serverless",
+}
+`;
+
+exports[`createMCPConfig > Integration with VSCode > creates config object compatible with VSCode extension 1`] = `
+{
+  "args": [
+    "cloud",
+    "mcp",
+    "proxy",
+    "--cluster-id",
+    "vscode-cluster-123",
+    "--mcp-server-id",
+    "vscode-mcp-456",
+  ],
+  "command": "rpk",
+  "name": "vscode-test-server",
+}
+`;
+
+exports[`createMCPConfig > Non-production environment (with -X cloud_environment flag) > includes environment flag for serverless cluster 1`] = `
+{
+  "args": [
+    "-X",
+    "cloud_environment=integration",
+    "cloud",
+    "mcp",
+    "proxy",
+    "--serverless-cluster-id",
+    "cluster-123",
+    "--mcp-server-id",
+    "mcp-456",
+  ],
+  "command": "rpk",
+  "name": "test-server",
+}
+`;
+
+exports[`createMCPConfig > Non-production environment for VSCode and Cursor > Cursor config includes environment flag 1`] = `
+{
+  "args": [
+    "-X",
+    "cloud_environment=integration",
+    "cloud",
+    "mcp",
+    "proxy",
+    "--cluster-id",
+    "dev-cluster",
+    "--mcp-server-id",
+    "dev-mcp",
+  ],
+  "command": "rpk",
+  "name": "cursor-dev-server",
+}
+`;
+
+exports[`createMCPConfig > Non-production environment for VSCode and Cursor > VSCode config includes environment flag 1`] = `
+{
+  "args": [
+    "-X",
+    "cloud_environment=integration",
+    "cloud",
+    "mcp",
+    "proxy",
+    "--cluster-id",
+    "dev-cluster",
+    "--mcp-server-id",
+    "dev-mcp",
+  ],
+  "command": "rpk",
+  "name": "vscode-dev-server",
+}
+`;
+
+exports[`createMCPConfig > Preprod environment > includes preprod environment flag in args 1`] = `
+{
+  "args": [
+    "-X",
+    "cloud_environment=preprod",
+    "cloud",
+    "mcp",
+    "proxy",
+    "--cluster-id",
+    "cluster-123",
+    "--mcp-server-id",
+    "mcp-456",
+  ],
+  "command": "rpk",
+  "name": "test-server",
+}
+`;
+
+exports[`createMCPConfig > Production environment (no -X cloud_environment flag) > creates config for serverless cluster 1`] = `
+{
+  "args": [
+    "cloud",
+    "mcp",
+    "proxy",
+    "--serverless-cluster-id",
+    "cluster-123",
+    "--mcp-server-id",
+    "mcp-456",
+  ],
+  "command": "rpk",
+  "name": "test-server",
+}
+`;
+
+exports[`createMCPConfig > Production environment (no -X cloud_environment flag) > creates config with empty strings for missing IDs 1`] = `
+{
+  "args": [
+    "cloud",
+    "mcp",
+    "proxy",
+    "--cluster-id",
+    "",
+    "--mcp-server-id",
+    "",
+  ],
+  "command": "rpk",
+  "name": "test-server",
+}
+`;
+
+exports[`getClientCommand > Default scope handling > claude-code command - defaults to "local" scope when not provided 1`] = `
+"claude mcp add-json test-server --scope local \\
+'{"type":"stdio","command":"rpk","args":[
+"cloud","mcp","proxy",
+"--cluster-id","cluster-123",
+"--mcp-server-id","mcp-456"]}'"
+`;
+
+exports[`getClientCommand > Default scope handling > gemini command - uses provided scope 1`] = `
+"gemini mcp add test-server \\
+--scope user \\
+--transport stdio rpk \\
+--args \\
+"cloud" "mcp" "proxy" \\
+"--cluster-id" "cluster-123" \\
+"--mcp-server-id" "mcp-456""
+`;
+
+exports[`getClientCommand > Non-production environment (with -X cloud_environment flag) > 'auggie' command > returns command 1`] = `
+"auggie mcp add test-server \\
+--transport stdio \\
+--command rpk \\
+--args "-X" "cloud_environment=integration" \\
+"cloud" "mcp" "proxy" \\
+"--cluster-id" "cluster-123" \\
+"--mcp-server-id" "mcp-456""
+`;
+
+exports[`getClientCommand > Non-production environment (with -X cloud_environment flag) > 'claude-code' command > returns command 1`] = `
+"claude mcp add-json test-server --scope local \\
+'{"type":"stdio","command":"rpk","args":[
+"-X","cloud_environment=integration","cloud","mcp","proxy",
+"--cluster-id","cluster-123",
+"--mcp-server-id","mcp-456"]}'"
+`;
+
+exports[`getClientCommand > Non-production environment (with -X cloud_environment flag) > 'codex' command > returns command 1`] = `
+"codex mcp add test-server -- rpk \\
+"-X" "cloud_environment=integration" \\
+"cloud" "mcp" "proxy" \\
+"--cluster-id" "cluster-123" \\
+"--mcp-server-id" "mcp-456""
+`;
+
+exports[`getClientCommand > Non-production environment (with -X cloud_environment flag) > 'gemini' command > returns command 1`] = `
+"gemini mcp add test-server \\
+--scope local \\
+--transport stdio rpk \\
+--args "-X" "cloud_environment=integration" \\
+"cloud" "mcp" "proxy" \\
+"--cluster-id" "cluster-123" \\
+"--mcp-server-id" "mcp-456""
+`;
+
+exports[`getClientCommand > Production environment (no -X cloud_environment flag) > 'auggie' command > returns command 1`] = `
+"auggie mcp add test-server \\
+--transport stdio \\
+--command rpk \\
+--args \\
+"cloud" "mcp" "proxy" \\
+"--cluster-id" "cluster-123" \\
+"--mcp-server-id" "mcp-456""
+`;
+
+exports[`getClientCommand > Production environment (no -X cloud_environment flag) > 'claude-code' command > returns command 1`] = `
+"claude mcp add-json test-server --scope user \\
+'{"type":"stdio","command":"rpk","args":[
+"cloud","mcp","proxy",
+"--cluster-id","cluster-123",
+"--mcp-server-id","mcp-456"]}'"
+`;
+
+exports[`getClientCommand > Production environment (no -X cloud_environment flag) > 'codex' command > returns command 1`] = `
+"codex mcp add test-server -- rpk \\
+\\
+"cloud" "mcp" "proxy" \\
+"--cluster-id" "cluster-123" \\
+"--mcp-server-id" "mcp-456""
+`;
+
+exports[`getClientCommand > Production environment (no -X cloud_environment flag) > 'gemini' command > returns command 1`] = `
+"gemini mcp add test-server \\
+--scope project \\
+--transport stdio rpk \\
+--args \\
+"cloud" "mcp" "proxy" \\
+"--cluster-id" "cluster-123" \\
+"--mcp-server-id" "mcp-456""
+`;
+
+exports[`getClientCommand > Serverless cluster flag > auggie command - serverless cluster 1`] = `
+"auggie mcp add test-server \\
+--transport stdio \\
+--command rpk \\
+--args \\
+"cloud" "mcp" "proxy" \\
+"--serverless-cluster-id" "cluster-123" \\
+"--mcp-server-id" "mcp-456""
+`;
+
+exports[`getClientCommand > Serverless cluster flag > codex command - regular cluster 1`] = `
+"codex mcp add test-server -- rpk \\
+\\
+"cloud" "mcp" "proxy" \\
+"--cluster-id" "cluster-123" \\
+"--mcp-server-id" "mcp-456""
+`;
+
+exports[`getClientConfig > Non-production environment (with -X cloud_environment flag) > 'auggie' config > returns config 1`] = `
+"{
+  "mcpServers": {
+    "test-server": {
+      "command": "rpk",
+      "args": [
+        "-X",
+        "cloud_environment=integration",
+        "cloud",
+        "mcp",
+        "proxy",
+        "--cluster-id",
+        "cluster-123",
+        "--mcp-server-id",
+        "mcp-456"
+      ]
+    }
+  }
+}"
+`;
+
+exports[`getClientConfig > Non-production environment (with -X cloud_environment flag) > 'claude-code' config > returns config 1`] = `
+"{
+  "mcp": {
+    "servers": {
+      "test-server": {
+        "command": "rpk",
+        "args": [
+          "-X",
+          "cloud_environment=integration",
+          "cloud",
+          "mcp",
+          "proxy",
+          "--cluster-id",
+          "cluster-123",
+          "--mcp-server-id",
+          "mcp-456"
+        ]
+      }
+    }
+  }
+}"
+`;
+
+exports[`getClientConfig > Non-production environment (with -X cloud_environment flag) > 'claude-desktop' config > returns config 1`] = `
+"{
+  "mcp": {
+    "servers": {
+      "test-server": {
+        "command": "rpk",
+        "args": [
+          "-X",
+          "cloud_environment=integration",
+          "cloud",
+          "mcp",
+          "proxy",
+          "--cluster-id",
+          "cluster-123",
+          "--mcp-server-id",
+          "mcp-456"
+        ]
+      }
+    }
+  }
+}"
+`;
+
+exports[`getClientConfig > Non-production environment (with -X cloud_environment flag) > 'cline' config > returns config 1`] = `
+"{
+  "mcpServers": {
+    "test-server": {
+      "command": "rpk",
+      "args": [
+        "-X",
+        "cloud_environment=integration",
+        "cloud",
+        "mcp",
+        "proxy",
+        "--cluster-id",
+        "cluster-123",
+        "--mcp-server-id",
+        "mcp-456"
+      ]
+    }
+  }
+}"
+`;
+
+exports[`getClientConfig > Non-production environment (with -X cloud_environment flag) > 'codex' config > returns config 1`] = `
+"[mcp_servers.test-server]
+command = "rpk"
+args = ["-X","cloud_environment=integration", "cloud", "mcp", "proxy", "--cluster-id", "cluster-123", "--mcp-server-id", "mcp-456"]"
+`;
+
+exports[`getClientConfig > Non-production environment (with -X cloud_environment flag) > 'cursor' config > returns config 1`] = `
+"{
+  "mcpServers": {
+    "test-server": {
+      "command": "rpk",
+      "args": [
+        "-X",
+        "cloud_environment=integration",
+        "cloud",
+        "mcp",
+        "proxy",
+        "--cluster-id",
+        "cluster-123",
+        "--mcp-server-id",
+        "mcp-456"
+      ]
+    }
+  }
+}"
+`;
+
+exports[`getClientConfig > Non-production environment (with -X cloud_environment flag) > 'gemini' config > returns config 1`] = `
+"{
+  "mcpServers": {
+    "test-server": {
+      "command": "rpk",
+      "args": [
+        "-X",
+        "cloud_environment=integration",
+        "cloud",
+        "mcp",
+        "proxy",
+        "--cluster-id",
+        "cluster-123",
+        "--mcp-server-id",
+        "mcp-456"
+      ]
+    }
+  }
+}"
+`;
+
+exports[`getClientConfig > Non-production environment (with -X cloud_environment flag) > 'manus' config > returns config 1`] = `
+"{
+  "mcpServers": {
+    "test-server": {
+      "command": "rpk",
+      "args": [
+        "-X",
+        "cloud_environment=integration",
+        "cloud",
+        "mcp",
+        "proxy",
+        "--cluster-id",
+        "cluster-123",
+        "--mcp-server-id",
+        "mcp-456"
+      ]
+    }
+  }
+}"
+`;
+
+exports[`getClientConfig > Non-production environment (with -X cloud_environment flag) > 'vscode' config > returns config 1`] = `
+"{
+  "mcp": {
+    "servers": {
+      "test-server": {
+        "command": "rpk",
+        "args": [
+          "-X",
+          "cloud_environment=integration",
+          "cloud",
+          "mcp",
+          "proxy",
+          "--cluster-id",
+          "cluster-123",
+          "--mcp-server-id",
+          "mcp-456"
+        ]
+      }
+    }
+  }
+}"
+`;
+
+exports[`getClientConfig > Non-production environment (with -X cloud_environment flag) > 'warp' config > returns config 1`] = `
+"{
+  "mcpServers": {
+    "test-server": {
+      "command": "rpk",
+      "args": [
+        "-X",
+      "cloud_environment=integration",
+      "cloud",
+        "mcp",
+        "proxy",
+        "--cluster-id",
+        "cluster-123",
+        "--mcp-server-id",
+        "mcp-456"
+      ]
+    }
+  }
+}"
+`;
+
+exports[`getClientConfig > Non-production environment (with -X cloud_environment flag) > 'windsurf' config > returns config 1`] = `
+"{
+  "mcpServers": {
+    "test-server": {
+      "command": "rpk",
+      "args": [
+        "-X",
+      "cloud_environment=integration",
+      "cloud",
+        "mcp",
+        "proxy",
+        "--cluster-id",
+        "cluster-123",
+        "--mcp-server-id",
+        "mcp-456"
+      ]
+    }
+  }
+}"
+`;
+
+exports[`getClientConfig > Production environment (no -X flag) > 'auggie' config > returns config 1`] = `
+"{
+  "mcpServers": {
+    "test-server": {
+      "command": "rpk",
+      "args": [
+        "cloud",
+        "mcp",
+        "proxy",
+        "--cluster-id",
+        "cluster-123",
+        "--mcp-server-id",
+        "mcp-456"
+      ]
+    }
+  }
+}"
+`;
+
+exports[`getClientConfig > Production environment (no -X flag) > 'claude-code' config > returns config 1`] = `
+"{
+  "mcp": {
+    "servers": {
+      "test-server": {
+        "command": "rpk",
+        "args": [
+          "cloud",
+          "mcp",
+          "proxy",
+          "--cluster-id",
+          "cluster-123",
+          "--mcp-server-id",
+          "mcp-456"
+        ]
+      }
+    }
+  }
+}"
+`;
+
+exports[`getClientConfig > Production environment (no -X flag) > 'claude-desktop' config > returns config 1`] = `
+"{
+  "mcp": {
+    "servers": {
+      "test-server": {
+        "command": "rpk",
+        "args": [
+          "cloud",
+          "mcp",
+          "proxy",
+          "--cluster-id",
+          "cluster-123",
+          "--mcp-server-id",
+          "mcp-456"
+        ]
+      }
+    }
+  }
+}"
+`;
+
+exports[`getClientConfig > Production environment (no -X flag) > 'cline' config > returns config 1`] = `
+"{
+  "mcpServers": {
+    "test-server": {
+      "command": "rpk",
+      "args": [
+        "cloud",
+        "mcp",
+        "proxy",
+        "--cluster-id",
+        "cluster-123",
+        "--mcp-server-id",
+        "mcp-456"
+      ]
+    }
+  }
+}"
+`;
+
+exports[`getClientConfig > Production environment (no -X flag) > 'codex' config > returns config 1`] = `
+"[mcp_servers.test-server]
+command = "rpk"
+args = ["cloud", "mcp", "proxy", "--cluster-id", "cluster-123", "--mcp-server-id", "mcp-456"]"
+`;
+
+exports[`getClientConfig > Production environment (no -X flag) > 'cursor' config > returns config 1`] = `
+"{
+  "mcpServers": {
+    "test-server": {
+      "command": "rpk",
+      "args": [
+        "cloud",
+        "mcp",
+        "proxy",
+        "--cluster-id",
+        "cluster-123",
+        "--mcp-server-id",
+        "mcp-456"
+      ]
+    }
+  }
+}"
+`;
+
+exports[`getClientConfig > Production environment (no -X flag) > 'gemini' config > returns config 1`] = `
+"{
+  "mcpServers": {
+    "test-server": {
+      "command": "rpk",
+      "args": [
+        "cloud",
+        "mcp",
+        "proxy",
+        "--cluster-id",
+        "cluster-123",
+        "--mcp-server-id",
+        "mcp-456"
+      ]
+    }
+  }
+}"
+`;
+
+exports[`getClientConfig > Production environment (no -X flag) > 'manus' config > returns config 1`] = `
+"{
+  "mcpServers": {
+    "test-server": {
+      "command": "rpk",
+      "args": [
+        "cloud",
+        "mcp",
+        "proxy",
+        "--cluster-id",
+        "cluster-123",
+        "--mcp-server-id",
+        "mcp-456"
+      ]
+    }
+  }
+}"
+`;
+
+exports[`getClientConfig > Production environment (no -X flag) > 'vscode' config > returns config 1`] = `
+"{
+  "mcp": {
+    "servers": {
+      "test-server": {
+        "command": "rpk",
+        "args": [
+          "cloud",
+          "mcp",
+          "proxy",
+          "--cluster-id",
+          "cluster-123",
+          "--mcp-server-id",
+          "mcp-456"
+        ]
+      }
+    }
+  }
+}"
+`;
+
+exports[`getClientConfig > Production environment (no -X flag) > 'warp' config > returns config 1`] = `
+"{
+  "mcpServers": {
+    "test-server": {
+      "command": "rpk",
+      "args": [
+        "cloud",
+        "mcp",
+        "proxy",
+        "--cluster-id",
+        "cluster-123",
+        "--mcp-server-id",
+        "mcp-456"
+      ]
+    }
+  }
+}"
+`;
+
+exports[`getClientConfig > Production environment (no -X flag) > 'windsurf' config > returns config 1`] = `
+"{
+  "mcpServers": {
+    "test-server": {
+      "command": "rpk",
+      "args": [
+        "cloud",
+        "mcp",
+        "proxy",
+        "--cluster-id",
+        "cluster-123",
+        "--mcp-server-id",
+        "mcp-456"
+      ]
+    }
+  }
+}"
+`;
+
+exports[`getRpkCommand > Default placeholders > uses placeholder when clusterId is not provided 1`] = `
+"rpk cloud mcp proxy \\
+--cluster-id YOUR_CLUSTER_ID \\
+--mcp-server-id mcp-456 \\
+--install --client claude-code"
+`;
+
+exports[`getRpkCommand > Default placeholders > uses placeholder when mcpServerId is not provided 1`] = `
+"rpk cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id YOUR_MCP_SERVER_ID \\
+--install --client claude-code"
+`;
+
+exports[`getRpkCommand > Default placeholders > uses serverless placeholder when clusterId is not provided for serverless 1`] = `
+"rpk cloud mcp proxy \\
+--serverless-cluster-id YOUR_SERVERLESS_CLUSTER_ID \\
+--mcp-server-id mcp-456 \\
+--install --client claude-code"
+`;
+
+exports[`getRpkCommand > Non-production environment (with -X cloud_environment flag) > clientType: 'auggie' > generates correct command with environment flag 1`] = `
+"rpk -X cloud_environment=integration cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client auggie"
+`;
+
+exports[`getRpkCommand > Non-production environment (with -X cloud_environment flag) > clientType: 'claude-code' > generates correct command with environment flag 1`] = `
+"rpk -X cloud_environment=integration cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client claude-code"
+`;
+
+exports[`getRpkCommand > Non-production environment (with -X cloud_environment flag) > clientType: 'claude-desktop' > generates correct command with environment flag 1`] = `
+"rpk -X cloud_environment=integration cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client claude-desktop"
+`;
+
+exports[`getRpkCommand > Non-production environment (with -X cloud_environment flag) > clientType: 'cline' > generates correct command with environment flag 1`] = `
+"rpk -X cloud_environment=integration cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client cline"
+`;
+
+exports[`getRpkCommand > Non-production environment (with -X cloud_environment flag) > clientType: 'codex' > generates correct command with environment flag 1`] = `
+"rpk -X cloud_environment=integration cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client codex"
+`;
+
+exports[`getRpkCommand > Non-production environment (with -X cloud_environment flag) > clientType: 'cursor' > generates correct command with environment flag 1`] = `
+"rpk -X cloud_environment=integration cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client cursor"
+`;
+
+exports[`getRpkCommand > Non-production environment (with -X cloud_environment flag) > clientType: 'gemini' > generates correct command with environment flag 1`] = `
+"rpk -X cloud_environment=integration cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client gemini"
+`;
+
+exports[`getRpkCommand > Non-production environment (with -X cloud_environment flag) > clientType: 'manus' > generates correct command with environment flag 1`] = `
+"rpk -X cloud_environment=integration cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client manus"
+`;
+
+exports[`getRpkCommand > Non-production environment (with -X cloud_environment flag) > clientType: 'vscode' > generates correct command with environment flag 1`] = `
+"rpk -X cloud_environment=integration cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client vscode"
+`;
+
+exports[`getRpkCommand > Non-production environment (with -X cloud_environment flag) > clientType: 'warp' > generates correct command with environment flag 1`] = `
+"rpk -X cloud_environment=integration cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client warp"
+`;
+
+exports[`getRpkCommand > Non-production environment (with -X cloud_environment flag) > clientType: 'windsurf' > generates correct command with environment flag 1`] = `
+"rpk -X cloud_environment=integration cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client windsurf"
+`;
+
+exports[`getRpkCommand > Preprod environment > includes preprod environment flag 1`] = `
+"rpk -X cloud_environment=preprod cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client claude-code"
+`;
+
+exports[`getRpkCommand > Production environment (no -X cloud_environment flag) > clientType: 'auggie' > generates correct command 1`] = `
+"rpk cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client auggie"
+`;
+
+exports[`getRpkCommand > Production environment (no -X cloud_environment flag) > clientType: 'claude-code' > generates correct command 1`] = `
+"rpk cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client claude-code"
+`;
+
+exports[`getRpkCommand > Production environment (no -X cloud_environment flag) > clientType: 'claude-desktop' > generates correct command 1`] = `
+"rpk cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client claude-desktop"
+`;
+
+exports[`getRpkCommand > Production environment (no -X cloud_environment flag) > clientType: 'cline' > generates correct command 1`] = `
+"rpk cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client cline"
+`;
+
+exports[`getRpkCommand > Production environment (no -X cloud_environment flag) > clientType: 'codex' > generates correct command 1`] = `
+"rpk cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client codex"
+`;
+
+exports[`getRpkCommand > Production environment (no -X cloud_environment flag) > clientType: 'cursor' > generates correct command 1`] = `
+"rpk cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client cursor"
+`;
+
+exports[`getRpkCommand > Production environment (no -X cloud_environment flag) > clientType: 'gemini' > generates correct command 1`] = `
+"rpk cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client gemini"
+`;
+
+exports[`getRpkCommand > Production environment (no -X cloud_environment flag) > clientType: 'manus' > generates correct command 1`] = `
+"rpk cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client manus"
+`;
+
+exports[`getRpkCommand > Production environment (no -X cloud_environment flag) > clientType: 'vscode' > generates correct command 1`] = `
+"rpk cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client vscode"
+`;
+
+exports[`getRpkCommand > Production environment (no -X cloud_environment flag) > clientType: 'warp' > generates correct command 1`] = `
+"rpk cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client warp"
+`;
+
+exports[`getRpkCommand > Production environment (no -X cloud_environment flag) > clientType: 'windsurf' > generates correct command 1`] = `
+"rpk cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client windsurf"
+`;
+
+exports[`getRpkCommand > Production environment (no -X cloud_environment flag) > generates command without client type (uses placeholder) 1`] = `
+"rpk cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client YOUR_CLIENT_TYPE"
+`;
+
+exports[`getRpkCommand > Serverless cluster flag > uses --cluster-id for regular clusters 1`] = `
+"rpk cloud mcp proxy \\
+--cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client claude-code"
+`;
+
+exports[`getRpkCommand > Serverless cluster flag > uses --serverless-cluster-id for serverless clusters 1`] = `
+"rpk cloud mcp proxy \\
+--serverless-cluster-id cluster-123 \\
+--mcp-server-id mcp-456 \\
+--install --client claude-code"
+`;

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/auggie.tsx
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/auggie.tsx
@@ -16,7 +16,7 @@ import AuggieLogo from '../../../../../assets/auggie.svg';
 import { RemoteMCPConnectDocsAlert } from '../../remote-mcp-connect-docs-alert';
 import { InstallRpkListItem } from '../install-rpk-list-item';
 import { LoginToRpkListItem } from '../login-to-rpk-list-item';
-import { getClientCommand, getClientConfig, getMCPServerName, type MCPServer } from '../utils';
+import { ClientType, getClientCommand, getClientConfig, getMCPServerName, type MCPServer } from '../utils';
 
 interface ClientAuggieProps {
   mcpServer: MCPServer;
@@ -27,14 +27,14 @@ export const ClientAuggie = ({ mcpServer }: ClientAuggieProps) => {
   const mcpServerId = mcpServer?.id;
   const mcpServerName = getMCPServerName(mcpServer?.displayName ?? '');
 
-  const auggieCommand = getClientCommand('auggie', {
+  const auggieCommand = getClientCommand(ClientType.AUGGIE, {
     mcpServerName,
     clusterId,
     mcpServerId,
     isServerless: config.isServerless,
   });
 
-  const augmentCodeConfigJson = getClientConfig('auggie', {
+  const augmentCodeConfigJson = getClientConfig(ClientType.AUGGIE, {
     mcpServerName,
     clusterId,
     mcpServerId,

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/auggie.tsx
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/auggie.tsx
@@ -16,7 +16,7 @@ import AuggieLogo from '../../../../../assets/auggie.svg';
 import { RemoteMCPConnectDocsAlert } from '../../remote-mcp-connect-docs-alert';
 import { InstallRpkListItem } from '../install-rpk-list-item';
 import { LoginToRpkListItem } from '../login-to-rpk-list-item';
-import { getMCPServerName, getRpkCloudEnvironment, type MCPServer } from '../utils';
+import { getClientCommand, getClientConfig, getMCPServerName, type MCPServer } from '../utils';
 
 interface ClientAuggieProps {
   mcpServer: MCPServer;
@@ -27,55 +27,19 @@ export const ClientAuggie = ({ mcpServer }: ClientAuggieProps) => {
   const mcpServerId = mcpServer?.id;
   const mcpServerName = getMCPServerName(mcpServer?.displayName ?? '');
 
-  const clusterFlag = config.isServerless ? '--serverless-cluster-id' : '--cluster-id';
+  const auggieCommand = getClientCommand('auggie', {
+    mcpServerName,
+    clusterId,
+    mcpServerId,
+    isServerless: config.isServerless,
+  });
 
-  const showCloudEnvironmentFlag = getRpkCloudEnvironment() !== 'production';
-
-  const cloudEnvArg = showCloudEnvironmentFlag ? `"cloud_environment=${getRpkCloudEnvironment()}" ` : '';
-  const auggieCommand = `auggie mcp add ${mcpServerName} \\
---transport stdio \\
---command rpk \\
---args "-X" ${cloudEnvArg}\\
-"cloud" "mcp" "proxy" \\
-"${clusterFlag}" "${clusterId}" \\
-"--mcp-server-id" "${mcpServerId}"`;
-
-  const augmentCodeConfigJson = showCloudEnvironmentFlag
-    ? `{
-  "mcpServers": {
-    "${mcpServerName}": {
-      "command": "rpk",
-      "args": [
-        "-X",
-        "cloud_environment=${getRpkCloudEnvironment()}",
-        "cloud",
-        "mcp",
-        "proxy",
-        "${clusterFlag}",
-        "${clusterId}",
-        "--mcp-server-id",
-        "${mcpServerId}"
-      ]
-    }
-  }
-}`
-    : `{
-  "mcpServers": {
-    "${mcpServerName}": {
-      "command": "rpk",
-      "args": [
-        "-X",
-        "cloud",
-        "mcp",
-        "proxy",
-        "${clusterFlag}",
-        "${clusterId}",
-        "--mcp-server-id",
-        "${mcpServerId}"
-      ]
-    }
-  }
-}`;
+  const augmentCodeConfigJson = getClientConfig('auggie', {
+    mcpServerName,
+    clusterId,
+    mcpServerId,
+    isServerless: config.isServerless,
+  });
 
   return (
     <div className="space-y-4">

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/claude-code.tsx
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/claude-code.tsx
@@ -27,7 +27,7 @@ import ClaudeCodeLogo from '../../../../../assets/claude-code.svg';
 import { RemoteMCPConnectDocsAlert } from '../../remote-mcp-connect-docs-alert';
 import { InstallRpkListItem } from '../install-rpk-list-item';
 import { LoginToRpkListItem } from '../login-to-rpk-list-item';
-import { getClientCommand, getClientConfig, getMCPServerName, type MCPServer } from '../utils';
+import { ClientType, getClientCommand, getClientConfig, getMCPServerName, type MCPServer } from '../utils';
 
 interface ClientClaudeCodeProps {
   mcpServer: MCPServer;
@@ -40,7 +40,7 @@ export const ClientClaudeCode = ({ mcpServer }: ClientClaudeCodeProps) => {
   const mcpServerId = mcpServer?.id;
   const mcpServerName = getMCPServerName(mcpServer?.displayName ?? '');
 
-  const claudeCodeCommand = getClientCommand('claude-code', {
+  const claudeCodeCommand = getClientCommand(ClientType.CLAUDE_CODE, {
     mcpServerName,
     clusterId,
     mcpServerId,
@@ -48,7 +48,7 @@ export const ClientClaudeCode = ({ mcpServer }: ClientClaudeCodeProps) => {
     selectedScope,
   });
 
-  const claudeCodeConfigJson = getClientConfig('claude-code', {
+  const claudeCodeConfigJson = getClientConfig(ClientType.CLAUDE_CODE, {
     mcpServerName,
     clusterId,
     mcpServerId,

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/claude-code.tsx
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/claude-code.tsx
@@ -27,7 +27,7 @@ import ClaudeCodeLogo from '../../../../../assets/claude-code.svg';
 import { RemoteMCPConnectDocsAlert } from '../../remote-mcp-connect-docs-alert';
 import { InstallRpkListItem } from '../install-rpk-list-item';
 import { LoginToRpkListItem } from '../login-to-rpk-list-item';
-import { getMCPServerName, getRpkCloudEnvironment, type MCPServer } from '../utils';
+import { getClientCommand, getClientConfig, getMCPServerName, type MCPServer } from '../utils';
 
 interface ClientClaudeCodeProps {
   mcpServer: MCPServer;
@@ -39,57 +39,21 @@ export const ClientClaudeCode = ({ mcpServer }: ClientClaudeCodeProps) => {
   const clusterId = config?.clusterId;
   const mcpServerId = mcpServer?.id;
   const mcpServerName = getMCPServerName(mcpServer?.displayName ?? '');
-  const clusterFlag = config.isServerless ? '--serverless-cluster-id' : '--cluster-id';
 
-  const showCloudEnvironmentFlag = getRpkCloudEnvironment() !== 'production';
-  const cloudEnvArg = showCloudEnvironmentFlag ? `"cloud_environment=${getRpkCloudEnvironment()}",` : '';
+  const claudeCodeCommand = getClientCommand('claude-code', {
+    mcpServerName,
+    clusterId,
+    mcpServerId,
+    isServerless: config.isServerless,
+    selectedScope,
+  });
 
-  const claudeCodeCommand = `claude mcp add-json ${mcpServerName} --scope ${selectedScope} \\
-'{"type":"stdio","command":"rpk","args":[
-"-X",${cloudEnvArg}"cloud","mcp","proxy",
-"${clusterFlag}","${clusterId}",
-"--mcp-server-id","${mcpServerId}"]}'`;
-
-  const claudeCodeConfigJson = showCloudEnvironmentFlag
-    ? `{
-  "mcp": {
-    "servers": {
-      "${mcpServerName}": {
-        "command": "rpk",
-        "args": [
-          "-X",
-          "cloud_environment=${getRpkCloudEnvironment()}",
-          "cloud",
-          "mcp",
-          "proxy",
-          "${clusterFlag}",
-          "${clusterId}",
-          "--mcp-server-id",
-          "${mcpServerId}"
-        ]
-      }
-    }
-  }
-}`
-    : `{
-  "mcp": {
-    "servers": {
-      "${mcpServerName}": {
-        "command": "rpk",
-        "args": [
-          "-X",
-          "cloud",
-          "mcp",
-          "proxy",
-          "${clusterFlag}",
-          "${clusterId}",
-          "--mcp-server-id",
-          "${mcpServerId}"
-        ]
-      }
-    }
-  }
-}`;
+  const claudeCodeConfigJson = getClientConfig('claude-code', {
+    mcpServerName,
+    clusterId,
+    mcpServerId,
+    isServerless: config.isServerless,
+  });
 
   return (
     <div className="space-y-4">

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/claude-desktop.tsx
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/claude-desktop.tsx
@@ -16,7 +16,7 @@ import ClaudeDesktopLogo from '../../../../../assets/claude-desktop.svg';
 import { RemoteMCPConnectDocsAlert } from '../../remote-mcp-connect-docs-alert';
 import { InstallRpkListItem } from '../install-rpk-list-item';
 import { LoginToRpkListItem } from '../login-to-rpk-list-item';
-import { getMCPServerName, getRpkCloudEnvironment, getRpkCommand, type MCPServer } from '../utils';
+import { getClientConfig, getMCPServerName, getRpkCommand, type MCPServer } from '../utils';
 
 interface ClientClaudeDesktopProps {
   mcpServer: MCPServer;
@@ -34,49 +34,12 @@ export const ClientClaudeDesktop = ({ mcpServer }: ClientClaudeDesktopProps) => 
     isServerless: config.isServerless,
   });
 
-  const clusterFlag = config.isServerless ? '--serverless-cluster-id' : '--cluster-id';
-  const showCloudEnvironmentFlag = getRpkCloudEnvironment() !== 'production';
-
-  const claudeDesktopConfigJson = showCloudEnvironmentFlag
-    ? `{
-  "mcp": {
-    "servers": {
-      "${mcpServerName}": {
-        "command": "rpk",
-        "args": [
-          "-X",
-          "cloud_environment=${getRpkCloudEnvironment()}",
-          "cloud",
-          "mcp",
-          "proxy",
-          "${clusterFlag}",
-          "${clusterId}",
-          "--mcp-server-id",
-          "${mcpServerId}"
-        ]
-      }
-    }
-  }
-}`
-    : `{
-  "mcp": {
-    "servers": {
-      "${mcpServerName}": {
-        "command": "rpk",
-        "args": [
-          "-X",
-          "cloud",
-          "mcp",
-          "proxy",
-          "${clusterFlag}",
-          "${clusterId}",
-          "--mcp-server-id",
-          "${mcpServerId}"
-        ]
-      }
-    }
-  }
-}`;
+  const claudeDesktopConfigJson = getClientConfig('claude-desktop', {
+    mcpServerName,
+    clusterId,
+    mcpServerId,
+    isServerless: config.isServerless,
+  });
 
   return (
     <div className="space-y-4">

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/claude-desktop.tsx
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/claude-desktop.tsx
@@ -16,7 +16,7 @@ import ClaudeDesktopLogo from '../../../../../assets/claude-desktop.svg';
 import { RemoteMCPConnectDocsAlert } from '../../remote-mcp-connect-docs-alert';
 import { InstallRpkListItem } from '../install-rpk-list-item';
 import { LoginToRpkListItem } from '../login-to-rpk-list-item';
-import { getClientConfig, getMCPServerName, getRpkCommand, type MCPServer } from '../utils';
+import { ClientType, getClientConfig, getMCPServerName, getRpkCommand, type MCPServer } from '../utils';
 
 interface ClientClaudeDesktopProps {
   mcpServer: MCPServer;
@@ -34,7 +34,7 @@ export const ClientClaudeDesktop = ({ mcpServer }: ClientClaudeDesktopProps) => 
     isServerless: config.isServerless,
   });
 
-  const claudeDesktopConfigJson = getClientConfig('claude-desktop', {
+  const claudeDesktopConfigJson = getClientConfig(ClientType.CLAUDE_DESKTOP, {
     mcpServerName,
     clusterId,
     mcpServerId,

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/cline.tsx
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/cline.tsx
@@ -17,7 +17,7 @@ import ClineLogo from '../../../../../assets/cline.svg';
 import { RemoteMCPConnectDocsAlert } from '../../remote-mcp-connect-docs-alert';
 import { InstallRpkListItem } from '../install-rpk-list-item';
 import { LoginToRpkListItem } from '../login-to-rpk-list-item';
-import { getMCPServerName, getRpkCloudEnvironment, type MCPServer } from '../utils';
+import { getClientConfig, getMCPServerName, type MCPServer } from '../utils';
 
 interface ClientClineProps {
   mcpServer: MCPServer;
@@ -28,45 +28,12 @@ export const ClientCline = ({ mcpServer }: ClientClineProps) => {
   const mcpServerId = mcpServer?.id;
   const mcpServerName = getMCPServerName(mcpServer?.displayName ?? '');
 
-  const clusterFlag = config.isServerless ? '--serverless-cluster-id' : '--cluster-id';
-  const showCloudEnvironmentFlag = getRpkCloudEnvironment() !== 'production';
-
-  const clineConfigJson = showCloudEnvironmentFlag
-    ? `{
-  "mcpServers": {
-    "${mcpServerName}": {
-      "command": "rpk",
-      "args": [
-        "-X",
-        "cloud_environment=${getRpkCloudEnvironment()}",
-        "cloud",
-        "mcp",
-        "proxy",
-        "${clusterFlag}",
-        "${clusterId}",
-        "--mcp-server-id",
-        "${mcpServerId}"
-      ]
-    }
-  }
-}`
-    : `{
-  "mcpServers": {
-    "${mcpServerName}": {
-      "command": "rpk",
-      "args": [
-        "-X",
-        "cloud",
-        "mcp",
-        "proxy",
-        "${clusterFlag}",
-        "${clusterId}",
-        "--mcp-server-id",
-        "${mcpServerId}"
-      ]
-    }
-  }
-}`;
+  const clineConfigJson = getClientConfig('cline', {
+    mcpServerName,
+    clusterId,
+    mcpServerId,
+    isServerless: config.isServerless,
+  });
 
   return (
     <div className="space-y-4">

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/cline.tsx
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/cline.tsx
@@ -17,7 +17,7 @@ import ClineLogo from '../../../../../assets/cline.svg';
 import { RemoteMCPConnectDocsAlert } from '../../remote-mcp-connect-docs-alert';
 import { InstallRpkListItem } from '../install-rpk-list-item';
 import { LoginToRpkListItem } from '../login-to-rpk-list-item';
-import { getClientConfig, getMCPServerName, type MCPServer } from '../utils';
+import { ClientType, getClientConfig, getMCPServerName, type MCPServer } from '../utils';
 
 interface ClientClineProps {
   mcpServer: MCPServer;
@@ -28,7 +28,7 @@ export const ClientCline = ({ mcpServer }: ClientClineProps) => {
   const mcpServerId = mcpServer?.id;
   const mcpServerName = getMCPServerName(mcpServer?.displayName ?? '');
 
-  const clineConfigJson = getClientConfig('cline', {
+  const clineConfigJson = getClientConfig(ClientType.CLINE, {
     mcpServerName,
     clusterId,
     mcpServerId,

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/codex.tsx
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/codex.tsx
@@ -16,7 +16,7 @@ import CodexLogo from '../../../../../assets/codex.svg';
 import { RemoteMCPConnectDocsAlert } from '../../remote-mcp-connect-docs-alert';
 import { InstallRpkListItem } from '../install-rpk-list-item';
 import { LoginToRpkListItem } from '../login-to-rpk-list-item';
-import { getClientCommand, getClientConfig, getMCPServerName, type MCPServer } from '../utils';
+import { ClientType, getClientCommand, getClientConfig, getMCPServerName, type MCPServer } from '../utils';
 
 interface ClientCodexProps {
   mcpServer: MCPServer;
@@ -27,14 +27,14 @@ export const ClientCodex = ({ mcpServer }: ClientCodexProps) => {
   const clusterId = config?.clusterId;
   const mcpServerId = mcpServer?.id;
 
-  const codexMcpAddCommand = getClientCommand('codex', {
+  const codexMcpAddCommand = getClientCommand(ClientType.CODEX, {
     mcpServerName,
     clusterId,
     mcpServerId,
     isServerless: config.isServerless,
   });
 
-  const codexConfigToml = getClientConfig('codex', {
+  const codexConfigToml = getClientConfig(ClientType.CODEX, {
     mcpServerName,
     clusterId,
     mcpServerId,

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/codex.tsx
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/codex.tsx
@@ -16,7 +16,7 @@ import CodexLogo from '../../../../../assets/codex.svg';
 import { RemoteMCPConnectDocsAlert } from '../../remote-mcp-connect-docs-alert';
 import { InstallRpkListItem } from '../install-rpk-list-item';
 import { LoginToRpkListItem } from '../login-to-rpk-list-item';
-import { getMCPServerName, getRpkCloudEnvironment, type MCPServer } from '../utils';
+import { getClientCommand, getClientConfig, getMCPServerName, type MCPServer } from '../utils';
 
 interface ClientCodexProps {
   mcpServer: MCPServer;
@@ -24,27 +24,22 @@ interface ClientCodexProps {
 
 export const ClientCodex = ({ mcpServer }: ClientCodexProps) => {
   const mcpServerName = getMCPServerName(mcpServer?.displayName ?? '');
-
   const clusterId = config?.clusterId;
   const mcpServerId = mcpServer?.id;
-  const clusterFlag = config.isServerless ? '--serverless-cluster-id' : '--cluster-id';
 
-  const showCloudEnvironmentFlag = getRpkCloudEnvironment() !== 'production';
-  const cloudEnvArg = showCloudEnvironmentFlag ? `"cloud_environment=${getRpkCloudEnvironment()}" ` : '';
+  const codexMcpAddCommand = getClientCommand('codex', {
+    mcpServerName,
+    clusterId,
+    mcpServerId,
+    isServerless: config.isServerless,
+  });
 
-  const codexMcpAddCommand = `codex mcp add ${mcpServerName} -- rpk \\
-"-X" ${cloudEnvArg}\\
-"cloud" "mcp" "proxy" \\
-"${clusterFlag}" "${clusterId}" \\
-"--mcp-server-id" "${mcpServerId}"`;
-
-  const codexConfigToml = showCloudEnvironmentFlag
-    ? `[mcp_servers.${mcpServerName}]
-command = "rpk"
-args = ["-X","cloud_environment=${getRpkCloudEnvironment()}", "cloud", "mcp", "proxy", "${clusterFlag}", "${clusterId}", "--mcp-server-id", "${mcpServerId}"]`
-    : `[mcp_servers.${mcpServerName}]
-command = "rpk"
-args = ["-X", "cloud", "mcp", "proxy", "${clusterFlag}", "${clusterId}", "--mcp-server-id", "${mcpServerId}"]`;
+  const codexConfigToml = getClientConfig('codex', {
+    mcpServerName,
+    clusterId,
+    mcpServerId,
+    isServerless: config.isServerless,
+  });
 
   return (
     <div className="space-y-4">

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/cursor.tsx
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/cursor.tsx
@@ -19,7 +19,7 @@ import CursorLogo from '../../../../../assets/cursor.svg';
 import { RemoteMCPConnectDocsAlert } from '../../remote-mcp-connect-docs-alert';
 import { InstallRpkListItem } from '../install-rpk-list-item';
 import { LoginToRpkListItem } from '../login-to-rpk-list-item';
-import { createMCPConfig, getMCPServerName, getRpkCloudEnvironment, type MCPServer } from '../utils';
+import { createMCPConfig, getClientConfig, getMCPServerName, type MCPServer } from '../utils';
 
 interface ClientCursorProps {
   mcpServer: MCPServer;
@@ -45,45 +45,12 @@ export const ClientCursor = ({ mcpServer }: ClientCursorProps) => {
     window.open(cursorLink, '_blank');
   };
 
-  const clusterFlag = config.isServerless ? '--serverless-cluster-id' : '--cluster-id';
-  const showCloudEnvironmentFlag = getRpkCloudEnvironment() !== 'production';
-
-  const cursorConfigJson = showCloudEnvironmentFlag
-    ? `{
-  "mcpServers": {
-    "${mcpServerName}": {
-      "command": "rpk",
-      "args": [
-        "-X",
-        "cloud_environment=${getRpkCloudEnvironment()}",
-        "cloud",
-        "mcp",
-        "proxy",
-        "${clusterFlag}",
-        "${clusterId}",
-        "--mcp-server-id",
-        "${mcpServerId}"
-      ]
-    }
-  }
-}`
-    : `{
-  "mcpServers": {
-    "${mcpServerName}": {
-      "command": "rpk",
-      "args": [
-        "-X",
-        "cloud",
-        "mcp",
-        "proxy",
-        "${clusterFlag}",
-        "${clusterId}",
-        "--mcp-server-id",
-        "${mcpServerId}"
-      ]
-    }
-  }
-}`;
+  const cursorConfigJson = getClientConfig('cursor', {
+    mcpServerName,
+    clusterId,
+    mcpServerId,
+    isServerless: config.isServerless,
+  });
 
   return (
     <div className="space-y-4">

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/cursor.tsx
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/cursor.tsx
@@ -19,7 +19,7 @@ import CursorLogo from '../../../../../assets/cursor.svg';
 import { RemoteMCPConnectDocsAlert } from '../../remote-mcp-connect-docs-alert';
 import { InstallRpkListItem } from '../install-rpk-list-item';
 import { LoginToRpkListItem } from '../login-to-rpk-list-item';
-import { createMCPConfig, getClientConfig, getMCPServerName, type MCPServer } from '../utils';
+import { ClientType, createMCPConfig, getClientConfig, getMCPServerName, type MCPServer } from '../utils';
 
 interface ClientCursorProps {
   mcpServer: MCPServer;
@@ -45,7 +45,7 @@ export const ClientCursor = ({ mcpServer }: ClientCursorProps) => {
     window.open(cursorLink, '_blank');
   };
 
-  const cursorConfigJson = getClientConfig('cursor', {
+  const cursorConfigJson = getClientConfig(ClientType.CURSOR, {
     mcpServerName,
     clusterId,
     mcpServerId,

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/gemini.tsx
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/gemini.tsx
@@ -27,7 +27,7 @@ import GeminiLogo from '../../../../../assets/gemini.svg';
 import { RemoteMCPConnectDocsAlert } from '../../remote-mcp-connect-docs-alert';
 import { InstallRpkListItem } from '../install-rpk-list-item';
 import { LoginToRpkListItem } from '../login-to-rpk-list-item';
-import { getMCPServerName, getRpkCloudEnvironment, type MCPServer } from '../utils';
+import { getClientCommand, getClientConfig, getMCPServerName, type MCPServer } from '../utils';
 
 interface ClientGeminiProps {
   mcpServer: MCPServer;
@@ -39,55 +39,21 @@ export const ClientGemini = ({ mcpServer }: ClientGeminiProps) => {
   const clusterId = config?.clusterId;
   const mcpServerId = mcpServer?.id;
   const mcpServerName = getMCPServerName(mcpServer?.displayName ?? '');
-  const clusterFlag = config.isServerless ? '--serverless-cluster-id' : '--cluster-id';
 
-  const showCloudEnvironmentFlag = getRpkCloudEnvironment() !== 'production';
-  const cloudEnvArg = showCloudEnvironmentFlag ? `"cloud_environment=${getRpkCloudEnvironment()}" ` : '';
+  const geminiCommand = getClientCommand('gemini', {
+    mcpServerName,
+    clusterId,
+    mcpServerId,
+    isServerless: config.isServerless,
+    selectedScope,
+  });
 
-  const geminiCommand = `gemini mcp add ${mcpServerName} \\
---scope ${selectedScope} \\
---transport stdio rpk \\
---args "-X" ${cloudEnvArg}\\
-"cloud" "mcp" "proxy" \\
-"${clusterFlag}" "${clusterId}" \\
-"--mcp-server-id" "${mcpServerId}"`;
-
-  const geminiConfigJson = showCloudEnvironmentFlag
-    ? `{
-  "mcpServers": {
-    "${mcpServerName}": {
-      "command": "rpk",
-      "args": [
-        "-X",
-        "cloud_environment=${getRpkCloudEnvironment()}",
-        "cloud",
-        "mcp",
-        "proxy",
-        "${clusterFlag}",
-        "${clusterId}",
-        "--mcp-server-id",
-        "${mcpServerId}"
-      ]
-    }
-  }
-}`
-    : `{
-  "mcpServers": {
-    "${mcpServerName}": {
-      "command": "rpk",
-      "args": [
-        "-X",
-        "cloud",
-        "mcp",
-        "proxy",
-        "${clusterFlag}",
-        "${clusterId}",
-        "--mcp-server-id",
-        "${mcpServerId}"
-      ]
-    }
-  }
-}`;
+  const geminiConfigJson = getClientConfig('gemini', {
+    mcpServerName,
+    clusterId,
+    mcpServerId,
+    isServerless: config.isServerless,
+  });
 
   return (
     <div className="space-y-4">

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/gemini.tsx
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/gemini.tsx
@@ -27,7 +27,7 @@ import GeminiLogo from '../../../../../assets/gemini.svg';
 import { RemoteMCPConnectDocsAlert } from '../../remote-mcp-connect-docs-alert';
 import { InstallRpkListItem } from '../install-rpk-list-item';
 import { LoginToRpkListItem } from '../login-to-rpk-list-item';
-import { getClientCommand, getClientConfig, getMCPServerName, type MCPServer } from '../utils';
+import { ClientType, getClientCommand, getClientConfig, getMCPServerName, type MCPServer } from '../utils';
 
 interface ClientGeminiProps {
   mcpServer: MCPServer;
@@ -40,7 +40,7 @@ export const ClientGemini = ({ mcpServer }: ClientGeminiProps) => {
   const mcpServerId = mcpServer?.id;
   const mcpServerName = getMCPServerName(mcpServer?.displayName ?? '');
 
-  const geminiCommand = getClientCommand('gemini', {
+  const geminiCommand = getClientCommand(ClientType.GEMINI, {
     mcpServerName,
     clusterId,
     mcpServerId,
@@ -48,7 +48,7 @@ export const ClientGemini = ({ mcpServer }: ClientGeminiProps) => {
     selectedScope,
   });
 
-  const geminiConfigJson = getClientConfig('gemini', {
+  const geminiConfigJson = getClientConfig(ClientType.GEMINI, {
     mcpServerName,
     clusterId,
     mcpServerId,

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/manus.tsx
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/manus.tsx
@@ -16,7 +16,7 @@ import { Cable, FileJson, Plus, Send } from 'lucide-react';
 import ManusLogo from '../../../../../assets/manus.svg';
 import { InstallRpkListItem } from '../install-rpk-list-item';
 import { LoginToRpkListItem } from '../login-to-rpk-list-item';
-import { getClientConfig, getMCPServerName, type MCPServer } from '../utils';
+import { ClientType, getClientConfig, getMCPServerName, type MCPServer } from '../utils';
 
 interface ClientManusProps {
   mcpServer: MCPServer;
@@ -27,7 +27,7 @@ export const ClientManus = ({ mcpServer }: ClientManusProps) => {
   const mcpServerId = mcpServer?.id;
   const mcpServerName = getMCPServerName(mcpServer?.displayName ?? '');
 
-  const manusConfigJson = getClientConfig('manus', {
+  const manusConfigJson = getClientConfig(ClientType.MANUS, {
     mcpServerName,
     clusterId,
     mcpServerId,

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/manus.tsx
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/manus.tsx
@@ -16,7 +16,7 @@ import { Cable, FileJson, Plus, Send } from 'lucide-react';
 import ManusLogo from '../../../../../assets/manus.svg';
 import { InstallRpkListItem } from '../install-rpk-list-item';
 import { LoginToRpkListItem } from '../login-to-rpk-list-item';
-import { getMCPServerName, getRpkCloudEnvironment, type MCPServer } from '../utils';
+import { getClientConfig, getMCPServerName, type MCPServer } from '../utils';
 
 interface ClientManusProps {
   mcpServer: MCPServer;
@@ -27,45 +27,12 @@ export const ClientManus = ({ mcpServer }: ClientManusProps) => {
   const mcpServerId = mcpServer?.id;
   const mcpServerName = getMCPServerName(mcpServer?.displayName ?? '');
 
-  const clusterFlag = config.isServerless ? '--serverless-cluster-id' : '--cluster-id';
-  const showCloudEnvironmentFlag = getRpkCloudEnvironment() !== 'production';
-
-  const manusConfigJson = showCloudEnvironmentFlag
-    ? `{
-  "mcpServers": {
-    "${mcpServerName}": {
-      "command": "rpk",
-      "args": [
-        "-X",
-        "cloud_environment=${getRpkCloudEnvironment()}",
-        "cloud",
-        "mcp",
-        "proxy",
-        "${clusterFlag}",
-        "${clusterId}",
-        "--mcp-server-id",
-        "${mcpServerId}"
-      ]
-    }
-  }
-}`
-    : `{
-  "mcpServers": {
-    "${mcpServerName}": {
-      "command": "rpk",
-      "args": [
-        "-X",
-        "cloud",
-        "mcp",
-        "proxy",
-        "${clusterFlag}",
-        "${clusterId}",
-        "--mcp-server-id",
-        "${mcpServerId}"
-      ]
-    }
-  }
-}`;
+  const manusConfigJson = getClientConfig('manus', {
+    mcpServerName,
+    clusterId,
+    mcpServerId,
+    isServerless: config.isServerless,
+  });
 
   return (
     <div>

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/vscode.tsx
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/vscode.tsx
@@ -17,7 +17,7 @@ import VSCodeLogo from '../../../../../assets/vscode.svg';
 import { RemoteMCPConnectDocsAlert } from '../../remote-mcp-connect-docs-alert';
 import { InstallRpkListItem } from '../install-rpk-list-item';
 import { LoginToRpkListItem } from '../login-to-rpk-list-item';
-import { createMCPConfig, getMCPServerName, getRpkCloudEnvironment, type MCPServer } from '../utils';
+import { createMCPConfig, getClientConfig, getMCPServerName, type MCPServer } from '../utils';
 
 interface ClientVscodeProps {
   mcpServer: MCPServer;
@@ -44,9 +44,6 @@ export const ClientVscode = ({ mcpServer, enableMcpDiscovery = true }: ClientVsc
     window.open(vscodeLink, '_blank');
   };
 
-  const clusterFlag = config.isServerless ? '--serverless-cluster-id' : '--cluster-id';
-  const showCloudEnvironmentFlag = getRpkCloudEnvironment() !== 'production';
-
   const mcpDiscoveryConfig = enableMcpDiscovery
     ? `"chat.mcp.discovery.enabled": {
     "windsurf": true,
@@ -56,46 +53,12 @@ export const ClientVscode = ({ mcpServer, enableMcpDiscovery = true }: ClientVsc
 }`
     : '';
 
-  const vscodeConfigJson = showCloudEnvironmentFlag
-    ? `{
-  "mcp": {
-    "servers": {
-      "${mcpServerName}": {
-        "command": "rpk",
-        "args": [
-          "-X", 
-          "cloud_environment=${getRpkCloudEnvironment()}",
-          "cloud",
-          "mcp",
-          "proxy",
-          "${clusterFlag}",
-          "${clusterId}",
-          "--mcp-server-id",
-          "${mcpServerId}"
-        ]
-      }
-    }
-  }
-}`
-    : `{
-  "mcp": {
-    "servers": {
-      "${mcpServerName}": {
-        "command": "rpk",
-        "args": [
-          "-X", 
-          "cloud",
-          "mcp",
-          "proxy",
-          "${clusterFlag}",
-          "${clusterId}",
-          "--mcp-server-id",
-          "${mcpServerId}"
-        ]
-      }
-    }
-  }
-}`;
+  const vscodeConfigJson = getClientConfig('vscode', {
+    mcpServerName,
+    clusterId,
+    mcpServerId,
+    isServerless: config.isServerless,
+  });
 
   return (
     <div className="space-y-4">

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/vscode.tsx
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/vscode.tsx
@@ -17,7 +17,7 @@ import VSCodeLogo from '../../../../../assets/vscode.svg';
 import { RemoteMCPConnectDocsAlert } from '../../remote-mcp-connect-docs-alert';
 import { InstallRpkListItem } from '../install-rpk-list-item';
 import { LoginToRpkListItem } from '../login-to-rpk-list-item';
-import { createMCPConfig, getClientConfig, getMCPServerName, type MCPServer } from '../utils';
+import { ClientType, createMCPConfig, getClientConfig, getMCPServerName, type MCPServer } from '../utils';
 
 interface ClientVscodeProps {
   mcpServer: MCPServer;
@@ -53,7 +53,7 @@ export const ClientVscode = ({ mcpServer, enableMcpDiscovery = true }: ClientVsc
 }`
     : '';
 
-  const vscodeConfigJson = getClientConfig('vscode', {
+  const vscodeConfigJson = getClientConfig(ClientType.VSCODE, {
     mcpServerName,
     clusterId,
     mcpServerId,

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/warp.tsx
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/warp.tsx
@@ -16,7 +16,7 @@ import WarpLogo from '../../../../../assets/warp.svg';
 import { RemoteMCPConnectDocsAlert } from '../../remote-mcp-connect-docs-alert';
 import { InstallRpkListItem } from '../install-rpk-list-item';
 import { LoginToRpkListItem } from '../login-to-rpk-list-item';
-import { getMCPServerName, getRpkCloudEnvironment, type MCPServer } from '../utils';
+import { getClientConfig, getMCPServerName, type MCPServer } from '../utils';
 
 interface ClientWarpProps {
   mcpServer: MCPServer;
@@ -27,41 +27,12 @@ export const ClientWarp = ({ mcpServer }: ClientWarpProps) => {
   const mcpServerId = mcpServer?.id;
   const mcpServerName = getMCPServerName(mcpServer?.displayName ?? '');
 
-  const clusterFlag = config.isServerless ? '--serverless-cluster-id' : '--cluster-id';
-  const showCloudEnvironmentFlag = getRpkCloudEnvironment() !== 'production';
-
-  const warpConfigJson = showCloudEnvironmentFlag
-    ? `{
-  "${mcpServerName}": {
-    "command": "rpk",
-    "args": [
-      "-X",
-      "cloud_environment=${getRpkCloudEnvironment()}",
-      "cloud",
-      "mcp",
-      "proxy",
-      "${clusterFlag}",
-      "${clusterId}",
-      "--mcp-server-id",
-      "${mcpServerId}"
-    ]
-  }
-}`
-    : `{
-  "${mcpServerName}": {
-    "command": "rpk",
-    "args": [
-      "-X",
-      "cloud",
-      "mcp",
-      "proxy",
-      "${clusterFlag}",
-      "${clusterId}",
-      "--mcp-server-id",
-      "${mcpServerId}"
-    ]
-  }
-}`;
+  const warpConfigJson = getClientConfig('warp', {
+    mcpServerName,
+    clusterId,
+    mcpServerId,
+    isServerless: config.isServerless,
+  });
 
   return (
     <div className="space-y-4">

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/warp.tsx
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/warp.tsx
@@ -16,7 +16,7 @@ import WarpLogo from '../../../../../assets/warp.svg';
 import { RemoteMCPConnectDocsAlert } from '../../remote-mcp-connect-docs-alert';
 import { InstallRpkListItem } from '../install-rpk-list-item';
 import { LoginToRpkListItem } from '../login-to-rpk-list-item';
-import { getClientConfig, getMCPServerName, type MCPServer } from '../utils';
+import { ClientType, getClientConfig, getMCPServerName, type MCPServer } from '../utils';
 
 interface ClientWarpProps {
   mcpServer: MCPServer;
@@ -27,7 +27,7 @@ export const ClientWarp = ({ mcpServer }: ClientWarpProps) => {
   const mcpServerId = mcpServer?.id;
   const mcpServerName = getMCPServerName(mcpServer?.displayName ?? '');
 
-  const warpConfigJson = getClientConfig('warp', {
+  const warpConfigJson = getClientConfig(ClientType.WARP, {
     mcpServerName,
     clusterId,
     mcpServerId,

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/windsurf.tsx
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/windsurf.tsx
@@ -18,7 +18,7 @@ import WindsurfLogo from '../../../../../assets/windsurf.svg';
 import { RemoteMCPConnectDocsAlert } from '../../remote-mcp-connect-docs-alert';
 import { InstallRpkListItem } from '../install-rpk-list-item';
 import { LoginToRpkListItem } from '../login-to-rpk-list-item';
-import { getClientConfig, getMCPServerName, type MCPServer } from '../utils';
+import { ClientType, getClientConfig, getMCPServerName, type MCPServer } from '../utils';
 
 interface ClientWindsurfProps {
   mcpServer: MCPServer;
@@ -28,7 +28,7 @@ export const ClientWindsurf = ({ mcpServer }: ClientWindsurfProps) => {
   const clusterId = config?.clusterId;
   const mcpServerName = getMCPServerName(mcpServer?.displayName ?? '');
 
-  const windsurfConfigJson = getClientConfig('windsurf', {
+  const windsurfConfigJson = getClientConfig(ClientType.WINDSURF, {
     mcpServerName,
     clusterId,
     mcpServerId: mcpServer?.id,

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/windsurf.tsx
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/clients/windsurf.tsx
@@ -18,7 +18,7 @@ import WindsurfLogo from '../../../../../assets/windsurf.svg';
 import { RemoteMCPConnectDocsAlert } from '../../remote-mcp-connect-docs-alert';
 import { InstallRpkListItem } from '../install-rpk-list-item';
 import { LoginToRpkListItem } from '../login-to-rpk-list-item';
-import { getMCPServerName, getRpkCloudEnvironment, type MCPServer } from '../utils';
+import { getClientConfig, getMCPServerName, type MCPServer } from '../utils';
 
 interface ClientWindsurfProps {
   mcpServer: MCPServer;
@@ -27,25 +27,13 @@ interface ClientWindsurfProps {
 export const ClientWindsurf = ({ mcpServer }: ClientWindsurfProps) => {
   const clusterId = config?.clusterId;
   const mcpServerName = getMCPServerName(mcpServer?.displayName ?? '');
-  const clusterFlag = config.isServerless ? '--serverless-cluster-id' : '--cluster-id';
 
-  const showCloudEnvironmentFlag = getRpkCloudEnvironment() !== 'production';
-  const baseArgs = ['-X'];
-  if (showCloudEnvironmentFlag) {
-    baseArgs.push(`cloud_environment=${getRpkCloudEnvironment()}`);
-  }
-  baseArgs.push('cloud', 'mcp', 'proxy', clusterFlag, `${clusterId}`, '--mcp-server-id', mcpServer?.id);
-
-  const windsurfConfig = {
-    mcpServers: {
-      [mcpServerName]: {
-        command: 'rpk',
-        args: baseArgs,
-      },
-    },
-  };
-
-  const windsurfConfigJson = JSON.stringify(windsurfConfig, null, 2);
+  const windsurfConfigJson = getClientConfig('windsurf', {
+    mcpServerName,
+    clusterId,
+    mcpServerId: mcpServer?.id,
+    isServerless: config.isServerless,
+  });
 
   return (
     <div className="space-y-4">

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/remote-mcp-connect-client-guide.tsx
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/remote-mcp-connect-client-guide.tsx
@@ -43,21 +43,7 @@ import { ClientManus } from './clients/manus';
 import { ClientVscode } from './clients/vscode';
 import { ClientWarp } from './clients/warp';
 import { ClientWindsurf } from './clients/windsurf';
-import type { MCPServer } from './utils';
-
-const AVAILABLE_CLIENTS = [
-  'claude-code',
-  'claude-desktop',
-  'vscode',
-  'cursor',
-  'windsurf',
-  'gemini',
-  'codex',
-  'warp',
-  'auggie',
-  'cline',
-  'manus',
-] as const;
+import { AVAILABLE_CLIENTS, type MCPServer } from './utils';
 
 type Client = (typeof AVAILABLE_CLIENTS)[number];
 

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/remote-mcp-connect-client-guide.tsx
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/remote-mcp-connect-client-guide.tsx
@@ -43,22 +43,20 @@ import { ClientManus } from './clients/manus';
 import { ClientVscode } from './clients/vscode';
 import { ClientWarp } from './clients/warp';
 import { ClientWindsurf } from './clients/windsurf';
-import { AVAILABLE_CLIENTS, type MCPServer } from './utils';
+import { AVAILABLE_CLIENTS, ClientType, type MCPServer } from './utils';
 
-type Client = (typeof AVAILABLE_CLIENTS)[number];
-
-const CLIENT_INFO: Record<Client, { name: string; logo: string; alt: string }> = {
-  'claude-code': { name: 'Claude Code', logo: ClaudeCodeLogo, alt: 'Claude Code CLI' },
-  'claude-desktop': { name: 'Claude Desktop', logo: ClaudeDesktopLogo, alt: 'Claude Desktop app' },
-  vscode: { name: 'VSCode', logo: VSCodeLogo, alt: 'VSCode IDE' },
-  cursor: { name: 'Cursor', logo: CursorLogo, alt: 'Cursor IDE' },
-  windsurf: { name: 'Windsurf', logo: WindsurfLogo, alt: 'Windsurf IDE' },
-  gemini: { name: 'Gemini', logo: GeminiLogo, alt: 'Gemini CLI' },
-  codex: { name: 'Codex', logo: CodexLogo, alt: 'Codex CLI' },
-  warp: { name: 'Warp', logo: WarpLogo, alt: 'Warp CLI' },
-  auggie: { name: 'Auggie', logo: AuggieLogo, alt: 'Auggie (Augment Code) CLI' },
-  cline: { name: 'Cline', logo: ClineLogo, alt: 'Cline CLI' },
-  manus: { name: 'Manus', logo: ManusLogo, alt: 'Manus CLI' },
+const CLIENT_INFO: Record<ClientType, { name: string; logo: string; alt: string }> = {
+  [ClientType.CLAUDE_CODE]: { name: 'Claude Code', logo: ClaudeCodeLogo, alt: 'Claude Code CLI' },
+  [ClientType.CLAUDE_DESKTOP]: { name: 'Claude Desktop', logo: ClaudeDesktopLogo, alt: 'Claude Desktop app' },
+  [ClientType.VSCODE]: { name: 'VSCode', logo: VSCodeLogo, alt: 'VSCode IDE' },
+  [ClientType.CURSOR]: { name: 'Cursor', logo: CursorLogo, alt: 'Cursor IDE' },
+  [ClientType.WINDSURF]: { name: 'Windsurf', logo: WindsurfLogo, alt: 'Windsurf IDE' },
+  [ClientType.GEMINI]: { name: 'Gemini', logo: GeminiLogo, alt: 'Gemini CLI' },
+  [ClientType.CODEX]: { name: 'Codex', logo: CodexLogo, alt: 'Codex CLI' },
+  [ClientType.WARP]: { name: 'Warp', logo: WarpLogo, alt: 'Warp CLI' },
+  [ClientType.AUGGIE]: { name: 'Auggie', logo: AuggieLogo, alt: 'Auggie (Augment Code) CLI' },
+  [ClientType.CLINE]: { name: 'Cline', logo: ClineLogo, alt: 'Cline CLI' },
+  [ClientType.MANUS]: { name: 'Manus', logo: ManusLogo, alt: 'Manus CLI' },
 };
 
 interface RemoteMCPConnectClientGuideProps {
@@ -66,33 +64,33 @@ interface RemoteMCPConnectClientGuideProps {
 }
 
 interface RemoteMCPClientGuideContentProps {
-  client: Client;
+  client: ClientType;
   mcpServer: MCPServer;
 }
 
 const RemoteMCPClientGuideContent = ({ client, mcpServer }: RemoteMCPClientGuideContentProps) => {
   switch (client) {
-    case 'claude-code':
+    case ClientType.CLAUDE_CODE:
       return <ClientClaudeCode mcpServer={mcpServer} />;
-    case 'claude-desktop':
+    case ClientType.CLAUDE_DESKTOP:
       return <ClientClaudeDesktop mcpServer={mcpServer} />;
-    case 'vscode':
+    case ClientType.VSCODE:
       return <ClientVscode mcpServer={mcpServer} />;
-    case 'cursor':
+    case ClientType.CURSOR:
       return <ClientCursor mcpServer={mcpServer} />;
-    case 'windsurf':
+    case ClientType.WINDSURF:
       return <ClientWindsurf mcpServer={mcpServer} />;
-    case 'gemini':
+    case ClientType.GEMINI:
       return <ClientGemini mcpServer={mcpServer} />;
-    case 'codex':
+    case ClientType.CODEX:
       return <ClientCodex mcpServer={mcpServer} />;
-    case 'warp':
+    case ClientType.WARP:
       return <ClientWarp mcpServer={mcpServer} />;
-    case 'auggie':
+    case ClientType.AUGGIE:
       return <ClientAuggie mcpServer={mcpServer} />;
-    case 'cline':
+    case ClientType.CLINE:
       return <ClientCline mcpServer={mcpServer} />;
-    case 'manus':
+    case ClientType.MANUS:
       return <ClientManus mcpServer={mcpServer} />;
     default:
       return <ClientClaudeCode mcpServer={mcpServer} />;
@@ -100,13 +98,13 @@ const RemoteMCPClientGuideContent = ({ client, mcpServer }: RemoteMCPClientGuide
 };
 
 export const RemoteMCPConnectClientGuide = ({ mcpServer }: RemoteMCPConnectClientGuideProps) => {
-  const [client, setClient] = useState<Client>('claude-code');
+  const [client, setClient] = useState<ClientType>(ClientType.CLAUDE_CODE);
 
   return (
     <div className="space-y-2">
       <Label className="text-sm font-medium">Connect to your client</Label>
       <div>
-        <Select value={client} onValueChange={(value) => setClient(value as Client)}>
+        <Select value={client} onValueChange={(value) => setClient(value as ClientType)}>
           <SelectTrigger className="w-[180px]">
             <SelectValue placeholder="Select a client" />
           </SelectTrigger>

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/utils.test.ts
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/utils.test.ts
@@ -1,0 +1,626 @@
+/**
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import {
+  AVAILABLE_CLIENTS,
+  createMCPConfig,
+  getClientCommand,
+  getClientConfig,
+  getMCPServerName,
+  getRpkCloudEnvironment,
+  getRpkCommand,
+} from './utils';
+
+const mockLocation = (hostname: string) => {
+  Object.defineProperty(window, 'location', {
+    value: { hostname },
+    writable: true,
+    configurable: true,
+  });
+};
+
+describe('getRpkCloudEnvironment', () => {
+  test('returns "integration" when hostname includes "main"', () => {
+    mockLocation('main--redpanda-cloud.netlify.app');
+    expect(getRpkCloudEnvironment()).toBe('integration');
+  });
+
+  test('returns "preprod" when hostname includes "preprod"', () => {
+    mockLocation('preprod--redpanda-cloud.netlify.app');
+    expect(getRpkCloudEnvironment()).toBe('preprod');
+  });
+
+  test('returns "production" when hostname includes "cloud.redpanda.com"', () => {
+    mockLocation('cloud.redpanda.com');
+    expect(getRpkCloudEnvironment()).toBe('production');
+  });
+
+  test('returns "integration" for other hostnames (default case)', () => {
+    mockLocation('localhost:3004');
+    expect(getRpkCloudEnvironment()).toBe('integration');
+  });
+
+  test('returns "integration" for development environments', () => {
+    mockLocation('127.0.0.1');
+    expect(getRpkCloudEnvironment()).toBe('integration');
+  });
+});
+
+describe('getMCPServerName', () => {
+  test('converts display name to lowercase', () => {
+    expect(getMCPServerName('MyServer')).toBe('redpanda-myserver');
+    expect(getMCPServerName('TEST SERVER')).toBe('redpanda-test-server');
+  });
+
+  test('replaces spaces with hyphens', () => {
+    expect(getMCPServerName('my test server')).toBe('redpanda-my-test-server');
+    expect(getMCPServerName('multiple   spaces')).toBe('redpanda-multiple-spaces');
+  });
+
+  test('removes special characters', () => {
+    expect(getMCPServerName('my@server#123')).toBe('redpanda-myserver123');
+    expect(getMCPServerName('test!@#$%^&*()server')).toBe('redpanda-testserver');
+    expect(getMCPServerName('my.server.name')).toBe('redpanda-myservername');
+  });
+
+  test('preserves hyphens and underscores', () => {
+    expect(getMCPServerName('my-server_name')).toBe('redpanda-my-server_name');
+    expect(getMCPServerName('test_server-123')).toBe('redpanda-test_server-123');
+  });
+
+  test('replaces multiple consecutive hyphens with single hyphen', () => {
+    expect(getMCPServerName('my---server')).toBe('redpanda-my-server');
+    expect(getMCPServerName('test----name')).toBe('redpanda-test-name');
+  });
+
+  test('removes leading and trailing hyphens', () => {
+    expect(getMCPServerName('-myserver-')).toBe('redpanda-myserver');
+    expect(getMCPServerName('---test---')).toBe('redpanda-test');
+  });
+
+  test('does not add prefix if name already contains "redpanda"', () => {
+    expect(getMCPServerName('redpanda-server')).toBe('redpanda-server');
+    expect(getMCPServerName('my-redpanda-server')).toBe('my-redpanda-server');
+    expect(getMCPServerName('redpanda')).toBe('redpanda');
+  });
+
+  test('adds prefix if name does not contain "redpanda"', () => {
+    expect(getMCPServerName('my-server')).toBe('redpanda-my-server');
+    expect(getMCPServerName('test')).toBe('redpanda-test');
+  });
+
+  test('handles empty string', () => {
+    expect(getMCPServerName('')).toBe('redpanda-');
+  });
+
+  test('handles complex scenarios', () => {
+    expect(getMCPServerName('My Server @ Test (2024)!')).toBe('redpanda-my-server-test-2024');
+    expect(getMCPServerName('  Leading and Trailing Spaces  ')).toBe('redpanda-leading-and-trailing-spaces');
+    expect(getMCPServerName('MCP!!!Server---123')).toBe('redpanda-mcpserver-123');
+  });
+
+  test('handles names with only special characters', () => {
+    expect(getMCPServerName('!@#$%^&*()')).toBe('redpanda-');
+    expect(getMCPServerName('---')).toBe('redpanda-');
+  });
+
+  test('case sensitivity with redpanda prefix', () => {
+    expect(getMCPServerName('Redpanda Server')).toBe('redpanda-server');
+    expect(getMCPServerName('REDPANDA SERVER')).toBe('redpanda-server');
+    expect(getMCPServerName('RedPanda')).toBe('redpanda');
+  });
+});
+
+describe('getRpkCommand', () => {
+  const baseParams = {
+    clusterId: 'cluster-123',
+    mcpServerId: 'mcp-456',
+    isServerless: false,
+  };
+
+  describe('Production environment (no -X cloud_environment flag)', () => {
+    beforeAll(() => {
+      mockLocation('cloud.redpanda.com');
+    });
+
+    describe.each(AVAILABLE_CLIENTS.map((client) => ({ clientType: client })))(
+      'clientType: $clientType',
+      ({ clientType }) => {
+        test('generates correct command', () => {
+          const command = getRpkCommand({ ...baseParams, clientType });
+          expect(command).toMatchSnapshot();
+        });
+      },
+    );
+
+    test('generates command without client type (uses placeholder)', () => {
+      const command = getRpkCommand(baseParams);
+      expect(command).toMatchSnapshot();
+    });
+  });
+
+  describe('Non-production environment (with -X cloud_environment flag)', () => {
+    beforeAll(() => {
+      mockLocation('main--redpanda-cloud.netlify.app');
+    });
+
+    describe.each(AVAILABLE_CLIENTS.map((client) => ({ clientType: client })))(
+      'clientType: $clientType',
+      ({ clientType }) => {
+        test('generates correct command with environment flag', () => {
+          const command = getRpkCommand({ ...baseParams, clientType });
+          expect(command).toMatchSnapshot();
+        });
+      },
+    );
+  });
+
+  describe('Serverless cluster flag', () => {
+    beforeAll(() => {
+      mockLocation('cloud.redpanda.com');
+    });
+
+    test('uses --serverless-cluster-id for serverless clusters', () => {
+      const command = getRpkCommand({
+        ...baseParams,
+        clientType: 'claude-code',
+        isServerless: true,
+      });
+      expect(command).toContain('--serverless-cluster-id');
+      expect(command).toMatchSnapshot();
+    });
+
+    test('uses --cluster-id for regular clusters', () => {
+      const command = getRpkCommand({
+        ...baseParams,
+        clientType: 'claude-code',
+        isServerless: false,
+      });
+      expect(command).toContain('--cluster-id');
+      expect(command).not.toContain('--serverless-cluster-id');
+      expect(command).toMatchSnapshot();
+    });
+  });
+
+  describe('Default placeholders', () => {
+    beforeAll(() => {
+      mockLocation('cloud.redpanda.com');
+    });
+
+    test('uses placeholder when clusterId is not provided', () => {
+      const command = getRpkCommand({
+        mcpServerId: 'mcp-456',
+        clientType: 'claude-code',
+        isServerless: false,
+      });
+      expect(command).toContain('YOUR_CLUSTER_ID');
+      expect(command).toMatchSnapshot();
+    });
+
+    test('uses placeholder when mcpServerId is not provided', () => {
+      const command = getRpkCommand({
+        clusterId: 'cluster-123',
+        clientType: 'claude-code',
+        isServerless: false,
+      });
+      expect(command).toContain('YOUR_MCP_SERVER_ID');
+      expect(command).toMatchSnapshot();
+    });
+
+    test('uses serverless placeholder when clusterId is not provided for serverless', () => {
+      const command = getRpkCommand({
+        mcpServerId: 'mcp-456',
+        clientType: 'claude-code',
+        isServerless: true,
+      });
+      expect(command).toContain('YOUR_SERVERLESS_CLUSTER_ID');
+      expect(command).toMatchSnapshot();
+    });
+  });
+
+  describe('Preprod environment', () => {
+    beforeAll(() => {
+      mockLocation('preprod--redpanda-cloud.netlify.app');
+    });
+
+    test('includes preprod environment flag', () => {
+      const command = getRpkCommand({
+        ...baseParams,
+        clientType: 'claude-code',
+      });
+      expect(command).toContain('-X cloud_environment=preprod');
+      expect(command).toMatchSnapshot();
+    });
+  });
+});
+
+describe('createMCPConfig', () => {
+  const baseParams = {
+    mcpServerName: 'test-server',
+    clusterId: 'cluster-123',
+    mcpServerId: 'mcp-456',
+    isServerless: false,
+  };
+
+  describe('Production environment (no -X cloud_environment flag)', () => {
+    beforeAll(() => {
+      mockLocation('cloud.redpanda.com');
+    });
+
+    test('creates config with all parameters', () => {
+      const config = createMCPConfig(baseParams);
+      expect(config.name).toBe('test-server');
+      expect(config.command).toBe('rpk');
+      expect(config.args).toEqual([
+        'cloud',
+        'mcp',
+        'proxy',
+        '--cluster-id',
+        'cluster-123',
+        '--mcp-server-id',
+        'mcp-456',
+      ]);
+    });
+
+    test('creates config for serverless cluster', () => {
+      const config = createMCPConfig({
+        ...baseParams,
+        isServerless: true,
+      });
+      expect(config.args).toContain('--serverless-cluster-id');
+      expect(config.args).not.toContain('--cluster-id');
+      expect(config).toMatchSnapshot();
+    });
+
+    test('creates config with empty strings for missing IDs', () => {
+      const config = createMCPConfig({
+        mcpServerName: 'test-server',
+      });
+      expect(config.args).toContain('');
+      expect(config).toMatchSnapshot();
+    });
+  });
+
+  describe('Non-production environment (with -X cloud_environment flag)', () => {
+    beforeAll(() => {
+      mockLocation('main--redpanda-cloud.netlify.app');
+    });
+
+    test('includes environment flag in args', () => {
+      const config = createMCPConfig(baseParams);
+      expect(config.args[0]).toBe('-X');
+      expect(config.args[1]).toBe('cloud_environment=integration');
+      expect(config.args).toEqual([
+        '-X',
+        'cloud_environment=integration',
+        'cloud',
+        'mcp',
+        'proxy',
+        '--cluster-id',
+        'cluster-123',
+        '--mcp-server-id',
+        'mcp-456',
+      ]);
+    });
+
+    test('includes environment flag for serverless cluster', () => {
+      const config = createMCPConfig({
+        ...baseParams,
+        isServerless: true,
+      });
+      expect(config.args).toContain('-X');
+      expect(config.args).toContain('cloud_environment=integration');
+      expect(config.args).toContain('--serverless-cluster-id');
+      expect(config).toMatchSnapshot();
+    });
+  });
+
+  describe('Preprod environment', () => {
+    beforeAll(() => {
+      mockLocation('preprod--redpanda-cloud.netlify.app');
+    });
+
+    test('includes preprod environment flag in args', () => {
+      const config = createMCPConfig(baseParams);
+      expect(config.args[0]).toBe('-X');
+      expect(config.args[1]).toBe('cloud_environment=preprod');
+      expect(config).toMatchSnapshot();
+    });
+  });
+
+  describe('Empty clusterId and mcpServerId', () => {
+    beforeAll(() => {
+      mockLocation('cloud.redpanda.com');
+    });
+
+    test('uses empty strings when IDs are not provided', () => {
+      const config = createMCPConfig({
+        mcpServerName: 'my-server',
+        clusterId: undefined,
+        mcpServerId: undefined,
+      });
+      expect(config.name).toBe('my-server');
+      expect(config.args[3]).toBe('--cluster-id');
+      expect(config.args[4]).toBe('');
+      expect(config.args[5]).toBe('--mcp-server-id');
+      expect(config.args[6]).toBe('');
+    });
+  });
+
+  describe('Integration with VSCode', () => {
+    beforeAll(() => {
+      mockLocation('cloud.redpanda.com');
+    });
+
+    test('creates config object compatible with VSCode extension', () => {
+      const config = createMCPConfig({
+        mcpServerName: 'vscode-test-server',
+        clusterId: 'vscode-cluster-123',
+        mcpServerId: 'vscode-mcp-456',
+        isServerless: false,
+      });
+
+      // VSCode extension expects this exact structure
+      expect(config).toHaveProperty('name');
+      expect(config).toHaveProperty('command');
+      expect(config).toHaveProperty('args');
+      expect(config.name).toBe('vscode-test-server');
+      expect(config.command).toBe('rpk');
+      expect(Array.isArray(config.args)).toBe(true);
+      expect(config).toMatchSnapshot();
+    });
+
+    test('creates config for VSCode with serverless cluster', () => {
+      const config = createMCPConfig({
+        mcpServerName: 'vscode-serverless',
+        clusterId: 'serverless-123',
+        mcpServerId: 'mcp-789',
+        isServerless: true,
+      });
+
+      expect(config.args).toContain('--serverless-cluster-id');
+      expect(config).toMatchSnapshot();
+    });
+  });
+
+  describe('Integration with Cursor', () => {
+    beforeAll(() => {
+      mockLocation('cloud.redpanda.com');
+    });
+
+    test('creates config object compatible with Cursor IDE', () => {
+      const config = createMCPConfig({
+        mcpServerName: 'cursor-test-server',
+        clusterId: 'cursor-cluster-123',
+        mcpServerId: 'cursor-mcp-456',
+        isServerless: false,
+      });
+
+      // Cursor IDE expects this exact structure
+      expect(config).toHaveProperty('name');
+      expect(config).toHaveProperty('command');
+      expect(config).toHaveProperty('args');
+      expect(config.name).toBe('cursor-test-server');
+      expect(config.command).toBe('rpk');
+      expect(Array.isArray(config.args)).toBe(true);
+      expect(config).toMatchSnapshot();
+    });
+
+    test('creates config for Cursor with serverless cluster', () => {
+      const config = createMCPConfig({
+        mcpServerName: 'cursor-serverless',
+        clusterId: 'serverless-456',
+        mcpServerId: 'mcp-999',
+        isServerless: true,
+      });
+
+      expect(config.args).toContain('--serverless-cluster-id');
+      expect(config).toMatchSnapshot();
+    });
+  });
+
+  describe('Non-production environment for VSCode and Cursor', () => {
+    beforeAll(() => {
+      mockLocation('main--redpanda-cloud.netlify.app');
+    });
+
+    test('VSCode config includes environment flag', () => {
+      const config = createMCPConfig({
+        mcpServerName: 'vscode-dev-server',
+        clusterId: 'dev-cluster',
+        mcpServerId: 'dev-mcp',
+      });
+
+      expect(config.args).toContain('-X');
+      expect(config.args).toContain('cloud_environment=integration');
+      expect(config).toMatchSnapshot();
+    });
+
+    test('Cursor config includes environment flag', () => {
+      const config = createMCPConfig({
+        mcpServerName: 'cursor-dev-server',
+        clusterId: 'dev-cluster',
+        mcpServerId: 'dev-mcp',
+      });
+
+      expect(config.args).toContain('-X');
+      expect(config.args).toContain('cloud_environment=integration');
+      expect(config).toMatchSnapshot();
+    });
+  });
+});
+
+describe('getClientCommand', () => {
+  const baseParams = {
+    mcpServerName: 'test-server',
+    clusterId: 'cluster-123',
+    mcpServerId: 'mcp-456',
+    isServerless: false,
+  };
+
+  describe('Production environment (no -X cloud_environment flag)', () => {
+    beforeAll(() => {
+      mockLocation('cloud.redpanda.com');
+    });
+
+    describe.each([
+      { client: 'auggie' as const, returns: 'command' as const },
+      { client: 'claude-code' as const, returns: 'command' as const, extraParams: { selectedScope: 'user' as const } },
+      { client: 'codex' as const, returns: 'command' as const },
+      { client: 'gemini' as const, returns: 'command' as const, extraParams: { selectedScope: 'project' as const } },
+      { client: 'cursor' as const, returns: '' as const, reason: 'uses button/link approach' },
+      { client: 'vscode' as const, returns: '' as const, reason: 'uses button/link approach' },
+      { client: 'cline' as const, returns: '' as const, reason: 'no CLI command' },
+      { client: 'manus' as const, returns: '' as const, reason: 'no CLI command' },
+      { client: 'warp' as const, returns: '' as const, reason: 'no CLI command' },
+      { client: 'windsurf' as const, returns: '' as const, reason: 'no CLI command' },
+      { client: 'claude-desktop' as const, returns: '' as const, reason: 'uses rpk command directly' },
+    ])('$client command', ({ client, returns, extraParams = {}, reason }) => {
+      test(`returns ${returns}${reason ? ` (${reason})` : ''}`, () => {
+        const command = getClientCommand(client, { ...baseParams, ...extraParams });
+        if (returns === 'command') {
+          expect(command).toMatchSnapshot();
+        } else {
+          expect(command).toBe('');
+        }
+      });
+    });
+  });
+
+  describe('Non-production environment (with -X cloud_environment flag)', () => {
+    beforeAll(() => {
+      mockLocation('main--redpanda-cloud.netlify.app');
+    });
+
+    describe.each([
+      { client: 'auggie' as const, returns: 'command' as const },
+      { client: 'claude-code' as const, returns: 'command' as const },
+      { client: 'codex' as const, returns: 'command' as const },
+      { client: 'gemini' as const, returns: 'command' as const },
+      { client: 'cursor' as const, returns: '' as const, reason: 'uses button/link approach' },
+      { client: 'vscode' as const, returns: '' as const, reason: 'uses button/link approach' },
+      { client: 'cline' as const, returns: '' as const, reason: 'no CLI command' },
+      { client: 'manus' as const, returns: '' as const, reason: 'no CLI command' },
+      { client: 'warp' as const, returns: '' as const, reason: 'no CLI command' },
+      { client: 'windsurf' as const, returns: '' as const, reason: 'no CLI command' },
+      { client: 'claude-desktop' as const, returns: '' as const, reason: 'uses rpk command directly' },
+    ])('$client command', ({ client, returns, reason }) => {
+      test(`returns ${returns}${reason ? ` (${reason})` : ''}`, () => {
+        const command = getClientCommand(client, baseParams);
+        if (returns === 'command') {
+          expect(command).toMatchSnapshot();
+        } else {
+          expect(command).toBe('');
+        }
+      });
+    });
+  });
+
+  describe('Serverless cluster flag', () => {
+    beforeAll(() => {
+      mockLocation('cloud.redpanda.com');
+    });
+
+    test('auggie command - serverless cluster', () => {
+      const command = getClientCommand('auggie', {
+        ...baseParams,
+        isServerless: true,
+      });
+      expect(command).toMatchSnapshot();
+    });
+
+    test('codex command - regular cluster', () => {
+      const command = getClientCommand('codex', {
+        ...baseParams,
+        isServerless: false,
+      });
+      expect(command).toMatchSnapshot();
+    });
+  });
+
+  describe('Default scope handling', () => {
+    beforeAll(() => {
+      mockLocation('cloud.redpanda.com');
+    });
+
+    test('claude-code command - defaults to "local" scope when not provided', () => {
+      const command = getClientCommand('claude-code', baseParams);
+      expect(command).toMatchSnapshot();
+    });
+
+    test('gemini command - uses provided scope', () => {
+      const command = getClientCommand('gemini', {
+        ...baseParams,
+        selectedScope: 'user',
+      });
+      expect(command).toMatchSnapshot();
+    });
+  });
+});
+
+describe('getClientConfig', () => {
+  const baseParams = {
+    mcpServerName: 'test-server',
+    clusterId: 'cluster-123',
+    mcpServerId: 'mcp-456',
+    isServerless: false,
+  };
+
+  describe('Production environment (no -X flag)', () => {
+    beforeAll(() => {
+      mockLocation('cloud.redpanda.com');
+    });
+
+    describe.each([
+      { client: 'auggie' as const },
+      { client: 'claude-code' as const },
+      { client: 'claude-desktop' as const },
+      { client: 'codex' as const },
+      { client: 'gemini' as const },
+      { client: 'cursor' as const },
+      { client: 'vscode' as const },
+      { client: 'cline' as const },
+      { client: 'manus' as const },
+      { client: 'warp' as const },
+      { client: 'windsurf' as const },
+    ])('$client config', ({ client }) => {
+      test('returns config', () => {
+        const config = getClientConfig(client, baseParams);
+        expect(config).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('Non-production environment (with -X cloud_environment flag)', () => {
+    beforeAll(() => {
+      mockLocation('main--redpanda-cloud.netlify.app');
+    });
+
+    describe.each([
+      { client: 'auggie' as const },
+      { client: 'claude-code' as const },
+      { client: 'claude-desktop' as const },
+      { client: 'codex' as const },
+      { client: 'gemini' as const },
+      { client: 'cursor' as const },
+      { client: 'vscode' as const },
+      { client: 'cline' as const },
+      { client: 'manus' as const },
+      { client: 'warp' as const },
+      { client: 'windsurf' as const },
+    ])('$client config', ({ client }) => {
+      test('returns config', () => {
+        const config = getClientConfig(client, baseParams);
+        expect(config).toMatchSnapshot();
+      });
+    });
+  });
+});

--- a/frontend/src/components/pages/mcp-servers/connect-client-guide/utils.ts
+++ b/frontend/src/components/pages/mcp-servers/connect-client-guide/utils.ts
@@ -141,21 +141,33 @@ export const getCloudEnvArgsForInlineJson = () => {
   return cloudEnv !== 'production' ? `"-X","cloud_environment=${cloudEnv}",` : '';
 };
 
-export const AVAILABLE_CLIENTS = [
-  'claude-code',
-  'claude-desktop',
-  'vscode',
-  'cursor',
-  'windsurf',
-  'gemini',
-  'codex',
-  'warp',
-  'auggie',
-  'cline',
-  'manus',
-] as const;
+export enum ClientType {
+  CLAUDE_CODE = 'claude-code',
+  CLAUDE_DESKTOP = 'claude-desktop',
+  VSCODE = 'vscode',
+  CURSOR = 'cursor',
+  WINDSURF = 'windsurf',
+  GEMINI = 'gemini',
+  CODEX = 'codex',
+  WARP = 'warp',
+  AUGGIE = 'auggie',
+  CLINE = 'cline',
+  MANUS = 'manus',
+}
 
-export type ClientType = (typeof AVAILABLE_CLIENTS)[number];
+export const AVAILABLE_CLIENTS = [
+  ClientType.CLAUDE_CODE,
+  ClientType.CLAUDE_DESKTOP,
+  ClientType.VSCODE,
+  ClientType.CURSOR,
+  ClientType.WINDSURF,
+  ClientType.GEMINI,
+  ClientType.CODEX,
+  ClientType.WARP,
+  ClientType.AUGGIE,
+  ClientType.CLINE,
+  ClientType.MANUS,
+] as const;
 
 interface ClientCommandParams {
   mcpServerName: string;
@@ -174,7 +186,7 @@ export const getClientCommand = (clientType: ClientType, params: ClientCommandPa
   const clusterFlag = isServerless ? '--serverless-cluster-id' : '--cluster-id';
 
   switch (clientType) {
-    case 'auggie':
+    case ClientType.AUGGIE:
       return `auggie mcp add ${mcpServerName} \\
 --transport stdio \\
 --command rpk \\
@@ -183,21 +195,21 @@ export const getClientCommand = (clientType: ClientType, params: ClientCommandPa
 "${clusterFlag}" "${clusterId}" \\
 "--mcp-server-id" "${mcpServerId}"`;
 
-    case 'claude-code':
+    case ClientType.CLAUDE_CODE:
       return `claude mcp add-json ${mcpServerName} --scope ${selectedScope} \\
 '{"type":"stdio","command":"rpk","args":[
 ${getCloudEnvArgsForInlineJson()}"cloud","mcp","proxy",
 "${clusterFlag}","${clusterId}",
 "--mcp-server-id","${mcpServerId}"]}'`;
 
-    case 'codex':
+    case ClientType.CODEX:
       return `codex mcp add ${mcpServerName} -- rpk \\
 ${getCloudEnvArgsForShell()}\\
 "cloud" "mcp" "proxy" \\
 "${clusterFlag}" "${clusterId}" \\
 "--mcp-server-id" "${mcpServerId}"`;
 
-    case 'gemini':
+    case ClientType.GEMINI:
       return `gemini mcp add ${mcpServerName} \\
 --scope ${selectedScope} \\
 --transport stdio rpk \\
@@ -206,11 +218,11 @@ ${getCloudEnvArgsForShell()}\\
 "${clusterFlag}" "${clusterId}" \\
 "--mcp-server-id" "${mcpServerId}"`;
 
-    case 'cursor':
+    case ClientType.CURSOR:
       // Cursor uses a button/link approach, command is less common
       return '';
 
-    case 'vscode':
+    case ClientType.VSCODE:
       // VSCode uses a button/link approach, command is less common
       return '';
 
@@ -228,7 +240,7 @@ export const getClientConfig = (clientType: ClientType, params: ClientCommandPar
   const clusterFlag = isServerless ? '--serverless-cluster-id' : '--cluster-id';
 
   switch (clientType) {
-    case 'auggie':
+    case ClientType.AUGGIE:
       return `{
   "mcpServers": {
     "${mcpServerName}": {
@@ -246,9 +258,9 @@ export const getClientConfig = (clientType: ClientType, params: ClientCommandPar
   }
 }`;
 
-    case 'claude-code':
-    case 'claude-desktop':
-    case 'vscode':
+    case ClientType.CLAUDE_CODE:
+    case ClientType.CLAUDE_DESKTOP:
+    case ClientType.VSCODE:
       return `{
   "mcp": {
     "servers": {
@@ -268,10 +280,10 @@ export const getClientConfig = (clientType: ClientType, params: ClientCommandPar
   }
 }`;
 
-    case 'cline':
-    case 'cursor':
-    case 'gemini':
-    case 'manus':
+    case ClientType.CLINE:
+    case ClientType.CURSOR:
+    case ClientType.GEMINI:
+    case ClientType.MANUS:
       return `{
   "mcpServers": {
     "${mcpServerName}": {
@@ -289,13 +301,13 @@ export const getClientConfig = (clientType: ClientType, params: ClientCommandPar
   }
 }`;
 
-    case 'codex':
+    case ClientType.CODEX:
       return `[mcp_servers.${mcpServerName}]
 command = "rpk"
 args = [${getCloudEnvArgsForToml()}"cloud", "mcp", "proxy", "${clusterFlag}", "${clusterId}", "--mcp-server-id", "${mcpServerId}"]`;
 
-    case 'warp':
-    case 'windsurf':
+    case ClientType.WARP:
+    case ClientType.WINDSURF:
       return `{
   "mcpServers": {
     "${mcpServerName}": {


### PR DESCRIPTION
This PR:
- moves to enums so that all cases are covered.
- adds unit tests
- prevents adding `"-X"` flag when `rpk cloud mcp proxy` command is used in production.