### PR TITLE
frontend: remove beta badges from agentic AI sidebar items

### DIFF
--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -139,7 +139,6 @@ export type SidebarItem = {
   icon?: JSX.Element;
   order: number;
   group?: string; // "Agentic AI" - for grouping related items
-  isBeta?: boolean; // true - for displaying beta badge
 };
 
 export type Breadcrumb = {
@@ -323,7 +322,6 @@ setTimeout(() => {
           icon: r.icon,
           order: i,
           group: r.group,
-          isBeta: r.isBeta,
         }) as SidebarItem
     );
 

--- a/frontend/src/federation/console-app.tsx
+++ b/frontend/src/federation/console-app.tsx
@@ -239,7 +239,6 @@ function ConsoleAppInner({
           icon: r.icon,
           order: i,
           group: r.group,
-          isBeta: r.isBeta,
         }) as SidebarItem
     );
 

--- a/frontend/src/utils/route-utils.tsx
+++ b/frontend/src/utils/route-utils.tsx
@@ -56,7 +56,6 @@ export type SidebarItem = {
   icon?: LucideIcon | ((props: React.SVGProps<SVGSVGElement>) => JSX.Element);
   visibilityCheck?: () => MenuItemState;
   group?: string; // For grouping related items (e.g., "Agentic AI")
-  isBeta?: boolean; // For displaying beta badge
 };
 
 // Visibility state for menu items
@@ -325,9 +324,6 @@ const routesIgnoredInEmbedded = ['/overview', '/reassign-partitions', '/admin'];
 // Routes that should be hidden in serverless mode
 const routesIgnoredInServerless = ['/overview', '/quotas', '/reassign-partitions', '/admin', '/transforms'];
 
-// Routes with beta badge suffix
-const BETA_ROUTES = ['/knowledgebases', '/agents', '/transcripts'];
-
 /**
  * Process a single sidebar item for legacy sidebar display.
  */
@@ -343,10 +339,9 @@ function processSidebarItem(item: SidebarItem): NavLinkProps | null {
 
   const isEnabled = visibility.disabledReasons.length === 0;
   const disabledText = getDisabledText(visibility.disabledReasons);
-  const title = formatTitle(item.path, String(item.title));
 
   return {
-    title,
+    title: String(item.title),
     to: item.path,
     icon: item.icon,
     isDisabled: !isEnabled,
@@ -373,13 +368,6 @@ function getDisabledText(reasons: DisabledReason[]): string {
 }
 
 /**
- * Format title with beta suffix if needed.
- */
-function formatTitle(path: string, title: string): string {
-  return BETA_ROUTES.includes(path) ? `${title} (beta)` : title;
-}
-
-/**
  * Creates visible sidebar items for the legacy @redpanda-data/ui Sidebar.
  */
 export function createVisibleSidebarItems(): NavLinkProps[] {
@@ -392,12 +380,11 @@ export function createVisibleSidebarItems(): NavLinkProps[] {
  */
 export function getEmbeddedAvailableRoutes(): SidebarItem[] {
   return SIDEBAR_ITEMS.map((item) => {
-    // Mark AI-related routes with group and beta flag
+    // Mark AI-related routes with group
     if (item.path === '/knowledgebases' || item.path === '/agents' || item.path === '/transcripts') {
       return {
         ...item,
         group: 'Agentic AI',
-        isBeta: true,
       };
     }
 


### PR DESCRIPTION
Remove (beta) suffix from Knowledge Bases, AI Agents, and Transcripts menu item titles, and stop passing isBeta flag to the host sidebar.