### PR TITLE
fix: lower log level for new kafka conns

### DIFF
--- a/backend/pkg/factory/kafka/client_hooks.go
+++ b/backend/pkg/factory/kafka/client_hooks.go
@@ -138,7 +138,7 @@ func (c clientHooks) OnBrokerConnect(meta kgo.BrokerMetadata, dialDur time.Durat
 		return
 	}
 	c.openConnections.WithLabelValues(kgo.NodeName(meta.NodeID)).Inc()
-	c.logger.Info("kafka connection succeeded",
+	c.logger.Debug("kafka connection succeeded",
 		slog.String("host", meta.Host),
 		slog.Duration("dial_duration", dialDur),
 		slog.Int("node_id", int(meta.NodeID)))


### PR DESCRIPTION
This used to be debug, but was increased to info at some point for debugging purposes and then never changed back to debug. This too verbose to keep at info by default