### PR TITLE
frontend: enable transcripts UI via feature flag

### DIFF
--- a/frontend/src/components/constants.ts
+++ b/frontend/src/components/constants.ts
@@ -17,7 +17,7 @@ export const FEATURE_FLAGS = {
   enableAiAgentsInConsoleServerless: false,
   enableMcpServiceAccount: false,
   enablePipelineServiceAccount: false,
-  enableTracingInConsole: true,
+  enableTranscriptsInConsole: true,
   shadowlinkCloudUi: false,
 };
 

--- a/frontend/src/utils/route-utils.tsx
+++ b/frontend/src/utils/route-utils.tsx
@@ -261,7 +261,7 @@ export const SIDEBAR_ITEMS: SidebarItem[] = [
     title: 'Transcripts',
     icon: ActivityIcon,
     visibilityCheck: routeVisibility(
-      () => isEmbedded() && isFeatureFlagEnabled('enableTracingInConsole'),
+      () => isEmbedded() && isFeatureFlagEnabled('enableTranscriptsInConsole'),
       [Feature.TracingService]
     ),
   },
@@ -313,7 +313,7 @@ const routesIgnoredInEmbedded = ['/overview', '/reassign-partitions', '/admin'];
 const routesIgnoredInServerless = ['/overview', '/quotas', '/reassign-partitions', '/admin', '/transforms'];
 
 // Routes with beta badge suffix
-const BETA_ROUTES = ['/knowledgebases', '/agents'];
+const BETA_ROUTES = ['/knowledgebases', '/agents', '/transcripts'];
 
 /**
  * Process a single sidebar item for legacy sidebar display.
@@ -380,7 +380,7 @@ export function createVisibleSidebarItems(): NavLinkProps[] {
 export function getEmbeddedAvailableRoutes(): SidebarItem[] {
   return SIDEBAR_ITEMS.map((item) => {
     // Mark AI-related routes with group and beta flag
-    if (item.path === '/knowledgebases' || item.path === '/agents') {
+    if (item.path === '/knowledgebases' || item.path === '/agents' || item.path === '/transcripts') {
       return {
         ...item,
         group: 'Agentic AI',


### PR DESCRIPTION
Transcripts sidebar item was not appearing in Cloud UI because there was no feature flag set in LaunchDarkly to propagate from Cloud UI.

https://app.launchdarkly.com/projects/default/flags/enable-transcripts-in-console
<img width="2356" height="1305" alt="Screenshot 2026-01-15 at 22 12 23" src="https://github.com/user-attachments/assets/1716995d-bef7-4086-ae76-6ed7db711053" />
