### PR TITLE
fix: add formatSummaryLabel helper function and update ACL tests for consistency

### DIFF
--- a/frontend/src/components/pages/acls/new-acl/create-acl.tsx
+++ b/frontend/src/components/pages/acls/new-acl/create-acl.tsx
@@ -75,6 +75,11 @@ export const formatLabel = (text: string): string => {
     .replace('id', 'ID'); // transactional ids => transactional IDs
 };
 
+// Helper function to format summary labels, keeping certain words capitalized
+export const formatSummaryLabel = (text: string): string => {
+  return text.replace('id', 'ID'); // transactional ids => transactional IDs
+};
+
 // Helper function to get resource name for selector label
 const getResourceName = (resourceType: ResourceType): string => {
   const resourceNames: Record<string, string> = {
@@ -240,7 +245,7 @@ const Summary = ({ sharedConfig, rules }: SummaryProps) => {
                 key={rule.id}
               >
                 {/* Combined Resource and Selector */}
-                <p className="text-gray-600 text-xs" data-testid={`${getRuleDataTestId(rule)}-title`}>
+                <p className="capitalize-first text-gray-600 text-xs" data-testid={`${getRuleDataTestId(rule)}-title`}>
                   {(() => {
                     let text: string;
                     if (rule.resourceType === ResourceTypeCluster || rule.resourceType === ResourceTypeSchemaRegistry) {
@@ -251,7 +256,7 @@ const Summary = ({ sharedConfig, rules }: SummaryProps) => {
                       const matchType = rule.selectorType === ResourcePatternTypeLiteral ? 'matching' : 'starting with';
                       text = `${getPluralResourceName(rule.resourceType)} ${matchType}: "${rule.selectorValue}"`;
                     }
-                    return formatLabel(text);
+                    return formatSummaryLabel(text);
                   })()}
                 </p>
 

--- a/frontend/src/components/redpanda-ui/style/theme.css
+++ b/frontend/src/components/redpanda-ui/style/theme.css
@@ -178,3 +178,12 @@
     }
   }
 }
+
+@layer utilities {
+  .capitalize-first {
+    text-transform: lowercase;
+  }
+  .capitalize-first::first-letter {
+    text-transform: uppercase;
+  }
+}

--- a/frontend/tests/console/acl.spec.ts
+++ b/frontend/tests/console/acl.spec.ts
@@ -90,6 +90,16 @@ test.describe('ACL Creation', () => {
             DESCRIBE: OperationTypeAllow,
           },
         } as Rule,
+        {
+          id: 4,
+          resourceType: ResourceTypeTransactionalId,
+          mode: ModeCustom,
+          selectorType: ResourcePatternTypePrefix,
+          selectorValue: '__test',
+          operations: {
+            DESCRIBE: OperationTypeAllow,
+          },
+        } as Rule,
       ],
     },
   ].map(({ testName, principal, host, operation }) => {
@@ -953,7 +963,7 @@ test.describe('Allow all operations', () => {
           selectorValue: '',
           operations: {},
           resourceType: type,
-        }) as Rule,
+        }) as Rule
     );
 
     aclPages.map(({ createPage, type }) => {
@@ -1165,7 +1175,7 @@ test.describe('Multiples ACLs to same principal', () => {
 
         // Verify URL contains host query parameter
         await page.waitForURL(
-          `**/security/acls/${encodeURIComponent(principal)}/details?host=${encodeURIComponent(firstHost)}`,
+          `**/security/acls/${encodeURIComponent(principal)}/details?host=${encodeURIComponent(firstHost)}`
         );
 
         // Validate all rules from first ACL are present
@@ -1188,7 +1198,7 @@ test.describe('Multiples ACLs to same principal', () => {
 
         // Verify URL contains host query parameter
         await page.waitForURL(
-          `**/security/acls/${encodeURIComponent(principal)}/details?host=${encodeURIComponent(secondHost)}`,
+          `**/security/acls/${encodeURIComponent(principal)}/details?host=${encodeURIComponent(secondHost)}`
         );
 
         // Validate all rules from second ACL are present
@@ -1223,7 +1233,7 @@ test.describe('Multiples ACLs to same principal', () => {
 
       // Verify navigation to detail page with host parameter
       await page.waitForURL(
-        `**/security/acls/${encodeURIComponent(principal)}/details?host=${encodeURIComponent(firstHost)}`,
+        `**/security/acls/${encodeURIComponent(principal)}/details?host=${encodeURIComponent(firstHost)}`
       );
 
       // Verify ACL details are shown (not the host selector anymore)
@@ -1244,7 +1254,7 @@ test.describe('Multiples ACLs to same principal', () => {
 
       // Verify navigation to detail page with second host parameter
       await page.waitForURL(
-        `**/security/acls/${encodeURIComponent(principal)}/details?host=${encodeURIComponent(secondHost)}`,
+        `**/security/acls/${encodeURIComponent(principal)}/details?host=${encodeURIComponent(secondHost)}`
       );
 
       // Verify ACL details for second host are shown


### PR DESCRIPTION
This pull request introduces a new helper function for formatting summary labels in the ACL creation UI, updates the summary display to use this improved formatting, and adds test coverage for checking __ in ACL topic names. Most other changes are minor formatting or consistency updates in test files.

Bug:

<img width="1458" height="990" alt="Screenshot 2025-10-14 at 12 16 37 PM" src="https://github.com/user-attachments/assets/ef22ece7-c53f-459f-9338-9ab77fca6f6c" />


Fix
<img width="1458" height="990" alt="Screenshot 2025-10-14 at 12 16 52 PM" src="https://github.com/user-attachments/assets/b8aa8417-7482-4146-8d36-2474fbb4dd2c" />
