### PR TITLE
fix: task error modal not closing

### DIFF
--- a/frontend/src/components/pages/connect/helper.tsx
+++ b/frontend/src/components/pages/connect/helper.tsx
@@ -809,7 +809,7 @@ export const TaskState = observer(
 
       const close = () => showErr(undefined);
       errModal = (
-        <Modal isOpen={err !== null} onClose={close}>
+        <Modal isOpen={err !== null && err !== undefined} onClose={close}>
           <ModalOverlay />
           <ModalContent minW="5xl">
             <ModalHeader>


### PR DESCRIPTION
## Summary
- Fix task error modal opening when clicking on state and then not closing due to strict equality check changed by linter

The linter (Ultracite/Biome) changed `err != null` to `err !== null`, which broke the modal close functionality since `err` is of type `string | undefined`.

## Test plan
- Open a connector with a failed task
- Click "Show Error" to open the error modal
- Click "Close" button - modal should now close properly