### PR TITLE
cors: add Private Network Access support for BYOC deployments

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/fxamacker/cbor/v2 v2.9.0
 	github.com/getkin/kin-openapi v0.133.0
 	github.com/go-chi/chi/v5 v5.2.3
-	github.com/go-chi/cors v1.2.2
 	github.com/go-git/go-billy/v5 v5.6.2
 	github.com/go-git/go-git/v5 v5.16.3
 	github.com/go-viper/mapstructure/v2 v2.4.0
@@ -48,6 +47,7 @@ require (
 	github.com/redpanda-data/common-go/net v0.1.1-0.20240429123545-4da3d2b371f7
 	github.com/redpanda-data/common-go/rpadmin v0.2.0
 	github.com/redpanda-data/common-go/rpsr v0.1.2
+	github.com/rs/cors v1.11.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.38.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -162,8 +162,6 @@ github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
 github.com/go-chi/chi/v5 v5.2.3 h1:WQIt9uxdsAbgIYgid+BpYc+liqQZGMHRaUwp0JUcvdE=
 github.com/go-chi/chi/v5 v5.2.3/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
-github.com/go-chi/cors v1.2.2 h1:Jmey33TE+b+rB7fT8MUy1u0I4L+NARQlK6LhzKPSyQE=
-github.com/go-chi/cors v1.2.2/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
 github.com/go-git/go-billy/v5 v5.6.2 h1:6Q86EsPXMa7c3YZ3aLAQsMA0VlWmy43r6FHqa/UNbRM=
@@ -422,6 +420,8 @@ github.com/rodaine/protogofakeit v0.1.1 h1:ZKouljuRM3A+TArppfBqnH8tGZHOwM/pjvtXe
 github.com/rodaine/protogofakeit v0.1.1/go.mod h1:pXn/AstBYMaSfc1/RqH3N82pBuxtWgejz1AlYpY1mI0=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
+github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=

--- a/backend/pkg/config/server.go
+++ b/backend/pkg/config/server.go
@@ -27,6 +27,14 @@ type Server struct {
 	// CSRF-attacks.
 	AllowedOrigins []string `yaml:"allowedOrigins"`
 
+	// AllowPrivateNetwork enables Chrome's Private Network Access preflight handling.
+	// When enabled, the server responds with Access-Control-Allow-Private-Network: true
+	// for CORS preflight requests that include Access-Control-Request-Private-Network.
+	// This is required for BYOC deployments where browsers access a public origin
+	// (e.g., cloud.redpanda.com) but traffic routes to private IP addresses via VPN.
+	// See: https://developer.chrome.com/blog/private-network-access-preflight
+	AllowPrivateNetwork bool `yaml:"allowPrivateNetwork"`
+
 	// Debug allows to configure the pprof debug handler options.
 	Debug DebugConfig `yaml:"debug"`
 }


### PR DESCRIPTION
## What

Add Chrome Private Network Access (PNA) support via new `server.allowPrivateNetwork` config option.

## Why

BYOC users with split-tunnel VPN report Console works in Safari/Firefox but fails in Chrome. Chrome's PNA enforcement blocks requests from public origins (cloud.redpanda.com) to private network addresses (100.64.0.0/10 range used by their VPN).

The fix is to respond with `Access-Control-Allow-Private-Network: true` on CORS preflight requests.

## Implementation details

**Config**: New `server.allowPrivateNetwork` boolean option (default false). Environment variable: `SERVER_ALLOWPRIVATENETWORK`.

**Middleware**: The go-chi/cors library lacks native PNA support, so this wraps the CORS handler to inject the response header when browsers send `Access-Control-Request-Private-Network: true`.

BYOC deployments should set `allowPrivateNetwork: true` in their Console configuration.

## References
- JIRA CIAINFRA-2284
- Chrome PNA spec: https://developer.chrome.com/blog/private-network-access-preflight