### PR TITLE
Front end/fix/support multiple acl same principal

### DIFF
--- a/frontend/src/components/pages/acls/Acl.List.tsx
+++ b/frontend/src/components/pages/acls/Acl.List.tsx
@@ -727,7 +727,9 @@ const AclsTab = observer((_: { principalGroups: AclPrincipalGroup[] }) => {
                       type="button"
                       className="hoverLink"
                       onClick={() => {
-                        navigate(`/security/acls/${record.principalName}/details`);
+                        navigate(
+                          `/security/acls/${record.principalName}/details?host=${encodeURIComponent(record.host)}`,
+                        );
                       }}
                     >
                       <Flex>

--- a/frontend/src/components/pages/acls/UserDetails.tsx
+++ b/frontend/src/components/pages/acls/UserDetails.tsx
@@ -9,15 +9,14 @@
  * by the Apache License, Version 2.0
  */
 
-import { useQuery } from '@connectrpc/connect-query';
 import { Box, DataTable, Text } from '@redpanda-data/ui';
-import { EmbeddedAclDetail } from 'components/pages/acls/new-acl/ACLDetails';
+import { UserAclsCard } from 'components/pages/roles/UserAclsCard';
+import { UserInformationCard } from 'components/pages/roles/UserInformationCard';
+import { UserRolesCard } from 'components/pages/roles/UserRolesCard';
 import { Button } from 'components/redpanda-ui/components/button';
-import { Card, CardContent, CardHeader, CardTitle } from 'components/redpanda-ui/components/card';
 import { makeObservable, observable } from 'mobx';
 import { observer } from 'mobx-react';
-import type { ListACLsRequest } from '../../../protogen/redpanda/api/dataplane/v1/acl_pb';
-import { listACLs } from '../../../protogen/redpanda/api/dataplane/v1/acl-ACLService_connectquery';
+import { useGetAclsByPrincipal } from '../../../react-query/api/acl';
 import { appGlobal } from '../../../state/appGlobal';
 import { api, rolesApi } from '../../../state/backendApi';
 import { AclRequestDefault } from '../../../state/restInterfaces';
@@ -28,7 +27,6 @@ import { PageComponent, type PageInitHelper } from '../Page';
 import { DeleteUserConfirmModal } from './DeleteUserConfirmModal';
 import type { AclPrincipalGroup } from './Models';
 import { ChangePasswordModal, ChangeRolesModal } from './UserEditModals';
-import { UserRoleTags } from './UserPermissionAssignments';
 
 @observer
 class UserDetailsPage extends PageComponent<{ userName: string }> {
@@ -80,30 +78,19 @@ class UserDetailsPage extends PageComponent<{ userName: string }> {
 
     const isServiceAccount = api.serviceAccounts.users.includes(userName);
 
-    let canEdit = true;
-    // The only thing that can be editted in a user is its roles
-    // If the roles api is not available, then no need for an edit button
-    if (!Features.rolesApi) canEdit = false;
-
     return (
       <PageContent>
-        <div className="flex justify-between">
+        <div className="flex flex-col gap-4">
+          <UserInformationCard
+            username={userName}
+            saslMechanism={this.mechanism}
+            onEditPassword={api.isAdminApiConfigured ? () => (this.isChangePasswordModalOpen = true) : undefined}
+          />
+          <UserPermissionDetailsContent
+            userName={userName}
+            onChangeRoles={Features.rolesApi ? () => (this.isChangeRolesModalOpen = true) : undefined}
+          />
           <div>
-            <h3>Permissions</h3>
-            <p className="text-sm text-gray-600">The following permissions are assigned to this principal.</p>
-          </div>
-          <div className="flex gap-3">
-            {Features.rolesApi && (
-              <Button variant="outline" onClick={() => (this.isChangeRolesModalOpen = true)} disabled={!canEdit}>
-                Assign roles
-              </Button>
-            )}
-            {api.isAdminApiConfigured && (
-              <Button variant="outline" onClick={() => (this.isChangePasswordModalOpen = true)} disabled={!canEdit}>
-                Change password
-              </Button>
-            )}
-            {/* todo: refactor delete user dialog into a "fire and forget" dialog and use it in the overview list (and here) */}
             {isServiceAccount && (
               <DeleteUserConfirmModal
                 onConfirm={async () => {
@@ -125,48 +112,31 @@ class UserDetailsPage extends PageComponent<{ userName: string }> {
                 }}
                 buttonEl={
                   <Button variant="destructive" disabled={!isServiceAccount}>
-                    Delete
+                    Delete user
                   </Button>
                 }
                 userName={userName}
               />
             )}
           </div>
+
+          {/*Modals*/}
+          {api.isAdminApiConfigured && (
+            <ChangePasswordModal
+              userName={userName}
+              isOpen={this.isChangePasswordModalOpen}
+              setIsOpen={(value: boolean) => (this.isChangePasswordModalOpen = value)}
+            />
+          )}
+
+          {Features.rolesApi && (
+            <ChangeRolesModal
+              userName={userName}
+              isOpen={this.isChangeRolesModalOpen}
+              setIsOpen={(value: boolean) => (this.isChangeRolesModalOpen = value)}
+            />
+          )}
         </div>
-
-        <div className="grid grid-cols-5 gap-3 start">
-          <div className="sm:col-span-5 md:col-span-3">
-            <UserPermissionDetailsContent userName={userName} />
-          </div>
-
-          <div className="sm:col-span-5 md:col-span-2">
-            <Card size="full">
-              <CardHeader>
-                <CardTitle className="text-lg font-medium text-gray-900">Assignments</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <UserRoleTags userName={userName} verticalView={false} />
-              </CardContent>
-            </Card>
-          </div>
-        </div>
-
-        {/*Modals*/}
-        {api.isAdminApiConfigured && (
-          <ChangePasswordModal
-            userName={userName}
-            isOpen={this.isChangePasswordModalOpen}
-            setIsOpen={(value: boolean) => (this.isChangePasswordModalOpen = value)}
-          />
-        )}
-
-        {Features.rolesApi && (
-          <ChangeRolesModal
-            userName={userName}
-            isOpen={this.isChangeRolesModalOpen}
-            setIsOpen={(value: boolean) => (this.isChangeRolesModalOpen = value)}
-          />
-        )}
       </PageContent>
     );
   }
@@ -174,7 +144,7 @@ class UserDetailsPage extends PageComponent<{ userName: string }> {
 
 export default UserDetailsPage;
 
-const UserPermissionDetailsContent = observer((p: { userName: string }) => {
+const UserPermissionDetailsContent = observer((p: { userName: string; onChangeRoles?: () => void }) => {
   // Get all roles and ACLs matching this user
   const roles: {
     principalType: string;
@@ -191,45 +161,12 @@ const UserPermissionDetailsContent = observer((p: { userName: string }) => {
     }
   }
 
-  const { data: hasAcls } = useQuery(
-    listACLs,
-    {
-      filter: {
-        principal: `User:${p.userName}`,
-      },
-    } as ListACLsRequest,
-    {
-      enabled: !!p.userName,
-      select: (response) => {
-        return response.resources.length > 0;
-      },
-    },
-  );
-
-  if (hasAcls) {
-    roles.push({
-      principalType: 'User',
-      principalName: p.userName,
-    });
-  }
+  const { data: acls } = useGetAclsByPrincipal(`User:${p.userName}`);
 
   return (
-    <div className="gap-3 flex flex-col">
-      {roles.map((g) => {
-        return (
-          <EmbeddedAclDetail
-            principal={`${g.principalType}:${g.principalName}`}
-            key={`key-${g.principalType}:${g.principalName}`}
-          />
-        );
-      })}
-      {roles.length === 0 && (
-        <Card size="full">
-          <CardContent>
-            <p>No permissions assigned to this user.</p>
-          </CardContent>
-        </Card>
-      )}
+    <div className="flex flex-col gap-4">
+      <UserRolesCard roles={roles} onChangeRoles={p.onChangeRoles} />
+      <UserAclsCard acls={acls} />
     </div>
   );
 });

--- a/frontend/src/components/pages/acls/new-acl/ACL.model.test.ts
+++ b/frontend/src/components/pages/acls/new-acl/ACL.model.test.ts
@@ -1,0 +1,532 @@
+/**
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { create } from '@bufbuild/protobuf';
+import {
+  ACL_Operation,
+  ACL_PermissionType,
+  ACL_ResourcePatternType,
+  ACL_ResourceType,
+  ListACLsResponse_PolicySchema,
+  ListACLsResponse_ResourceSchema,
+  ListACLsResponseSchema,
+} from 'protogen/redpanda/api/dataplane/v1/acl_pb';
+import { describe, expect, test } from 'vitest';
+import {
+  getAclFromAclListResponse,
+  ModeAllowAll,
+  ModeCustom,
+  ModeDenyAll,
+  OperationTypeAllow,
+  OperationTypeDeny,
+  ResourcePatternTypeLiteral,
+  ResourcePatternTypePrefix,
+} from './ACL.model';
+
+describe('getAclFromAclListResponse', () => {
+  describe('Single host scenarios', () => {
+    test('should return single AclDetail for single host', () => {
+      const response = create(ListACLsResponseSchema, {
+        resources: [
+          create(ListACLsResponse_ResourceSchema, {
+            resourceType: ACL_ResourceType.TOPIC,
+            resourceName: 'test-topic',
+            resourcePatternType: ACL_ResourcePatternType.LITERAL,
+            acls: [
+              create(ListACLsResponse_PolicySchema, {
+                principal: 'User:alice',
+                host: '192.168.1.1',
+                operation: ACL_Operation.READ,
+                permissionType: ACL_PermissionType.ALLOW,
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const result = getAclFromAclListResponse(response);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].sharedConfig).toEqual({
+        principal: 'User:alice',
+        host: '192.168.1.1',
+      });
+      expect(result[0].rules).toHaveLength(1);
+      expect(result[0].rules[0].resourceType).toBe('topic');
+      expect(result[0].rules[0].selectorValue).toBe('test-topic');
+      expect(result[0].rules[0].operations.READ).toBe(OperationTypeAllow);
+    });
+
+    test('should handle multiple operations for same resource on single host', () => {
+      const response = create(ListACLsResponseSchema, {
+        resources: [
+          create(ListACLsResponse_ResourceSchema, {
+            resourceType: ACL_ResourceType.TOPIC,
+            resourceName: 'test-topic',
+            resourcePatternType: ACL_ResourcePatternType.LITERAL,
+            acls: [
+              create(ListACLsResponse_PolicySchema, {
+                principal: 'User:alice',
+                host: '192.168.1.1',
+                operation: ACL_Operation.READ,
+                permissionType: ACL_PermissionType.ALLOW,
+              }),
+              create(ListACLsResponse_PolicySchema, {
+                principal: 'User:alice',
+                host: '192.168.1.1',
+                operation: ACL_Operation.WRITE,
+                permissionType: ACL_PermissionType.ALLOW,
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const result = getAclFromAclListResponse(response);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].rules).toHaveLength(1);
+      expect(result[0].rules[0].operations.READ).toBe(OperationTypeAllow);
+      expect(result[0].rules[0].operations.WRITE).toBe(OperationTypeAllow);
+    });
+  });
+
+  describe('Multiple host scenarios', () => {
+    test('should return separate AclDetail for each host', () => {
+      const response = create(ListACLsResponseSchema, {
+        resources: [
+          create(ListACLsResponse_ResourceSchema, {
+            resourceType: ACL_ResourceType.TOPIC,
+            resourceName: 'test-topic',
+            resourcePatternType: ACL_ResourcePatternType.LITERAL,
+            acls: [
+              create(ListACLsResponse_PolicySchema, {
+                principal: 'User:alice',
+                host: '192.168.1.1',
+                operation: ACL_Operation.READ,
+                permissionType: ACL_PermissionType.ALLOW,
+              }),
+              create(ListACLsResponse_PolicySchema, {
+                principal: 'User:alice',
+                host: '192.168.1.2',
+                operation: ACL_Operation.WRITE,
+                permissionType: ACL_PermissionType.DENY,
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const result = getAclFromAclListResponse(response);
+
+      expect(result).toHaveLength(2);
+
+      // Check first host
+      const host1Result = result.find((r) => r.sharedConfig.host === '192.168.1.1');
+      expect(host1Result).toBeDefined();
+      expect(host1Result?.sharedConfig.principal).toBe('User:alice');
+      expect(host1Result?.rules[0].operations.READ).toBe(OperationTypeAllow);
+      expect(host1Result?.rules[0].operations.WRITE).toBeUndefined();
+
+      // Check second host
+      const host2Result = result.find((r) => r.sharedConfig.host === '192.168.1.2');
+      expect(host2Result).toBeDefined();
+      expect(host2Result?.sharedConfig.principal).toBe('User:alice');
+      expect(host2Result?.rules[0].operations.WRITE).toBe(OperationTypeDeny);
+      expect(host2Result?.rules[0].operations.READ).toBeUndefined();
+    });
+
+    test('should group multiple resources by host correctly', () => {
+      const response = create(ListACLsResponseSchema, {
+        resources: [
+          create(ListACLsResponse_ResourceSchema, {
+            resourceType: ACL_ResourceType.TOPIC,
+            resourceName: 'topic-1',
+            resourcePatternType: ACL_ResourcePatternType.LITERAL,
+            acls: [
+              create(ListACLsResponse_PolicySchema, {
+                principal: 'User:alice',
+                host: '192.168.1.1',
+                operation: ACL_Operation.READ,
+                permissionType: ACL_PermissionType.ALLOW,
+              }),
+            ],
+          }),
+          create(ListACLsResponse_ResourceSchema, {
+            resourceType: ACL_ResourceType.TOPIC,
+            resourceName: 'topic-2',
+            resourcePatternType: ACL_ResourcePatternType.LITERAL,
+            acls: [
+              create(ListACLsResponse_PolicySchema, {
+                principal: 'User:alice',
+                host: '192.168.1.1',
+                operation: ACL_Operation.WRITE,
+                permissionType: ACL_PermissionType.ALLOW,
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const result = getAclFromAclListResponse(response);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].rules).toHaveLength(2);
+      expect(result[0].rules[0].selectorValue).toBe('topic-1');
+      expect(result[0].rules[1].selectorValue).toBe('topic-2');
+    });
+
+    test('should handle three hosts with different operations', () => {
+      const response = create(ListACLsResponseSchema, {
+        resources: [
+          create(ListACLsResponse_ResourceSchema, {
+            resourceType: ACL_ResourceType.CLUSTER,
+            resourceName: 'kafka-cluster',
+            resourcePatternType: ACL_ResourcePatternType.LITERAL,
+            acls: [
+              create(ListACLsResponse_PolicySchema, {
+                principal: 'User:admin',
+                host: 'host-a',
+                operation: ACL_Operation.CREATE,
+                permissionType: ACL_PermissionType.ALLOW,
+              }),
+              create(ListACLsResponse_PolicySchema, {
+                principal: 'User:admin',
+                host: 'host-b',
+                operation: ACL_Operation.ALTER,
+                permissionType: ACL_PermissionType.ALLOW,
+              }),
+              create(ListACLsResponse_PolicySchema, {
+                principal: 'User:admin',
+                host: 'host-c',
+                operation: ACL_Operation.DESCRIBE,
+                permissionType: ACL_PermissionType.DENY,
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const result = getAclFromAclListResponse(response);
+
+      expect(result).toHaveLength(3);
+      expect(result.map((r) => r.sharedConfig.host)).toEqual(expect.arrayContaining(['host-a', 'host-b', 'host-c']));
+
+      const hostA = result.find((r) => r.sharedConfig.host === 'host-a');
+      expect(hostA?.rules[0].operations.CREATE).toBe(OperationTypeAllow);
+
+      const hostB = result.find((r) => r.sharedConfig.host === 'host-b');
+      expect(hostB?.rules[0].operations.ALTER).toBe(OperationTypeAllow);
+
+      const hostC = result.find((r) => r.sharedConfig.host === 'host-c');
+      expect(hostC?.rules[0].operations.DESCRIBE).toBe(OperationTypeDeny);
+    });
+  });
+
+  describe('Mode detection', () => {
+    test('should detect ModeAllowAll when ALL operation is ALLOW', () => {
+      const response = create(ListACLsResponseSchema, {
+        resources: [
+          create(ListACLsResponse_ResourceSchema, {
+            resourceType: ACL_ResourceType.TOPIC,
+            resourceName: 'test-topic',
+            resourcePatternType: ACL_ResourcePatternType.LITERAL,
+            acls: [
+              create(ListACLsResponse_PolicySchema, {
+                principal: 'User:alice',
+                host: '192.168.1.1',
+                operation: ACL_Operation.ALL,
+                permissionType: ACL_PermissionType.ALLOW,
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const result = getAclFromAclListResponse(response);
+
+      expect(result[0].rules[0].mode).toBe(ModeAllowAll);
+      expect(result[0].rules[0].operations.ALL).toBe(OperationTypeAllow);
+    });
+
+    test('should detect ModeDenyAll when ALL operation is DENY', () => {
+      const response = create(ListACLsResponseSchema, {
+        resources: [
+          create(ListACLsResponse_ResourceSchema, {
+            resourceType: ACL_ResourceType.TOPIC,
+            resourceName: 'test-topic',
+            resourcePatternType: ACL_ResourcePatternType.LITERAL,
+            acls: [
+              create(ListACLsResponse_PolicySchema, {
+                principal: 'User:alice',
+                host: '192.168.1.1',
+                operation: ACL_Operation.ALL,
+                permissionType: ACL_PermissionType.DENY,
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const result = getAclFromAclListResponse(response);
+
+      expect(result[0].rules[0].mode).toBe(ModeDenyAll);
+      expect(result[0].rules[0].operations.ALL).toBe(OperationTypeDeny);
+    });
+
+    test('should detect ModeCustom for mixed operations', () => {
+      const response = create(ListACLsResponseSchema, {
+        resources: [
+          create(ListACLsResponse_ResourceSchema, {
+            resourceType: ACL_ResourceType.TOPIC,
+            resourceName: 'test-topic',
+            resourcePatternType: ACL_ResourcePatternType.LITERAL,
+            acls: [
+              create(ListACLsResponse_PolicySchema, {
+                principal: 'User:alice',
+                host: '192.168.1.1',
+                operation: ACL_Operation.READ,
+                permissionType: ACL_PermissionType.ALLOW,
+              }),
+              create(ListACLsResponse_PolicySchema, {
+                principal: 'User:alice',
+                host: '192.168.1.1',
+                operation: ACL_Operation.WRITE,
+                permissionType: ACL_PermissionType.DENY,
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const result = getAclFromAclListResponse(response);
+
+      expect(result[0].rules[0].mode).toBe(ModeCustom);
+    });
+
+    test('should detect ModeAllowAll when all possible operations are ALLOW', () => {
+      const response = create(ListACLsResponseSchema, {
+        resources: [
+          create(ListACLsResponse_ResourceSchema, {
+            resourceType: ACL_ResourceType.GROUP,
+            resourceName: 'test-group',
+            resourcePatternType: ACL_ResourcePatternType.LITERAL,
+            acls: [
+              create(ListACLsResponse_PolicySchema, {
+                principal: 'User:alice',
+                host: '192.168.1.1',
+                operation: ACL_Operation.DELETE,
+                permissionType: ACL_PermissionType.ALLOW,
+              }),
+              create(ListACLsResponse_PolicySchema, {
+                principal: 'User:alice',
+                host: '192.168.1.1',
+                operation: ACL_Operation.DESCRIBE,
+                permissionType: ACL_PermissionType.ALLOW,
+              }),
+              create(ListACLsResponse_PolicySchema, {
+                principal: 'User:alice',
+                host: '192.168.1.1',
+                operation: ACL_Operation.READ,
+                permissionType: ACL_PermissionType.ALLOW,
+              }),
+            ],
+          }),
+        ],
+      });
+
+      // for context groups, possible operations are DELETE, DESCRIBE, READ.
+      // consumerGroup: {
+      //   DELETE: OperationTypeNotSet,
+      //   DESCRIBE: OperationTypeNotSet,
+      //   READ: OperationTypeNotSet,
+      // },
+
+      const result = getAclFromAclListResponse(response);
+
+      expect(result[0].rules[0].mode).toBe(ModeAllowAll);
+    });
+  });
+
+  describe('Resource types and patterns', () => {
+    test('should handle CLUSTER resource type', () => {
+      const response = create(ListACLsResponseSchema, {
+        resources: [
+          create(ListACLsResponse_ResourceSchema, {
+            resourceType: ACL_ResourceType.CLUSTER,
+            resourceName: 'kafka-cluster',
+            resourcePatternType: ACL_ResourcePatternType.LITERAL,
+            acls: [
+              create(ListACLsResponse_PolicySchema, {
+                principal: 'User:admin',
+                host: '*',
+                operation: ACL_Operation.CLUSTER_ACTION,
+                permissionType: ACL_PermissionType.ALLOW,
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const result = getAclFromAclListResponse(response);
+
+      expect(result[0].rules[0].resourceType).toBe('cluster');
+      expect(result[0].rules[0].operations.CLUSTER_ACTION).toBe(OperationTypeAllow);
+      expect(result[0].rules[0].selectorType).toBe(ResourcePatternTypeLiteral);
+    });
+
+    test('should handle PREFIX pattern type', () => {
+      const response = create(ListACLsResponseSchema, {
+        resources: [
+          create(ListACLsResponse_ResourceSchema, {
+            resourceType: ACL_ResourceType.TOPIC,
+            resourceName: 'test-',
+            resourcePatternType: ACL_ResourcePatternType.PREFIXED,
+            acls: [
+              create(ListACLsResponse_PolicySchema, {
+                principal: 'User:alice',
+                host: '192.168.1.1',
+                operation: ACL_Operation.READ,
+                permissionType: ACL_PermissionType.ALLOW,
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const result = getAclFromAclListResponse(response);
+
+      expect(result[0].rules[0].selectorType).toBe(ResourcePatternTypePrefix);
+      expect(result[0].rules[0].selectorValue).toBe('test-');
+    });
+
+    test('should handle TRANSACTIONAL_ID resource type', () => {
+      const response = create(ListACLsResponseSchema, {
+        resources: [
+          create(ListACLsResponse_ResourceSchema, {
+            resourceType: ACL_ResourceType.TRANSACTIONAL_ID,
+            resourceName: 'tx-123',
+            resourcePatternType: ACL_ResourcePatternType.LITERAL,
+            acls: [
+              create(ListACLsResponse_PolicySchema, {
+                principal: 'User:producer',
+                host: '10.0.0.1',
+                operation: ACL_Operation.WRITE,
+                permissionType: ACL_PermissionType.ALLOW,
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const result = getAclFromAclListResponse(response);
+
+      expect(result[0].rules[0].resourceType).toBe('transactionalId');
+    });
+  });
+
+  describe('Edge cases', () => {
+    test('should return empty array for empty response', () => {
+      const response = create(ListACLsResponseSchema, {
+        resources: [],
+      });
+
+      const result = getAclFromAclListResponse(response);
+
+      expect(result).toEqual([]);
+    });
+
+    test('should handle wildcard host', () => {
+      const response = create(ListACLsResponseSchema, {
+        resources: [
+          create(ListACLsResponse_ResourceSchema, {
+            resourceType: ACL_ResourceType.TOPIC,
+            resourceName: 'test-topic',
+            resourcePatternType: ACL_ResourcePatternType.LITERAL,
+            acls: [
+              create(ListACLsResponse_PolicySchema, {
+                principal: 'User:alice',
+                host: '*',
+                operation: ACL_Operation.READ,
+                permissionType: ACL_PermissionType.ALLOW,
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const result = getAclFromAclListResponse(response);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].sharedConfig.host).toBe('*');
+    });
+
+    test('should maintain separate rule IDs for each host', () => {
+      const response = create(ListACLsResponseSchema, {
+        resources: [
+          create(ListACLsResponse_ResourceSchema, {
+            resourceType: ACL_ResourceType.TOPIC,
+            resourceName: 'topic-1',
+            resourcePatternType: ACL_ResourcePatternType.LITERAL,
+            acls: [
+              create(ListACLsResponse_PolicySchema, {
+                principal: 'User:alice',
+                host: 'host-a',
+                operation: ACL_Operation.READ,
+                permissionType: ACL_PermissionType.ALLOW,
+              }),
+              create(ListACLsResponse_PolicySchema, {
+                principal: 'User:alice',
+                host: 'host-b',
+                operation: ACL_Operation.READ,
+                permissionType: ACL_PermissionType.ALLOW,
+              }),
+            ],
+          }),
+          create(ListACLsResponse_ResourceSchema, {
+            resourceType: ACL_ResourceType.TOPIC,
+            resourceName: 'topic-2',
+            resourcePatternType: ACL_ResourcePatternType.LITERAL,
+            acls: [
+              create(ListACLsResponse_PolicySchema, {
+                principal: 'User:alice',
+                host: 'host-a',
+                operation: ACL_Operation.WRITE,
+                permissionType: ACL_PermissionType.ALLOW,
+              }),
+              create(ListACLsResponse_PolicySchema, {
+                principal: 'User:alice',
+                host: 'host-b',
+                operation: ACL_Operation.WRITE,
+                permissionType: ACL_PermissionType.ALLOW,
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const result = getAclFromAclListResponse(response);
+
+      expect(result).toHaveLength(2);
+
+      // Each host should have 2 rules with IDs 0 and 1
+      const hostA = result.find((r) => r.sharedConfig.host === 'host-a');
+      expect(hostA?.rules).toHaveLength(2);
+      expect(hostA?.rules[0].id).toBe(0);
+      expect(hostA?.rules[1].id).toBe(1);
+
+      const hostB = result.find((r) => r.sharedConfig.host === 'host-b');
+      expect(hostB?.rules).toHaveLength(2);
+      expect(hostB?.rules[0].id).toBe(0);
+      expect(hostB?.rules[1].id).toBe(1);
+    });
+  });
+});

--- a/frontend/src/components/pages/acls/new-acl/ACL.model.tsx
+++ b/frontend/src/components/pages/acls/new-acl/ACL.model.tsx
@@ -572,3 +572,7 @@ export const handleResponses = (toast: (op: UseToastOptions) => void, errors: Co
     });
   }
 };
+
+export const handleUrlWithHost = (baseUrl: string, host: string | undefined): string => {
+  return host ? `${baseUrl}?host=${encodeURIComponent(host)}` : baseUrl;
+};

--- a/frontend/src/components/pages/acls/new-acl/ACL.model.tsx
+++ b/frontend/src/components/pages/acls/new-acl/ACL.model.tsx
@@ -323,84 +323,105 @@ function getOperationNameFromGRPC(grpcOp: ACL_Operation): string {
   }
 }
 
-// function to convert ACL List response to AclDetail
-export const getAclFromAclListResponse = (aclList: ListACLsResponse): AclDetail => {
-  // Extract principal and host from the first ACL entry (assuming all have the same host)
-  let principal = '';
-  let host = '*';
+// function to convert ACL List response to AclDetail array (one per host)
+export const getAclFromAclListResponse = (aclList: ListACLsResponse): AclDetail[] => {
+  // Extract all unique hosts and principal from the response
+  const hostsMap = new Map<string, { principal: string; rulesMap: Map<string, Rule>; ruleIdCounter: number }>();
 
-  if (aclList.resources.length > 0 && aclList.resources[0].acls.length > 0) {
-    principal = aclList.resources[0].acls[0].principal;
-    host = aclList.resources[0].acls[0].host;
-  }
+  // First pass: identify all unique hosts and initialize data structures
+  aclList.resources.forEach((resource) => {
+    resource.acls.forEach((acl) => {
+      if (!hostsMap.has(acl.host)) {
+        hostsMap.set(acl.host, {
+          principal: acl.principal,
+          rulesMap: new Map<string, Rule>(),
+          ruleIdCounter: 0,
+        });
+      }
+    });
+  });
 
-  // Transform resources into rules
-  const rulesMap = new Map<string, Rule>();
-  let ruleIdCounter = 0;
-
+  // Second pass: process each resource and group by host
   aclList.resources.forEach((resource) => {
     const resourceType = getResourceTypeFromGRPC(resource.resourceType);
     const selectorType = getResourcePatternTypeFromGRPC(resource.resourcePatternType);
     const selectorValue = resource.resourceName;
 
-    // Create a unique key for each resource configuration
-    const ruleKey = `${resourceType}-${selectorType}-${selectorValue}`;
-
-    if (!rulesMap.has(ruleKey)) {
-      rulesMap.set(ruleKey, {
-        id: ruleIdCounter++,
-        resourceType,
-        mode: ModeCustom,
-        selectorType,
-        selectorValue,
-        operations: {},
-      });
-    }
-
-    // biome-ignore lint/style/noNonNullAssertion: in the previous line we ensured the key exists
-    const rule = rulesMap.get(ruleKey)!;
-
-    // Add operations from ACLs (assuming all ACLs have the same principal and host)
+    // Process ACLs for each host separately
     resource.acls.forEach((acl) => {
+      const hostData = hostsMap.get(acl.host);
+      if (!hostData) return;
+
+      const { rulesMap } = hostData;
+
+      // Create a unique key for each resource configuration
+      const ruleKey = `${resourceType}-${selectorType}-${selectorValue}`;
+
+      if (!rulesMap.has(ruleKey)) {
+        rulesMap.set(ruleKey, {
+          id: hostData.ruleIdCounter++,
+          resourceType,
+          mode: ModeCustom,
+          selectorType,
+          selectorValue,
+          operations: {},
+        });
+      }
+
+      // biome-ignore lint/style/noNonNullAssertion: in the previous lines we ensured the key exists
+      const rule = rulesMap.get(ruleKey)!;
+
+      // Add operation from this ACL
       const operationName = getOperationNameFromGRPC(acl.operation);
       const operationType = getOperationTypeFromGRPC(acl.permissionType);
 
       rule.operations[operationName] = operationType;
     });
-
-    // Determine mode based on operations
-    const operationValues = Object.values(rule.operations);
-    const allOperationKeys = Object.keys(getOperationsForResourceType(resourceType));
-
-    if (rule.operations.ALL) {
-      if (rule.operations.ALL === OperationTypeAllow) {
-        rule.mode = ModeAllowAll;
-      }
-      if (rule.operations.ALL === OperationTypeDeny) {
-        rule.mode = ModeDenyAll;
-      }
-    } else if (
-      allOperationKeys.length === operationValues.length &&
-      operationValues.every((op) => op === OperationTypeAllow)
-    ) {
-      rule.mode = ModeAllowAll;
-    } else if (
-      allOperationKeys.length === operationValues.length &&
-      operationValues.every((op) => op === OperationTypeDeny)
-    ) {
-      rule.mode = ModeDenyAll;
-    } else {
-      rule.mode = ModeCustom;
-    }
   });
 
-  return {
-    sharedConfig: {
-      principal,
-      host,
-    },
-    rules: Array.from(rulesMap.values()),
-  };
+  // Third pass: determine mode for each rule and build final result
+  const results: AclDetail[] = [];
+
+  hostsMap.forEach((hostData, host) => {
+    const { principal, rulesMap } = hostData;
+
+    // Determine mode for each rule
+    rulesMap.forEach((rule) => {
+      const operationValues = Object.values(rule.operations);
+      const allOperationKeys = Object.keys(getOperationsForResourceType(rule.resourceType));
+
+      if (rule.operations.ALL) {
+        if (rule.operations.ALL === OperationTypeAllow) {
+          rule.mode = ModeAllowAll;
+        }
+        if (rule.operations.ALL === OperationTypeDeny) {
+          rule.mode = ModeDenyAll;
+        }
+      } else if (
+        allOperationKeys.length === operationValues.length &&
+        operationValues.every((op) => op === OperationTypeAllow)
+      ) {
+        rule.mode = ModeAllowAll;
+      } else if (
+        allOperationKeys.length === operationValues.length &&
+        operationValues.every((op) => op === OperationTypeDeny)
+      ) {
+        rule.mode = ModeDenyAll;
+      } else {
+        rule.mode = ModeCustom;
+      }
+    });
+
+    results.push({
+      sharedConfig: {
+        principal,
+        host,
+      },
+      rules: Array.from(rulesMap.values()),
+    });
+  });
+
+  return results;
 };
 
 export const getOperationsForResourceType = (resourceType: ResourceType): Record<string, OperationType> => {
@@ -573,6 +594,6 @@ export const handleResponses = (toast: (op: UseToastOptions) => void, errors: Co
   }
 };
 
-export const handleUrlWithHost = (baseUrl: string, host: string | undefined): string => {
+export const handleUrlWithHost = (baseUrl: string, host: string): string => {
   return host ? `${baseUrl}?host=${encodeURIComponent(host)}` : baseUrl;
 };

--- a/frontend/src/components/pages/acls/new-acl/ACLDetails.tsx
+++ b/frontend/src/components/pages/acls/new-acl/ACLDetails.tsx
@@ -11,7 +11,6 @@
 
 import { Button } from 'components/redpanda-ui/components/button';
 import { Card, CardContent, CardHeader, CardTitle } from 'components/redpanda-ui/components/card';
-import { Edit } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useGetAclsByPrincipal } from '../../../../react-query/api/acl';
 import {
@@ -56,11 +55,10 @@ interface ACLDetailsProps {
     host: string;
   };
   rules: Rule[];
-  onUpdateACL: () => void;
   isSimpleView?: boolean; // this prop show SharedConfig, this is used for emmbedded this component on legacy user page
 }
 
-export function ACLDetails({ sharedConfig, rules, onUpdateACL, isSimpleView = false }: ACLDetailsProps) {
+export function ACLDetails({ sharedConfig, rules, isSimpleView = false }: ACLDetailsProps) {
   const navigate = useNavigate();
 
   const getGoTo = (sc: SharedConfig) => {
@@ -82,29 +80,6 @@ export function ACLDetails({ sharedConfig, rules, onUpdateACL, isSimpleView = fa
 
   return (
     <div>
-      {/* Header */}
-      <div className={`${isSimpleView ? 'hidden' : ''}`}>
-        <div className=" py-4">
-          <div className=" mx-auto">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-4">
-                <div>
-                  <p className="text-sm text-gray-600">View the created ACL configuration</p>
-                </div>
-              </div>
-              <Button
-                className="bg-gray-900 hover:bg-gray-800 text-white"
-                onClick={onUpdateACL}
-                data-testid="update-acl-button"
-              >
-                <Edit className="w-4 h-4 mr-2" />
-                Edit
-              </Button>
-            </div>
-          </div>
-        </div>
-      </div>
-
       {/* Main Content */}
       <main>
         <div className=" mx-auto">
@@ -239,22 +214,15 @@ export function ACLDetails({ sharedConfig, rules, onUpdateACL, isSimpleView = fa
 }
 
 const EmbeddedAclDetail = ({ principal }: { principal: string }) => {
-  const navigate = useNavigate();
-
   const { data } = useGetAclsByPrincipal(principal);
 
-  if (!data) {
+  if (!data || data.length === 0) {
     return <div>Loading...</div>;
   }
 
-  return (
-    <ACLDetails
-      sharedConfig={data.sharedConfig}
-      rules={data.rules}
-      onUpdateACL={() => navigate(`/security/acls/${parsePrincipal(data.sharedConfig.principal).name}/update`)}
-      isSimpleView={true}
-    />
-  );
+  const acl = data[0];
+
+  return <ACLDetails sharedConfig={acl.sharedConfig} rules={acl.rules} isSimpleView={true} />;
 };
 
 export { EmbeddedAclDetail };

--- a/frontend/src/components/pages/acls/new-acl/ACLDetails.tsx
+++ b/frontend/src/components/pages/acls/new-acl/ACLDetails.tsx
@@ -14,7 +14,6 @@ import { Card, CardContent, CardHeader, CardTitle } from 'components/redpanda-ui
 import { Edit } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useGetAclsByPrincipal } from '../../../../react-query/api/acl';
-import { MatchingUsersCard } from '../../roles/MatchingUsersCard';
 import {
   formatLabel,
   getIdFromRule,
@@ -58,17 +57,10 @@ interface ACLDetailsProps {
   };
   rules: Rule[];
   onUpdateACL: () => void;
-  showMatchingUsers?: boolean;
   isSimpleView?: boolean; // this prop show SharedConfig, this is used for emmbedded this component on legacy user page
 }
 
-export function ACLDetails({
-  sharedConfig,
-  rules,
-  onUpdateACL,
-  showMatchingUsers = false,
-  isSimpleView = false,
-}: ACLDetailsProps) {
+export function ACLDetails({ sharedConfig, rules, onUpdateACL, isSimpleView = false }: ACLDetailsProps) {
   const navigate = useNavigate();
 
   const getGoTo = (sc: SharedConfig) => {
@@ -116,9 +108,9 @@ export function ACLDetails({
       {/* Main Content */}
       <main>
         <div className=" mx-auto">
-          <div className={`grid grid-cols-1 ${showMatchingUsers ? 'lg:grid-cols-3' : ''} gap-8`}>
+          <div className="grid grid-cols-1 gap-8">
             {/* Left Column - Configuration Details */}
-            <div className={`${showMatchingUsers ? 'lg:col-span-2' : ''} space-y-6`}>
+            <div className="space-y-6">
               {/* Shared Configuration */}
               <Card size="full" className={`${isSimpleView ? 'hidden' : ''}`}>
                 <CardHeader className="pb-4">
@@ -239,11 +231,6 @@ export function ACLDetails({
                 </CardContent>
               </Card>
             </div>
-
-            {/* Right Column - Matching Users */}
-            {showMatchingUsers && (
-              <MatchingUsersCard principalType={data.principalType} principal={sharedConfig.principal} />
-            )}
           </div>
         </div>
       </main>

--- a/frontend/src/components/pages/acls/new-acl/AclDetailPage.tsx
+++ b/frontend/src/components/pages/acls/new-acl/AclDetailPage.tsx
@@ -9,10 +9,13 @@
  * by the Apache License, Version 2.0
  */
 
+import { Pencil } from 'lucide-react';
 import { useEffect } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { uiState } from 'state/uiState';
 import { useGetAclsByPrincipal } from '../../../../react-query/api/acl';
+import { Button } from '../../../redpanda-ui/components/button';
+import { Text } from '../../../redpanda-ui/components/typography';
 import { handleUrlWithHost } from './ACL.model';
 import { ACLDetails } from './ACLDetails';
 import { HostSelector } from './HostSelector';
@@ -49,12 +52,22 @@ const AclDetailPage = () => {
   }
 
   return (
-    <ACLDetails
-      sharedConfig={acls.sharedConfig}
-      rules={acls.rules}
-      onUpdateACL={() => navigate(handleUrlWithHost(`/security/acls/${aclName}/update`, host))}
-      isSimpleView={false}
-    />
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <Text>
+          ACL Configuration Details for <strong>{aclName}</strong>
+        </Text>
+        <Button
+          onClick={() => navigate(handleUrlWithHost(`/security/acls/${aclName}/update`, host))}
+          data-testid="update-acl-button"
+          variant="secondary"
+        >
+          <Pencil className="w-4 h-4 mr-2" />
+          Edit
+        </Button>
+      </div>
+      <ACLDetails sharedConfig={acls.sharedConfig} rules={acls.rules} isSimpleView={false} />
+    </div>
   );
 };
 

--- a/frontend/src/components/pages/acls/new-acl/AclDetailPage.tsx
+++ b/frontend/src/components/pages/acls/new-acl/AclDetailPage.tsx
@@ -10,16 +10,22 @@
  */
 
 import { useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { uiState } from 'state/uiState';
 import { useGetAclsByPrincipal } from '../../../../react-query/api/acl';
-import { parsePrincipal } from './ACL.model';
+import { handleUrlWithHost } from './ACL.model';
 import { ACLDetails } from './ACLDetails';
+import { HostSelector } from './HostSelector';
 
 const AclDetailPage = () => {
   const { aclName = '' } = useParams<{ aclName: string }>();
   const navigate = useNavigate();
-  const { data } = useGetAclsByPrincipal(`User:${aclName}`);
+  const [searchParams] = useSearchParams();
+  const host = searchParams.get('host') || undefined;
+
+  const { data, isLoading } = useGetAclsByPrincipal(`User:${aclName}`, host);
+
+  const [acls, ...hosts] = data || [];
 
   useEffect(() => {
     uiState.pageBreadcrumbs = [
@@ -30,15 +36,23 @@ const AclDetailPage = () => {
     ];
   }, [aclName]);
 
-  if (!data) {
+  if (isLoading) {
     return <div>Loading...</div>;
+  }
+
+  if (!acls || !data) {
+    return <div>No ACL data found</div>;
+  }
+
+  if (!!hosts && hosts.length > 0) {
+    return <HostSelector principalName={aclName} hosts={data} baseUrl={`/security/acls/${aclName}/details`} />;
   }
 
   return (
     <ACLDetails
-      sharedConfig={data.sharedConfig}
-      rules={data.rules}
-      onUpdateACL={() => navigate(`/security/acls/${parsePrincipal(data.sharedConfig.principal).name}/update`)}
+      sharedConfig={acls.sharedConfig}
+      rules={acls.rules}
+      onUpdateACL={() => navigate(handleUrlWithHost(`/security/acls/${aclName}/update`, host))}
       isSimpleView={false}
     />
   );

--- a/frontend/src/components/pages/acls/new-acl/AclUpdatePage.tsx
+++ b/frontend/src/components/pages/acls/new-acl/AclUpdatePage.tsx
@@ -11,8 +11,10 @@
 
 import { useToast } from '@redpanda-data/ui';
 import {
+  getAclFromAclListResponse,
   getOperationsForResourceType,
   handleResponses,
+  handleUrlWithHost,
   ModeAllowAll,
   ModeDenyAll,
   OperationTypeAllow,
@@ -23,8 +25,9 @@ import {
   type SharedConfig,
 } from 'components/pages/acls/new-acl/ACL.model';
 import CreateACL from 'components/pages/acls/new-acl/CreateACL';
+import { HostSelector } from 'components/pages/acls/new-acl/HostSelector';
 import { useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { useGetAclsByPrincipal, useUpdateAclMutation } from '../../../../react-query/api/acl';
 import { uiState } from '../../../../state/uiState';
 import PageContent from '../../../misc/PageContent';
@@ -33,6 +36,8 @@ const AclUpdatePage = () => {
   const toast = useToast();
   const navigate = useNavigate();
   const { aclName = '' } = useParams<{ aclName: string }>();
+  const [searchParams] = useSearchParams();
+  const host = searchParams.get('host') ?? undefined;
 
   useEffect(() => {
     uiState.pageBreadcrumbs = [
@@ -44,19 +49,33 @@ const AclUpdatePage = () => {
   }, [aclName]);
 
   // Fetch existing ACL data
-  const { data, isLoading } = useGetAclsByPrincipal(`User:${aclName}`);
+  const { data, isLoading } = useGetAclsByPrincipal(`User:${aclName}`, host, (response) => {
+    const possibleHosts = response.resources.reduce<Set<string>>((uniqueHosts, resource) => {
+      resource.acls.forEach((acl) => {
+        uniqueHosts.add(acl.host);
+      });
+      return uniqueHosts;
+    }, new Set<string>());
+
+    const aclDetails = getAclFromAclListResponse(response);
+    // When host filter is provided, we expect only one AclDetail in the array
+    return { acls: aclDetails[0], hosts: Array.from(possibleHosts) };
+  });
 
   const { applyUpdates } = useUpdateAclMutation();
+
+  const { acls, hosts } = data ?? { acls: undefined, hosts: [] };
 
   const updateAclMutation =
     (actualRules: Rule[], sharedConfig: SharedConfig) => async (_: string, _2: string, rules: Rule[]) => {
       const applyResult = await applyUpdates(actualRules, sharedConfig, rules);
       handleResponses(toast, applyResult.errors, applyResult.created);
 
-      navigate(`/security/acls/${parsePrincipal(sharedConfig.principal).name}/details`);
+      const detailsPath = `/security/acls/${parsePrincipal(sharedConfig.principal).name}/details`;
+      navigate(handleUrlWithHost(detailsPath, host));
     };
 
-  if (isLoading || !data) {
+  if (isLoading || !acls) {
     return (
       <PageContent>
         <div className="flex items-center justify-center h-96">
@@ -66,8 +85,16 @@ const AclUpdatePage = () => {
     );
   }
 
+  if (!!hosts && hosts.length > 1) {
+    return (
+      <PageContent>
+        <HostSelector principalName={aclName} hosts={hosts} baseUrl={`/security/acls/${aclName}/update`} />
+      </PageContent>
+    );
+  }
+
   // Ensure all operations are present for each rule
-  const rulesWithAllOperations = data.rules.map((rule) => {
+  const rulesWithAllOperations = acls.rules.map((rule) => {
     const allOperations = getOperationsForResourceType(rule.resourceType);
     let mergedOperations = { ...allOperations };
 
@@ -94,10 +121,10 @@ const AclUpdatePage = () => {
   return (
     <PageContent>
       <CreateACL
-        onSubmit={updateAclMutation(data.rules, data.sharedConfig)}
-        onCancel={() => navigate(`/security/acls/${aclName}/details`)}
+        onSubmit={updateAclMutation(acls.rules, acls.sharedConfig)}
+        onCancel={() => navigate(handleUrlWithHost(`/security/acls/${aclName}/details`, host))}
         rules={rulesWithAllOperations}
-        sharedConfig={data.sharedConfig}
+        sharedConfig={acls.sharedConfig}
         edit={true}
         principalType={PrincipalTypeUser}
       />

--- a/frontend/src/components/pages/acls/new-acl/HostSelector.test.tsx
+++ b/frontend/src/components/pages/acls/new-acl/HostSelector.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { fireEvent, renderWithRouter, screen, waitFor } from 'test-utils';
+import { HostSelector } from './HostSelector';
+
+const mockNavigate = vi.fn();
+const mockSearchParams = new URLSearchParams();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useSearchParams: () => [mockSearchParams],
+  };
+});
+
+describe('HostSelector', () => {
+  const defaultProps = {
+    principalName: 'test-user',
+    hosts: ['192.168.1.1', '192.168.1.2', '192.168.1.3'],
+    baseUrl: '/security/acls/test-user/details',
+  };
+
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  describe('Rendering', () => {
+    test('should render card with correct title', () => {
+      renderWithRouter(<HostSelector {...defaultProps} />);
+
+      expect(screen.getByText('Multiple Hosts Found')).toBeVisible();
+    });
+
+    test('should display principal name in description text', () => {
+      renderWithRouter(<HostSelector {...defaultProps} />);
+
+      expect(screen.getByTestId('host-selector-principal-name')).toBeVisible();
+      expect(screen.getByTestId('host-selector-principal-name')).toHaveTextContent('test-user');
+      expect(screen.getByTestId('host-selector-description')).toBeVisible();
+      expect(screen.getByTestId('host-selector-description')).toHaveTextContent(
+        /principal has ACLs configured for multiple hosts/i,
+      );
+    });
+
+    test('should render all host values in the table', () => {
+      renderWithRouter(<HostSelector {...defaultProps} />);
+
+      expect(screen.getByText('192.168.1.1')).toBeVisible();
+      expect(screen.getByText('192.168.1.2')).toBeVisible();
+      expect(screen.getByText('192.168.1.3')).toBeVisible();
+    });
+
+    test('should render correct number of table rows', () => {
+      renderWithRouter(<HostSelector {...defaultProps} />);
+
+      // Verify each host has a row using testIds
+      expect(screen.getByTestId('host-selector-row-192.168.1.1')).toBeVisible();
+      expect(screen.getByTestId('host-selector-row-192.168.1.2')).toBeVisible();
+      expect(screen.getByTestId('host-selector-row-192.168.1.3')).toBeVisible();
+    });
+  });
+
+  describe('Table structure', () => {
+    test('should render table headers', () => {
+      renderWithRouter(<HostSelector {...defaultProps} />);
+
+      expect(screen.getByText('Principal')).toBeVisible();
+      expect(screen.getByText('Host')).toBeVisible();
+    });
+
+    test('should display principal name and host value in each row', () => {
+      renderWithRouter(<HostSelector {...defaultProps} />);
+
+      // Check that each host has a corresponding principal name and host value with testIds
+      for (const host of defaultProps.hosts) {
+        expect(screen.getByTestId(`host-selector-principal-${host}`)).toBeVisible();
+        expect(screen.getByTestId(`host-selector-principal-${host}`)).toHaveTextContent('test-user');
+        expect(screen.getByTestId(`host-selector-host-${host}`)).toBeVisible();
+        expect(screen.getByTestId(`host-selector-host-${host}`)).toHaveTextContent(host);
+      }
+    });
+  });
+
+  describe('Navigation', () => {
+    test('should navigate with correct query parameter when clicking a host row', async () => {
+      renderWithRouter(<HostSelector {...defaultProps} />);
+
+      const firstRow = screen.getByTestId('host-selector-row-192.168.1.1');
+      fireEvent.click(firstRow);
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledTimes(1);
+        expect(mockNavigate).toHaveBeenCalledWith('/security/acls/test-user/details?host=192.168.1.1');
+      });
+    });
+
+    test('should navigate to different URLs when clicking different hosts', async () => {
+      renderWithRouter(<HostSelector {...defaultProps} />);
+
+      // Click first host
+      const firstRow = screen.getByTestId('host-selector-row-192.168.1.1');
+      fireEvent.click(firstRow);
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/security/acls/test-user/details?host=192.168.1.1');
+      });
+
+      // Click second host
+      const secondRow = screen.getByTestId('host-selector-row-192.168.1.2');
+      fireEvent.click(secondRow);
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/security/acls/test-user/details?host=192.168.1.2');
+      });
+    });
+
+    test('should properly encode host values with special characters', async () => {
+      const propsWithSpecialChars = {
+        ...defaultProps,
+        hosts: ['host@example.com', '*.domain.com', 'host with spaces'],
+      };
+
+      renderWithRouter(<HostSelector {...propsWithSpecialChars} />);
+
+      const row = screen.getByTestId('host-selector-row-host@example.com');
+      fireEvent.click(row);
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/security/acls/test-user/details?host=host%40example.com');
+      });
+    });
+
+    test('should use provided baseUrl correctly', async () => {
+      const customBaseUrl = '/security/roles/my-role/details';
+      const customProps = {
+        ...defaultProps,
+        baseUrl: customBaseUrl,
+      };
+
+      renderWithRouter(<HostSelector {...customProps} />);
+
+      const row = screen.getByTestId('host-selector-row-192.168.1.1');
+      fireEvent.click(row);
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/security/roles/my-role/details?host=192.168.1.1');
+      });
+    });
+  });
+
+  describe('Edge cases', () => {
+    test('should render with single host', () => {
+      const singleHostProps = {
+        ...defaultProps,
+        hosts: ['192.168.1.1'],
+      };
+
+      renderWithRouter(<HostSelector {...singleHostProps} />);
+
+      expect(screen.getByTestId('host-selector-row-192.168.1.1')).toBeVisible();
+      expect(screen.getByTestId('host-selector-host-192.168.1.1')).toHaveTextContent('192.168.1.1');
+    });
+
+    test('should render with many hosts', () => {
+      const manyHostsProps = {
+        ...defaultProps,
+        hosts: Array.from({ length: 10 }, (_, i) => `192.168.1.${i + 1}`),
+      };
+
+      renderWithRouter(<HostSelector {...manyHostsProps} />);
+
+      // Verify first and last host are present
+      expect(screen.getByTestId('host-selector-row-192.168.1.1')).toBeVisible();
+      expect(screen.getByTestId('host-selector-row-192.168.1.10')).toBeVisible();
+
+      // Verify all 10 rows exist
+      for (let i = 1; i <= 10; i++) {
+        expect(screen.getByTestId(`host-selector-row-192.168.1.${i}`)).toBeVisible();
+      }
+    });
+  });
+});

--- a/frontend/src/components/pages/acls/new-acl/HostSelector.tsx
+++ b/frontend/src/components/pages/acls/new-acl/HostSelector.tsx
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Card, CardContent, CardHeader, CardTitle } from '../../../redpanda-ui/components/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../../redpanda-ui/components/table';
+import { Text } from '../../../redpanda-ui/components/typography';
+import type { AclDetail } from './ACL.model';
+
+interface HostSelectorProps {
+  principalName: string;
+  hosts: AclDetail[];
+  baseUrl: string;
+}
+
+export const HostSelector = ({ principalName, hosts, baseUrl }: HostSelectorProps) => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  return (
+    <div className="flex items-center w-2/3">
+      <Card size={'full'}>
+        <CardHeader>
+          <CardTitle>Multiple Hosts Found</CardTitle>
+        </CardHeader>
+        <CardContent className={' flex flex-col gap-2'}>
+          <Text className="mb-4 text-gray-600" data-testid="host-selector-description">
+            This{' '}
+            <Text as="span" className={'font-bold'} data-testid="host-selector-principal-name">
+              {principalName}
+            </Text>{' '}
+            principal has ACLs configured for multiple hosts. Please select a host to view its ACL configuration:
+          </Text>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Principal</TableHead>
+                <TableHead>Host</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {hosts.map(({ sharedConfig: { host: hostValue } }) => (
+                <TableRow
+                  key={hostValue}
+                  className="cursor-pointer hover:bg-gray-50"
+                  onClick={() => {
+                    const newSearchParams = new URLSearchParams(searchParams);
+                    newSearchParams.set('host', hostValue);
+                    navigate(`${baseUrl}?${newSearchParams.toString()}`);
+                  }}
+                  testId={`host-selector-row-${hostValue}`}
+                >
+                  <TableCell className="font-medium" testId={`host-selector-principal-${hostValue}`}>
+                    {principalName}
+                  </TableCell>
+                  <TableCell className="font-medium" testId={`host-selector-host-${hostValue}`}>
+                    {hostValue}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/frontend/src/components/pages/roles/RoleDetailPage.tsx
+++ b/frontend/src/components/pages/roles/RoleDetailPage.tsx
@@ -49,10 +49,15 @@ const SecurityAclRulesTable = ({ data, roleName }: SecurityAclRulesTableProps) =
           </TableHeader>
           <TableBody>
             {data.map((aclData) => (
-              <TableRow key={`table-item-${aclData.sharedConfig.principal}-${aclData.sharedConfig.host}`}>
-                <TableCell>{aclData.sharedConfig.principal}</TableCell>
-                <TableCell>{aclData.sharedConfig.host}</TableCell>
-                <TableCell>{aclData.rules.length}</TableCell>
+              <TableRow
+                key={`table-item-${aclData.sharedConfig.principal}-${aclData.sharedConfig.host}`}
+                data-testid={`role-acl-table-row-${aclData.sharedConfig.host}`}
+              >
+                <TableCell testId={`role-acl-principal-${aclData.sharedConfig.host}`}>
+                  {aclData.sharedConfig.principal}
+                </TableCell>
+                <TableCell testId={`role-acl-host-${aclData.sharedConfig.host}`}>{aclData.sharedConfig.host}</TableCell>
+                <TableCell testId={`role-acl-count-${aclData.sharedConfig.host}`}>{aclData.rules.length}</TableCell>
                 <TableCell>
                   <div className="flex gap-2 justify-end">
                     <Button
@@ -61,6 +66,7 @@ const SecurityAclRulesTable = ({ data, roleName }: SecurityAclRulesTableProps) =
                       onClick={() => {
                         navigate(handleUrlWithHost(`/security/roles/${roleName}/details`, aclData.sharedConfig.host));
                       }}
+                      testId={`view-role-acl-${aclData.sharedConfig.host}`}
                     >
                       <Eye className="w-4 h-4" />
                     </Button>
@@ -70,6 +76,7 @@ const SecurityAclRulesTable = ({ data, roleName }: SecurityAclRulesTableProps) =
                       onClick={() => {
                         navigate(handleUrlWithHost(`/security/roles/${roleName}/update`, aclData.sharedConfig.host));
                       }}
+                      testId={`edit-role-acl-${aclData.sharedConfig.host}`}
                     >
                       <Pencil className="w-4 h-4" />
                     </Button>

--- a/frontend/src/components/pages/roles/RoleDetailPage.tsx
+++ b/frontend/src/components/pages/roles/RoleDetailPage.tsx
@@ -15,6 +15,59 @@ import { uiState } from 'state/uiState';
 import { useGetAclsByPrincipal } from '../../../react-query/api/acl';
 import PageContent from '../../misc/PageContent';
 import { ACLDetails } from '../acls/new-acl/ACLDetails';
+import { MatchingUsersCard } from './MatchingUsersCard';
+import { Card, CardContent, CardHeader } from '../../redpanda-ui/components/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../redpanda-ui/components/table';
+import { Button } from '../../redpanda-ui/components/button';
+import { type AclDetail, handleUrlWithHost } from '../acls/new-acl/ACL.model';
+
+interface SecurityAclRulesTableProps {
+  data: AclDetail[];
+  roleName: string;
+}
+
+const SecurityAclRulesTable = ({ data, roleName }: SecurityAclRulesTableProps) => {
+  const navigate = useNavigate();
+
+  return (
+    <Card size="full">
+      <CardHeader>
+        <h2 className="text-lg font-medium">Security ACL rules</h2>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Principal</TableHead>
+              <TableHead>Host</TableHead>
+              <TableHead>Count ACLs</TableHead>
+              <TableHead>{''}</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {data.map((aclData) => (
+              <TableRow key={`table-item-${aclData.sharedConfig.principal}-${aclData.sharedConfig.host}`}>
+                <TableCell>{aclData.sharedConfig.principal}</TableCell>
+                <TableCell>{aclData.sharedConfig.host}</TableCell>
+                <TableCell>{aclData.rules.length}</TableCell>
+                <TableCell>
+                  <Button
+                    variant="secondary"
+                    onClick={() => {
+                      navigate(handleUrlWithHost(`/security/roles/${roleName}/update`, aclData.sharedConfig.host));
+                    }}
+                  >
+                    Edit
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+};
 
 const RoleDetailPage = () => {
   const { roleName = '' } = useParams<{ roleName: string }>();
@@ -30,9 +83,9 @@ const RoleDetailPage = () => {
   }, [roleName]);
 
   // Fetch ACLs for the role
-  const { data: aclData } = useGetAclsByPrincipal(`RedpandaRole:${roleName}`);
+  const { data, isLoading } = useGetAclsByPrincipal(`RedpandaRole:${roleName}`);
 
-  if (!aclData) {
+  if (isLoading) {
     return (
       <PageContent>
         <div className="flex items-center justify-center h-96">
@@ -42,16 +95,36 @@ const RoleDetailPage = () => {
     );
   }
 
-  return (
-    <PageContent>
-      {aclData && (
+  if (!data) {
+    return (
+      <PageContent>
+        <div className="flex items-center justify-center h-96">
+          <div className="text-gray-500">No Role data found.</div>
+        </div>
+      </PageContent>
+    );
+  }
+
+  const renderACLInformation = () => {
+    if (data.length === 1) {
+      const aclData = data[0];
+      return (
         <ACLDetails
           sharedConfig={aclData.sharedConfig}
           rules={aclData.rules}
           onUpdateACL={() => navigate(`/security/roles/${roleName}/update`)}
-          showMatchingUsers={true}
         />
-      )}
+      );
+    }
+    return <SecurityAclRulesTable data={data} roleName={roleName} />;
+  };
+
+  return (
+    <PageContent>
+      <div className="grid grid-cols-3 gap-4">
+        <div className="col-span-2 w-full">{renderACLInformation()}</div>
+        <MatchingUsersCard principalType="RedpandaRole" principal={`Redpanda:${roleName}`} />
+      </div>
     </PageContent>
   );
 };

--- a/frontend/src/components/pages/roles/RoleDetailPage.tsx
+++ b/frontend/src/components/pages/roles/RoleDetailPage.tsx
@@ -9,8 +9,9 @@
  * by the Apache License, Version 2.0
  */
 
-import { useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useEffect, useMemo } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { Eye, Pencil } from 'lucide-react';
 import { uiState } from 'state/uiState';
 import { useGetAclsByPrincipal } from '../../../react-query/api/acl';
 import PageContent from '../../misc/PageContent';
@@ -26,6 +27,7 @@ interface SecurityAclRulesTableProps {
   roleName: string;
 }
 
+// Table to display multiple ACL rules for a role
 const SecurityAclRulesTable = ({ data, roleName }: SecurityAclRulesTableProps) => {
   const navigate = useNavigate();
 
@@ -51,14 +53,26 @@ const SecurityAclRulesTable = ({ data, roleName }: SecurityAclRulesTableProps) =
                 <TableCell>{aclData.sharedConfig.host}</TableCell>
                 <TableCell>{aclData.rules.length}</TableCell>
                 <TableCell>
-                  <Button
-                    variant="secondary"
-                    onClick={() => {
-                      navigate(handleUrlWithHost(`/security/roles/${roleName}/update`, aclData.sharedConfig.host));
-                    }}
-                  >
-                    Edit
-                  </Button>
+                  <div className="flex gap-2 justify-end">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        navigate(handleUrlWithHost(`/security/roles/${roleName}/details`, aclData.sharedConfig.host));
+                      }}
+                    >
+                      <Eye className="w-4 h-4" />
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        navigate(handleUrlWithHost(`/security/roles/${roleName}/update`, aclData.sharedConfig.host));
+                      }}
+                    >
+                      <Pencil className="w-4 h-4" />
+                    </Button>
+                  </div>
                 </TableCell>
               </TableRow>
             ))}
@@ -72,6 +86,8 @@ const SecurityAclRulesTable = ({ data, roleName }: SecurityAclRulesTableProps) =
 const RoleDetailPage = () => {
   const { roleName = '' } = useParams<{ roleName: string }>();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const host = searchParams.get('host') ?? undefined;
 
   useEffect(() => {
     uiState.pageBreadcrumbs = [
@@ -83,7 +99,29 @@ const RoleDetailPage = () => {
   }, [roleName]);
 
   // Fetch ACLs for the role
-  const { data, isLoading } = useGetAclsByPrincipal(`RedpandaRole:${roleName}`);
+  const { data, isLoading } = useGetAclsByPrincipal(`RedpandaRole:${roleName}`, host);
+
+  const renderACLInformation = useMemo(() => {
+    if (!data || data.length === 0) {
+      return (
+        <div className="flex items-center justify-center h-96">
+          <div className="text-gray-500">No Role data found.</div>
+        </div>
+      );
+    }
+
+    if (data.length === 1) {
+      const acl = data[0];
+      return (
+        <ACLDetails
+          sharedConfig={acl.sharedConfig}
+          rules={acl.rules}
+          onUpdateACL={() => navigate(handleUrlWithHost(`/security/roles/${roleName}/update`, host))}
+        />
+      );
+    }
+    return <SecurityAclRulesTable data={data} roleName={roleName} />;
+  }, [data, roleName, navigate, host]);
 
   if (isLoading) {
     return (
@@ -95,34 +133,10 @@ const RoleDetailPage = () => {
     );
   }
 
-  if (!data) {
-    return (
-      <PageContent>
-        <div className="flex items-center justify-center h-96">
-          <div className="text-gray-500">No Role data found.</div>
-        </div>
-      </PageContent>
-    );
-  }
-
-  const renderACLInformation = () => {
-    if (data.length === 1) {
-      const aclData = data[0];
-      return (
-        <ACLDetails
-          sharedConfig={aclData.sharedConfig}
-          rules={aclData.rules}
-          onUpdateACL={() => navigate(`/security/roles/${roleName}/update`)}
-        />
-      );
-    }
-    return <SecurityAclRulesTable data={data} roleName={roleName} />;
-  };
-
   return (
     <PageContent>
-      <div className="grid grid-cols-3 gap-4">
-        <div className="col-span-2 w-full">{renderACLInformation()}</div>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div className="col-span-2 w-full">{renderACLInformation}</div>
         <MatchingUsersCard principalType="RedpandaRole" principal={`Redpanda:${roleName}`} />
       </div>
     </PageContent>

--- a/frontend/src/components/pages/roles/RoleDetailPage.tsx
+++ b/frontend/src/components/pages/roles/RoleDetailPage.tsx
@@ -9,18 +9,19 @@
  * by the Apache License, Version 2.0
  */
 
+import { Eye, Pencil } from 'lucide-react';
 import { useEffect, useMemo } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import { Eye, Pencil } from 'lucide-react';
 import { uiState } from 'state/uiState';
 import { useGetAclsByPrincipal } from '../../../react-query/api/acl';
 import PageContent from '../../misc/PageContent';
-import { ACLDetails } from '../acls/new-acl/ACLDetails';
-import { MatchingUsersCard } from './MatchingUsersCard';
+import { Button } from '../../redpanda-ui/components/button';
 import { Card, CardContent, CardHeader } from '../../redpanda-ui/components/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../redpanda-ui/components/table';
-import { Button } from '../../redpanda-ui/components/button';
+import { Text } from '../../redpanda-ui/components/typography';
 import { type AclDetail, handleUrlWithHost } from '../acls/new-acl/ACL.model';
+import { ACLDetails } from '../acls/new-acl/ACLDetails';
+import { MatchingUsersCard } from './MatchingUsersCard';
 
 interface SecurityAclRulesTableProps {
   data: AclDetail[];
@@ -112,16 +113,10 @@ const RoleDetailPage = () => {
 
     if (data.length === 1) {
       const acl = data[0];
-      return (
-        <ACLDetails
-          sharedConfig={acl.sharedConfig}
-          rules={acl.rules}
-          onUpdateACL={() => navigate(handleUrlWithHost(`/security/roles/${roleName}/update`, host))}
-        />
-      );
+      return <ACLDetails sharedConfig={acl.sharedConfig} rules={acl.rules} />;
     }
     return <SecurityAclRulesTable data={data} roleName={roleName} />;
-  }, [data, roleName, navigate, host]);
+  }, [data, roleName]);
 
   if (isLoading) {
     return (
@@ -135,6 +130,24 @@ const RoleDetailPage = () => {
 
   return (
     <PageContent>
+      <div className="flex justify-between items-center">
+        <Text>
+          Viewing role <Text as="span">{roleName}</Text>{' '}
+        </Text>
+        {(!!host || data?.length === 1) && (
+          <div>
+            <Button
+              onClick={() => navigate(handleUrlWithHost(`/security/roles/${roleName}/update`, host))}
+              data-testid="update-acl-button"
+              variant="secondary"
+            >
+              <Pencil className="w-4 h-4 mr-2" />
+              Edit ACL
+            </Button>
+          </div>
+        )}
+      </div>
+
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
         <div className="col-span-2 w-full">{renderACLInformation}</div>
         <MatchingUsersCard principalType="RedpandaRole" principal={`Redpanda:${roleName}`} />

--- a/frontend/src/components/pages/roles/RoleUpdatePage.tsx
+++ b/frontend/src/components/pages/roles/RoleUpdatePage.tsx
@@ -13,6 +13,7 @@ import { useToast } from '@redpanda-data/ui';
 import {
   getOperationsForResourceType,
   handleResponses,
+  handleUrlWithHost,
   ModeAllowAll,
   ModeDenyAll,
   OperationTypeAllow,
@@ -22,8 +23,9 @@ import {
   type SharedConfig,
 } from 'components/pages/acls/new-acl/ACL.model';
 import CreateACL from 'components/pages/acls/new-acl/CreateACL';
+import { HostSelector } from 'components/pages/acls/new-acl/HostSelector';
 import { useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { useGetAclsByPrincipal, useUpdateAclMutation } from '../../../react-query/api/acl';
 import { uiState } from '../../../state/uiState';
 import PageContent from '../../misc/PageContent';
@@ -32,6 +34,8 @@ const RoleUpdatePage = () => {
   const toast = useToast();
   const navigate = useNavigate();
   const { roleName = '' } = useParams<{ roleName: string }>();
+  const [searchParams] = useSearchParams();
+  const host = searchParams.get('host') ?? undefined;
 
   const { applyUpdates } = useUpdateAclMutation();
 
@@ -45,17 +49,17 @@ const RoleUpdatePage = () => {
   }, [roleName]);
 
   // Fetch existing ACL data for the role
-  const { data, isLoading } = useGetAclsByPrincipal(`RedpandaRole:${roleName}`);
+  const { data, isLoading } = useGetAclsByPrincipal(`RedpandaRole:${roleName}`, host);
 
   const updateRoleAclMutation =
     (actualRules: Rule[], sharedConfig: SharedConfig) => async (_: string, _2: string, rules: Rule[]) => {
       const applyResult = await applyUpdates(actualRules, sharedConfig, rules);
       handleResponses(toast, applyResult.errors, applyResult.created);
 
-      navigate(`/security/roles/${roleName}/details`);
+      navigate(handleUrlWithHost(`/security/roles/${roleName}/details`, host));
     };
 
-  if (isLoading || !data) {
+  if (isLoading || !data || data.length === 0) {
     return (
       <PageContent>
         <div className="flex items-center justify-center h-96">
@@ -65,8 +69,30 @@ const RoleUpdatePage = () => {
     );
   }
 
+  // If multiple hosts exist and no host is selected, show host selector
+  if (data.length > 1 && !host) {
+    return (
+      <PageContent>
+        <HostSelector principalName={roleName} hosts={data} baseUrl={`/security/roles/${roleName}/update`} />
+      </PageContent>
+    );
+  }
+
+  // Get the ACL for the selected host (or the only one available)
+  const acl = host ? data.find((d) => d.sharedConfig.host === host) : data[0];
+
+  if (!acl) {
+    return (
+      <PageContent>
+        <div className="flex items-center justify-center h-96">
+          <div className="text-gray-500">No ACL data found for host: {host}</div>
+        </div>
+      </PageContent>
+    );
+  }
+
   // Ensure all operations are present for each rule
-  const rulesWithAllOperations = data.rules.map((rule) => {
+  const rulesWithAllOperations = acl.rules.map((rule) => {
     const allOperations = getOperationsForResourceType(rule.resourceType);
     let mergedOperations = { ...allOperations };
 
@@ -93,10 +119,10 @@ const RoleUpdatePage = () => {
   return (
     <PageContent>
       <CreateACL
-        onSubmit={updateRoleAclMutation(data.rules, data.sharedConfig)}
-        onCancel={() => navigate(`/security/roles/${roleName}/details`)}
+        onSubmit={updateRoleAclMutation(acl.rules, acl.sharedConfig)}
+        onCancel={() => navigate(handleUrlWithHost(`/security/roles/${roleName}/details`, host))}
         rules={rulesWithAllOperations}
-        sharedConfig={data.sharedConfig}
+        sharedConfig={acl.sharedConfig}
         edit={true}
         principalType={PrincipalTypeRedpandaRole}
       />

--- a/frontend/src/components/pages/roles/UserAclsCard.test.tsx
+++ b/frontend/src/components/pages/roles/UserAclsCard.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import type { AclDetail } from '../acls/new-acl/ACL.model';
+import { UserAclsCard } from './UserAclsCard';
+
+// Mock useNavigate
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+  };
+});
+
+const mockAcls: AclDetail[] = [
+  {
+    sharedConfig: {
+      principal: 'User:test-user',
+      host: '*',
+    },
+    rules: [
+      {
+        id: 1,
+        resourceType: 'topic',
+        mode: 'custom',
+        selectorType: 'literal',
+        selectorValue: 'test-topic',
+        operations: {
+          READ: 'allow',
+          WRITE: 'allow',
+        },
+      },
+    ],
+  },
+  {
+    sharedConfig: {
+      principal: 'User:test-user',
+      host: '192.168.1.1',
+    },
+    rules: [
+      {
+        id: 2,
+        resourceType: 'cluster',
+        mode: 'custom',
+        selectorType: 'any',
+        selectorValue: '',
+        operations: {
+          DESCRIBE: 'allow',
+        },
+      },
+    ],
+  },
+];
+
+describe('UserAclsCard', () => {
+  it('should render empty state when no ACLs provided', () => {
+    render(
+      <BrowserRouter>
+        <UserAclsCard acls={[]} />
+      </BrowserRouter>,
+    );
+
+    expect(screen.getByText('ACLs (0)')).toBeInTheDocument();
+    expect(screen.getByText('No ACLs assigned to this user.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create ACL' })).toBeInTheDocument();
+  });
+
+  it('should render empty state when acls is undefined', () => {
+    render(
+      <BrowserRouter>
+        <UserAclsCard acls={undefined} />
+      </BrowserRouter>,
+    );
+
+    expect(screen.getByText('ACLs (0)')).toBeInTheDocument();
+    expect(screen.getByText('No ACLs assigned to this user.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create ACL' })).toBeInTheDocument();
+  });
+
+  it('should render ACL table with correct count', () => {
+    render(
+      <BrowserRouter>
+        <UserAclsCard acls={mockAcls} />
+      </BrowserRouter>,
+    );
+
+    expect(screen.getByText('ACLs (2)')).toBeInTheDocument();
+  });
+
+  it('should render ACL rows with principal and host', () => {
+    render(
+      <BrowserRouter>
+        <UserAclsCard acls={mockAcls} />
+      </BrowserRouter>,
+    );
+
+    expect(screen.getByTestId('acl-principal-User:test-user-*')).toHaveTextContent('User:test-user');
+    expect(screen.getByTestId('acl-principal-User:test-user-192.168.1.1')).toHaveTextContent('User:test-user');
+    expect(screen.getByTestId('acl-host-*')).toHaveTextContent('*');
+    expect(screen.getByTestId('acl-host-192.168.1.1')).toHaveTextContent('192.168.1.1');
+  });
+
+  it('should render action buttons for each ACL', () => {
+    render(
+      <BrowserRouter>
+        <UserAclsCard acls={mockAcls} />
+      </BrowserRouter>,
+    );
+
+    expect(screen.getByTestId('view-acl-User:test-user-*')).toBeInTheDocument();
+    expect(screen.getByTestId('view-acl-User:test-user-192.168.1.1')).toBeInTheDocument();
+  });
+
+  it('should render table headers', () => {
+    render(
+      <BrowserRouter>
+        <UserAclsCard acls={mockAcls} />
+      </BrowserRouter>,
+    );
+
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Hosts')).toBeInTheDocument();
+    expect(screen.getByText('Actions')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/pages/roles/UserAclsCard.tsx
+++ b/frontend/src/components/pages/roles/UserAclsCard.tsx
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { Eye } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '../../redpanda-ui/components/button';
+import { Card, CardAction, CardContent, CardHeader, CardTitle } from '../../redpanda-ui/components/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../redpanda-ui/components/table';
+import { type AclDetail, handleUrlWithHost } from '../acls/new-acl/ACL.model';
+
+interface UserAclsCardProps {
+  acls?: AclDetail[];
+}
+
+export const UserAclsCard = ({ acls }: UserAclsCardProps) => {
+  const navigate = useNavigate();
+
+  if (!acls || acls.length === 0) {
+    return (
+      <Card size="full">
+        <CardHeader className="flex justify-between items-center">
+          <CardTitle>ACLs (0)</CardTitle>
+          <CardAction>
+            <Button
+              variant="outline"
+              onClick={() => {
+                navigate('/security/acls/create');
+              }}
+              testId="create-acl-button"
+            >
+              Create ACL
+            </Button>
+          </CardAction>
+        </CardHeader>
+        <CardContent>
+          <p>No ACLs assigned to this user.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card size="full">
+      <CardHeader className="flex justify-between items-center">
+        <CardTitle>ACLs ({acls.length})</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Hosts</TableHead>
+              <TableHead align="right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {acls.map((r) => {
+              return (
+                <TableRow key={`acl-${r.sharedConfig.principal}-${r.sharedConfig.host}`}>
+                  <TableCell testId={`acl-principal-${r.sharedConfig.principal}-${r.sharedConfig.host}`}>
+                    {r.sharedConfig.principal}
+                  </TableCell>
+                  <TableCell testId={`acl-host-${r.sharedConfig.host}`}>{r.sharedConfig.host}</TableCell>
+                  <TableCell align="right">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        navigate(
+                          handleUrlWithHost(`/security/acls/${r.sharedConfig.principal}/details`, r.sharedConfig.host),
+                        );
+                      }}
+                      testId={`view-acl-${r.sharedConfig.principal}-${r.sharedConfig.host}`}
+                    >
+                      <Eye className="w-4 h-4" />
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+};

--- a/frontend/src/components/pages/roles/UserInformationCard.tsx
+++ b/frontend/src/components/pages/roles/UserInformationCard.tsx
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { Button } from '../../redpanda-ui/components/button';
+import { Card, CardContent, CardHeader, CardTitle } from '../../redpanda-ui/components/card';
+import { Separator } from '../../redpanda-ui/components/separator';
+import { Text } from '../../redpanda-ui/components/typography';
+
+interface UserInformationCardProps {
+  username: string;
+  saslMechanism: string;
+  onEditPassword?: () => void;
+}
+
+export const UserInformationCard = ({ username, saslMechanism, onEditPassword }: UserInformationCardProps) => {
+  return (
+    <Card size="full">
+      <CardHeader>
+        <CardTitle>User Information</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Username Row */}
+        <div className="grid grid-cols-3 items-center gap-4 py-2">
+          <Text variant="label">Username</Text>
+          <Text variant="default">{username}</Text>
+        </div>
+
+        <Separator />
+
+        {/* Password Row */}
+        <div className="grid grid-cols-3 items-center gap-4 py-2">
+          <Text variant="label">Password</Text>
+          <Text variant="muted">Passwords cannot be viewed</Text>
+          <div className="flex justify-end">
+            {onEditPassword && (
+              <Button variant="outline" size="sm" onClick={onEditPassword}>
+                Edit
+              </Button>
+            )}
+          </div>
+        </div>
+
+        <Separator />
+
+        {/* SASL Mechanism Row */}
+        <div className="grid grid-cols-3 items-center gap-4 py-2">
+          <Text variant="label">SASL Mechanism</Text>
+          <Text variant="default">{saslMechanism}</Text>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/frontend/src/components/pages/roles/UserRolesCard.test.tsx
+++ b/frontend/src/components/pages/roles/UserRolesCard.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { UserRolesCard } from './UserRolesCard';
+
+// Mock useNavigate
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+  };
+});
+
+const mockRoles = [
+  {
+    principalType: 'RedpandaRole',
+    principalName: 'admin',
+  },
+  {
+    principalType: 'RedpandaRole',
+    principalName: 'viewer',
+  },
+];
+
+describe('UserRolesCard', () => {
+  it('should render empty state when no roles provided', () => {
+    render(
+      <BrowserRouter>
+        <UserRolesCard roles={[]} />
+      </BrowserRouter>,
+    );
+
+    expect(screen.getByText('Roles')).toBeInTheDocument();
+    expect(screen.getByText('No permissions assigned to this user.')).toBeInTheDocument();
+  });
+
+  it('should render Assign Role button in empty state when onChangeRoles is provided', () => {
+    const mockOnChangeRoles = vi.fn();
+    render(
+      <BrowserRouter>
+        <UserRolesCard roles={[]} onChangeRoles={mockOnChangeRoles} />
+      </BrowserRouter>,
+    );
+
+    expect(screen.getByTestId('assign-role-button')).toBeInTheDocument();
+  });
+
+  it('should not render Assign Role button in empty state when onChangeRoles is not provided', () => {
+    render(
+      <BrowserRouter>
+        <UserRolesCard roles={[]} />
+      </BrowserRouter>,
+    );
+
+    expect(screen.queryByTestId('assign-role-button')).not.toBeInTheDocument();
+  });
+
+  it('should render roles table with role names', () => {
+    render(
+      <BrowserRouter>
+        <UserRolesCard roles={mockRoles} />
+      </BrowserRouter>,
+    );
+
+    expect(screen.getByTestId('role-name-admin')).toHaveTextContent('admin');
+    expect(screen.getByTestId('role-name-viewer')).toHaveTextContent('viewer');
+  });
+
+  it('should render action buttons for each role', () => {
+    render(
+      <BrowserRouter>
+        <UserRolesCard roles={mockRoles} />
+      </BrowserRouter>,
+    );
+
+    expect(screen.getByTestId('view-role-admin')).toBeInTheDocument();
+    expect(screen.getByTestId('view-role-viewer')).toBeInTheDocument();
+  });
+
+  it('should render table headers', () => {
+    render(
+      <BrowserRouter>
+        <UserRolesCard roles={mockRoles} />
+      </BrowserRouter>,
+    );
+
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Actions')).toBeInTheDocument();
+  });
+
+  it('should render Change Role button when roles exist and onChangeRoles is provided', () => {
+    const mockOnChangeRoles = vi.fn();
+    render(
+      <BrowserRouter>
+        <UserRolesCard roles={mockRoles} onChangeRoles={mockOnChangeRoles} />
+      </BrowserRouter>,
+    );
+
+    expect(screen.getByTestId('change-role-button')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/pages/roles/UserRolesCard.tsx
+++ b/frontend/src/components/pages/roles/UserRolesCard.tsx
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { Eye } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '../../redpanda-ui/components/button';
+import { Card, CardAction, CardContent, CardHeader, CardTitle } from '../../redpanda-ui/components/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../redpanda-ui/components/table';
+import { handleUrlWithHost } from '../acls/new-acl/ACL.model';
+
+interface Role {
+  principalType: string;
+  principalName: string;
+}
+
+interface UserRolesCardProps {
+  roles: Role[];
+  onChangeRoles?: () => void;
+}
+
+export const UserRolesCard = ({ roles, onChangeRoles }: UserRolesCardProps) => {
+  const navigate = useNavigate();
+
+  if (roles.length === 0) {
+    return (
+      <Card size="full">
+        <CardHeader className="flex justify-between items-center">
+          <CardTitle>Roles</CardTitle>
+          <CardAction>
+            {onChangeRoles && (
+              <Button variant="outline" onClick={onChangeRoles} testId="assign-role-button">
+                Assign Role
+              </Button>
+            )}
+          </CardAction>
+        </CardHeader>
+        <CardContent>
+          <p>No permissions assigned to this user.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card size="full">
+      <CardHeader className="flex justify-between items-center">
+        <CardTitle>Roles</CardTitle>
+        <CardAction>
+          {onChangeRoles && (
+            <Button variant="outline" onClick={onChangeRoles} testId="change-role-button">
+              Change Role
+            </Button>
+          )}
+        </CardAction>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead align="right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {roles.map((r) => {
+              return (
+                <TableRow key={`role-${r.principalType}-${r.principalName}`}>
+                  <TableCell testId={`role-name-${r.principalName}`}>{r.principalName}</TableCell>
+                  <TableCell align="right">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        navigate(handleUrlWithHost(`/security/roles/${r.principalName}/details`, ''));
+                      }}
+                      testId={`view-role-${r.principalName}`}
+                    >
+                      <Eye className="w-4 h-4" />
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+};

--- a/frontend/src/react-query/api/acl.tsx
+++ b/frontend/src/react-query/api/acl.tsx
@@ -511,7 +511,7 @@ export const useUpdateAclMutation = () => {
   return { applyUpdates };
 };
 
-export const useGetAclsByPrincipal = <T = AclDetail>(
+export const useGetAclsByPrincipal = <T = AclDetail[]>(
   principal: string,
   host?: string,
   transformFn?: (aclList: ListACLsResponse) => T,

--- a/frontend/src/react-query/api/acl.tsx
+++ b/frontend/src/react-query/api/acl.tsx
@@ -513,6 +513,7 @@ export const useUpdateAclMutation = () => {
 
 export const useGetAclsByPrincipal = <T = AclDetail>(
   principal: string,
+  host?: string,
   transformFn?: (aclList: ListACLsResponse) => T,
 ) => {
   return useQuery(
@@ -520,6 +521,7 @@ export const useGetAclsByPrincipal = <T = AclDetail>(
     {
       filter: {
         principal,
+        host,
       },
     } as ListACLsRequest,
     {

--- a/frontend/tests/console-enterprise/acl.spec.ts
+++ b/frontend/tests/console-enterprise/acl.spec.ts
@@ -1,4 +1,4 @@
-import { type Page, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 import {
   ModeAllowAll,
   ModeCustom,
@@ -1274,6 +1274,304 @@ test.describe('Allow all operations', () => {
           await aclPage.validateSharedConfig();
         });
       });
+    });
+  });
+});
+
+test.describe('Multiples ACL, different hosts but same role', () => {
+  const firstHost = '*';
+  const secondHost = '1.1.1.1';
+
+  const firstACLRules: Rule[] = [
+    {
+      id: 0,
+      resourceType: ResourceTypeCluster,
+      mode: ModeCustom,
+      selectorType: ResourcePatternTypeLiteral,
+      selectorValue: 'kafka-cluster',
+      operations: {
+        DESCRIBE: OperationTypeAllow,
+        CREATE: OperationTypeAllow,
+        ALTER: OperationTypeDeny,
+        CLUSTER_ACTION: OperationTypeAllow,
+      },
+    },
+    {
+      id: 1,
+      resourceType: ResourceTypeTopic,
+      mode: ModeCustom,
+      selectorType: ResourcePatternTypeLiteral,
+      selectorValue: 'events-topic',
+      operations: {
+        DESCRIBE: OperationTypeAllow,
+        READ: OperationTypeAllow,
+        WRITE: OperationTypeAllow,
+        CREATE: OperationTypeAllow,
+        DELETE: OperationTypeDeny,
+      },
+    },
+    {
+      id: 2,
+      resourceType: ResourceTypeTransactionalId,
+      mode: ModeCustom,
+      selectorType: ResourcePatternTypeLiteral,
+      selectorValue: '*',
+      operations: {
+        DESCRIBE: OperationTypeAllow,
+      },
+    },
+  ];
+
+  const secondACLRules: Rule[] = [
+    {
+      id: 0,
+      resourceType: ResourceTypeTopic,
+      mode: ModeCustom,
+      selectorType: ResourcePatternTypeLiteral,
+      selectorValue: 'payments-topic',
+      operations: {
+        DESCRIBE: OperationTypeAllow,
+        READ: OperationTypeAllow,
+        WRITE: OperationTypeAllow,
+      },
+    },
+    {
+      id: 1,
+      resourceType: ResourceTypeTopic,
+      mode: ModeCustom,
+      selectorType: ResourcePatternTypePrefix,
+      selectorValue: 'logs-',
+      operations: {
+        DESCRIBE: OperationTypeAllow,
+        READ: OperationTypeAllow,
+      },
+    },
+  ];
+
+  const roleName = generatePrincipalName();
+
+  test('Create 2 ACLs with same role, 1 with host * and 1 with host 1.1.1.1', async ({ page }) => {
+    await test.step('Create first ACL host *', async () => {
+      const rolePage = new RolePage(page);
+      await rolePage.goto();
+
+      await test.step('Set role name and host', async () => {
+        await rolePage.setPrincipal(roleName);
+        await rolePage.setHost(firstHost);
+      });
+
+      await test.step('Configure all rules', async () => {
+        await rolePage.configureRules(firstACLRules);
+      });
+
+      await test.step('Verify the summary shows the correct operations', async () => {
+        await rolePage.validateAllSummaryRules(firstACLRules);
+      });
+
+      await test.step('Submit the form', async () => {
+        await rolePage.submitForm();
+      });
+
+      await test.step('Wait for navigation to detail page', async () => {
+        await rolePage.waitForDetailPage();
+      });
+    });
+
+    await test.step('Create second ACL host 1.1.1.1', async () => {
+      const rolePage = new RolePage(page);
+      await rolePage.goto();
+
+      await test.step('Set role name and host', async () => {
+        await rolePage.setPrincipal(roleName);
+        await rolePage.setHost(secondHost);
+      });
+
+      await test.step('Configure topic rules', async () => {
+        await rolePage.configureRules(secondACLRules);
+      });
+
+      await test.step('Verify the summary shows the correct operations', async () => {
+        await rolePage.validateAllSummaryRules(secondACLRules);
+      });
+
+      await test.step('Submit the form', async () => {
+        await rolePage.submitForm();
+      });
+
+      await test.step('Wait for navigation to detail page', async () => {
+        await rolePage.waitForDetailPage();
+      });
+    });
+
+    await test.step('Validate role appears in the list', async () => {
+      const rolePage = new RolePage(page);
+      await rolePage.gotoList();
+
+      // Verify role appears in the list (only one item for the role, regardless of multiple hosts)
+      const roleListItem = page.getByTestId(`role-list-item-${roleName}`);
+      await expect(roleListItem).toBeVisible({ timeout: 1000 });
+    });
+
+    await test.step('Validate SecurityAclRulesTable shows both hosts', async () => {
+      const rolePage = new RolePage(page);
+
+      // Navigate to role detail page without host parameter
+      await page.goto(`/security/roles/${encodeURIComponent(roleName)}/details`);
+      await rolePage.waitForDetailPage();
+
+      // Verify SecurityAclRulesTable is displayed with both hosts
+      const firstHostRow = page.getByTestId(`role-acl-table-row-${firstHost}`);
+      await expect(firstHostRow).toBeVisible();
+
+      const secondHostRow = page.getByTestId(`role-acl-table-row-${secondHost}`);
+      await expect(secondHostRow).toBeVisible();
+
+      // Verify host cells show correct values
+      const firstHostCell = page.getByTestId(`role-acl-host-${firstHost}`);
+      await expect(firstHostCell).toHaveText(firstHost);
+
+      const secondHostCell = page.getByTestId(`role-acl-host-${secondHost}`);
+      await expect(secondHostCell).toHaveText(secondHost);
+
+      // Verify count cells show correct number of rules
+      const firstHostCount = page.getByTestId(`role-acl-count-${firstHost}`);
+      await expect(firstHostCount).toHaveText(firstACLRules.length.toString());
+
+      const secondHostCount = page.getByTestId(`role-acl-count-${secondHost}`);
+      await expect(secondHostCount).toHaveText(secondACLRules.length.toString());
+    });
+
+    await test.step('Click view button for first host and validate rules', async () => {
+      const rolePage = new RolePage(page);
+
+      // Click view button for first host
+      const viewFirstHostButton = page.getByTestId(`view-role-acl-${firstHost}`);
+      await viewFirstHostButton.click();
+
+      await rolePage.waitForDetailPage();
+
+      // Verify URL contains host parameter
+      const url = page.url();
+      expect(url).toContain(
+        `/security/roles/${encodeURIComponent(roleName)}/details?host=${encodeURIComponent(firstHost)}`,
+      );
+
+      // Validate all rules from first ACL are present
+      await rolePage.validateAllDetailRules(firstACLRules, `RedpandaRole:${roleName}`, firstHost);
+    });
+
+    await test.step('Navigate back and click view button for second host', async () => {
+      const rolePage = new RolePage(page);
+
+      // Navigate back to detail page without host parameter
+      await page.goto(`/security/roles/${encodeURIComponent(roleName)}/details`);
+      await rolePage.waitForDetailPage();
+
+      // Verify SecurityAclRulesTable is shown again
+      await expect(page.getByTestId(`role-acl-table-row-${firstHost}`)).toBeVisible();
+
+      // Click view button for second host
+      const viewSecondHostButton = page.getByTestId(`view-role-acl-${secondHost}`);
+      await viewSecondHostButton.click();
+
+      await rolePage.waitForDetailPage();
+
+      // Verify URL contains second host parameter
+      await page.waitForURL(
+        `**/security/roles/${encodeURIComponent(roleName)}/details?host=${encodeURIComponent(secondHost)}`,
+      );
+      const url = page.url();
+      expect(url).toContain(`host=${encodeURIComponent(secondHost)}`);
+
+      // Validate all rules from second ACL are present
+      await rolePage.validateAllDetailRules(secondACLRules, `RedpandaRole:${roleName}`, secondHost);
+    });
+
+    await test.step('Navigate to update page without host parameter - verify HostSelector', async () => {
+      // Navigate directly to the update page without specifying host
+      await page.goto(`/security/roles/${encodeURIComponent(roleName)}/update`);
+
+      // Verify that HostSelector is displayed
+      const hostSelectorDescription = page.getByTestId('host-selector-description');
+      await expect(hostSelectorDescription).toBeVisible();
+
+      // Verify the title shows "Multiple Hosts Found"
+      await expect(page.getByText('Multiple Hosts Found')).toBeVisible();
+
+      // Verify both host options are shown
+      const firstHostRow = page.getByTestId(`host-selector-row-${firstHost}`);
+      await expect(firstHostRow).toBeVisible();
+
+      const secondHostRow = page.getByTestId(`host-selector-row-${secondHost}`);
+      await expect(secondHostRow).toBeVisible();
+    });
+
+    await test.step('Select first host from HostSelector and verify navigation', async () => {
+      const rolePage = new RolePage(page);
+
+      // Click on the first host row
+      const firstHostRow = page.getByTestId(`host-selector-row-${firstHost}`);
+      await firstHostRow.click();
+
+      // Verify navigation to update page with host parameter
+      await page.waitForURL(
+        `**/security/roles/${encodeURIComponent(roleName)}/update?host=${encodeURIComponent(firstHost)}`,
+      );
+
+      // Verify URL contains the host parameter
+      const url = page.url();
+      expect(url).toContain(`host=${encodeURIComponent(firstHost)}`);
+
+      // Verify we're on the update page (should show the form)
+      await rolePage.waitForUpdatePage();
+    });
+
+    await test.step('Validate updating one ACL does not affect the other', async () => {
+      const rolePage = new RolePage(page);
+
+      // Navigate to first ACL update page
+      await page.goto(`/security/roles/${encodeURIComponent(roleName)}/update?host=${encodeURIComponent(firstHost)}`);
+      await rolePage.waitForUpdatePage();
+
+      // Create modified rules with one operation changed (DESCRIBE from allow to deny in cluster rule)
+      const modifiedFirstACLRules: Rule[] = [
+        {
+          ...firstACLRules[0],
+          operations: {
+            ...firstACLRules[0].operations,
+            DESCRIBE: OperationTypeDeny, // Changed from allow to deny
+          },
+        },
+        firstACLRules[1], // Topic rule unchanged
+        firstACLRules[2], // TransactionalId rule unchanged
+      ];
+
+      // Apply the update
+      await rolePage.updateRules(modifiedFirstACLRules);
+
+      // Submit the form
+      await rolePage.submitForm();
+
+      // Wait for navigation back to detail page
+      await rolePage.waitForDetailPage();
+
+      // Verify URL contains the correct host parameter
+      let url = page.url();
+      expect(url).toContain(`host=${encodeURIComponent(firstHost)}`);
+
+      // Validate the updated rules
+      await rolePage.validateAllDetailRules(modifiedFirstACLRules, `RedpandaRole:${roleName}`, firstHost);
+
+      // Now verify the second ACL (host 1.1.1.1) was not affected
+      await page.goto(`/security/roles/${encodeURIComponent(roleName)}/details?host=${encodeURIComponent(secondHost)}`);
+      await rolePage.waitForDetailPage();
+
+      // Verify URL contains the second host parameter
+      url = page.url();
+      expect(url).toContain(`host=${encodeURIComponent(secondHost)}`);
+
+      // Verify second ACL's rules remain unchanged
+      await rolePage.validateAllDetailRules(secondACLRules, `RedpandaRole:${roleName}`, secondHost);
     });
   });
 });

--- a/frontend/tests/console/acl.spec.ts
+++ b/frontend/tests/console/acl.spec.ts
@@ -1008,3 +1008,301 @@ test.describe('Allow all operations', () => {
     });
   });
 });
+
+test.describe('Multiples ACLs to same principal', () => {
+  const firstHost = '*';
+  const secondHost = '1.1.1.1';
+
+  const firstACLRules: Rule[] = [
+    {
+      id: 0,
+      resourceType: ResourceTypeCluster,
+      mode: ModeCustom,
+      selectorType: ResourcePatternTypeLiteral,
+      selectorValue: 'kafka-cluster',
+      operations: {
+        DESCRIBE: OperationTypeAllow,
+        CREATE: OperationTypeAllow,
+        ALTER: OperationTypeDeny,
+        CLUSTER_ACTION: OperationTypeAllow,
+      },
+    },
+    {
+      id: 1,
+      resourceType: ResourceTypeTopic,
+      mode: ModeCustom,
+      selectorType: ResourcePatternTypeLiteral,
+      selectorValue: 'events-topic',
+      operations: {
+        DESCRIBE: OperationTypeAllow,
+        READ: OperationTypeAllow,
+        WRITE: OperationTypeAllow,
+        CREATE: OperationTypeAllow,
+        DELETE: OperationTypeDeny,
+      },
+    },
+    {
+      id: 2,
+      resourceType: ResourceTypeTransactionalId,
+      mode: ModeCustom,
+      selectorType: ResourcePatternTypeLiteral,
+      selectorValue: '*',
+      operations: {
+        DESCRIBE: OperationTypeAllow,
+      },
+    },
+  ];
+
+  const secondACLRules: Rule[] = [
+    {
+      id: 0,
+      resourceType: ResourceTypeTopic,
+      mode: ModeCustom,
+      selectorType: ResourcePatternTypeLiteral,
+      selectorValue: 'payments-topic',
+      operations: {
+        DESCRIBE: OperationTypeAllow,
+        READ: OperationTypeAllow,
+        WRITE: OperationTypeAllow,
+      },
+    },
+    {
+      id: 1,
+      resourceType: ResourceTypeTopic,
+      mode: ModeCustom,
+      selectorType: ResourcePatternTypePrefix,
+      selectorValue: 'logs-',
+      operations: {
+        DESCRIBE: OperationTypeAllow,
+        READ: OperationTypeAllow,
+      },
+    },
+  ];
+
+  const principal = generatePrincipalName();
+
+  test('Create 2 ACLs with same principal, 1 with host * and 1 with host 1.1.1.1', async ({ page }) => {
+    await test.step('Create first ACL host *', async () => {
+      const aclPage = new ACLPage(page);
+      await aclPage.goto();
+
+      await test.step('Set principal and host', async () => {
+        await aclPage.setPrincipal(principal);
+        await aclPage.setHost(firstHost);
+      });
+
+      await test.step('Configure all rules', async () => {
+        await aclPage.configureRules(firstACLRules);
+      });
+
+      await test.step('Verify the summary shows the correct operations', async () => {
+        await aclPage.validateAllSummaryRules(firstACLRules);
+      });
+
+      await test.step('Submit the form', async () => {
+        await aclPage.submitForm();
+      });
+
+      await test.step('Wait for navigation to detail page', async () => {
+        await aclPage.waitForDetailPage();
+      });
+    });
+    await test.step('Create second ACL host 1.1.1.1', async () => {
+      const aclPage = new ACLPage(page);
+      await aclPage.goto();
+
+      await test.step('Set principal and host', async () => {
+        await aclPage.setPrincipal(principal);
+        await aclPage.setHost(secondHost);
+      });
+
+      await test.step('Configure topic rules', async () => {
+        await aclPage.configureRules(secondACLRules);
+      });
+
+      await test.step('Verify the summary shows the correct operations', async () => {
+        await aclPage.validateAllSummaryRules(secondACLRules);
+      });
+
+      await test.step('Submit the form', async () => {
+        await aclPage.submitForm();
+      });
+
+      await test.step('Wait for navigation to detail page', async () => {
+        await aclPage.waitForDetailPage();
+      });
+    });
+    await test.step('Validate both ACLs appear in the list with correct details', async () => {
+      const aclPage = new ACLPage(page);
+      await aclPage.gotoList();
+
+      // Verify first ACL with host='*' appears in the list
+      const firstAclListItem = page.getByTestId(`acl-list-item-${principal}-${firstHost}`);
+      await expect(firstAclListItem).toBeVisible({ timeout: 1000 });
+
+      // Verify second ACL with host='1.1.1.1' appears in the list
+      const secondAclListItem = page.getByTestId(`acl-list-item-${principal}-${secondHost}`);
+      await expect(secondAclListItem).toBeVisible({ timeout: 1000 });
+    });
+    await test.step('Validate detail pages for both ACLs from list ACL page', async () => {
+      const aclPage = new ACLPage(page);
+
+      await aclPage.gotoList();
+
+      // Click on first ACL with host='*'
+      await test.step('Click first ACL (host=*) and validate rules', async () => {
+        const firstAclListItem = page.getByTestId(`acl-list-item-${principal}-${firstHost}`);
+        await firstAclListItem.click();
+
+        await aclPage.waitForDetailPage();
+
+        // Verify URL does not have host query param (or has host=*)
+        const url = page.url();
+        expect(url).toContain(
+          `/security/acls/${encodeURIComponent(principal)}/details?host=${encodeURIComponent(firstHost)}`,
+        );
+
+        // Validate all rules from first ACL are present
+        await aclPage.validateAllDetailRules(firstACLRules, principal, firstHost);
+      });
+
+      // Navigate back to ACL list
+      await test.step('Navigate back to ACL list', async () => {
+        await aclPage.gotoList();
+      });
+
+      // Click on second ACL with host='1.1.1.1'
+      await test.step('Click second ACL (host=1.1.1.1) and validate rules', async () => {
+        const secondAclListItem = page.getByTestId(`acl-list-item-${principal}-${secondHost}`);
+        await secondAclListItem.click();
+
+        await aclPage.waitForDetailPage();
+
+        // Verify URL contains host query parameter
+        await page.waitForURL(
+          `**/security/acls/${encodeURIComponent(principal)}/details?host=${encodeURIComponent(secondHost)}`,
+        );
+        const url = page.url();
+        expect(url).toContain(`host=${encodeURIComponent(secondHost)}`);
+
+        // Validate all rules from second ACL are present
+        await aclPage.validateAllDetailRules(secondACLRules, principal, secondHost);
+      });
+    });
+
+    await test.step('Navigate directly to detail page without host parameter', async () => {
+      // Navigate directly to the ACL detail page without specifying host
+      await page.goto(`/security/acls/${encodeURIComponent(principal)}/details`);
+
+      // Verify that HostSelector is displayed
+      const hostSelectorDescription = page.getByTestId('host-selector-description');
+      await expect(hostSelectorDescription).toBeVisible();
+
+      // Verify the title shows "Multiple Hosts Found"
+      await expect(page.getByText('Multiple Hosts Found')).toBeVisible();
+
+      // Verify both host options are shown
+      const firstHostRow = page.getByTestId(`host-selector-row-${firstHost}`);
+      await expect(firstHostRow).toBeVisible();
+
+      const secondHostRow = page.getByTestId(`host-selector-row-${secondHost}`);
+      await expect(secondHostRow).toBeVisible();
+    });
+    await test.step('Select first host and verify navigation', async () => {
+      const aclPage = new ACLPage(page);
+
+      // Click on the first host row
+      const firstHostRow = page.getByTestId(`host-selector-row-${firstHost}`);
+      await firstHostRow.click();
+
+      // Verify navigation to detail page with host parameter
+      await page.waitForURL(
+        `**/security/acls/${encodeURIComponent(principal)}/details?host=${encodeURIComponent(firstHost)}`,
+      );
+
+      // Verify URL contains the host parameter
+      const url = page.url();
+      expect(url).toContain(`host=${encodeURIComponent(firstHost)}`);
+
+      // Verify ACL details are shown (not the host selector anymore)
+      await aclPage.validateAllDetailRules(firstACLRules, principal, firstHost);
+    });
+    await test.step('Navigate back without host parameter and select second host', async () => {
+      const aclPage = new ACLPage(page);
+
+      // Navigate back to the detail page without host parameter
+      await page.goto(`/security/acls/${encodeURIComponent(principal)}/details`);
+
+      // Verify HostSelector is shown again
+      await expect(page.getByText('Multiple Hosts Found')).toBeVisible();
+
+      // Click on the second host row
+      const secondHostRow = page.getByTestId(`host-selector-row-${secondHost}`);
+      await secondHostRow.click();
+
+      // Verify navigation to detail page with second host parameter
+      await page.waitForURL(
+        `**/security/acls/${encodeURIComponent(principal)}/details?host=${encodeURIComponent(secondHost)}`,
+      );
+
+      // Verify URL contains the second host parameter
+      const url = page.url();
+      expect(url).toContain(`host=${encodeURIComponent(secondHost)}`);
+
+      // Verify ACL details for second host are shown
+      await aclPage.validateAllDetailRules(secondACLRules, principal, secondHost);
+    });
+
+    await test.step('Validate if customer need to update one ACL the other one is not affected', async () => {
+      const aclPage = new ACLPage(page);
+
+      // Navigate to first ACL detail page
+      await page.goto(`/security/acls/${encodeURIComponent(principal)}/details?host=${encodeURIComponent(firstHost)}`);
+      await aclPage.waitForDetailPage();
+
+      // Click update button to navigate to update page
+      await aclPage.clickUpdateButtonFromDetailPage();
+      await aclPage.waitForUpdatePage();
+
+      // Create modified rules with one operation changed (DESCRIBE from allow to deny in cluster rule)
+      const modifiedFirstACLRules: Rule[] = [
+        {
+          ...firstACLRules[0],
+          operations: {
+            ...firstACLRules[0].operations,
+            DESCRIBE: OperationTypeDeny, // Changed from allow to deny
+          },
+        },
+        firstACLRules[1], // Topic rule unchanged
+        firstACLRules[2], // TransactionalId rule unchanged
+      ];
+
+      // Apply the update
+      await aclPage.updateRules(modifiedFirstACLRules);
+
+      // Submit the form
+      await aclPage.submitForm();
+
+      // Wait for navigation back to detail page
+      await aclPage.waitForDetailPage();
+
+      // Verify URL contains the correct host parameter
+      let url = page.url();
+      expect(url).toContain(`host=${encodeURIComponent(firstHost)}`);
+
+      // Validate the updated rules
+      await aclPage.validateAllDetailRules(modifiedFirstACLRules, principal, firstHost);
+
+      // Now verify the second ACL (host 1.1.1.1) was not affected
+      await page.goto(`/security/acls/${encodeURIComponent(principal)}/details?host=${encodeURIComponent(secondHost)}`);
+      await aclPage.waitForDetailPage();
+
+      // Verify URL contains the second host parameter
+      url = page.url();
+      expect(url).toContain(`host=${encodeURIComponent(secondHost)}`);
+
+      // Verify second ACL's rules remain unchanged
+      await aclPage.validateAllDetailRules(secondACLRules, principal, secondHost);
+    });
+  });
+});


### PR DESCRIPTION
This pull request refactors the ACL details and user details pages to improve handling of ACLs that span multiple hosts and to streamline the UI for viewing and editing ACLs. The changes introduce host-aware navigation, update the ACL data model to support multiple hosts, and simplify several UI components for clarity and maintainability.

**ACL Data Model and API Handling**

* Refactored the `getAclFromAclListResponse` function to return an array of ACL details, grouping ACLs by host and principal, instead of a single object. This enables proper handling of users with ACLs on multiple hosts. [[1]](diffhunk://#diff-bb16f56423203d939663dc148f543966ece54d368e8e97b9d82569e1401892b1L326-R362) [[2]](diffhunk://#diff-bb16f56423203d939663dc148f543966ece54d368e8e97b9d82569e1401892b1L360-R391) [[3]](diffhunk://#diff-bb16f56423203d939663dc148f543966ece54d368e8e97b9d82569e1401892b1L397-R424)
* Added the `handleUrlWithHost` utility to generate URLs that include the host as a query parameter, ensuring navigation and editing actions are host-specific.

**ACL Details and Host Selection UI**

* Updated the ACL details page (`AclDetailPage.tsx`) to support selection between multiple hosts when viewing a user's ACLs. If multiple hosts exist, a `HostSelector` component is rendered to allow the user to choose which host's ACLs to view. [[1]](diffhunk://#diff-050ad1441cf7dd0b071a5b9abaca8706d36a271636c8a6727fdfa468d313305aR12-R31) [[2]](diffhunk://#diff-050ad1441cf7dd0b071a5b9abaca8706d36a271636c8a6727fdfa468d313305aL33-R70)
* Removed unnecessary props and matching users UI from the `ACLDetails` component, simplifying its interface and focusing it on displaying ACL configuration details. [[1]](diffhunk://#diff-e20f2348167e3eb7e6f7719896bb7b6ead4848434a589d9297ab526046648b46L60-R61) [[2]](diffhunk://#diff-e20f2348167e3eb7e6f7719896bb7b6ead4848434a589d9297ab526046648b46L93-R88) [[3]](diffhunk://#diff-e20f2348167e3eb7e6f7719896bb7b6ead4848434a589d9297ab526046648b46L242-L246) [[4]](diffhunk://#diff-e20f2348167e3eb7e6f7719896bb7b6ead4848434a589d9297ab526046648b46L255-R225)

**User Details Page Refactor**

* Refactored the user details page to use new card components (`UserInformationCard`, `UserRolesCard`, `UserAclsCard`) and updated the layout for clarity. The page now passes host information when navigating to ACL details, ensuring correct context is preserved. [[1]](diffhunk://#diff-75bd08b299577dde1397b8bfe4e92543966e16c9fa28fc77374cf972823d9400L12-R19) [[2]](diffhunk://#diff-75bd08b299577dde1397b8bfe4e92543966e16c9fa28fc77374cf972823d9400L31) [[3]](diffhunk://#diff-75bd08b299577dde1397b8bfe4e92543966e16c9fa28fc77374cf972823d9400L83-L106) [[4]](diffhunk://#diff-75bd08b299577dde1397b8bfe4e92543966e16c9fa28fc77374cf972823d9400L128-L152) [[5]](diffhunk://#diff-75bd08b299577dde1397b8bfe4e92543966e16c9fa28fc77374cf972823d9400R139-R147) [[6]](diffhunk://#diff-75bd08b299577dde1397b8bfe4e92543966e16c9fa28fc77374cf972823d9400L194-R169) [[7]](diffhunk://#diff-e1bb13cc9cdcadd17701953fbd5f4a714abec8363da6e82decec427b64588a15L730-R732)

**ACL Update Page Improvements**

* Updated the ACL update page to support host-specific editing by reading the host from query parameters and using the new host-aware data model and navigation utilities. [[1]](diffhunk://#diff-773ab72c46f48acae12b031b136c78f4473c57de28b4fdc53b27961a23550bfcR14-R17) [[2]](diffhunk://#diff-773ab72c46f48acae12b031b136c78f4473c57de28b4fdc53b27961a23550bfcR28-R30) [[3]](diffhunk://#diff-773ab72c46f48acae12b031b136c78f4473c57de28b4fdc53b27961a23550bfcR39-R40)