### PR TITLE
Fixes defaults in create topic modal

### DIFF
--- a/frontend/src/components/pages/topics/CreateTopicModal/create-topic-modal.tsx
+++ b/frontend/src/components/pages/topics/CreateTopicModal/create-topic-modal.tsx
@@ -98,6 +98,7 @@ export class CreateTopicModalContent extends Component<Props> {
           <div style={{ display: 'flex', gap: '2em' }}>
             <Label style={{ flexBasis: '160px' }} text="Partitions">
               <NumInput
+                data-testid="topic-partitions"
                 min={1}
                 onChange={(e) => {
                   state.partitions = e;
@@ -109,6 +110,7 @@ export class CreateTopicModalContent extends Component<Props> {
             <Label style={{ flexBasis: '160px' }} text="Replication Factor">
               <Box>
                 <NumInput
+                  data-testid="topic-replication-factor"
                   disabled={isServerless()}
                   min={1}
                   onChange={(e) => {
@@ -131,6 +133,7 @@ export class CreateTopicModalContent extends Component<Props> {
             {!api.isRedpanda && (
               <Label style={{ flexBasis: '160px' }} text="Min In-Sync Replicas">
                 <NumInput
+                  data-testid="topic-min-insync-replicas"
                   min={1}
                   onChange={(e) => {
                     state.minInSyncReplicas = e;
@@ -161,6 +164,7 @@ export class CreateTopicModalContent extends Component<Props> {
             )}
             <Label style={{ flexBasis: '220px', flexGrow: 1 }} text="Retention Time">
               <RetentionTimeSelect
+                data-testid="topic-retention-time"
                 defaultConfigValue={state.defaults.retentionTime}
                 onChangeUnit={(x) => {
                   state.retentionTimeUnit = x;
@@ -174,6 +178,7 @@ export class CreateTopicModalContent extends Component<Props> {
             </Label>
             <Label style={{ flexBasis: '220px', flexGrow: 1 }} text="Retention Size">
               <RetentionSizeSelect
+                data-testid="topic-retention-size"
                 defaultConfigValue={state.defaults.retentionBytes}
                 onChangeUnit={(x) => {
                   state.retentionSizeUnit = x;
@@ -209,6 +214,7 @@ export function NumInput(p: {
   addonBefore?: React.ReactNode;
   addonAfter?: React.ReactNode;
   className?: string;
+  'data-testid'?: string;
 }) {
   // We need to keep track of intermediate values.
   // Otherwise, typing '2e' for example, would be rejected.
@@ -258,6 +264,7 @@ export function NumInput(p: {
 
       <Input
         className={`numericInput ${p.className ?? ''}`}
+        data-testid={p['data-testid']}
         disabled={p.disabled}
         onBlur={() => {
           const s = editValue;
@@ -304,6 +311,7 @@ function RetentionTimeSelect(p: {
   onChangeValue: (v: number) => void;
   onChangeUnit: (u: RetentionTimeUnit) => void;
   defaultConfigValue?: string | undefined;
+  'data-testid'?: string;
 }) {
   const { value, unit } = p;
   const numDisabled = unit === 'default' || unit === 'infinite';
@@ -370,6 +378,7 @@ function RetentionTimeSelect(p: {
           />
         </Box>
       }
+      data-testid={p['data-testid']}
       disabled={numDisabled}
       min={0}
       onChange={(x) => p.onChangeValue(x ?? 0)}
@@ -385,6 +394,7 @@ function RetentionSizeSelect(p: {
   onChangeValue: (v: number) => void;
   onChangeUnit: (u: RetentionSizeUnit) => void;
   defaultConfigValue?: string | undefined;
+  'data-testid'?: string;
 }) {
   const { value, unit } = p;
   const numDisabled = unit === 'default' || unit === 'infinite';
@@ -450,6 +460,7 @@ function RetentionSizeSelect(p: {
           />
         </Box>
       }
+      data-testid={p['data-testid']}
       disabled={numDisabled}
       min={0}
       onChange={(x) => p.onChangeValue(x ?? -1)}

--- a/frontend/tests/console/topics/topic-create-defaults.spec.ts
+++ b/frontend/tests/console/topics/topic-create-defaults.spec.ts
@@ -1,0 +1,255 @@
+// spec: specs/topics.md
+// seed: tests/seed.spec.ts
+
+import { expect, test } from '@playwright/test';
+
+/**
+ * Mock cluster API response for testing default values
+ */
+const mockClusterResponse = {
+  clusterInfo: {
+    controllerId: 0,
+    brokers: [
+      {
+        brokerId: 0,
+        logDirSize: 283431018,
+        address: 'redpanda',
+        rack: null,
+        config: {
+          configs: [
+            {
+              name: 'log.retention.ms',
+              value: '604800000', // 7 days in milliseconds
+              source: 'DEFAULT_CONFIG',
+              type: 'LONG',
+              isExplicitlySet: false,
+              isDefaultValue: true,
+              isReadOnly: false,
+              isSensitive: false,
+              synonyms: [
+                {
+                  name: 'log_retention_ms',
+                  value: '604800000',
+                  source: 'DEFAULT_CONFIG',
+                },
+              ],
+            },
+            {
+              name: 'log.retention.bytes',
+              value: '18446744073709551615', // Max uint64 = infinite
+              source: 'DEFAULT_CONFIG',
+              type: 'LONG',
+              isExplicitlySet: false,
+              isDefaultValue: true,
+              isReadOnly: false,
+              isSensitive: false,
+              synonyms: [
+                {
+                  name: 'retention_bytes',
+                  value: '18446744073709551615',
+                  source: 'DEFAULT_CONFIG',
+                },
+              ],
+            },
+            {
+              name: 'num.partitions',
+              value: '1',
+              source: 'DEFAULT_CONFIG',
+              type: 'INT',
+              isExplicitlySet: false,
+              isDefaultValue: true,
+              isReadOnly: false,
+              isSensitive: false,
+              synonyms: [
+                {
+                  name: 'default_topic_partitions',
+                  value: '1',
+                  source: 'DEFAULT_CONFIG',
+                },
+              ],
+            },
+            {
+              name: 'default.replication.factor',
+              value: '1',
+              source: 'DEFAULT_CONFIG',
+              type: 'SHORT',
+              isExplicitlySet: false,
+              isDefaultValue: true,
+              isReadOnly: false,
+              isSensitive: false,
+              synonyms: [
+                {
+                  name: 'default_topic_replications',
+                  value: '1',
+                  source: 'DEFAULT_CONFIG',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+    kafkaVersion: 'Redpanda v25.3.2',
+  },
+};
+
+test.describe('Create Topic Modal - Default Values', () => {
+  test('should display correct default values from cluster configuration', async ({ page }) => {
+    // Mock the /api/cluster endpoint to return our test data
+    await page.route('**/api/cluster', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockClusterResponse),
+      });
+    });
+
+    await test.step('Navigate to topics page and open create modal', async () => {
+      await page.goto('/topics');
+      await page.getByTestId('create-topic-button').click();
+      await expect(page.getByTestId('topic-name')).toBeVisible({ timeout: 5000 });
+    });
+
+    await test.step('Verify partitions default value', async () => {
+      const partitionsInput = page.getByTestId('topic-partitions');
+      await expect(partitionsInput).toBeVisible();
+      await expect(partitionsInput).toHaveAttribute('placeholder', '1');
+      await expect(partitionsInput).toHaveValue('');
+    });
+
+    await test.step('Verify replication factor default value', async () => {
+      const replicationInput = page.getByTestId('topic-replication-factor');
+      await expect(replicationInput).toBeVisible();
+      await expect(replicationInput).toHaveAttribute('placeholder', '1');
+      await expect(replicationInput).toHaveValue('');
+    });
+
+    await test.step('Verify retention time default value shows 7 days', async () => {
+      // prettyMilliseconds(604800000) with verbose=true, unitCount=2 returns "7 days"
+      const retentionTimeInput = page.getByTestId('topic-retention-time');
+      await expect(retentionTimeInput).toBeVisible();
+      await expect(retentionTimeInput).toHaveAttribute('placeholder', '7 days');
+      await expect(retentionTimeInput).toHaveValue('');
+    });
+
+    await test.step('Verify retention size default value shows Infinite', async () => {
+      // 18446744073709551615 (max uint64) is treated as infinite
+      const retentionSizeInput = page.getByTestId('topic-retention-size');
+      await expect(retentionSizeInput).toBeVisible();
+      await expect(retentionSizeInput).toHaveAttribute('placeholder', 'Infinite');
+      await expect(retentionSizeInput).toHaveValue('');
+    });
+
+    // Close the modal
+    await page.getByRole('button', { name: 'Cancel' }).click();
+  });
+
+  test('should display custom default values when cluster returns different config', async ({ page }) => {
+    // Create a modified response with different default values
+    const customClusterResponse = {
+      clusterInfo: {
+        ...mockClusterResponse.clusterInfo,
+        brokers: [
+          {
+            ...mockClusterResponse.clusterInfo.brokers[0],
+            config: {
+              configs: [
+                {
+                  name: 'log.retention.ms',
+                  value: '86400000', // 1 day in milliseconds
+                  source: 'DEFAULT_CONFIG',
+                  type: 'LONG',
+                  isExplicitlySet: false,
+                  isDefaultValue: true,
+                  isReadOnly: false,
+                  isSensitive: false,
+                  synonyms: [],
+                },
+                {
+                  name: 'log.retention.bytes',
+                  value: '1073741824', // 1 GiB
+                  source: 'DEFAULT_CONFIG',
+                  type: 'LONG',
+                  isExplicitlySet: false,
+                  isDefaultValue: true,
+                  isReadOnly: false,
+                  isSensitive: false,
+                  synonyms: [],
+                },
+                {
+                  name: 'num.partitions',
+                  value: '3',
+                  source: 'DEFAULT_CONFIG',
+                  type: 'INT',
+                  isExplicitlySet: false,
+                  isDefaultValue: true,
+                  isReadOnly: false,
+                  isSensitive: false,
+                  synonyms: [],
+                },
+                {
+                  name: 'default.replication.factor',
+                  value: '3',
+                  source: 'DEFAULT_CONFIG',
+                  type: 'SHORT',
+                  isExplicitlySet: false,
+                  isDefaultValue: true,
+                  isReadOnly: false,
+                  isSensitive: false,
+                  synonyms: [],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    await page.route('**/api/cluster', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(customClusterResponse),
+      });
+    });
+
+    await test.step('Navigate to topics page and open create modal', async () => {
+      await page.goto('/topics');
+      await page.getByTestId('create-topic-button').click();
+      await expect(page.getByTestId('topic-name')).toBeVisible({ timeout: 5000 });
+    });
+
+    await test.step('Verify partitions shows custom default of 3', async () => {
+      const partitionsInput = page.getByTestId('topic-partitions');
+      await expect(partitionsInput).toBeVisible();
+      await expect(partitionsInput).toHaveAttribute('placeholder', '3');
+      await expect(partitionsInput).toHaveValue('');
+    });
+
+    await test.step('Verify replication factor shows custom default of 3', async () => {
+      const replicationInput = page.getByTestId('topic-replication-factor');
+      await expect(replicationInput).toBeVisible();
+      await expect(replicationInput).toHaveAttribute('placeholder', '3');
+      await expect(replicationInput).toHaveValue('');
+    });
+
+    await test.step('Verify retention time shows 1 day', async () => {
+      // prettyMilliseconds(86400000) with verbose=true returns "1 day"
+      const retentionTimeInput = page.getByTestId('topic-retention-time');
+      await expect(retentionTimeInput).toBeVisible();
+      await expect(retentionTimeInput).toHaveAttribute('placeholder', '1 day');
+      await expect(retentionTimeInput).toHaveValue('');
+    });
+
+    await test.step('Verify retention size shows 1 GiB', async () => {
+      // prettyBytes(1073741824) returns "1 GiB"
+      const retentionSizeInput = page.getByTestId('topic-retention-size');
+      await expect(retentionSizeInput).toBeVisible();
+      await expect(retentionSizeInput).toHaveAttribute('placeholder', '1 GiB');
+      await expect(retentionSizeInput).toHaveValue('');
+    });
+
+    // Close the modal
+    await page.getByRole('button', { name: 'Cancel' }).click();
+  });
+});


### PR DESCRIPTION
I think the regression was introduced recently with ultracite changes which changed == null to === null. 

The types are `number | undefined` (not null), but the check was changed to === null which never matches undefined.

