### PR TITLE
feat(serde): support Git repo cloning via GitHub app

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/go-git/go-billy/v5 v5.7.0
 	github.com/go-git/go-git/v5 v5.16.5
 	github.com/go-viper/mapstructure/v2 v2.4.0
+	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/schema v1.4.1
@@ -133,7 +134,6 @@ require (
 	github.com/go-resty/resty/v2 v2.16.5 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.4+incompatible // indirect
 	github.com/gofrs/uuid/v5 v5.3.2 // indirect
-	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/cel-go v0.26.1 // indirect

--- a/backend/pkg/config/git.go
+++ b/backend/pkg/config/git.go
@@ -38,6 +38,7 @@ type Git struct {
 	// Authentication Configs
 	BasicAuth GitAuthBasicAuth `yaml:"basicAuth"`
 	SSH       GitAuthSSH       `yaml:"ssh"`
+	GithubApp GitGithubApp     `yaml:"githubApp"`
 
 	// CloneSubmodules enables shallow cloning of submodules at recursion depth of 1.
 	CloneSubmodules bool `yaml:"cloneSubmodules"`
@@ -47,6 +48,7 @@ type Git struct {
 func (c *Git) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	c.BasicAuth.RegisterFlagsWithPrefix(f, prefix)
 	c.SSH.RegisterFlagsWithPrefix(f, prefix)
+	c.GithubApp.RegisterFlagsWithPrefix(f, prefix)
 }
 
 // Validate all root and child config structs
@@ -59,6 +61,10 @@ func (c *Git) Validate() error {
 	}
 	if c.MaxFileSize <= 0 {
 		return errors.New("git config is enabled but file max size is <= 0")
+	}
+
+	if err := c.GithubApp.Validate(); err != nil {
+		return err
 	}
 
 	return c.Repository.Validate()

--- a/backend/pkg/config/git_auth_ssh.go
+++ b/backend/pkg/config/git_auth_ssh.go
@@ -25,3 +25,5 @@ func (c *GitAuthSSH) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	f.StringVar(&c.PrivateKey, prefix+"git.ssh.private-key", "", "Private key for Git authentication")
 	f.StringVar(&c.Passphrase, prefix+"git.ssh.passphrase", "", "Passphrase to decrypt private key")
 }
+
+

--- a/backend/pkg/config/github_auth_app.go
+++ b/backend/pkg/config/github_auth_app.go
@@ -1,0 +1,50 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package config
+
+import (
+	"errors"
+	"flag"
+)
+
+// GitGithubApp is the configuration to authenticate against Git via GitHub App.
+type GitGithubApp struct {
+	Enabled            bool   `yaml:"enabled"`
+	AppID              int64  `yaml:"appId"`
+	InstallationID     int64  `yaml:"installationId"`
+	PrivateKey         string `yaml:"privateKey"`
+	PrivateKeyFilePath string `yaml:"privateKeyFilepath"`
+}
+
+// RegisterFlagsWithPrefix for sensitive GitHub App configs
+func (c *GitGithubApp) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
+	f.StringVar(&c.PrivateKey, prefix+"git.github-app.private-key", "", "Private key for GitHub App authentication")
+}
+
+// Validate the GitHub App authentication configuration.
+func (c *GitGithubApp) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+
+	if c.AppID <= 0 {
+		return errors.New("github app authentication is enabled but appId is not set or invalid")
+	}
+
+	if c.InstallationID <= 0 {
+		return errors.New("github app authentication is enabled but installationId is not set or invalid")
+	}
+
+	if c.PrivateKey == "" && c.PrivateKeyFilePath == "" {
+		return errors.New("github app authentication is enabled but neither privateKey nor privateKeyFilepath is set")
+	}
+
+	return nil
+}

