### PR TITLE
Add Claude Code workflows for PR review and interactive assistance

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,52 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    # Only org members with write access can trigger via @claude mentions
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Configure git credentials
+        run: gh auth setup-git
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: ""
+          allowed_non_write_users: ""
+          use_commit_signing: true
+          claude_args: |
+            --disallowedTools WebFetch,WebSearch
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*)"


### PR DESCRIPTION
Adds interactive `@claude` workflow for PR/issue assistance. Security hardened with tool restrictions.

- Only org members with write access can trigger via `@claude` mentions
- `WebFetch`/`WebSearch` disabled to prevent prompt injection
- Bash restricted to specific `gh` commands only