### PR TITLE
frontend: fix connector name validation in JSON mode

### DIFF
--- a/frontend/src/components/pages/connect/create-connector.tsx
+++ b/frontend/src/components/pages/connect/create-connector.tsx
@@ -437,7 +437,8 @@ const ConnectorWizard = observer(({ connectClusters, activeCluster }: ConnectorW
           const intervalSec = 100;
           const timer = new TimeSince();
 
-          const connectorName = connectorRef?.propsByName.get('name')?.value as string;
+          // Get connector name from the actual config object (works in both form and JSON mode)
+          const connectorName = propertiesObject?.name as string;
 
           while (true) {
             const elapsedTime = timer.value;

--- a/frontend/src/state/connect/state.ts
+++ b/frontend/src/state/connect/state.ts
@@ -198,12 +198,14 @@ export class ConnectClusterStore {
           throw new Error('Cluster name is missing or empty. Cannot create secrets without a valid cluster.');
         }
 
-        const connectorName = connector?.propsByName.get('name');
-        if (!connectorName) {
+        // Get connector name from the actual config object (works in both form and JSON mode)
+        const configObj = connector?.getConfigObject() as Record<string, unknown> | undefined;
+        const connectorNameValue = configObj?.name;
+
+        if (connectorNameValue === undefined || connectorNameValue === null) {
           throw new Error("Connector configuration is missing the 'name' property");
         }
 
-        const connectorNameValue = connectorName.value;
         if (typeof connectorNameValue !== 'string') {
           let receivedType: string;
           if (connectorNameValue === null) {


### PR DESCRIPTION
When creating a connector using JSON mode, the name validation was incorrectly checking the propsByName map which doesn't get updated when editing JSON directly. This caused validation to fail with "Connector name cannot be empty" even when the name was present in the JSON config.

Fixed in two locations:
1. Secret creation validation in ConnectClusterStore.createConnector
2. Post-creation navigation in ConnectorWizard.transitionConditionMet

Both now validate against the actual config object which works correctly in both form and JSON modes.