### PR TITLE
Fix search pagination in list messages

### DIFF
--- a/frontend/src/components/pages/topics/Tab.Messages/index.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/index.tsx
@@ -640,8 +640,12 @@ export const TopicMessageView: FC<TopicMessageViewProps> = (props) => {
   }, [searchFunc]);
 
   // Message Table rendering variables and functions
+  // Bound pageIndex to valid range based on filtered results
+  const totalPages = Math.max(1, Math.ceil(filteredMessages.length / pageSize));
+  const boundedPageIndex = Math.min(pageIndex, totalPages - 1);
+
   const paginationParams = {
-    pageIndex,
+    pageIndex: boundedPageIndex,
     pageSize,
   };
 


### PR DESCRIPTION
## Summary
Fixes an issue where searching/filtering messages while on page 2+ would show no results because the pagination index exceeded the filtered result set.

## Changes
- Bound `pageIndex` to valid range based on filtered results count
- Preserves original `pageIndex` state so clearing the search returns to the same page

## Test plan
- Navigate to a topic with enough messages to have multiple pages
- Go to page 2
- Use the "Filter table content" search box to filter messages
- Verify results are displayed (previously showed empty)
- Clear the search and verify you return to page 2