### PR TITLE
frontend: fix markdown editor overflowing its container

### DIFF
--- a/frontend/src/components/ui/markdown-editor/markdown-editor.css
+++ b/frontend/src/components/ui/markdown-editor/markdown-editor.css
@@ -1,8 +1,15 @@
 /* Milkdown Editor Styles */
 
+.markdown-editor-wrapper {
+  min-width: 0;
+}
+
 .markdown-editor-wrapper .milkdown {
   min-height: 80px;
   padding: 0.5rem 0.75rem;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  overflow: hidden;
 }
 
 .markdown-editor-wrapper .milkdown .editor {


### PR DESCRIPTION
## What

Fix the markdown editor (Milkdown) overflowing its card container on AI agent create and edit pages when content contains long lines.

## Why

Long text without natural break points (URLs, bold headers, etc.) would push past the card boundary and break the entire page layout.

## Implementation details

Pure CSS fix on the shared `.markdown-editor-wrapper` and `.milkdown` classes:

- `min-width: 0` on the wrapper -- flex/grid children default to `min-width: auto`, which prevents them from shrinking below content width. This override allows the editor to respect its container's bounds.
- `overflow-wrap: break-word` -- breaks long words/URLs at the container edge instead of overflowing.
- `overflow: hidden` -- hard containment boundary so nothing escapes.

Affects both create and edit pages since they share the same `MarkdownEditor` component.