### PR TITLE
fix(test): resolve flaky Kafka Connect integration test

### DIFF
--- a/backend/pkg/api/api_integration_test.go
+++ b/backend/pkg/api/api_integration_test.go
@@ -62,7 +62,7 @@ func (s *APIIntegrationTestSuite) SetupSuite() {
 	require := require.New(t)
 
 	ctx := context.Background()
-	container, err := redpanda.Run(ctx, "redpandadata/redpanda:v25.3.1")
+	container, err := redpanda.Run(ctx, testutil.RedpandaImage())
 	require.NoError(err)
 	s.redpandaContainer = container
 

--- a/backend/pkg/api/connect/integration/api_suite_test.go
+++ b/backend/pkg/api/connect/integration/api_suite_test.go
@@ -73,7 +73,7 @@ func (s *APISuite) SetupSuite() {
 
 	// 2. Start Redpanda Docker container
 	container, err := redpanda.Run(ctx,
-		"redpandadata/redpanda:v25.2.1",
+		testutil.RedpandaImage(),
 		redpanda.WithEnableWasmTransform(),
 		network.WithNetwork([]string{"redpanda"}, s.network),
 		redpanda.WithListener("redpanda:29092"),

--- a/backend/pkg/api/handle_kafka_connect_integration_test.go
+++ b/backend/pkg/api/handle_kafka_connect_integration_test.go
@@ -47,7 +47,7 @@ func (s *APIIntegrationTestSuite) TestHandleCreateConnector() {
 	require.NoError(err)
 
 	redpandaContainer, err := redpanda.Run(ctx,
-		"redpandadata/redpanda:v25.2.1",
+		testutil.RedpandaImage(),
 		network.WithNetwork([]string{"redpanda"}, testNetwork),
 		redpanda.WithListener("redpanda:29092"),
 	)

--- a/backend/pkg/console/console_integration_test.go
+++ b/backend/pkg/console/console_integration_test.go
@@ -47,7 +47,7 @@ func (s *ConsoleIntegrationTestSuite) SetupSuite() {
 	require := require.New(t)
 
 	ctx := context.Background()
-	container, err := redpanda.Run(ctx, "redpandadata/redpanda:v25.2.1")
+	container, err := redpanda.Run(ctx, testutil.RedpandaImage())
 	require.NoError(err)
 	s.redpandaContainer = container
 

--- a/backend/pkg/serde/service_integration_test.go
+++ b/backend/pkg/serde/service_integration_test.go
@@ -116,8 +116,7 @@ func (s *SerdeIntegrationTestSuite) SetupSuite() {
 
 	ctx := t.Context()
 
-	// redpandaContainer, err := redpanda.Run(ctx, "redpandadata/redpanda:v23.3.18")
-	redpandaContainer, err := redpanda.Run(ctx, "redpandadata/redpanda-unstable:v24.2.1-rc5")
+	redpandaContainer, err := redpanda.Run(ctx, testutil.RedpandaImage())
 	require.NoError(err)
 
 	s.redpandaContainer = redpandaContainer

--- a/backend/pkg/testutil/images.go
+++ b/backend/pkg/testutil/images.go
@@ -1,0 +1,126 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package testutil
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+// ImageConfig represents a Docker image configuration.
+type ImageConfig struct {
+	Repository string `json:"repository"`
+	Tag        string `json:"tag"`
+}
+
+// String returns the full image reference (repository:tag or repository@digest).
+func (c ImageConfig) String() string {
+	if strings.HasPrefix(c.Tag, "sha256:") {
+		return c.Repository + "@" + c.Tag
+	}
+	return c.Repository + ":" + c.Tag
+}
+
+type imagesConfig struct {
+	Images map[string]ImageConfig `json:"images"`
+}
+
+var (
+	configOnce   sync.Once
+	parsedConfig imagesConfig
+	errConfig    error
+)
+
+func findTestImagesJSON() (string, error) {
+	// Get the directory of this source file
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", errors.New("failed to get current file path")
+	}
+
+	// Navigate from backend/pkg/testutil to repo root
+	dir := filepath.Dir(currentFile)
+	for i := 0; i < 10; i++ {
+		candidate := filepath.Join(dir, "test-images.json")
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	return "", errors.New("test-images.json not found")
+}
+
+func loadConfig() (imagesConfig, error) {
+	configOnce.Do(func() {
+		path, err := findTestImagesJSON()
+		if err != nil {
+			errConfig = err
+			return
+		}
+
+		//nolint:gosec // G304: path is derived from runtime.Caller, not user input
+		data, err := os.ReadFile(path)
+		if err != nil {
+			errConfig = fmt.Errorf("failed to read test-images.json: %w", err)
+			return
+		}
+
+		errConfig = json.Unmarshal(data, &parsedConfig)
+	})
+	return parsedConfig, errConfig
+}
+
+func getImage(name, envVar string) string {
+	// Check environment variable override first
+	if override := os.Getenv(envVar); override != "" {
+		return override
+	}
+
+	cfg, err := loadConfig()
+	if err != nil {
+		panic(fmt.Sprintf("failed to load test-images.json: %v", err))
+	}
+
+	img, ok := cfg.Images[name]
+	if !ok {
+		panic(fmt.Sprintf("image %q not found in test-images.json", name))
+	}
+
+	return img.String()
+}
+
+// RedpandaImage returns the Docker image for Redpanda tests.
+// Can be overridden with TEST_IMAGE_REDPANDA environment variable.
+func RedpandaImage() string {
+	return getImage("redpanda", "TEST_IMAGE_REDPANDA")
+}
+
+// KafkaConnectImage returns the Docker image for Kafka Connect tests.
+// Can be overridden with TEST_IMAGE_KAFKA_CONNECT environment variable.
+func KafkaConnectImage() string {
+	return getImage("kafkaConnect", "TEST_IMAGE_KAFKA_CONNECT")
+}
+
+// OwlShopImage returns the Docker image for OwlShop tests.
+// Can be overridden with TEST_IMAGE_OWL_SHOP environment variable.
+func OwlShopImage() string {
+	return getImage("owlShop", "TEST_IMAGE_OWL_SHOP")
+}

--- a/backend/pkg/testutil/images_test.go
+++ b/backend/pkg/testutil/images_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package testutil
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedpandaImage(t *testing.T) {
+	img := RedpandaImage()
+	require.NotEmpty(t, img)
+	assert.True(t, strings.HasPrefix(img, "redpandadata/redpanda:"), "expected redpanda image, got: %s", img)
+}
+
+func TestKafkaConnectImage(t *testing.T) {
+	img := KafkaConnectImage()
+	require.NotEmpty(t, img)
+	assert.True(t, strings.Contains(img, "connectors"), "expected connectors image, got: %s", img)
+}
+
+func TestOwlShopImage(t *testing.T) {
+	img := OwlShopImage()
+	require.NotEmpty(t, img)
+	assert.True(t, strings.Contains(img, "owl-shop"), "expected owl-shop image, got: %s", img)
+}
+
+func TestImageConfigString(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   ImageConfig
+		expected string
+	}{
+		{
+			name:     "tag format",
+			config:   ImageConfig{Repository: "redpandadata/redpanda", Tag: "v25.3.6"},
+			expected: "redpandadata/redpanda:v25.3.6",
+		},
+		{
+			name:     "digest format",
+			config:   ImageConfig{Repository: "docker.cloudsmith.io/redpanda/connectors", Tag: "sha256:abc123"},
+			expected: "docker.cloudsmith.io/redpanda/connectors@sha256:abc123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.config.String())
+		})
+	}
+}
+
+func TestEnvOverride(t *testing.T) {
+	t.Setenv("TEST_IMAGE_REDPANDA", "custom/redpanda:test")
+	img := RedpandaImage()
+	assert.Equal(t, "custom/redpanda:test", img)
+}

--- a/backend/pkg/testutil/kafkaconnect.go
+++ b/backend/pkg/testutil/kafkaconnect.go
@@ -38,8 +38,7 @@ func RunRedpandaConnectorsContainer(ctx context.Context, bootstrapServers []stri
 
 	request := testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			// Pin to digest for reproducibility - :latest tag can have variable behavior
-			Image:        "docker.cloudsmith.io/redpanda/connectors-unsupported/connectors@sha256:0ff21e793ef3042f2f48fb3d6549fae0ef687950a76b8017ab9d8b17c33cadb0",
+			Image:        KafkaConnectImage(),
 			ExposedPorts: []string{"8083/tcp"},
 			Env: map[string]string{
 				"CONNECT_CONFIGURATION":     testConnectConfig,

--- a/frontend/tests/shared/global-setup.mjs
+++ b/frontend/tests/shared/global-setup.mjs
@@ -1,5 +1,6 @@
 import { GenericContainer, Network, Wait } from 'testcontainers';
 
+import { KAFKA_CONNECT_IMAGE, OWL_SHOP_IMAGE, REDPANDA_IMAGE } from './test-images.mjs';
 import { exec } from 'node:child_process';
 import { existsSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
@@ -68,7 +69,7 @@ async function setupDockerNetwork(state) {
 
 async function startRedpandaContainer(network, state, ports) {
   console.log('Starting Redpanda container...');
-  const redpanda = await new GenericContainer('redpandadata/redpanda:v25.3.2')
+  const redpanda = await new GenericContainer(REDPANDA_IMAGE)
     .withNetwork(network)
     .withNetworkAliases('redpanda')
     .withExposedPorts(
@@ -169,7 +170,7 @@ schemaRegistry:
   address: "http://redpanda:8081"
 `;
 
-  const owlshop = await new GenericContainer('quay.io/cloudhut/owl-shop:master')
+  const owlshop = await new GenericContainer(OWL_SHOP_IMAGE)
     .withPlatform('linux/amd64')
     .withNetwork(network)
     .withNetworkAliases('owlshop')
@@ -240,8 +241,7 @@ topic.creation.enable=false
 
   let connect;
   try {
-    // Pin to digest for reproducibility - :latest tag can have variable behavior
-    connect = await new GenericContainer('docker.cloudsmith.io/redpanda/connectors-unsupported/connectors@sha256:0ff21e793ef3042f2f48fb3d6549fae0ef687950a76b8017ab9d8b17c33cadb0')
+    connect = await new GenericContainer(KAFKA_CONNECT_IMAGE)
       .withPlatform('linux/amd64')
       .withNetwork(network)
       .withNetworkAliases('connect')
@@ -588,7 +588,7 @@ async function startBackendServer(network, isEnterprise, imageTag, state, varian
 
 async function startDestinationRedpandaContainer(network, state, ports) {
   console.log('Starting destination Redpanda container for shadowlink...');
-  const destRedpanda = await new GenericContainer('redpandadata/redpanda:v25.3.2')
+  const destRedpanda = await new GenericContainer(REDPANDA_IMAGE)
     .withNetwork(network)
     .withNetworkAliases('dest-cluster')
     .withExposedPorts(

--- a/frontend/tests/shared/test-images.mjs
+++ b/frontend/tests/shared/test-images.mjs
@@ -1,0 +1,45 @@
+/**
+ * Central Docker image configuration for E2E tests.
+ * Reads from the shared test-images.json at the repository root.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Path to shared config at repo root: frontend/tests/shared -> repo root
+const configPath = resolve(__dirname, '../../../test-images.json');
+const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+
+/**
+ * Format an image reference from repository and tag.
+ * Uses @ separator for digests (sha256:...), : for regular tags.
+ */
+function formatImage(imageConfig) {
+  const { repository, tag } = imageConfig;
+  if (tag.startsWith('sha256:')) {
+    return `${repository}@${tag}`;
+  }
+  return `${repository}:${tag}`;
+}
+
+/**
+ * Redpanda Docker image.
+ * Override with TEST_IMAGE_REDPANDA environment variable.
+ */
+export const REDPANDA_IMAGE = process.env.TEST_IMAGE_REDPANDA || formatImage(config.images.redpanda);
+
+/**
+ * Kafka Connect Docker image.
+ * Override with TEST_IMAGE_KAFKA_CONNECT environment variable.
+ */
+export const KAFKA_CONNECT_IMAGE = process.env.TEST_IMAGE_KAFKA_CONNECT || formatImage(config.images.kafkaConnect);
+
+/**
+ * OwlShop Docker image.
+ * Override with TEST_IMAGE_OWL_SHOP environment variable.
+ */
+export const OWL_SHOP_IMAGE = process.env.TEST_IMAGE_OWL_SHOP || formatImage(config.images.owlShop);

--- a/test-images.json
+++ b/test-images.json
@@ -1,0 +1,16 @@
+{
+  "images": {
+    "redpanda": {
+      "repository": "redpandadata/redpanda",
+      "tag": "v25.3.6"
+    },
+    "kafkaConnect": {
+      "repository": "docker.cloudsmith.io/redpanda/connectors-unsupported/connectors",
+      "tag": "sha256:0ff21e793ef3042f2f48fb3d6549fae0ef687950a76b8017ab9d8b17c33cadb0"
+    },
+    "owlShop": {
+      "repository": "quay.io/cloudhut/owl-shop",
+      "tag": "master"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Fix cleanup order bug causing "network has active endpoints" errors
- Replace log-based wait with HTTP health check for better reliability
- Add log consumer for debugging container failures
- Remove WithAttachable flag for consistency
- Centralize Docker image versions in `test-images.json`

## Root Causes Fixed

1. **Cleanup order (LIFO bug)**: Network removal was registered before container cleanup, causing it to run after in Go's LIFO cleanup order
2. **Unreliable wait strategy**: Log-based wait didn't detect early container exits
3. **Image variability**: `:latest` tag can have inconsistent behavior

## Centralized Test Images

Docker image versions are now managed in a single `test-images.json` at the repo root:

```json
{
  "images": {
    "redpanda": { "repository": "redpandadata/redpanda", "tag": "v25.3.6" },
    "kafkaConnect": { "repository": "...", "tag": "sha256:..." },
    "owlShop": { "repository": "quay.io/cloudhut/owl-shop", "tag": "master" }
  }
}
```

**Go backend**: `testutil.RedpandaImage()`, `testutil.KafkaConnectImage()`, `testutil.OwlShopImage()`

**JS frontend**: `import { REDPANDA_IMAGE } from './test-images.mjs'`

**Environment overrides** for CI matrix builds:
```bash
TEST_IMAGE_REDPANDA=redpandadata/redpanda:v25.1.0 go test ./...
```