### PR TITLE
Adding routes as public func for downstream to access the routes

### DIFF
--- a/backend/pkg/api/routes.go
+++ b/backend/pkg/api/routes.go
@@ -484,6 +484,7 @@ func (api *API) setupConnectWithGRPCGateway(r chi.Router) {
 	r.Mount(grpcreflect.NewHandlerV1Alpha(reflector))
 }
 
+// Routes returns the api's mux router
 func (api *API) Routes() *chi.Mux {
 	return api.routes()
 }


### PR DESCRIPTION
Downstreams may need access to the routes to configure different styles of listeners. 