### PR TITLE
frontend(ai-agents): fix orphaned MCP server display and compact list UI

### DIFF
--- a/frontend/src/components/pages/agents/details/ai-agent-card-tab.tsx
+++ b/frontend/src/components/pages/agents/details/ai-agent-card-tab.tsx
@@ -597,7 +597,7 @@ export const AIAgentCardTab = () => {
                 <LinkIcon className="h-4 w-4" />
                 <Text className="font-semibold">Connect</Text>
               </CardTitle>
-              <Text className="text-muted-foreground text-sm">Use client SDKs to connect to the agent</Text>
+              <Text className="text-muted-foreground text-sm">Use client SDKs to connect to the agent.</Text>
             </div>
           </CardHeader>
           <CardContent className="space-y-4 px-4 pb-4">


### PR DESCRIPTION
## What

Fix orphaned MCP server handling and replace the bloated card layout with a compact row-based list in AI Agent configuration.

## Why

1. Deleted MCP servers referenced by agents became invisible - users couldn't see or remove stale references
2. The card layout wasted massive vertical space (120px min-height per server) for what's essentially a name and tool count

## Implementation details

**Orphaned server handling** (`ai-agent-configuration-tab.tsx`):
- `connectedMcpServers` and `availableMcpServers` now create placeholder objects for servers that exist in agent config but not in the system
- Placeholders have `state: UNSPECIFIED` and `displayName: "id (deleted)"` for detection

**Compact list UI** (`mcp-server-card.tsx`):
- Replaced cards with row-based list (~40px vs 120px per item)
- Server name + tool count badge on each row
- Expandable tool details via chevron click
- Missing servers show warning icon, red styling, and "Missing" badge

## References

In addition, there's a PR in internal cloud repo to lazily deal with down MCPs on start of the agent.

https://github.com/user-attachments/assets/c373f579-211a-49c2-87b1-9b1ffa53fd7f

