### PR TITLE
frontend: ensure no login infinite loop occurs

### DIFF
--- a/frontend/src/components/misc/login.tsx
+++ b/frontend/src/components/misc/login.tsx
@@ -101,10 +101,23 @@ const authenticationApi = observable({
 
 const AUTH_ELEMENTS: Partial<Record<AuthenticationMethod, React.FC>> = {
   [AuthenticationMethod.NONE]: observer(() => {
+    const { search } = useLocation();
+    const searchParams = new URLSearchParams(search);
+    // Don't auto-redirect if there was an auth error - user needs to see the login page
+    const hasError = searchParams.has('error_code') || authenticationApi.methodsErrorResponse !== null;
+
     useEffect(() => {
-      appGlobal.historyPush('/overview');
-    }, []);
-    return null;
+      if (!hasError) {
+        appGlobal.historyPush('/overview');
+      }
+    }, [hasError]);
+
+    return hasError ? (
+      <Alert status="info">
+        <AlertIcon />
+        <AlertDescription>No authentication is configured. Refresh the page to try again.</AlertDescription>
+      </Alert>
+    ) : null;
   }),
   [AuthenticationMethod.BASIC]: observer(() => {
     const formState = useLocalObservable(() => ({

--- a/frontend/src/components/require-auth.tsx
+++ b/frontend/src/components/require-auth.tsx
@@ -66,9 +66,12 @@ export default class RequireAuth extends Component<{ children: ReactNode }> {
         throw new Error('security client is not initialized');
       }
 
-      api.refreshUserData().catch(() => {
-        // Intentionally ignore errors during initial load
-      });
+      // Only fetch if not already fetching to prevent redirect loops
+      if (!api.isUserDataFetchInProgress) {
+        api.refreshUserData().catch(() => {
+          // Intentionally ignore errors during initial load
+        });
+      }
 
       return preLogin;
     }


### PR DESCRIPTION
## Summary
  - Fix infinite redirect loop between `/login` and `/overview` when auth is enabled and backend is unavailable
  - Add in-flight tracking to `refreshUserData()` to prevent duplicate concurrent auth requests
  - Update login page's NONE auth handler to not auto-redirect when there's an auth error

[Recording](https://github.com/user-attachments/assets/5468fde0-3285-4ddd-96a0-393c0a91ca0f)


