### PR TITLE
backend: remove flaky nolintlint linter

### DIFF
--- a/backend/.golangci.yaml
+++ b/backend/.golangci.yaml
@@ -30,7 +30,7 @@ linters:
     - nilerr
     - nilnesserr
     - noctx
-    - nolintlint
+
     - reassign
     - revive
     - rowserrcheck
@@ -76,10 +76,6 @@ linters:
         - G117 # Exported struct fields matching secret patterns - false positives on config structs
         - G704 # SSRF via taint analysis - false positive on HTTP clients
         - G705 # XSS via taint analysis - false positives on HTTP response writers
-    nolintlint:
-      require-explanation: true
-      require-specific: true
-      allow-unused: false
     sloglint:
       attr-only: true
       no-global: all


### PR DESCRIPTION
## Summary
Remove the `nolintlint` linter which has a known cache-related bug ([golangci/golangci-lint#3228](https://github.com/golangci/golangci-lint/issues/3228)) causing intermittent false positives in CI, reporting valid `//nolint` directives as unused. This is the same issue that led Prometheus to [disable nolintlint entirely](https://github.com/prometheus/prometheus/issues/16203).