### PR TITLE
Remove beta badge from Remote MCP menu item

### DIFF
--- a/frontend/src/components/routes.tsx
+++ b/frontend/src/components/routes.tsx
@@ -140,9 +140,9 @@ export function createVisibleSidebarItems(entries: IRouteEntry[]): NavLinkProps[
       }
       const isDisabled = !isEnabled;
 
-      // Handle Knowledge Base, MCP server and AI Agent routes with beta badge
+      // Handle Knowledge Base and AI Agent routes with beta badge
       const title =
-        entry.path === '/knowledgebases' || entry.path === '/mcp-servers' || entry.path === '/agents'
+        entry.path === '/knowledgebases' || entry.path === '/agents'
           ? getSidebarItemTitleWithBetaBadge({ route: entry })
           : entry.title;
 


### PR DESCRIPTION
## What

Remove beta badge from Remote MCP sidebar menu item.

## Why

Remote MCP feature is production-ready. Beta badge no longer applies.

## Implementation details

Modified `frontend/src/components/routes.tsx:143-147` to exclude `/mcp-servers` path from beta badge logic. Knowledge Bases and AI Agents retain their beta badges as they remain in beta.

Single line change - removed path condition from sidebar title badge check.