### PR TITLE
feat: Add configurable support for Kafka next-generation balancer (franz-go)

### DIFF
--- a/backend/pkg/config/kafka.go
+++ b/backend/pkg/config/kafka.go
@@ -18,9 +18,10 @@ import (
 // Kafka required for opening a connection to Kafka
 type Kafka struct {
 	// General
-	Brokers  []string `yaml:"brokers"`
-	ClientID string   `yaml:"clientId"`
-	RackID   string   `yaml:"rackId"`
+	Brokers              []string `yaml:"brokers"`
+	ClientID             string   `yaml:"clientId"`
+	RackID               string   `yaml:"rackId"`
+	KafkaNextGenBalancer bool     `yaml:"kafkaNextGenBalancer"`
 
 	TLS  TLS       `yaml:"tls"`
 	SASL KafkaSASL `yaml:"sasl"`

--- a/backend/pkg/factory/kafka/kafka.go
+++ b/backend/pkg/factory/kafka/kafka.go
@@ -44,6 +44,10 @@ import (
 	loggerpkg "github.com/redpanda-data/console/backend/pkg/logger"
 )
 
+type contextKey string
+
+const optInKafkaNextGenBalancerBeta contextKey = "opt_in_kafka_next_gen_balancer_beta"
+
 // ClientFactory defines the interface for creating and retrieving Kafka clients.
 type ClientFactory interface {
 	// GetKafkaClient retrieves a Kafka client based on the context.
@@ -142,6 +146,12 @@ func NewKgoConfig(cfg config.Kafka, logger *slog.Logger, metricsNamespace string
 		kgo.MetadataMinAge(time.Second),
 		kgo.WithLogger(kslog.New(loggerpkg.Named(logger, "kafka_client"))),
 		kgo.WithHooks(metricHooks),
+	}
+
+	// Add context with opt_in_kafka_next_gen_balancer_beta option if enabled
+	if cfg.KafkaNextGenBalancer {
+		ctx := context.WithValue(context.Background(), optInKafkaNextGenBalancerBeta, true)
+		opts = append(opts, kgo.WithContext(ctx))
 	}
 
 	// Add Rack Awareness if configured

--- a/docs/config/console.yaml
+++ b/docs/config/console.yaml
@@ -19,6 +19,7 @@
 #
 # Some examples:
 # kafka.rackId => KAFKA_RACKID
+# kafka.kafkaNextGenBalancer => KAFKA_KAFKANEXTGENBALANCER
 # kafka.tls.caFilepath => KAFKA_TLS_CAFILEPATH
 #
 # --- Note
@@ -38,6 +39,10 @@ kafka:
   # clientId: "console"
   # Optional: Rack identifier to optimize message consumption in multi-zone clusters.
   # rackId: "zone-a"
+  # Optional: Enable Kafka's next-generation balancer (beta feature from franz-go v1.19.0+).
+  # This enables improved partition assignment and rebalancing behavior.
+  # Defaults to false. Set to true to opt-in to the beta balancer.
+  # kafkaNextGenBalancer: false
   # sasl:
     # enabled: true
     # Supported mechanisms include:


### PR DESCRIPTION
Adds support for enabling Kafka’s next-generation balancer (a GA feature for Kafka ≥ 4.0.0) introduced in franz-go v1.19.0+. This feature provides improved partition assignment and rebalancing behavior.

By default, in the [franz-go](https://github.com/twmb/franz-go/blob/master/CHANGELOG.md#v1190) client, this feature is marked as hidden, as the maintainer noted potential instability concerns that have not yet received official recognition or confirmation.

This PR aims to resolve [issue #1815](https://github.com/redpanda-data/console/issues/1815).

