### PR TITLE
Migrate GitHub Actions workflows to Blacksmith runners

### DIFF
--- a/.github/workflows/backend-lint-test.yml
+++ b/.github/workflows/backend-lint-test.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   verify:
     name: Lint & Test Backend
-    runs-on: ubuntu-latest-4
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -41,7 +41,7 @@ permissions:
 jobs:
   validate:
     if: github.event_name == 'push' || github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v5
       - name: Buf – lint, format & breaking
@@ -61,7 +61,7 @@ jobs:
       github.event_name == 'push' &&
       github.repository == 'redpanda-data/console'
     needs: validate  # Only run after validation passes
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -94,7 +94,7 @@ jobs:
     if: |
       github.event_name == 'delete' &&
       github.repository == 'redpanda-data/console'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/frontend-review.yml
+++ b/.github/workflows/frontend-review.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   biome:
     name: runner / Biome
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     defaults:
       run:
         working-directory: frontend

--- a/.github/workflows/frontend-verify.yml
+++ b/.github/workflows/frontend-verify.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   lint:
     timeout-minutes: 3
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     defaults:
       run:
         working-directory: frontend
@@ -50,7 +50,7 @@ jobs:
 
   type-check:
     timeout-minutes: 3
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     defaults:
       run:
         working-directory: frontend
@@ -75,7 +75,7 @@ jobs:
 
   build:
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     defaults:
       run:
         working-directory: frontend
@@ -105,7 +105,7 @@ jobs:
 
   test-unit:
     timeout-minutes: 3
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     defaults:
       run:
         working-directory: frontend
@@ -136,7 +136,7 @@ jobs:
 
   test-integration:
     timeout-minutes: 5
-    runs-on: ubuntu-latest-8
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     strategy:
       fail-fast: false
       matrix:
@@ -172,7 +172,7 @@ jobs:
   e2e-test:
     needs: ["lint", "type-check", "build"]
     timeout-minutes: 30
-    runs-on: ubuntu-latest-8
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     defaults:
       run:
         working-directory: frontend

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 jobs:
   dispatch:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
Migrates all GitHub Actions workflows from GitHub-hosted runners to Blacksmith runners for improved CI/CD performance. Updates runner labels across all workflow files to use blacksmith-2vcpu-ubuntu-2404, blacksmith-4vcpu-ubuntu-2404, and blacksmith-8vcpu-ubuntu-2404.