### PR TITLE
Make secret value optional on save

### DIFF
--- a/frontend/src/components/pages/secrets/update-secret-modal.test.tsx
+++ b/frontend/src/components/pages/secrets/update-secret-modal.test.tsx
@@ -79,6 +79,8 @@ describe('UpdateSecretModal', () => {
 
     fireEvent.click(screen.getByText('Redpanda Cluster'));
     fireEvent.click(screen.getByText('MCP Server'));
+    fireEvent.click(screen.getByText('AI Agent'));
+    fireEvent.click(screen.getByText('Redpanda Connect'));
 
     fireEvent.click(screen.getByTestId('add-label-button'));
 
@@ -93,9 +95,8 @@ describe('UpdateSecretModal', () => {
         create(UpdateSecretRequestSchema, {
           request: create(UpdateSecretRequestSchemaDataPlane, {
             id: existingSecretId,
-            // @ts-expect-error js-base64 does not play nice with TypeScript 5: Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'Uint8Array<ArrayBuffer>'.
-            secretData: [],
-            scopes: [Scope.REDPANDA_CLUSTER, Scope.MCP_SERVER],
+            secretData: new Uint8Array([]),
+            scopes: [Scope.REDPANDA_CLUSTER, Scope.MCP_SERVER, Scope.AI_AGENT, Scope.REDPANDA_CONNECT],
             labels: {
               key: 'value',
               environment: 'production',
@@ -189,7 +190,6 @@ describe('UpdateSecretModal', () => {
         create(UpdateSecretRequestSchema, {
           request: create(UpdateSecretRequestSchemaDataPlane, {
             id: existingSecretId,
-            // @ts-expect-error js-base64 does not play nice with TypeScript 5: Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'Uint8Array<ArrayBuffer>'.
             secretData: base64ToUInt8Array(encodeBase64(updatedSecretValue)),
             scopes: [Scope.REDPANDA_CONNECT],
             labels: {

--- a/frontend/src/components/pages/secrets/update-secret-modal.tsx
+++ b/frontend/src/components/pages/secrets/update-secret-modal.tsx
@@ -22,7 +22,7 @@ import { useAppForm } from 'components/form/form';
 import { useGetPipelinesForSecretQuery } from 'react-query/api/pipeline';
 import { useListSecretsQuery, useUpdateSecretMutation } from 'react-query/api/secret';
 import { base64ToUInt8Array, encodeBase64 } from 'utils/utils';
-import z from 'zod';
+import { z } from 'zod';
 
 import { secretSchema } from './form/secret-schema';
 import { Scope, UpdateSecretRequestSchema } from '../../../protogen/redpanda/api/dataplane/v1/secret_pb';


### PR DESCRIPTION
To allow users to save labels/scopes independently, we need to remove the required validator on the secret value when updating. This needs to merge only after changes to console-enterprise (allowing independent updates) and console (relaxing proto validators) are merged.