### PR TITLE
fix: optimize Monaco editor for large JSON payloads

### DIFF
--- a/frontend/src/components/misc/kowl-json-view.tsx
+++ b/frontend/src/components/misc/kowl-json-view.tsx
@@ -39,6 +39,16 @@ export const KowlJsonView = observer((props: { srcObj: object | string | null | 
           language="json"
           options={{
             readOnly: true,
+            // PERFORMANCE CONFIG: Fixes blank content bug when scrolling large JSON (40-50KB+)
+            // Issue: wordWrap: 'on' + 40KB single-line strings = blank content appears during scroll
+            // Solution: Wrap at fixed column to break long lines into manageable chunks
+            wordWrap: 'wordWrapColumn',
+            wordWrapColumn: 120, // Lines >120 chars wrap. Prevents blank screen with large payloads
+            wrappingStrategy: 'simple', // 'advanced' causes 2s+ delays on large content
+            stopRenderingLineAfter: 10_000, // DO NOT set to -1: causes severe performance issues
+            maxTokenizationLineLength: 20_000, // Syntax highlighting limit
+            folding: false, // Unnecessary for read-only
+            scrollBeyondLastLine: false,
             // automaticLayout: false // too much lag on chrome
           }}
           value={str}


### PR DESCRIPTION
## Summary

Fixes whitespace & performance issues when viewing large Kafka message payloads (40-50KB+) in the message viewer. Previously, scrolling through large JSON with very long string values would show blank content and cause 2+ second render delays.

The problem:

<img width="2676" height="1090" alt="image" src="https://github.com/user-attachments/assets/a4bb7d19-297e-452e-a7c5-720b2bb52300" />

When scrolling a bit higher:

<img width="2668" height="906" alt="image" src="https://github.com/user-attachments/assets/fc9b9870-50bb-445b-8e3f-837e5b6c057e" />


## Changes

- Configure Monaco editor to wrap lines at 120 characters instead of viewport width
- Use simple wrapping strategy instead of advanced algorithm
- Keep default 10k character rendering limit per line (prevents severe performance degradation)
- Limit syntax highlighting to 20k characters per line
- Disable code folding (unnecessary for read-only JSON viewing)
- Add comprehensive inline documentation explaining each performance configuration option

##  Post fix

With the new Monacco settings it looks like this:

<img width="2412" height="1154" alt="ss-Ep1o6Tvv@2x" src="https://github.com/user-attachments/assets/1ce1dc3a-d0f3-4f18-bff0-8a31ed44bda4" />
