### PR TITLE
Remove beta badge from Remote MCP in embedded routes

### DIFF
--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -343,7 +343,7 @@ const routesIgnoredInServerless = ['/overview', '/quotas', '/reassign-partitions
 export const embeddedAvailableRoutesObservable = observable({
   get routes() {
     return APP_ROUTES.map((route) => {
-      if (route.path === '/knowledgebases' || route.path === '/mcp-servers' || route.path === '/agents') {
+      if (route.path === '/knowledgebases' || route.path === '/agents') {
         return {
           ...route,
           // Needed because we cannot use JSX in this file


### PR DESCRIPTION
## What

Remove beta badge from Remote MCP in embedded/Cloud UI routes.

## Why

PR #2088 removed the beta badge from the main sidebar logic in `routes.tsx`, but missed the `embeddedAvailableRoutesObservable` in `config.ts`. This observable is used for Cloud UI integration, causing the badge to persist in deployed environments.

## Implementation details

Modified `frontend/src/config.ts:346` to exclude `/mcp-servers` from beta badge logic in the embedded routes observable. Single line change matching the previous fix in routes.tsx.

## References

Previous PR: #2088