### PR TITLE
[UX-615] Remove incorrect SASL mechanism display

### DIFF
--- a/frontend/src/components/pages/acls/user-details.tsx
+++ b/frontend/src/components/pages/acls/user-details.tsx
@@ -33,7 +33,6 @@ import { PageComponent, type PageInitHelper, type PageProps } from '../page';
 @observer
 class UserDetailsPage extends PageComponent<{ userName: string }> {
   @observable username = '';
-  @observable mechanism: 'SCRAM-SHA-256' | 'SCRAM-SHA-512' = 'SCRAM-SHA-256';
 
   @observable isValidUsername = false;
   @observable isValidPassword = false;
@@ -91,7 +90,6 @@ class UserDetailsPage extends PageComponent<{ userName: string }> {
         <div className="flex flex-col gap-4">
           <UserInformationCard
             onEditPassword={api.isAdminApiConfigured ? () => (this.isChangePasswordModalOpen = true) : undefined}
-            saslMechanism={this.mechanism}
             username={userName}
           />
           <UserPermissionDetailsContent

--- a/frontend/src/components/pages/roles/user-information-card.tsx
+++ b/frontend/src/components/pages/roles/user-information-card.tsx
@@ -16,11 +16,10 @@ import { Text } from '../../redpanda-ui/components/typography';
 
 interface UserInformationCardProps {
   username: string;
-  saslMechanism: string;
   onEditPassword?: () => void;
 }
 
-export const UserInformationCard = ({ username, saslMechanism, onEditPassword }: UserInformationCardProps) => {
+export const UserInformationCard = ({ username, onEditPassword }: UserInformationCardProps) => {
   return (
     <Card size="full">
       <CardHeader>
@@ -46,14 +45,6 @@ export const UserInformationCard = ({ username, saslMechanism, onEditPassword }:
               </Button>
             )}
           </div>
-        </div>
-
-        <Separator />
-
-        {/* SASL Mechanism Row */}
-        <div className="grid grid-cols-3 items-center gap-4 py-2">
-          <Text variant="label">SASL mechanism</Text>
-          <Text variant="default">{saslMechanism}</Text>
         </div>
       </CardContent>
     </Card>


### PR DESCRIPTION
When listing users, we attempted to display the SASL mechanism, but it isn't currently available in the API call. We should restore it after creating/updating an API call to return the data.