### PR TITLE
a2a: display JSON-RPC errors with full details

### DIFF
--- a/frontend/src/components/pages/agents/details/a2a/chat/components/chat-message.tsx
+++ b/frontend/src/components/pages/agents/details/a2a/chat/components/chat-message.tsx
@@ -12,6 +12,7 @@
 import { Message, MessageBody, MessageContent, MessageMetadata } from 'components/ai-elements/message';
 
 import { ChatMessageActions } from './chat-message-actions';
+import { A2AErrorBlock } from './message-blocks/a2a-error-block';
 import { ArtifactBlock } from './message-blocks/artifact-block';
 import { TaskStatusUpdateBlock } from './message-blocks/task-status-update-block';
 import { ToolBlock } from './message-blocks/tool-block';
@@ -101,6 +102,8 @@ export const ChatMessage = ({ message, isLoading: _isLoading }: ChatMessageProps
               timestamp={block.timestamp}
             />
           );
+        case 'a2a-error':
+          return <A2AErrorBlock error={block.error} key={`${message.id}-error-${index}`} timestamp={block.timestamp} />;
         default:
           return null;
       }

--- a/frontend/src/components/pages/agents/details/a2a/chat/components/message-blocks/a2a-error-block.tsx
+++ b/frontend/src/components/pages/agents/details/a2a/chat/components/message-blocks/a2a-error-block.tsx
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import type { JSONRPCError } from '@a2a-js/sdk';
+import { Alert, AlertDescription, AlertTitle } from 'components/redpanda-ui/components/alert';
+import { Text } from 'components/redpanda-ui/components/typography';
+import { AlertCircleIcon } from 'lucide-react';
+
+type A2AErrorBlockProps = {
+  error: JSONRPCError;
+  timestamp: Date;
+};
+
+/**
+ * Map JSON-RPC error codes to human-readable names
+ */
+/**
+ * Map JSON-RPC/A2A error codes to human-readable names
+ * Based on a2a-go/a2a/errors.go codeToError mapping
+ */
+const getErrorCodeName = (code: number): string => {
+  const errorCodes: Record<number, string> = {
+    // Standard JSON-RPC 2.0 errors
+    [-32_700]: 'Parse Error',
+    [-32_600]: 'Invalid Request',
+    [-32_601]: 'Method Not Found',
+    [-32_602]: 'Invalid Params',
+    [-32_603]: 'Internal Error',
+    [-32_000]: 'Server Error',
+    // A2A-specific errors
+    [-32_001]: 'Task Not Found',
+    [-32_002]: 'Task Not Cancelable',
+    [-32_003]: 'Push Notifications Not Supported',
+    [-32_004]: 'Unsupported Operation',
+    [-32_005]: 'Content Type Not Supported',
+    [-32_006]: 'Invalid Agent Response',
+    [-32_007]: 'Authenticated Extended Card Not Configured',
+    [-32_008]: 'Authentication Failed',
+    [-32_009]: 'Forbidden',
+  };
+
+  return errorCodes[code] || `Error ${code}`;
+};
+
+/**
+ * A2A Error Block - displays JSON-RPC errors with full details
+ */
+export const A2AErrorBlock = ({ error, timestamp }: A2AErrorBlockProps) => {
+  const time = timestamp.toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    fractionalSecondDigits: 3,
+  });
+
+  const errorCodeName = getErrorCodeName(error.code);
+  const hasData = error.data && Object.keys(error.data).length > 0;
+
+  return (
+    <Alert className="mb-4" icon={<AlertCircleIcon />} variant="destructive">
+      <AlertTitle>{errorCodeName}</AlertTitle>
+      <AlertDescription>
+        <div className="flex flex-col gap-2">
+          <Text className="text-destructive/90" variant="body">
+            {error.message}
+          </Text>
+
+          <div className="mt-1 flex flex-col gap-1 rounded border border-destructive/20 bg-destructive/5 p-3 font-mono text-xs">
+            <div className="flex gap-2">
+              <span className="font-semibold text-destructive">code:</span>
+              <span>{error.code}</span>
+            </div>
+            <div className="flex gap-2">
+              <span className="font-semibold text-destructive">message:</span>
+              <span>{error.message}</span>
+            </div>
+            {Boolean(hasData) && (
+              <div className="flex flex-col gap-1">
+                <span className="font-semibold text-destructive">data:</span>
+                <pre className="overflow-x-auto whitespace-pre-wrap text-xs">{JSON.stringify(error.data, null, 2)}</pre>
+              </div>
+            )}
+            <div className="mt-1 flex gap-2 border-destructive/20 border-t pt-1 text-destructive/60">
+              <span className="font-semibold">time:</span>
+              <span>{time}</span>
+            </div>
+          </div>
+        </div>
+      </AlertDescription>
+    </Alert>
+  );
+};

