### PR TITLE
Preserve service account in pipeline updates

### DIFF
--- a/frontend/src/components/pages/rp-connect/pipelines-edit.tsx
+++ b/frontend/src/components/pages/rp-connect/pipelines-edit.tsx
@@ -16,7 +16,7 @@ import { LintHintList } from 'components/ui/lint-hint/lint-hint-list';
 import { isFeatureFlagEnabled } from 'config';
 import { action, makeObservable, observable } from 'mobx';
 import { observer } from 'mobx-react';
-import { PipelineUpdateSchema } from 'protogen/redpanda/api/dataplane/v1/pipeline_pb';
+import { type Pipeline_ServiceAccount, PipelineUpdateSchema } from 'protogen/redpanda/api/dataplane/v1/pipeline_pb';
 import { Link } from 'react-router-dom';
 
 import { extractLintHintsFromError, formatPipelineError } from './errors';
@@ -40,6 +40,7 @@ class RpConnectPipelinesEdit extends PageComponent<{ pipelineId: string }> {
   @observable lintResults: Record<string, LintHint> = {};
   // TODO: Actually show this within the pipeline edit page
   @observable tags = {} as Record<string, string>;
+  @observable serviceAccount = undefined as unknown as Pipeline_ServiceAccount | undefined;
 
   constructor(p: Readonly<PageProps<{ pipelineId: string }>>) {
     super(p);
@@ -83,6 +84,7 @@ class RpConnectPipelinesEdit extends PageComponent<{ pipelineId: string }> {
       this.tasks = cpuToTasks(pipeline?.resources?.cpuShares) || MIN_TASKS;
       this.editorContent = pipeline.configYaml;
       this.tags = pipeline.tags;
+      this.serviceAccount = pipeline.serviceAccount;
     }
 
     const isNameEmpty = !this.displayName;
@@ -197,6 +199,7 @@ class RpConnectPipelinesEdit extends PageComponent<{ pipelineId: string }> {
           tags: {
             ...this.tags,
           },
+          serviceAccount: this.serviceAccount,
         })
       )
       .then(


### PR DESCRIPTION
## Problem

When updating a pipeline through the UI edit page, the service account field was being dropped from the update request. Since the backend replaces all fields when no field mask is provided, this caused existing service accounts to be cleared.

## Solution

Added `serviceAccount` as an observable field in the pipeline edit component and included it in the update payload, following the same pattern used for other optional fields like `tags`.

## Changes

- Added `serviceAccount` observable to store the field from the loaded pipeline
- Initialize it when loading the pipeline (line 87)
- Include it in the `PipelineUpdate` payload (line 202)
- Added type import for `Pipeline_ServiceAccount`

## Testing

1. Create/update a pipeline with a service account via API
2. Edit the pipeline in the UI (change name, config, etc.)
3. Verify service account is preserved after the update

Related to the A2A/OAuth2 integration work in cloudv2.