### PR TITLE
frontend: add tanstack router loaders

### DIFF
--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -51,12 +51,22 @@ import { NotFoundPage } from './components/misc/not-found-page';
 import { addBearerTokenInterceptor, checkExpiredLicenseInterceptor, getGrpcBasePath, setup } from './config';
 import { routeTree } from './routeTree.gen';
 
+// Create transport before router so loaders can use it
+const dataplaneTransport = createConnectTransport({
+  baseUrl: getGrpcBasePath(''), // Embedded mode handles the path separately.
+  interceptors: [addBearerTokenInterceptor, checkExpiredLicenseInterceptor],
+  jsonOptions: {
+    registry: protobufRegistry,
+  },
+});
+
 // Create router instance
 const router = createRouter({
   routeTree,
   context: {
     basePath: getBasePath(),
     queryClient,
+    dataplaneTransport,
   },
   basepath: getBasePath(),
   trailingSlash: 'never',
@@ -84,14 +94,6 @@ declare module '@tanstack/react-router' {
 const App = () => {
   const developerView = useDeveloperView();
   setup({});
-
-  const dataplaneTransport = createConnectTransport({
-    baseUrl: getGrpcBasePath(''), // Embedded mode handles the path separately.
-    interceptors: [addBearerTokenInterceptor, checkExpiredLicenseInterceptor],
-    jsonOptions: {
-      registry: protobufRegistry,
-    },
-  });
 
   // Need to use CustomFeatureFlagProvider for completeness with EmbeddedApp
   return (

--- a/frontend/src/components/misc/not-found-content.tsx
+++ b/frontend/src/components/misc/not-found-content.tsx
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { Center, Heading, Image, Stack } from '@redpanda-data/ui';
+import { Link } from '@tanstack/react-router';
+
+import errorBananaSlip from '../../assets/redpanda/ErrorBananaSlip.svg';
+
+type NotFoundContentProps = {
+  /** The type of resource that wasn't found (e.g., "AI Agent", "Shadow Link") */
+  resourceType: string;
+  /** The ID or name of the resource that wasn't found */
+  resourceId?: string;
+  /** The link to navigate back to (e.g., "/agents") */
+  backLink?: string;
+  /** The text for the back link (e.g., "Back to AI Agents") */
+  backLinkText?: string;
+};
+
+/**
+ * Reusable component for displaying resource-specific 404 pages.
+ * Used by route notFoundComponent handlers when a specific resource is not found.
+ */
+export const NotFoundContent = ({ resourceType, resourceId, backLink, backLinkText }: NotFoundContentProps) => {
+  const message = resourceId ? `${resourceType} "${resourceId}" not found.` : `${resourceType} not found.`;
+
+  return (
+    <Center data-testid="not-found-content" h="80vh">
+      <Stack spacing={4} textAlign="center">
+        <Image alt="Error" height="180px" src={errorBananaSlip} />
+        <Heading as="h1" fontSize={32} variant="lg">
+          {message}
+        </Heading>
+        {backLink ? (
+          <Link className="text-base underline" data-testid="back-link" to={backLink}>
+            {backLinkText ?? 'Go back'}
+          </Link>
+        ) : null}
+      </Stack>
+    </Center>
+  );
+};

--- a/frontend/src/components/pages/transcripts/transcript-list-page.test.tsx
+++ b/frontend/src/components/pages/transcripts/transcript-list-page.test.tsx
@@ -16,6 +16,7 @@ import { GetTraceResponseSchema, ListTracesResponseSchema } from 'protogen/redpa
 import { getTrace, listTraces } from 'protogen/redpanda/api/dataplane/v1alpha3/tracing-TracingService_connectquery';
 import { screen, waitFor } from 'test-utils';
 
+import { TRANSCRIPTS_PAGE_SIZE } from './transcript-list-page';
 import {
   createMockTranscript,
   createMockTranscriptSummary,
@@ -106,7 +107,7 @@ describe('TranscriptListPage', () => {
       expect(listTracesMock).toHaveBeenCalled();
       expect(listTracesMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          pageSize: 100,
+          pageSize: TRANSCRIPTS_PAGE_SIZE,
         }),
         expect.anything()
       );

--- a/frontend/src/components/pages/transcripts/transcript-list-page.tsx
+++ b/frontend/src/components/pages/transcripts/transcript-list-page.tsx
@@ -54,6 +54,8 @@ const TIME_RANGES = [
   { value: '24h', label: 'Last 24 hours', ms: 24 * 60 * 60 * 1000 },
 ];
 
+export const TRANSCRIPTS_PAGE_SIZE = 100;
+
 /** Props for the stats row component */
 type TranscriptsStatsRowProps = {
   isLoading: boolean;
@@ -306,7 +308,7 @@ export const TranscriptListPage: FC<TranscriptListPageProps> = ({ disableFacetin
   const { data, isLoading, error } = useListTracesQuery({
     startTime: timestamps.startTimestamp,
     endTime: timestamps.endTimestamp,
-    pageSize: 100,
+    pageSize: TRANSCRIPTS_PAGE_SIZE,
     pageToken: currentPageToken,
   });
 

--- a/frontend/src/embedded-app.tsx
+++ b/frontend/src/embedded-app.tsx
@@ -110,22 +110,8 @@ function EmbeddedApp({ basePath = '', ...p }: EmbeddedProps) {
 
   setup(p);
 
-  // Create router with dynamic basePath
-  const router = useMemo(
-    () =>
-      createRouter({
-        routeTree,
-        context: {
-          basePath,
-          queryClient,
-        },
-        basepath: basePath,
-        defaultNotFoundComponent: NotFoundPage,
-      }),
-    [basePath]
-  );
-
   // This transport handles the grpc requests for the embedded app.
+  // Created before router so loaders can use it via context.
   const dataplaneTransport = useMemo(
     () =>
       createConnectTransport({
@@ -136,6 +122,22 @@ function EmbeddedApp({ basePath = '', ...p }: EmbeddedProps) {
         },
       }),
     [p.urlOverride?.grpc]
+  );
+
+  // Create router with dynamic basePath
+  const router = useMemo(
+    () =>
+      createRouter({
+        routeTree,
+        context: {
+          basePath,
+          queryClient,
+          dataplaneTransport,
+        },
+        basepath: basePath,
+        defaultNotFoundComponent: NotFoundPage,
+      }),
+    [basePath, dataplaneTransport]
   );
 
   if (!p.isConsoleReadyToMount) {

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
+import type { Transport } from '@connectrpc/connect';
 import type { QueryClient } from '@tanstack/react-query';
 import { createRootRouteWithContext, Outlet, useLocation } from '@tanstack/react-router';
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools';
@@ -34,6 +35,7 @@ import { ModalContainer } from '../utils/modal-container';
 export type RouterContext = {
   basePath: string;
   queryClient: QueryClient;
+  dataplaneTransport: Transport;
 };
 
 export const Route = createRootRouteWithContext<RouterContext>()({

--- a/frontend/src/routes/agents/$id.tsx
+++ b/frontend/src/routes/agents/$id.tsx
@@ -9,8 +9,14 @@
  * by the Apache License, Version 2.0
  */
 
-import { createFileRoute } from '@tanstack/react-router';
+import { create } from '@bufbuild/protobuf';
+import { Code, ConnectError } from '@connectrpc/connect';
+import { createQueryOptions } from '@connectrpc/connect-query';
+import { createFileRoute, notFound, useParams } from '@tanstack/react-router';
 import { fallback, zodValidator } from '@tanstack/zod-adapter';
+import { NotFoundContent } from 'components/misc/not-found-content';
+import { GetAIAgentRequestSchema } from 'protogen/redpanda/api/dataplane/v1alpha3/ai_agent_pb';
+import { getAIAgent } from 'protogen/redpanda/api/dataplane/v1alpha3/ai_agent-AIAgentService_connectquery';
 import { z } from 'zod';
 
 import { AIAgentDetailsPage } from '../../components/pages/agents/details/ai-agent-details-page';
@@ -19,10 +25,30 @@ const searchSchema = z.object({
   tab: fallback(z.string().optional(), undefined),
 });
 
+function AIAgentNotFound() {
+  const { id } = useParams({ from: '/agents/$id' });
+  return (
+    <NotFoundContent backLink="/agents" backLinkText="Back to AI Agents" resourceId={id} resourceType="AI Agent" />
+  );
+}
+
 export const Route = createFileRoute('/agents/$id')({
   staticData: {
     title: 'AI Agent Details',
   },
   validateSearch: zodValidator(searchSchema),
+  loader: async ({ context: { queryClient, dataplaneTransport }, params: { id } }) => {
+    try {
+      await queryClient.ensureQueryData(
+        createQueryOptions(getAIAgent, create(GetAIAgentRequestSchema, { id }), { transport: dataplaneTransport })
+      );
+    } catch (error) {
+      if (error instanceof ConnectError && error.code === Code.NotFound) {
+        throw notFound();
+      }
+      throw error;
+    }
+  },
+  notFoundComponent: AIAgentNotFound,
   component: AIAgentDetailsPage,
 });

--- a/frontend/src/routes/agents/index.tsx
+++ b/frontend/src/routes/agents/index.tsx
@@ -9,8 +9,12 @@
  * by the Apache License, Version 2.0
  */
 
+import { create } from '@bufbuild/protobuf';
+import { createQueryOptions } from '@connectrpc/connect-query';
 import { createFileRoute } from '@tanstack/react-router';
 import { AIIcon } from 'components/icons';
+import { ListAIAgentsRequestSchema } from 'protogen/redpanda/api/dataplane/v1alpha3/ai_agent_pb';
+import { listAIAgents } from 'protogen/redpanda/api/dataplane/v1alpha3/ai_agent-AIAgentService_connectquery';
 
 import { AIAgentsListPage } from '../../components/pages/agents/list/ai-agent-list-page';
 
@@ -18,6 +22,13 @@ export const Route = createFileRoute('/agents/')({
   staticData: {
     title: 'AI Agents',
     icon: AIIcon,
+  },
+  loader: async ({ context: { queryClient, dataplaneTransport } }) => {
+    await queryClient.ensureQueryData(
+      createQueryOptions(listAIAgents, create(ListAIAgentsRequestSchema, { pageSize: 50 }), {
+        transport: dataplaneTransport,
+      })
+    );
   },
   component: AIAgentsListPage,
 });

--- a/frontend/src/routes/knowledgebases/$knowledgebaseId/index.tsx
+++ b/frontend/src/routes/knowledgebases/$knowledgebaseId/index.tsx
@@ -9,13 +9,46 @@
  * by the Apache License, Version 2.0
  */
 
-import { createFileRoute } from '@tanstack/react-router';
+import { create } from '@bufbuild/protobuf';
+import { Code, ConnectError } from '@connectrpc/connect';
+import { createQueryOptions } from '@connectrpc/connect-query';
+import { createFileRoute, notFound, useParams } from '@tanstack/react-router';
+import { NotFoundContent } from 'components/misc/not-found-content';
+import { GetKnowledgeBaseRequestSchema } from 'protogen/redpanda/api/dataplane/v1alpha3/knowledge_base_pb';
+import { getKnowledgeBase } from 'protogen/redpanda/api/dataplane/v1alpha3/knowledge_base-KnowledgeBaseService_connectquery';
 
 import { KnowledgeBaseDetailsPage } from '../../../components/pages/knowledgebase/details/knowledge-base-details-page';
+
+function KnowledgeBaseNotFound() {
+  const { knowledgebaseId } = useParams({ from: '/knowledgebases/$knowledgebaseId/' });
+  return (
+    <NotFoundContent
+      backLink="/knowledgebases"
+      backLinkText="Back to Knowledge Bases"
+      resourceId={knowledgebaseId}
+      resourceType="Knowledge Base"
+    />
+  );
+}
 
 export const Route = createFileRoute('/knowledgebases/$knowledgebaseId/')({
   staticData: {
     title: 'Knowledge Base Details',
   },
+  loader: async ({ context: { queryClient, dataplaneTransport }, params: { knowledgebaseId } }) => {
+    try {
+      await queryClient.ensureQueryData(
+        createQueryOptions(getKnowledgeBase, create(GetKnowledgeBaseRequestSchema, { id: knowledgebaseId }), {
+          transport: dataplaneTransport,
+        })
+      );
+    } catch (error) {
+      if (error instanceof ConnectError && error.code === Code.NotFound) {
+        throw notFound();
+      }
+      throw error;
+    }
+  },
+  notFoundComponent: KnowledgeBaseNotFound,
   component: KnowledgeBaseDetailsPage,
 });

--- a/frontend/src/routes/knowledgebases/index.tsx
+++ b/frontend/src/routes/knowledgebases/index.tsx
@@ -9,8 +9,12 @@
  * by the Apache License, Version 2.0
  */
 
+import { create } from '@bufbuild/protobuf';
+import { createQueryOptions } from '@connectrpc/connect-query';
 import { createFileRoute } from '@tanstack/react-router';
 import { BookOpenIcon } from 'components/icons';
+import { ListKnowledgeBasesRequestSchema } from 'protogen/redpanda/api/dataplane/v1alpha3/knowledge_base_pb';
+import { listKnowledgeBases } from 'protogen/redpanda/api/dataplane/v1alpha3/knowledge_base-KnowledgeBaseService_connectquery';
 
 import { KnowledgeBaseListPage } from '../../components/pages/knowledgebase/list/knowledge-base-list-page';
 
@@ -18,6 +22,13 @@ export const Route = createFileRoute('/knowledgebases/')({
   staticData: {
     title: 'Knowledge Bases',
     icon: BookOpenIcon,
+  },
+  loader: async ({ context: { queryClient, dataplaneTransport } }) => {
+    await queryClient.ensureQueryData(
+      createQueryOptions(listKnowledgeBases, create(ListKnowledgeBasesRequestSchema, {}), {
+        transport: dataplaneTransport,
+      })
+    );
   },
   component: KnowledgeBaseListPage,
 });

--- a/frontend/src/routes/mcp-servers/$id.tsx
+++ b/frontend/src/routes/mcp-servers/$id.tsx
@@ -9,8 +9,17 @@
  * by the Apache License, Version 2.0
  */
 
-import { createFileRoute } from '@tanstack/react-router';
+import { create } from '@bufbuild/protobuf';
+import { Code, ConnectError } from '@connectrpc/connect';
+import { createQueryOptions } from '@connectrpc/connect-query';
+import { createFileRoute, notFound, useParams } from '@tanstack/react-router';
 import { fallback, zodValidator } from '@tanstack/zod-adapter';
+import { NotFoundContent } from 'components/misc/not-found-content';
+import { isFeatureFlagEnabled } from 'config';
+import { GetMCPServerRequestSchema as GetMCPServerRequestSchemaV1 } from 'protogen/redpanda/api/dataplane/v1/mcp_pb';
+import { getMCPServer as getMCPServerV1 } from 'protogen/redpanda/api/dataplane/v1/mcp-MCPServerService_connectquery';
+import { GetMCPServerRequestSchema as GetMCPServerRequestSchemaV1Alpha3 } from 'protogen/redpanda/api/dataplane/v1alpha3/mcp_pb';
+import { getMCPServer as getMCPServerV1Alpha3 } from 'protogen/redpanda/api/dataplane/v1alpha3/mcp-MCPServerService_connectquery';
 import { z } from 'zod';
 
 import { RemoteMCPDetailsPage } from '../../components/pages/mcp-servers/details/remote-mcp-details-page';
@@ -19,10 +28,46 @@ const searchSchema = z.object({
   tab: fallback(z.string().optional(), undefined),
 });
 
+function MCPServerNotFound() {
+  const { id } = useParams({ from: '/mcp-servers/$id' });
+  return (
+    <NotFoundContent
+      backLink="/mcp-servers"
+      backLinkText="Back to MCP Servers"
+      resourceId={id}
+      resourceType="MCP Server"
+    />
+  );
+}
+
 export const Route = createFileRoute('/mcp-servers/$id')({
   staticData: {
     title: 'Remote MCP Details',
   },
   validateSearch: zodValidator(searchSchema),
+  loader: async ({ context: { queryClient, dataplaneTransport }, params: { id } }) => {
+    const useMcpV1 = isFeatureFlagEnabled('enableMcpServiceAccount');
+    try {
+      if (useMcpV1) {
+        await queryClient.ensureQueryData(
+          createQueryOptions(getMCPServerV1, create(GetMCPServerRequestSchemaV1, { id }), {
+            transport: dataplaneTransport,
+          })
+        );
+      } else {
+        await queryClient.ensureQueryData(
+          createQueryOptions(getMCPServerV1Alpha3, create(GetMCPServerRequestSchemaV1Alpha3, { id }), {
+            transport: dataplaneTransport,
+          })
+        );
+      }
+    } catch (error) {
+      if (error instanceof ConnectError && error.code === Code.NotFound) {
+        throw notFound();
+      }
+      throw error;
+    }
+  },
+  notFoundComponent: MCPServerNotFound,
   component: RemoteMCPDetailsPage,
 });

--- a/frontend/src/routes/mcp-servers/index.tsx
+++ b/frontend/src/routes/mcp-servers/index.tsx
@@ -9,8 +9,15 @@
  * by the Apache License, Version 2.0
  */
 
+import { create } from '@bufbuild/protobuf';
+import { createQueryOptions } from '@connectrpc/connect-query';
 import { createFileRoute } from '@tanstack/react-router';
 import { WrenchIcon } from 'components/icons';
+import { isFeatureFlagEnabled } from 'config';
+import { ListMCPServersRequestSchema as ListMCPServersRequestSchemaV1 } from 'protogen/redpanda/api/dataplane/v1/mcp_pb';
+import { listMCPServers as listMCPServersV1 } from 'protogen/redpanda/api/dataplane/v1/mcp-MCPServerService_connectquery';
+import { ListMCPServersRequestSchema as ListMCPServersRequestSchemaV1Alpha3 } from 'protogen/redpanda/api/dataplane/v1alpha3/mcp_pb';
+import { listMCPServers as listMCPServersV1Alpha3 } from 'protogen/redpanda/api/dataplane/v1alpha3/mcp-MCPServerService_connectquery';
 
 import { RemoteMCPListPage } from '../../components/pages/mcp-servers/list/remote-mcp-list-page';
 
@@ -18,6 +25,22 @@ export const Route = createFileRoute('/mcp-servers/')({
   staticData: {
     title: 'MCP Servers',
     icon: WrenchIcon,
+  },
+  loader: async ({ context: { queryClient, dataplaneTransport } }) => {
+    const useMcpV1 = isFeatureFlagEnabled('enableMcpServiceAccount');
+    if (useMcpV1) {
+      await queryClient.ensureQueryData(
+        createQueryOptions(listMCPServersV1, create(ListMCPServersRequestSchemaV1, { pageSize: 50 }), {
+          transport: dataplaneTransport,
+        })
+      );
+    } else {
+      await queryClient.ensureQueryData(
+        createQueryOptions(listMCPServersV1Alpha3, create(ListMCPServersRequestSchemaV1Alpha3, { pageSize: 50 }), {
+          transport: dataplaneTransport,
+        })
+      );
+    }
   },
   component: RemoteMCPListPage,
 });

--- a/frontend/src/routes/secrets/$id/edit.tsx
+++ b/frontend/src/routes/secrets/$id/edit.tsx
@@ -9,13 +9,42 @@
  * by the Apache License, Version 2.0
  */
 
-import { createFileRoute } from '@tanstack/react-router';
+import { create } from '@bufbuild/protobuf';
+import { Code, ConnectError } from '@connectrpc/connect';
+import { createQueryOptions } from '@connectrpc/connect-query';
+import { createFileRoute, notFound, useParams } from '@tanstack/react-router';
+import { NotFoundContent } from 'components/misc/not-found-content';
+import { GetSecretRequestSchema } from 'protogen/redpanda/api/console/v1alpha1/secret_pb';
+import { getSecret } from 'protogen/redpanda/api/console/v1alpha1/secret-SecretService_connectquery';
+import { GetSecretRequestSchema as GetSecretRequestSchemaDataPlane } from 'protogen/redpanda/api/dataplane/v1/secret_pb';
 
 import { SecretEditPage } from '../../../components/pages/secrets-store/edit/secret-edit-page';
+
+function SecretNotFound() {
+  const { id } = useParams({ from: '/secrets/$id/edit' });
+  return (
+    <NotFoundContent backLink="/secrets" backLinkText="Back to Secrets Store" resourceId={id} resourceType="Secret" />
+  );
+}
 
 export const Route = createFileRoute('/secrets/$id/edit')({
   staticData: {
     title: 'Edit Secret',
   },
+  loader: async ({ context: { queryClient, dataplaneTransport }, params: { id } }) => {
+    try {
+      const getSecretRequestDataPlane = create(GetSecretRequestSchemaDataPlane, { id });
+      const getSecretRequest = create(GetSecretRequestSchema, { request: getSecretRequestDataPlane });
+      await queryClient.ensureQueryData(
+        createQueryOptions(getSecret, getSecretRequest, { transport: dataplaneTransport })
+      );
+    } catch (error) {
+      if (error instanceof ConnectError && error.code === Code.NotFound) {
+        throw notFound();
+      }
+      throw error;
+    }
+  },
+  notFoundComponent: SecretNotFound,
   component: SecretEditPage,
 });

--- a/frontend/src/routes/secrets/index.tsx
+++ b/frontend/src/routes/secrets/index.tsx
@@ -9,8 +9,14 @@
  * by the Apache License, Version 2.0
  */
 
+import { create } from '@bufbuild/protobuf';
+import { createQueryOptions } from '@connectrpc/connect-query';
 import { createFileRoute } from '@tanstack/react-router';
 import { KeyIcon } from 'components/icons';
+import { ListSecretsRequestSchema } from 'protogen/redpanda/api/console/v1alpha1/secret_pb';
+import { listSecrets } from 'protogen/redpanda/api/console/v1alpha1/secret-SecretService_connectquery';
+import { ListSecretsRequestSchema as ListSecretsRequestSchemaDataPlane } from 'protogen/redpanda/api/dataplane/v1/secret_pb';
+import { MAX_PAGE_SIZE } from 'react-query/react-query.utils';
 
 import { SecretsStoreListPage } from '../../components/pages/secrets-store/secrets-store-list-page';
 
@@ -18,6 +24,17 @@ export const Route = createFileRoute('/secrets/')({
   staticData: {
     title: 'Secrets Store',
     icon: KeyIcon,
+  },
+  loader: async ({ context: { queryClient, dataplaneTransport } }) => {
+    const listSecretsRequestDataPlane = create(ListSecretsRequestSchemaDataPlane, {
+      pageSize: MAX_PAGE_SIZE,
+    });
+    const listSecretsRequest = create(ListSecretsRequestSchema, {
+      request: listSecretsRequestDataPlane,
+    });
+    await queryClient.ensureQueryData(
+      createQueryOptions(listSecrets, listSecretsRequest, { transport: dataplaneTransport })
+    );
   },
   component: SecretsStoreListPage,
 });

--- a/frontend/src/routes/shadowlinks/$name/edit.tsx
+++ b/frontend/src/routes/shadowlinks/$name/edit.tsx
@@ -9,13 +9,46 @@
  * by the Apache License, Version 2.0
  */
 
-import { createFileRoute } from '@tanstack/react-router';
+import { create } from '@bufbuild/protobuf';
+import { Code, ConnectError } from '@connectrpc/connect';
+import { createQueryOptions } from '@connectrpc/connect-query';
+import { createFileRoute, notFound, useParams } from '@tanstack/react-router';
+import { NotFoundContent } from 'components/misc/not-found-content';
+import { GetShadowLinkRequestSchema } from 'protogen/redpanda/api/dataplane/v1/shadowlink_pb';
+import { getShadowLink } from 'protogen/redpanda/api/dataplane/v1/shadowlink-ShadowLinkService_connectquery';
 
 import { ShadowLinkEditPage } from '../../../components/pages/shadowlinks/edit/shadowlink-edit-page';
+
+function ShadowLinkNotFound() {
+  const { name } = useParams({ from: '/shadowlinks/$name/edit' });
+  return (
+    <NotFoundContent
+      backLink="/shadowlinks"
+      backLinkText="Back to Shadow Links"
+      resourceId={name}
+      resourceType="Shadow Link"
+    />
+  );
+}
 
 export const Route = createFileRoute('/shadowlinks/$name/edit')({
   staticData: {
     title: 'Edit Shadow Link',
   },
+  loader: async ({ context: { queryClient, dataplaneTransport }, params: { name } }) => {
+    try {
+      await queryClient.ensureQueryData(
+        createQueryOptions(getShadowLink, create(GetShadowLinkRequestSchema, { name }), {
+          transport: dataplaneTransport,
+        })
+      );
+    } catch (error) {
+      if (error instanceof ConnectError && error.code === Code.NotFound) {
+        throw notFound();
+      }
+      throw error;
+    }
+  },
+  notFoundComponent: ShadowLinkNotFound,
   component: ShadowLinkEditPage,
 });

--- a/frontend/src/routes/shadowlinks/$name/index.tsx
+++ b/frontend/src/routes/shadowlinks/$name/index.tsx
@@ -9,13 +9,46 @@
  * by the Apache License, Version 2.0
  */
 
-import { createFileRoute } from '@tanstack/react-router';
+import { create } from '@bufbuild/protobuf';
+import { Code, ConnectError } from '@connectrpc/connect';
+import { createQueryOptions } from '@connectrpc/connect-query';
+import { createFileRoute, notFound, useParams } from '@tanstack/react-router';
+import { NotFoundContent } from 'components/misc/not-found-content';
+import { GetShadowLinkRequestSchema } from 'protogen/redpanda/api/dataplane/v1/shadowlink_pb';
+import { getShadowLink } from 'protogen/redpanda/api/dataplane/v1/shadowlink-ShadowLinkService_connectquery';
 
 import { ShadowLinkDetailsPage } from '../../../components/pages/shadowlinks/details/shadowlink-details-page';
+
+function ShadowLinkNotFound() {
+  const { name } = useParams({ from: '/shadowlinks/$name/' });
+  return (
+    <NotFoundContent
+      backLink="/shadowlinks"
+      backLinkText="Back to Shadow Links"
+      resourceId={name}
+      resourceType="Shadow Link"
+    />
+  );
+}
 
 export const Route = createFileRoute('/shadowlinks/$name/')({
   staticData: {
     title: 'Shadow Link Details',
   },
+  loader: async ({ context: { queryClient, dataplaneTransport }, params: { name } }) => {
+    try {
+      await queryClient.ensureQueryData(
+        createQueryOptions(getShadowLink, create(GetShadowLinkRequestSchema, { name }), {
+          transport: dataplaneTransport,
+        })
+      );
+    } catch (error) {
+      if (error instanceof ConnectError && error.code === Code.NotFound) {
+        throw notFound();
+      }
+      throw error;
+    }
+  },
+  notFoundComponent: ShadowLinkNotFound,
   component: ShadowLinkDetailsPage,
 });

--- a/frontend/src/routes/shadowlinks/index.tsx
+++ b/frontend/src/routes/shadowlinks/index.tsx
@@ -9,8 +9,12 @@
  * by the Apache License, Version 2.0
  */
 
+import { create } from '@bufbuild/protobuf';
+import { createQueryOptions } from '@connectrpc/connect-query';
 import { createFileRoute } from '@tanstack/react-router';
 import { ShieldIcon } from 'components/icons';
+import { ListShadowLinksRequestSchema } from 'protogen/redpanda/api/console/v1alpha1/shadowlink_pb';
+import { listShadowLinks } from 'protogen/redpanda/api/console/v1alpha1/shadowlink-ShadowLinkService_connectquery';
 
 import { ShadowLinkListPage } from '../../components/pages/shadowlinks/list/shadowlink-list-page';
 
@@ -18,6 +22,11 @@ export const Route = createFileRoute('/shadowlinks/')({
   staticData: {
     title: 'Shadow Links',
     icon: ShieldIcon,
+  },
+  loader: async ({ context: { queryClient, dataplaneTransport } }) => {
+    await queryClient.ensureQueryData(
+      createQueryOptions(listShadowLinks, create(ListShadowLinksRequestSchema, {}), { transport: dataplaneTransport })
+    );
   },
   component: ShadowLinkListPage,
 });

--- a/frontend/src/routes/transcripts/index.tsx
+++ b/frontend/src/routes/transcripts/index.tsx
@@ -9,14 +9,25 @@
  * by the Apache License, Version 2.0
  */
 
+import { create } from '@bufbuild/protobuf';
+import { createQueryOptions } from '@connectrpc/connect-query';
 import { createFileRoute } from '@tanstack/react-router';
 import { ActivityIcon } from 'components/icons';
-import { TranscriptListPage } from 'components/pages/transcripts/transcript-list-page';
+import { TRANSCRIPTS_PAGE_SIZE, TranscriptListPage } from 'components/pages/transcripts/transcript-list-page';
+import { ListTracesRequestSchema } from 'protogen/redpanda/api/dataplane/v1alpha3/tracing_pb';
+import { listTraces } from 'protogen/redpanda/api/dataplane/v1alpha3/tracing-TracingService_connectquery';
 
 export const Route = createFileRoute('/transcripts/')({
   staticData: {
     title: 'Transcripts',
     icon: ActivityIcon,
+  },
+  loader: async ({ context: { queryClient, dataplaneTransport } }) => {
+    await queryClient.ensureQueryData(
+      createQueryOptions(listTraces, create(ListTracesRequestSchema, { pageSize: TRANSCRIPTS_PAGE_SIZE }), {
+        transport: dataplaneTransport,
+      })
+    );
   },
   component: TranscriptListPage,
 });

--- a/frontend/src/test-utils.tsx
+++ b/frontend/src/test-utils.tsx
@@ -72,21 +72,21 @@ export function renderWithFileRoutes(
     },
   });
 
+  const finalTransport =
+    renderOptions.transport ??
+    createConnectTransport({
+      baseUrl: process.env.REACT_APP_PUBLIC_API_URL ?? '',
+    });
+
   const router = createRouter({
     routeTree,
     history: createMemoryHistory({
       initialEntries: [initialLocation],
     }),
-    context: { basePath: '', queryClient, ...routerContext },
+    context: { basePath: '', queryClient, dataplaneTransport: finalTransport, ...routerContext },
   });
 
   function Wrapper({ children }: PropsWithChildren): JSX.Element {
-    const finalTransport =
-      renderOptions.transport ??
-      createConnectTransport({
-        baseUrl: process.env.REACT_APP_PUBLIC_API_URL ?? '',
-      });
-
     return (
       <TransportProvider transport={finalTransport}>
         <QueryClientProvider client={queryClient}>
@@ -136,12 +136,16 @@ export function createTestRouterFromFiles(initialLocation = '/') {
     },
   });
 
+  const transport = createConnectTransport({
+    baseUrl: process.env.REACT_APP_PUBLIC_API_URL ?? '',
+  });
+
   const router = createRouter({
     routeTree,
     history: createMemoryHistory({
       initialEntries: [initialLocation],
     }),
-    context: { basePath: '', queryClient },
+    context: { basePath: '', queryClient, dataplaneTransport: transport },
   });
 
   return router;
@@ -174,7 +178,7 @@ const connectQueryWrapper = (
   const router = createRouter({
     routeTree,
     history: createMemoryHistory({ initialEntries: ['/'] }),
-    context: { basePath: '', queryClient },
+    context: { basePath: '', queryClient, dataplaneTransport: transport },
   });
 
   return {


### PR DESCRIPTION
# TanStack Router Improvements

## Overview

This PR improves TanStack Router integration by adding route loaders for data prefetching and resource-specific 404 handling for cloud-only routes.

## Changes

### 1. Router Context Enhancement

Added `dataplaneTransport` to the router context, enabling loaders to prefetch data using Connect Query.

**Files modified:**
- `src/routes/__root.tsx` - Added `dataplaneTransport: Transport` to `RouterContext` type
- `src/app.tsx` - Added transport to router context
- `src/embedded-app.tsx` - Added transport to router context
- `src/test-utils.tsx` - Updated test utilities to include transport in context

### 2. NotFoundContent Component

Created a reusable component for resource-specific 404 pages.

**New file:** `src/components/misc/not-found-content.tsx`

```typescript
type NotFoundContentProps = {
  resourceType: string;      // "AI Agent", "Shadow Link", etc.
  resourceId?: string;       // ID/name that wasn't found
  backLink?: string;         // "/agents"
  backLinkText?: string;     // "Back to AI Agents"
};
```

Features:
- Displays the banana slip error image
- Shows "{resourceType} '{resourceId}' not found" message
- Provides navigation back link using TanStack Router's `Link`

### 3. Route Loaders

Added loaders to cloud-only routes using `createQueryOptions` + `ensureQueryData` pattern for data prefetching.

#### List Pages (prefetch list data)

| Route | File | RPC |
|-------|------|-----|
| `/agents/` | `src/routes/agents/index.tsx` | `listAIAgents` |
| `/mcp-servers/` | `src/routes/mcp-servers/index.tsx` | `listMCPServers` (v1/v1alpha3) |
| `/shadowlinks/` | `src/routes/shadowlinks/index.tsx` | `listShadowLinks` |
| `/knowledgebases/` | `src/routes/knowledgebases/index.tsx` | `listKnowledgeBases` |
| `/transcripts/` | `src/routes/transcripts/index.tsx` | `listTraces` |
| `/secrets/` | `src/routes/secrets/index.tsx` | `listSecrets` |

#### Detail/Edit Pages (prefetch + notFoundComponent)

| Route | File | RPC |
|-------|------|-----|
| `/agents/$id` | `src/routes/agents/$id.tsx` | `getAIAgent` |
| `/mcp-servers/$id` | `src/routes/mcp-servers/$id.tsx` | `getMCPServer` (v1/v1alpha3) |
| `/shadowlinks/$name` | `src/routes/shadowlinks/$name/index.tsx` | `getShadowLink` |
| `/shadowlinks/$name/edit` | `src/routes/shadowlinks/$name/edit.tsx` | `getShadowLink` |
| `/knowledgebases/$knowledgebaseId` | `src/routes/knowledgebases/$knowledgebaseId/index.tsx` | `getKnowledgeBase` |
| `/secrets/$id/edit` | `src/routes/secrets/$id/edit.tsx` | `getSecret` |

### 4. NotFound Handling

Detail pages now handle `Code.NotFound` errors from gRPC by throwing `notFound()` and displaying a resource-specific 404 page via `notFoundComponent`.

**Pattern used:**
```typescript
loader: async ({ context: { queryClient, dataplaneTransport }, params: { id } }) => {
  try {
    await queryClient.ensureQueryData(
      createQueryOptions(getResource, create(GetResourceRequestSchema, { id }), {
        transport: dataplaneTransport
      })
    );
  } catch (error) {
    if (error instanceof ConnectError && error.code === Code.NotFound) {
      throw notFound();
    }
    throw error;
  }
},
notFoundComponent: ResourceNotFound,
```

## Benefits

1. **Faster page loads** - Data is prefetched during route transitions
2. **Better UX for 404s** - Resource-specific error messages with navigation back
3. **No loading flash** - Data available before component renders
4. **React Query cache reuse** - Components use cached data from loaders

## Notes

- MCP servers routes check `isFeatureFlagEnabled('enableMcpServiceAccount')` to determine v1 vs v1alpha3 API
- Router context uses `dataplaneTransport` explicitly (not generic `transport`) for clarity
- Components using controlplane transport continue to use `useControlplaneTransport()` hook
