### PR TITLE
frontend: disable transcripts UI by default

### DIFF
--- a/frontend/src/components/constants.ts
+++ b/frontend/src/components/constants.ts
@@ -17,7 +17,7 @@ export const FEATURE_FLAGS = {
   enableAiAgentsInConsoleServerless: false,
   enableMcpServiceAccount: false,
   enablePipelineServiceAccount: false,
-  enableTranscriptsInConsole: true,
+  enableTranscriptsInConsole: false,
   shadowlinkCloudUi: false,
 };
 


### PR DESCRIPTION
we need to wait for LaunchDarkly feature flag to load before we can decide if we should render transcripts UI in embedded mode within cloud UI, because otherwise the sidebar item may "flash" and show up for a brief moment before we get data from the LaunchDarkly EventStream.