### PR TITLE
fix: message viewer performance degradation on expanded rows during streaming

### DIFF
--- a/frontend/src/components/misc/KowlJsonView.tsx
+++ b/frontend/src/components/misc/KowlJsonView.tsx
@@ -11,7 +11,7 @@
 
 import { Box } from '@redpanda-data/ui';
 import { observer } from 'mobx-react';
-import type { CSSProperties } from 'react';
+import { type CSSProperties, useMemo } from 'react';
 import KowlEditor from './KowlEditor';
 
 export const KowlJsonView = observer(
@@ -19,7 +19,10 @@ export const KowlJsonView = observer(
     srcObj: object | string | null | undefined;
     style?: CSSProperties;
   }) => {
-    const str = typeof props.srcObj === 'string' ? props.srcObj : JSON.stringify(props.srcObj, undefined, 4);
+    const str = useMemo(
+      () => (typeof props.srcObj === 'string' ? props.srcObj : JSON.stringify(props.srcObj, undefined, 4)),
+      [props.srcObj],
+    );
 
     return (
       <Box
@@ -43,7 +46,6 @@ export const KowlJsonView = observer(
             language="json"
             options={{
               readOnly: true,
-              // automaticLayout: false // too much lag on chrome
             }}
           />
         </Box>


### PR DESCRIPTION
## Summary

- **Stabilize `subComponent` identity** in `MessageTable` using `useCallback` — prevents React from unmounting/remounting all expanded Monaco editors on every MobX-triggered re-render during gRPC streaming
- **Replace Monaco `automaticLayout`** with a single debounced `ResizeObserver` per editor — eliminates cascading layout recalculations and fixes existing Safari infinite loop
- **Memoize `JSON.stringify`** in `KowlJsonView` to skip redundant serialization on re-renders
- **Remove dead code** (`expandedKeys`, `toggleRecordExpand`) left over from the pre-DataTable migration

### Root cause

`MessageTable` is a MobX `observer` that re-renders on every message push during gRPC streaming search. The `subComponent` prop was an inline arrow function, so each re-render created a new function reference. `DataTable` uses this as a React component type — when the reference changes, React treats it as a different component, unmounting the old tree and mounting a new one for every expanded row. Each cycle destroys and recreates Monaco editor instances, causing 21+ seconds of pure scripting on protobuf-schema topics.

### Verified with Playwright

| Metric | Before | After |
|--------|--------|-------|
| Monaco destructions (10 rapid pushes, 2 expanded editors) | ~55 | **0** |
| Monaco creations | ~55 | **0** |
| Editor stability | Flicker/remount each push | Stable, no flicker |
