### PR TITLE
Sync zustand state with mobx

### DIFF
--- a/frontend/src/stores/topic-settings-store.ts
+++ b/frontend/src/stores/topic-settings-store.ts
@@ -10,6 +10,7 @@
  */
 
 import type { SortingState } from '@tanstack/react-table';
+import { runInAction } from 'mobx';
 import { create } from 'zustand';
 import { devtools, persist } from 'zustand/middleware';
 
@@ -20,7 +21,9 @@ import type {
   PartitionOffsetOriginType,
   PreviewTagV2,
   TimestampDisplayFormat,
+  TopicDetailsSettings,
 } from '../state/ui';
+import { uiSettings } from '../state/ui';
 
 /**
  * Search parameters for topic messages
@@ -152,6 +155,20 @@ const createDefaultTopicSettings = (topicName: string, overrides: Partial<TopicS
   quickSearch: '',
   ...overrides,
 });
+
+/**
+ * Subscribe to Zustand store changes and sync them to the legacy MobX uiSettings store.
+ * This ensures that changes made via Zustand are persisted by MobX's autorun mechanism.
+ */
+const syncPerTopicSettingsToMobX = (state: TopicSettingsStore) => {
+  // Wrap in runInAction to satisfy MobX strict mode
+  runInAction(() => {
+    // Update MobX store's perTopicSettings array
+    // MobX will track this change and trigger its autorun to save to localStorage
+    // Type assertion is safe here because TopicSettings matches TopicDetailsSettings structure
+    uiSettings.perTopicSettings = state.perTopicSettings as unknown as TopicDetailsSettings[];
+  });
+};
 
 export const useTopicSettingsStore = create<TopicSettingsStore>()(
   devtools(
@@ -431,3 +448,8 @@ export const useTopicSettingsStore = create<TopicSettingsStore>()(
     )
   )
 );
+
+// Subscribe to Zustand store changes and sync them to MobX
+// This ensures that changes made via Zustand are also reflected in the legacy MobX store
+// and persisted by MobX's autorun mechanism
+useTopicSettingsStore.subscribe(syncPerTopicSettingsToMobX);


### PR DESCRIPTION
This is actually needed a caused a bug (previewTags seemed not to be saved, they were overwriten by mobx's autorun).
We need this until we remove Mobx completely. 