### PR TITLE
Increase timeout and use filtering in tests

### DIFF
--- a/frontend/playwright.enterprise.config.ts
+++ b/frontend/playwright.enterprise.config.ts
@@ -12,6 +12,8 @@ dotenv.config();
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
+  // Entire test timeout (default is 30s)
+  timeout: 60 * 1000,
   expect: {
     timeout: 60 * 1000,
   },

--- a/frontend/tests/console/pages/ACLPage.ts
+++ b/frontend/tests/console/pages/ACLPage.ts
@@ -447,6 +447,7 @@ export class ACLPage {
   async validateListItem(host: string, principal: string) {
     await this.gotoList();
     // Validate that the ACL list item is visible with correct host and principal
+    await this.page.getByTestId('search-field-input').fill(principal);
     const listItem = this.page.getByTestId(`acl-list-item-${principal}-${host}`);
     await expect(listItem).toBeVisible({ timeout: 1000 });
   }

--- a/frontend/tests/console/pages/RolePage.ts
+++ b/frontend/tests/console/pages/RolePage.ts
@@ -33,6 +33,7 @@ export class RolePage extends ACLPage {
     await this.gotoList();
 
     // Validate that the ACL list item is visible with correct host and principal
+    await this.page.getByTestId('search-field-input').fill(principal);
     const listItem = this.page.getByTestId(`role-list-item-${principal}`);
     await expect(listItem).toBeVisible({ timeout: 1000 });
   }


### PR DESCRIPTION
The e2e enterprise tests were timing out after the default (30s) timeout, and, on several retries, some of the values we were looking for were getting pushed to the second page of results.

This bumps the timeout to 60s and enters style principal name in the filter box before checking that t in the filter box before checking that the entry exists.