### PR TITLE
frontend: Fix MCP inspector null response handling

### DIFF
--- a/frontend/src/components/pages/mcp-servers/details/remote-mcp-inspector-tab.tsx
+++ b/frontend/src/components/pages/mcp-servers/details/remote-mcp-inspector-tab.tsx
@@ -363,8 +363,11 @@ export const RemoteMCPInspectorTab = () => {
       serverToolResponse.content.length > 0
     ) {
       const firstContentItem = serverToolResponse.content[0];
-      if (firstContentItem.type === 'text' && firstContentItem.text) {
+      if (firstContentItem.type === 'text' && typeof firstContentItem.text === 'string') {
         // Try to parse text content as JSON for JSONView
+        if (firstContentItem.text === 'null') {
+          return firstContentItem.text;
+        }
         try {
           return JSON.parse(firstContentItem.text);
         } catch {


### PR DESCRIPTION
As reported by @birdayz for GCP BigQuery processor template, if the text response is `"null"` as a string, we actually attempt to parse it with `JSON.parse(text)`, but it will end up returning `null` due to how JavaScript works
```typescript
JSON.parse("null") === null)
```
and we don't usually render `null` by itself in React.
Now we fall back to the actual response verbatim without parsing if it equates to `null`.
<img width="872" height="198" alt="Screenshot 2025-10-06 at 15 33 58" src="https://github.com/user-attachments/assets/e139db4a-539d-4a26-a214-028ecb176ad6" />
