### PR TITLE
backend: add SR context to endpoints/ compat URL

### DIFF
--- a/backend/pkg/console/endpoint_compatibility.go
+++ b/backend/pkg/console/endpoint_compatibility.go
@@ -153,6 +153,12 @@ func (s *Service) GetEndpointCompatibility(ctx context.Context) (EndpointCompati
 			Method:         "POST",
 			HasRedpandaAPI: false,
 		},
+		{
+			URL:             "/api/schema-registry/contexts",
+			Method:          "GET",
+			HasRedpandaAPI:  true,
+			RedpandaFeature: redpandaFeatureSchemaRegistryContexts,
+		},
 	}
 
 	endpoints := make([]EndpointCompatibilityEndpoint, 0, len(endpointRequirements))

--- a/backend/pkg/console/redpanda_feature.go
+++ b/backend/pkg/console/redpanda_feature.go
@@ -34,7 +34,14 @@ const (
 
 	// redpandaFeatureSchemaRegistryACL represents Schema Registry ACL feature.
 	redpandaFeatureSchemaRegistryACL redpandaFeature = "redpanda_feature_schema_registry_acl"
+
+	// redpandaFeatureSchemaRegistryContexts represents Schema Registry Contexts feature.
+	redpandaFeatureSchemaRegistryContexts redpandaFeature = "redpanda_feature_schema_registry_contexts"
 )
+
+// clusterConfigSchemaRegistryQualifiedSubjects is the Redpanda cluster config
+// key that enables qualified subjects (contexts) in Schema Registry.
+const clusterConfigSchemaRegistryQualifiedSubjects = "schema_registry_enable_qualified_subjects"
 
 // checkRedpandaFeature checks whether redpanda has the specified feature in the specified state.
 // Multiple states can be passed to check if feature state is any one of the given states.
@@ -64,6 +71,17 @@ func (*Service) checkRedpandaFeature(ctx context.Context, redpandaCl redpandafac
 			}
 		}
 		return true
+	case redpandaFeatureSchemaRegistryContexts:
+		cfg, err := redpandaCl.SingleKeyConfig(ctx, clusterConfigSchemaRegistryQualifiedSubjects)
+		if err != nil {
+			return false
+		}
+		val, ok := cfg[clusterConfigSchemaRegistryQualifiedSubjects]
+		if !ok {
+			return false
+		}
+		enabled, ok := val.(bool)
+		return ok && enabled
 	default:
 		return false
 	}

--- a/backend/pkg/factory/redpanda/redpanda.go
+++ b/backend/pkg/factory/redpanda/redpanda.go
@@ -180,4 +180,7 @@ type AdminAPIClient interface {
 
 	// ClusterService returns a client for listing kafka connections
 	ClusterService(opts ...connect.ClientOption) adminv2connect.ClusterServiceClient
+
+	// SingleKeyConfig returns the value for a Redpanda Cluster config property
+	SingleKeyConfig(ctx context.Context, key string) (rpadmin.Config, error)
 }


### PR DESCRIPTION
This will detect whether the Schema Registry
Context feature is enabled in the cluster. This
will require users that which to use this feature
to also have configured the Admin API as there is
no way of telling this within the SR API directly.