### PR TITLE
Reduce channel buffers for message consumption

### DIFF
--- a/backend/pkg/console/list_messages.go
+++ b/backend/pkg/console/list_messages.go
@@ -483,8 +483,10 @@ func (s *Service) fetchMessages(ctx context.Context, cl *kgo.Client, progress IL
 	defer client.Close()
 
 	// 2. Create consumer workers
-	jobs := make(chan *kgo.Record, 100)
-	resultsCh := make(chan *TopicMessage, 100)
+	// Reduced from 100 to 20 to limit memory usage in serverless environments
+	// With large records (up to 1MB), 100 records = 1GB+ after deserialization
+	jobs := make(chan *kgo.Record, 20)
+	resultsCh := make(chan *TopicMessage, 20)
 	workerCtx, cancel := context.WithCancelCause(ctx)
 	defer cancel(errors.New("worker cancel"))
 


### PR DESCRIPTION
Reduces channel buffers from 100 to 20 records to limit memory usage during message consumption.

With large records (up to 1MB) and filters that have low match rates, the previous 100-record buffers could accumulate 2GB+ in memory (200 records × 10MB after deserialization). This change reduces peak memory to ~400MB in channels while maintaining acceptable throughput.