--- a/frontend/src/components/pages/agents/details/a2a/chat/hooks/use-chat-actions.ts
+++ b/frontend/src/components/pages/agents/details/a2a/chat/hooks/use-chat-actions.ts
@@ -18,7 +18,7 @@ import { streamMessage } from './use-message-streaming';
 import type { ChatMessage } from '../types';
 import { createA2AClient } from '../utils/a2a-client';
 import { clearChatHistory, deleteMessages, saveMessage } from '../utils/database-operations';
-import { createErrorMessage, createUserMessage } from '../utils/message-converter';
+import { createUserMessage } from '../utils/message-converter';
 
 type UseChatActionsParams = {
   agentId: string;
@@ -91,7 +91,7 @@ export const useChatActions = ({
       await saveMessage(userMessage, agentId);
 
       // Stream assistant response
-      const result = await streamMessage({
+      await streamMessage({
         prompt: prompt || 'Sent with attachments',
         agentId,
         agentCardUrl,
@@ -107,13 +107,6 @@ export const useChatActions = ({
           });
         },
       });
-
-      // Handle error if streaming failed
-      if (!result.success) {
-        const errorMessage = createErrorMessage(contextId);
-        setMessages((prev) => [...prev, errorMessage]);
-        await saveMessage(errorMessage, agentId, { failure: true });
-      }
 
       setIsLoading(false);
     },

--- a/frontend/src/components/pages/agents/details/a2a/chat/types.ts
+++ b/frontend/src/components/pages/agents/details/a2a/chat/types.ts
@@ -9,7 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
-import type { TaskState } from '@a2a-js/sdk';
+import type { JSONRPCError, TaskState } from '@a2a-js/sdk';
 import type { AIAgent } from 'protogen/redpanda/api/dataplane/v1alpha3/ai_agent_pb';
 
 /**
@@ -55,6 +55,11 @@ export type ContentBlock =
       final: boolean;
       timestamp: Date;
       usage?: MessageUsageMetadata;
+    }
+  | {
+      type: 'a2a-error';
+      error: JSONRPCError;
+      timestamp: Date;
     };
 
 // Message-level usage metadata (stored in database)


### PR DESCRIPTION
## What

Display A2A JSON-RPC errors with full details (code, message, data) instead of a useless generic error message.

## Why

The previous error handling showed "Sorry, I encountered an error. Please try again." - completely useless for debugging. Users had no idea what went wrong.

## Implementation details

- Add `a2a-error` ContentBlock type using SDK's `JSONRPCError` type
- New `A2AErrorBlock` component renders error details in a destructive Alert
- Error codes mapped to names based on a2a-go/a2a/errors.go (includes -32000 Server Error, -32008 Auth Failed, -32009 Forbidden)
- `parseA2AError()` extracts code/message/data from error strings
- Remove duplicate error handling in use-chat-actions.ts

## References

a2a-js PR: https://github.com/a2aproject/a2a-js/pull/315

<img width="1597" height="992" alt="20260127_18h27m45s_grim" src="https://github.com/user-attachments/assets/e2fa7fbc-b7af-47b8-9d54-f644ce9f3b86" />
