### PR TITLE
fix: clear errors on route navigation to prevent content blocking

### DIFF
--- a/frontend/src/components/misc/history-setter.tsx
+++ b/frontend/src/components/misc/history-setter.tsx
@@ -4,13 +4,17 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 import { trackHubspotPage } from '../../hubspot/hubspot.helper';
 import { appGlobal } from '../../state/app-global';
+import { api } from '../../state/backend-api';
 
 const HistorySetter = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  // Track page navigation in HubSpot
+  // Track page navigation in HubSpot and clear errors on route change
   useEffect(() => {
+    // Clear errors when navigating to a new route
+    api.errors = [];
+
     if (location.pathname) {
       trackHubspotPage(location.pathname);
     }


### PR DESCRIPTION
## Summary

Fixes a routing bug where navigation appears broken after encountering an error on a page. When users navigated from a page with errors (e.g., Schema Registry authorization error) to another page (e.g., Topics), the URL would update but the main content panel remained stuck showing the old error.

## Changes

- Added automatic error clearing in HistorySetter component when route changes
- Imported api from backend-api to access the errors array
- Updated comment to reflect the new behavior

## Root Cause

The ErrorDisplay component wraps RouteView and blocks rendering of all page content when api.errors.length > 0. While appGlobal.historyPush() clears errors for programmatic navigation, it was not being called for regular React Router navigation (e.g., clicking sidebar links). The errors persisted across route changes, blocking new page content from rendering.

## Impact

- Users can now navigate freely even after encountering errors
- Navigation no longer appears broken when moving between pages
- Error state is properly reset on each route change

## Files Modified

- frontend/src/components/misc/history-setter.tsx - Added error clearing on route change


## Ref 
[UX-647](https://redpandadata.atlassian.net/browse/UX-647)


[UX-647]: https://redpandadata.atlassian.net/browse/UX-647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