--- a/backend/pkg/git/github_app_auth.go
+++ b/backend/pkg/git/github_app_auth.go
@@ -1,0 +1,187 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package git
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/redpanda-data/console/backend/pkg/config"
+)
+
+const (
+	gitHubAPIBaseURL  = "https://api.github.com"
+	tokenExpiryBuffer = 5 * time.Minute
+)
+
+// gitHubAppAuth implements the go-git http.AuthMethod interface for GitHub App authentication.
+// It generates short-lived installation access tokens by signing JWTs with the App's private key.
+type gitHubAppAuth struct {
+	appID          int64
+	installationID int64
+	privateKey     *rsa.PrivateKey
+	logger         *slog.Logger
+	apiBaseURL     string
+
+	mu     sync.Mutex
+	token  string
+	expiry time.Time
+}
+
+type installationTokenResponse struct {
+	Token     string    `json:"token"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+func (a *gitHubAppAuth) SetAuth(r *http.Request) {
+	token, err := a.getValidToken()
+	if err != nil {
+		a.logger.Error("failed to get GitHub App installation token", slog.Any("error", err))
+		return
+	}
+
+	r.SetBasicAuth("x-access-token", token)
+}
+
+func (a *gitHubAppAuth) Name() string {
+	return "http-github-app-auth"
+}
+
+func (a *gitHubAppAuth) String() string {
+	return fmt.Sprintf("http-github-app-auth - GitHub App ID: %d", a.appID)
+}
+
+func (a *gitHubAppAuth) getValidToken() (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.token != "" && time.Now().Before(a.expiry.Add(-tokenExpiryBuffer)) {
+		return a.token, nil
+	}
+
+	return a.refreshToken()
+}
+
+func (a *gitHubAppAuth) refreshToken() (string, error) {
+	now := time.Now()
+	claims := jwt.RegisteredClaims{
+		IssuedAt:  jwt.NewNumericDate(now),
+		ExpiresAt: jwt.NewNumericDate(now.Add(10 * time.Minute)),
+		Issuer:    fmt.Sprintf("%d", a.appID),
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	signedJWT, err := token.SignedString(a.privateKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to sign JWT: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/app/installations/%d/access_tokens", a.apiBaseURL, a.installationID)
+	req, err := http.NewRequest(http.MethodPost, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+signedJWT)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to request installation token: %w", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("GitHub API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp installationTokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return "", fmt.Errorf("failed to decode installation token response: %w", err)
+	}
+
+	a.token = tokenResp.Token
+	a.expiry = tokenResp.ExpiresAt
+	a.logger.Debug("refreshed GitHub App installation token",
+		slog.Time("expires_at", tokenResp.ExpiresAt))
+
+	return a.token, nil
+}
+
+func parseRSAPrivateKey(pemData []byte) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode(pemData)
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode PEM block")
+	}
+
+	// Try PKCS#1 first (RSA PRIVATE KEY)
+	if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+
+	// Try PKCS#8 (PRIVATE KEY)
+	keyInterface, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse private key (tried PKCS#1 and PKCS#8): %w", err)
+	}
+
+	key, ok := keyInterface.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("PKCS#8 key is not an RSA private key")
+	}
+
+	return key, nil
+}
+
+func loadPrivateKeyPEM(cfg config.GitGithubApp) ([]byte, error) {
+	if cfg.PrivateKey != "" {
+		return []byte(cfg.PrivateKey), nil
+	}
+
+	data, err := os.ReadFile(cfg.PrivateKeyFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read private key file %q: %w", cfg.PrivateKeyFilePath, err)
+	}
+
+	return data, nil
+}
+
+func buildGithubAppAuth(cfg config.GitGithubApp, logger *slog.Logger) (*gitHubAppAuth, error) {
+	pemData, err := loadPrivateKeyPEM(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	privateKey, err := parseRSAPrivateKey(pemData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse GitHub App private key: %w", err)
+	}
+
+	return &gitHubAppAuth{
+		appID:          cfg.AppID,
+		installationID: cfg.InstallationID,
+		privateKey:     privateKey,
+		logger:         logger,
+		apiBaseURL:     gitHubAPIBaseURL,
+	}, nil
+}

--- a/backend/pkg/git/github_app_auth_test.go
+++ b/backend/pkg/git/github_app_auth_test.go
@@ -1,0 +1,186 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package git
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func generateTestRSAKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	return key
+}
+
+func encodePKCS1PEM(key *rsa.PrivateKey) []byte {
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+}
+
+func encodePKCS8PEM(t *testing.T, key *rsa.PrivateKey) []byte {
+	t.Helper()
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: der,
+	})
+}
+
+func TestParseRSAPrivateKey(t *testing.T) {
+	key := generateTestRSAKey(t)
+
+	t.Run("PKCS1 PEM", func(t *testing.T) {
+		pemData := encodePKCS1PEM(key)
+		parsed, err := parseRSAPrivateKey(pemData)
+		require.NoError(t, err)
+		assert.True(t, key.Equal(parsed))
+	})
+
+	t.Run("PKCS8 PEM", func(t *testing.T) {
+		pemData := encodePKCS8PEM(t, key)
+		parsed, err := parseRSAPrivateKey(pemData)
+		require.NoError(t, err)
+		assert.True(t, key.Equal(parsed))
+	})
+
+	t.Run("invalid PEM", func(t *testing.T) {
+		_, err := parseRSAPrivateKey([]byte("not a pem"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to decode PEM block")
+	})
+
+	t.Run("invalid key data", func(t *testing.T) {
+		pemData := pem.EncodeToMemory(&pem.Block{
+			Type:  "PRIVATE KEY",
+			Bytes: []byte("invalid key data"),
+		})
+		_, err := parseRSAPrivateKey(pemData)
+		require.Error(t, err)
+	})
+}
+
+func TestGitHubAppAuth_TokenRefresh(t *testing.T) {
+	key := generateTestRSAKey(t)
+	appID := int64(12345)
+	installationID := int64(67890)
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+
+		// Verify request path
+		expectedPath := fmt.Sprintf("/app/installations/%d/access_tokens", installationID)
+		assert.Equal(t, expectedPath, r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		// Verify JWT in Authorization header
+		authHeader := r.Header.Get("Authorization")
+		require.NotEmpty(t, authHeader)
+		assert.Contains(t, authHeader, "Bearer ")
+
+		tokenString := authHeader[len("Bearer "):]
+		parsedToken, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+			return &key.PublicKey, nil
+		})
+		require.NoError(t, err)
+		assert.True(t, parsedToken.Valid)
+
+		claims, ok := parsedToken.Claims.(jwt.MapClaims)
+		require.True(t, ok)
+		assert.Equal(t, fmt.Sprintf("%d", appID), claims["iss"])
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(installationTokenResponse{
+			Token:     fmt.Sprintf("ghs_test_token_%d", requestCount),
+			ExpiresAt: time.Now().Add(1 * time.Hour),
+		})
+	}))
+	defer server.Close()
+
+	auth := &gitHubAppAuth{
+		appID:          appID,
+		installationID: installationID,
+		privateKey:     key,
+		logger:         slog.Default(),
+		apiBaseURL:     server.URL,
+	}
+
+	// First call should fetch a token
+	token, err := auth.getValidToken()
+	require.NoError(t, err)
+	assert.Equal(t, "ghs_test_token_1", token)
+	assert.Equal(t, 1, requestCount)
+
+	// Second call should use the cached token
+	token, err = auth.getValidToken()
+	require.NoError(t, err)
+	assert.Equal(t, "ghs_test_token_1", token)
+	assert.Equal(t, 1, requestCount)
+
+	// Force expiry and verify refresh
+	auth.expiry = time.Now().Add(2 * time.Minute) // within the 5-min buffer
+	token, err = auth.getValidToken()
+	require.NoError(t, err)
+	assert.Equal(t, "ghs_test_token_2", token)
+	assert.Equal(t, 2, requestCount)
+}
+
+func TestGitHubAppAuth_SetAuth(t *testing.T) {
+	key := generateTestRSAKey(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(installationTokenResponse{
+			Token:     "ghs_test_token",
+			ExpiresAt: time.Now().Add(1 * time.Hour),
+		})
+	}))
+	defer server.Close()
+
+	auth := &gitHubAppAuth{
+		appID:          1,
+		installationID: 2,
+		privateKey:     key,
+		logger:         slog.Default(),
+		apiBaseURL:     server.URL,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "https://github.com/test/repo.git", nil)
+	auth.SetAuth(req)
+
+	username, password, ok := req.BasicAuth()
+	require.True(t, ok)
+	assert.Equal(t, "x-access-token", username)
+	assert.Equal(t, "ghs_test_token", password)
+}
+
+func TestGitHubAppAuth_NameAndString(t *testing.T) {
+	auth := &gitHubAppAuth{appID: 42}
+	assert.Equal(t, "http-github-app-auth", auth.Name())
+	assert.Contains(t, auth.String(), "42")
+}

--- a/backend/pkg/git/service.go
+++ b/backend/pkg/git/service.go
@@ -63,6 +63,9 @@ func NewService(cfg config.Git, logger *slog.Logger, onFilesUpdatedHook func()) 
 	case cfg.BasicAuth.Enabled:
 		childLogger.Debug("using BasicAuth for Git authentication")
 		auth = buildBasicAuth(cfg.BasicAuth)
+	case cfg.GithubApp.Enabled:
+		childLogger.Debug("using GitHub App for Git authentication")
+		auth, err = buildGithubAppAuth(cfg.GithubApp, childLogger)
 	default:
 		childLogger.Debug("using Git without authentication")
 	}


### PR DESCRIPTION
Currently to use protos from a private GitHub Repo you must setup either PAT or SSH key. Both methods are not recommended for organizations. This PR adds support for authentication via GitHub apps, which is a common way to authenticate apps in organizations. 