### PR TITLE
[UX-691] Add HSTS header for in-process TLS

### DIFF
--- a/backend/pkg/api/middlewares.go
+++ b/backend/pkg/api/middlewares.go
@@ -146,6 +146,18 @@ func createSetVersionInfoHeader(builtAt string) func(next http.Handler) http.Han
 	}
 }
 
+// Create a middleware that sets HSTS headers when serving via TLS
+func createHSTSHeaderMiddleware(tlsEnabled bool) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if tlsEnabled {
+				w.Header().Set("Strict-Transport-Security", "max-age=31536000")
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 // forceLoopbackMiddleware blocks requests not coming from the loopback interface.
 func forceLoopbackMiddleware(logger *slog.Logger) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {

--- a/backend/pkg/api/middlewares_test.go
+++ b/backend/pkg/api/middlewares_test.go
@@ -1,0 +1,42 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateHSTSHeaderMiddleware(t *testing.T) {
+	for _, enabled := range []bool{true, false} {
+		t.Run(fmt.Sprintf("%t", enabled), func(t *testing.T) {
+			middleware := createHSTSHeaderMiddleware(enabled)
+			ts := httptest.NewServer(middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Write([]byte("ok"))
+			})))
+
+			defer ts.Close()
+
+			resp, err := ts.Client().Get(ts.URL)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			val := resp.Header.Get("Strict-Transport-Security")
+			if enabled {
+				require.Equal(t, "max-age=31536000", val)
+			} else {
+				require.Equal(t, "", val)
+			}
+		})
+	}
+}

--- a/backend/pkg/api/routes.go
+++ b/backend/pkg/api/routes.go
@@ -502,6 +502,7 @@ func (api *API) Routes() *chi.Mux {
 // All the routes for the application are defined in one place.
 func (api *API) routes() *chi.Mux {
 	baseRouter := chi.NewRouter()
+	baseRouter.Use(createHSTSHeaderMiddleware(api.Cfg.REST.TLS.Enabled))
 	baseRouter.NotFound(rest.HandleNotFound(api.Logger))
 	baseRouter.MethodNotAllowed(rest.HandleMethodNotAllowed(api.Logger))
 


### PR DESCRIPTION
We support TLS within the console binary, but haven't set the HSTS header yet.

Before:
```
curl -svk https://localhost:9091/ 2>&1 | grep -i strict
<no results>
```

After:
```
curl -svk https://localhost:9091/ 2>&1 | grep -i strict
< strict-transport-security: max-age=31536000
```