### PR TITLE
fix: null-safe access for consumer group partition assignments

### DIFF
--- a/frontend/src/components/pages/consumers/group-details.tsx
+++ b/frontend/src/components/pages/consumers/group-details.tsx
@@ -179,7 +179,7 @@ class GroupDetails extends PageComponent<GroupDetailsProps> {
     }
 
     // Get info about each topic
-    const totalPartitions = group.members.flatMap((m) => m.assignments).sum((a) => a.partitionIds.length);
+    const totalPartitions = group.members.flatMap((m) => m.assignments).sum((a) => a.partitionIds?.length ?? 0);
 
     return (
       <PageContent className="groupDetails">
@@ -309,7 +309,7 @@ const GroupByTopics = observer(
 
     const topicLags = groupProps.group.topicOffsets;
     const allAssignments = groupProps.group.members.flatMap((m) =>
-      m.assignments.map((as) => ({ member: m, topicName: as.topicName, partitions: as.partitionIds }))
+      m.assignments.map((as) => ({ member: m, topicName: as.topicName, partitions: as.partitionIds ?? [] }))
     );
 
     const lagsFlat = topicLags.flatMap((topicLag) =>


### PR DESCRIPTION
## Summary
- Guard against `partitionIds: null` in consumer group member assignments, which crashes the group details page
- Backend can return null for some consumer types (e.g. Faust consumers)
- Two null-safety fixes: optional chaining in `.sum()` aggregation and nullish coalescing in `allAssignments` mapping

Closes #2239
Closes #2087