### PR TITLE
frontend: fix knowledge base secrets missing template wrapper

### DIFF
--- a/frontend/src/components/pages/knowledgebase/create/embedding-generator-section.tsx
+++ b/frontend/src/components/pages/knowledgebase/create/embedding-generator-section.tsx
@@ -25,6 +25,7 @@ import { Input } from 'components/redpanda-ui/components/input';
 import { Link, Text } from 'components/redpanda-ui/components/typography';
 import { EmbeddingModelSelect } from 'components/ui/ai/embedding-model-select';
 import { SecretSelector } from 'components/ui/secret/secret-selector';
+import { formatSecretTemplate } from 'components/ui/secret/secret-utils';
 import { Combine, ExternalLink } from 'lucide-react';
 import { Scope } from 'protogen/redpanda/api/dataplane/v1/secret_pb';
 import { Controller, type UseFormReturn } from 'react-hook-form';
@@ -152,7 +153,7 @@ export const EmbeddingGeneratorSection: React.FC<EmbeddingGeneratorSectionProps>
                       secretValueDescription: 'Your OpenAI API key',
                       emptyStateDescription: 'Create a secret to securely store your OpenAI API key',
                     }}
-                    onChange={field.onChange}
+                    onChange={(secretId) => field.onChange(formatSecretTemplate(secretId))}
                     placeholder="Select OpenAI API key from secrets"
                     scopes={[Scope.MCP_SERVER, Scope.AI_AGENT, Scope.REDPANDA_CONNECT, Scope.REDPANDA_CLUSTER]}
                     value={field.value || ''}
@@ -185,7 +186,7 @@ export const EmbeddingGeneratorSection: React.FC<EmbeddingGeneratorSectionProps>
                       secretValueDescription: 'Your Cohere API key',
                       emptyStateDescription: 'Create a secret to securely store your Cohere API key',
                     }}
-                    onChange={field.onChange}
+                    onChange={(secretId) => field.onChange(formatSecretTemplate(secretId))}
                     placeholder="Select Cohere API key from secrets"
                     scopes={[Scope.MCP_SERVER, Scope.AI_AGENT, Scope.REDPANDA_CONNECT, Scope.REDPANDA_CLUSTER]}
                     value={field.value || ''}

