### PR TITLE
fix: migrate ColumnSettings modal from MobX to Zustand

### DIFF
--- a/frontend/src/components/pages/topics/Tab.Messages/index.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/index.tsx
@@ -1252,7 +1252,11 @@ export const TopicMessageView: FC<TopicMessageViewProps> = (props) => {
             onRequireRawPayload={() => executeMessageSearch()}
           />
 
-          <ColumnSettings getShowDialog={() => showColumnSettingsModal} setShowDialog={setShowColumnSettingsModal} />
+          <ColumnSettings
+            getShowDialog={() => showColumnSettingsModal}
+            setShowDialog={setShowColumnSettingsModal}
+            topicName={props.topic.topicName}
+          />
 
           <PreviewFieldsModal
             getShowDialog={() => showPreviewFieldsModal}


### PR DESCRIPTION
Fixes the issue where column visibility and timestamp format changes in the Column Settings modal weren't reflected in the messages table until page refresh.

**Changes:**
- Migrated ColumnSettings component from MobX to Zustand state management
- Column and timestamp changes now update the UI immediately
- Added defensive event handling using `getTopicSettings()` to prevent stale reads during rapid interactions
- Implemented duplicate column prevention
- Follows the established pattern from PreviewFieldsModal and PreviewSettings components

The root cause was that ColumnSettings wrote to MobX state while TopicMessageView table read from Zustand state. Both now use Zustand as the single source of truth.