### PR TITLE
frontend: fix layout shifts on AI agent create page

### DIFF
--- a/frontend/src/components/pages/agents/create/ai-agent-create-page.tsx
+++ b/frontend/src/components/pages/agents/create/ai-agent-create-page.tsx
@@ -531,10 +531,10 @@ export const AIAgentCreatePage = () => {
               </Card>
             </div>
 
-            {/* Prompt */}
+            {/* System Prompt */}
             <Card size="full">
               <CardHeader>
-                <CardTitle>Prompt</CardTitle>
+                <CardTitle>System Prompt</CardTitle>
                 <Text variant="muted">Define the agent's behavior and instructions</Text>
               </CardHeader>
               <CardContent>

--- a/frontend/src/components/ui/markdown-editor/markdown-editor.tsx
+++ b/frontend/src/components/ui/markdown-editor/markdown-editor.tsx
@@ -6,7 +6,7 @@ import { history } from "@milkdown/kit/plugin/history";
 import { listener, listenerCtx } from "@milkdown/kit/plugin/listener";
 import { Milkdown, MilkdownProvider, useEditor } from "@milkdown/react";
 import { Badge } from "components/redpanda-ui/components/badge";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "components/redpanda-ui/components/tabs";
+import { Tabs, TabsList, TabsTrigger } from "components/redpanda-ui/components/tabs";
 import { Textarea } from "components/redpanda-ui/components/textarea";
 import { cn } from "components/redpanda-ui/lib/utils";
 import { useEffect, useRef, useState } from "react";
@@ -68,7 +68,7 @@ export function MarkdownEditorTabs({
 }) {
   return (
     <Tabs value={mode} onValueChange={(v) => onModeChange(v as MarkdownEditorMode)} className={className}>
-      <TabsList>
+      <TabsList transition={{ duration: 0 }}>
         <TabsTrigger value="editor" className="gap-1.5">
           Editor
           <Badge variant="outline" className="px-1 py-0 text-[10px] font-normal">
@@ -104,9 +104,13 @@ export function MarkdownEditor({
   }, [value]);
 
   // When switching from raw to editor, remount to pick up changes
+  const prevModeRef = useRef(activeMode);
   useEffect(() => {
-    if (activeMode === "editor") {
-      setEditorKey((k) => k + 1);
+    if (prevModeRef.current !== activeMode) {
+      prevModeRef.current = activeMode;
+      if (activeMode === "editor") {
+        setEditorKey((k) => k + 1);
+      }
     }
   }, [activeMode]);
 
@@ -146,10 +150,12 @@ export function MarkdownEditor({
   }
 
   // Uncontrolled mode - render with internal tabs
+  // Content is conditionally rendered instead of using TabsContent to avoid
+  // the motion blur/slide animation that looks jarring for an inline editor.
   return (
     <div className={cn("markdown-editor-wrapper", className)}>
       <Tabs value={activeMode} onValueChange={(v) => handleModeChange(v as MarkdownEditorMode)}>
-        <TabsList className="mb-2">
+        <TabsList className="mb-2" transition={{ duration: 0 }}>
           <TabsTrigger value="editor" className="gap-1.5">
             Editor
             <Badge variant="outline" className="px-1 py-0 text-[10px] font-normal">
@@ -158,15 +164,8 @@ export function MarkdownEditor({
           </TabsTrigger>
           <TabsTrigger value="raw">Raw</TabsTrigger>
         </TabsList>
-
-        <TabsContent value="editor" className="mt-0">
-          {editorContent}
-        </TabsContent>
-
-        <TabsContent value="raw" className="mt-0">
-          {rawContent}
-        </TabsContent>
       </Tabs>
+      {activeMode === "editor" ? editorContent : rawContent}
     </div>
   );
 }


### PR DESCRIPTION
## What

Fix three sources of layout jank on the AI agent create page.

## Why

The page had visible content jumps on load: the Prompt card bounced as the Milkdown editor double-mounted, the LLM config card grew then shrank as gateway state resolved, and tab switching triggered unnecessary blur/slide animations.

## Implementation details

**MarkdownEditor tab animation**: `TabsContent` wraps content in a `motion.div` with 500ms blur+slide transitions. The editor doesn't need this -- replaced with direct conditional rendering. Tab highlight animation also disabled (`transition={{ duration: 0 }}`).

**Milkdown double-mount**: The `editorKey` effect fired on initial mount because `activeMode` starts as `"editor"`, bumping the key and forcing an immediate unmount/remount cycle. Added a ref to track previous mode so the effect only fires on actual mode changes.

**LLM config gateway race**: While the gateway query was in-flight, `isUsingGateway` was `false`, so the API Token field rendered. Once the query completed and a gateway was auto-selected, the field disappeared. Now provider/model/API token fields show skeleton placeholders until gateway state fully settles. Gateway selector and max iterations render immediately since they don't depend on the resolved state.

# Refs


https://github.com/user-attachments/assets/51910d7d-ea19-4c39-9606-afb7e5546a50