--- a/frontend/src/components/pages/knowledgebase/create/indexer-section.tsx
+++ b/frontend/src/components/pages/knowledgebase/create/indexer-section.tsx
@@ -31,6 +31,7 @@ import {
 import { Text } from 'components/redpanda-ui/components/typography';
 import { RegexPatternsField } from 'components/ui/regex/regex-patterns-field';
 import { SecretSelector } from 'components/ui/secret/secret-selector';
+import { formatSecretTemplate } from 'components/ui/secret/secret-utils';
 import { TopicSelector } from 'components/ui/topic/topic-selector';
 import { UserSelector } from 'components/ui/user/user-selector';
 import { TableOfContents } from 'lucide-react';
@@ -164,7 +165,7 @@ export const IndexerSection: React.FC<IndexerSectionProps> = ({ form, availableS
                     secretValueDescription: 'Your Redpanda user password',
                     emptyStateDescription: 'Create a secret to securely store your Redpanda password',
                   }}
-                  onChange={field.onChange}
+                  onChange={(secretId) => field.onChange(formatSecretTemplate(secretId))}
                   placeholder="Select password or create new"
                   scopes={[Scope.MCP_SERVER, Scope.AI_AGENT, Scope.REDPANDA_CONNECT, Scope.REDPANDA_CLUSTER]}
                   value={field.value}

--- a/frontend/src/components/pages/knowledgebase/create/retrieval-section.tsx
+++ b/frontend/src/components/pages/knowledgebase/create/retrieval-section.tsx
@@ -24,6 +24,7 @@ import {
 import { Link, Text } from 'components/redpanda-ui/components/typography';
 import { RerankerModelSelect } from 'components/ui/ai/reranker-model-select';
 import { SecretSelector } from 'components/ui/secret/secret-selector';
+import { formatSecretTemplate } from 'components/ui/secret/secret-utils';
 import { ExternalLink, Shuffle } from 'lucide-react';
 import { Scope } from 'protogen/redpanda/api/dataplane/v1/secret_pb';
 import { Controller, type UseFormReturn } from 'react-hook-form';
@@ -117,7 +118,7 @@ export const RetrievalSection: React.FC<RetrievalSectionProps> = ({ form, availa
                         secretValueDescription: 'Your Cohere API key',
                         emptyStateDescription: 'Create a secret to securely store your Cohere API key',
                       }}
-                      onChange={field.onChange}
+                      onChange={(secretId) => field.onChange(formatSecretTemplate(secretId))}
                       placeholder="Select Cohere API key from secrets"
                       scopes={[Scope.MCP_SERVER, Scope.AI_AGENT, Scope.REDPANDA_CONNECT, Scope.REDPANDA_CLUSTER]}
                       value={field.value || ''}

--- a/frontend/src/components/pages/knowledgebase/create/vector-database-section.tsx
+++ b/frontend/src/components/pages/knowledgebase/create/vector-database-section.tsx
@@ -22,6 +22,7 @@ import {
 import { Input } from 'components/redpanda-ui/components/input';
 import { Text } from 'components/redpanda-ui/components/typography';
 import { SecretSelector } from 'components/ui/secret/secret-selector';
+import { formatSecretTemplate } from 'components/ui/secret/secret-utils';
 import { Database } from 'lucide-react';
 import { Scope } from 'protogen/redpanda/api/dataplane/v1/secret_pb';
 import { Controller, type UseFormReturn } from 'react-hook-form';
@@ -62,7 +63,7 @@ export const VectorDatabaseSection: React.FC<VectorDatabaseSectionProps> = ({ fo
                     secretValueDescription: 'PostgreSQL connection string',
                     emptyStateDescription: 'Create a secret to securely store your PostgreSQL connection string',
                   }}
-                  onChange={field.onChange}
+                  onChange={(secretId) => field.onChange(formatSecretTemplate(secretId))}
                   placeholder="postgresql://user:password@host:port/database"
                   scopes={[Scope.MCP_SERVER, Scope.AI_AGENT, Scope.REDPANDA_CONNECT, Scope.REDPANDA_CLUSTER]}
                   value={field.value}

--- a/frontend/src/components/ui/secret/secret-utils.test.ts
+++ b/frontend/src/components/ui/secret/secret-utils.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { describe, expect, test } from 'vitest';
+
+import { extractSecretName, formatSecretTemplate, SECRET_TEMPLATE_REGEX } from './secret-utils';
+
+describe('SECRET_TEMPLATE_REGEX', () => {
+  test('should match valid secret template format', () => {
+    expect(SECRET_TEMPLATE_REGEX.test('${secrets.MY_SECRET}')).toBe(true);
+    expect(SECRET_TEMPLATE_REGEX.test('${secrets.OPENAI_API_KEY}')).toBe(true);
+    expect(SECRET_TEMPLATE_REGEX.test('${secrets.DB_PASSWORD_123}')).toBe(true);
+  });
+
+  test('should not match invalid formats', () => {
+    expect(SECRET_TEMPLATE_REGEX.test('MY_SECRET')).toBe(false);
+    expect(SECRET_TEMPLATE_REGEX.test('secrets.MY_SECRET')).toBe(false);
+    expect(SECRET_TEMPLATE_REGEX.test('${MY_SECRET}')).toBe(false);
+    expect(SECRET_TEMPLATE_REGEX.test('${config.MY_SECRET}')).toBe(false);
+    expect(SECRET_TEMPLATE_REGEX.test('')).toBe(false);
+  });
+});
+
+describe('extractSecretName', () => {
+  test('should extract secret name from template format', () => {
+    expect(extractSecretName('${secrets.MY_SECRET}')).toBe('MY_SECRET');
+    expect(extractSecretName('${secrets.OPENAI_API_KEY}')).toBe('OPENAI_API_KEY');
+    expect(extractSecretName('${secrets.POSTGRES_DSN}')).toBe('POSTGRES_DSN');
+    expect(extractSecretName('${secrets.COHERE_API_KEY}')).toBe('COHERE_API_KEY');
+  });
+
+  test('should return original string if not in template format', () => {
+    expect(extractSecretName('MY_SECRET')).toBe('MY_SECRET');
+    expect(extractSecretName('OPENAI_API_KEY')).toBe('OPENAI_API_KEY');
+  });
+
+  test('should return empty string for empty input', () => {
+    expect(extractSecretName('')).toBe('');
+  });
+
+  test('should handle edge cases', () => {
+    expect(extractSecretName('${secrets.}')).toBe('${secrets.}');
+    expect(extractSecretName('${secrets.A}')).toBe('A');
+  });
+});
+
+describe('formatSecretTemplate', () => {
+  test('should wrap secret ID with template format', () => {
+    expect(formatSecretTemplate('MY_SECRET')).toBe('${secrets.MY_SECRET}');
+    expect(formatSecretTemplate('OPENAI_API_KEY')).toBe('${secrets.OPENAI_API_KEY}');
+    expect(formatSecretTemplate('POSTGRES_DSN')).toBe('${secrets.POSTGRES_DSN}');
+    expect(formatSecretTemplate('COHERE_API_KEY')).toBe('${secrets.COHERE_API_KEY}');
+  });
+
+  test('should handle various secret name formats', () => {
+    expect(formatSecretTemplate('SECRET_123')).toBe('${secrets.SECRET_123}');
+    expect(formatSecretTemplate('my_secret')).toBe('${secrets.my_secret}');
+    expect(formatSecretTemplate('A')).toBe('${secrets.A}');
+  });
+
+  test('should handle empty string', () => {
+    expect(formatSecretTemplate('')).toBe('${secrets.}');
+  });
+});
+
+describe('Round-trip conversion', () => {
+  test('should maintain secret name integrity through format and extract', () => {
+    const secretNames = ['OPENAI_API_KEY', 'POSTGRES_DSN', 'REDPANDA_PASSWORD', 'COHERE_API_KEY', 'SECRET_123'];
+
+    for (const secretName of secretNames) {
+      const formatted = formatSecretTemplate(secretName);
+      const extracted = extractSecretName(formatted);
+      expect(extracted).toBe(secretName);
+    }
+  });
+
+  test('should correctly identify template format after formatting', () => {
+    const secretName = 'MY_SECRET';
+    const formatted = formatSecretTemplate(secretName);
+
+    expect(SECRET_TEMPLATE_REGEX.test(formatted)).toBe(true);
+    expect(SECRET_TEMPLATE_REGEX.test(secretName)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Fix regression where knowledge base create form sends secrets without the `${secrets.}` wrapper.

## Why

Secrets were being sent as raw IDs (e.g., `OPENAI_API_KEY`) instead of properly formatted references (`${secrets.OPENAI_API_KEY}`), breaking secret resolution on the backend.

## Implementation details

All SecretSelector onChange handlers in the KB create form now wrap the selected secret ID with `formatSecretTemplate()` before storing in form state. The detail/edit page already had this fix - regression was isolated to the create flow.

Affected fields:
- `postgres_dsn` (vector-database-section.tsx)
- `openaiApiKey` (embedding-generator-section.tsx)
- `cohereApiKey` (embedding-generator-section.tsx)
- `redpandaPassword` (indexer-section.tsx)
- `rerankerApiKey` (retrieval-section.tsx)