### PR TITLE
backend: SR context support to legacy endpoints

### DIFF
--- a/backend/pkg/api/handle_schema_registry.go
+++ b/backend/pkg/api/handle_schema_registry.go
@@ -48,7 +48,7 @@ func (api *API) handleGetSchemaRegistryMode() http.HandlerFunc {
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		res, err := api.ConsoleSvc.GetSchemaRegistryMode(r.Context())
+		res, err := api.ConsoleSvc.GetSchemaRegistryMode(r.Context(), "")
 		if err != nil {
 			rest.SendRESTError(w, r, api.Logger, &rest.Error{
 				Err:      err,
@@ -102,7 +102,8 @@ func (api *API) handleGetSchemaUsagesByID() http.HandlerFunc {
 			return
 		}
 
-		res, err := api.ConsoleSvc.GetSchemaUsagesByID(r.Context(), schemaID)
+		subject := rest.GetQueryParam(r, "subject")
+		res, err := api.ConsoleSvc.GetSchemaUsagesByID(r.Context(), schemaID, subject)
 		if err != nil {
 			rest.SendRESTError(w, r, api.Logger, &rest.Error{
 				Err:      err,
@@ -248,13 +249,188 @@ func (api *API) handleDeleteSchemaRegistrySubjectConfig() http.HandlerFunc {
 	}
 }
 
+func (api *API) handleGetSchemaRegistrySubjectConfig() http.HandlerFunc {
+	if !api.Cfg.SchemaRegistry.Enabled {
+		return api.handleSchemaRegistryNotConfigured()
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		subjectName := getSubjectFromRequestPath(r)
+
+		res, err := api.ConsoleSvc.GetSchemaRegistryConfig(r.Context(), subjectName)
+		if err != nil {
+			var schemaError *sr.ResponseError
+			if errors.As(err, &schemaError) && schemaError.ErrorCode == 40401 {
+				rest.SendRESTError(w, r, api.Logger, &rest.Error{
+					Err:      err,
+					Status:   http.StatusNotFound,
+					Message:  "Requested subject does not exist",
+					IsSilent: false,
+				})
+				return
+			}
+
+			rest.SendRESTError(w, r, api.Logger, &rest.Error{
+				Err:      err,
+				Status:   http.StatusBadGateway,
+				Message:  fmt.Sprintf("Failed to retrieve subject's compatibility level: %v", err.Error()),
+				IsSilent: false,
+			})
+			return
+		}
+		rest.SendResponse(w, r, api.Logger, http.StatusOK, res)
+	}
+}
+
+func (api *API) handleGetSchemaRegistrySubjectMode() http.HandlerFunc {
+	if !api.Cfg.SchemaRegistry.Enabled {
+		return api.handleSchemaRegistryNotConfigured()
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		subjectName := getSubjectFromRequestPath(r)
+
+		res, err := api.ConsoleSvc.GetSchemaRegistryMode(r.Context(), subjectName)
+		if err != nil {
+			var schemaError *sr.ResponseError
+			if errors.As(err, &schemaError) && schemaError.ErrorCode == 40401 {
+				rest.SendRESTError(w, r, api.Logger, &rest.Error{
+					Err:      err,
+					Status:   http.StatusNotFound,
+					Message:  "Requested subject does not exist",
+					IsSilent: false,
+				})
+				return
+			}
+
+			rest.SendRESTError(w, r, api.Logger, &rest.Error{
+				Err:      err,
+				Status:   http.StatusBadGateway,
+				Message:  fmt.Sprintf("Failed to retrieve subject's mode: %v", err.Error()),
+				IsSilent: false,
+			})
+			return
+		}
+		rest.SendResponse(w, r, api.Logger, http.StatusOK, res)
+	}
+}
+
+func (api *API) handlePutSchemaRegistryMode() http.HandlerFunc {
+	if !api.Cfg.SchemaRegistry.Enabled {
+		return api.handleSchemaRegistryNotConfigured()
+	}
+
+	type request struct {
+		Mode sr.Mode `json:"mode"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		req := request{}
+		restErr := rest.Decode(w, r, &req)
+		if restErr != nil {
+			rest.SendRESTError(w, r, api.Logger, restErr)
+			return
+		}
+
+		res, err := api.ConsoleSvc.PutSchemaRegistryMode(r.Context(), req.Mode, "")
+		if err != nil {
+			rest.SendRESTError(w, r, api.Logger, &rest.Error{
+				Err:      err,
+				Status:   http.StatusBadGateway,
+				Message:  fmt.Sprintf("Failed to set global mode: %v", err.Error()),
+				IsSilent: false,
+			})
+			return
+		}
+		rest.SendResponse(w, r, api.Logger, http.StatusOK, res)
+	}
+}
+
+func (api *API) handlePutSchemaRegistrySubjectMode() http.HandlerFunc {
+	if !api.Cfg.SchemaRegistry.Enabled {
+		return api.handleSchemaRegistryNotConfigured()
+	}
+
+	type request struct {
+		Mode sr.Mode `json:"mode"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		subjectName := getSubjectFromRequestPath(r)
+
+		req := request{}
+		restErr := rest.Decode(w, r, &req)
+		if restErr != nil {
+			rest.SendRESTError(w, r, api.Logger, restErr)
+			return
+		}
+
+		res, err := api.ConsoleSvc.PutSchemaRegistryMode(r.Context(), req.Mode, subjectName)
+		if err != nil {
+			var schemaError *sr.ResponseError
+			if errors.As(err, &schemaError) && schemaError.ErrorCode == 40401 {
+				rest.SendRESTError(w, r, api.Logger, &rest.Error{
+					Err:      err,
+					Status:   http.StatusNotFound,
+					Message:  "Requested subject does not exist",
+					IsSilent: false,
+				})
+				return
+			}
+
+			rest.SendRESTError(w, r, api.Logger, &rest.Error{
+				Err:      err,
+				Status:   http.StatusBadGateway,
+				Message:  fmt.Sprintf("Failed to set subject's mode: %v", err.Error()),
+				IsSilent: false,
+			})
+			return
+		}
+		rest.SendResponse(w, r, api.Logger, http.StatusOK, res)
+	}
+}
+
+func (api *API) handleDeleteSchemaRegistrySubjectMode() http.HandlerFunc {
+	if !api.Cfg.SchemaRegistry.Enabled {
+		return api.handleSchemaRegistryNotConfigured()
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		subjectName := getSubjectFromRequestPath(r)
+
+		err := api.ConsoleSvc.DeleteSchemaRegistrySubjectMode(r.Context(), subjectName)
+		if err != nil {
+			var schemaError *sr.ResponseError
+			if errors.As(err, &schemaError) && schemaError.ErrorCode == 40401 {
+				rest.SendRESTError(w, r, api.Logger, &rest.Error{
+					Err:      err,
+					Status:   http.StatusNotFound,
+					Message:  "Requested subject does not exist",
+					IsSilent: false,
+				})
+				return
+			}
+
+			rest.SendRESTError(w, r, api.Logger, &rest.Error{
+				Err:      err,
+				Status:   http.StatusBadGateway,
+				Message:  fmt.Sprintf("Failed to delete subject's mode: %v", err.Error()),
+				IsSilent: false,
+			})
+			return
+		}
+		rest.SendResponse(w, r, api.Logger, http.StatusOK, nil)
+	}
+}
+
 func (api *API) handleGetSchemaSubjects() http.HandlerFunc {
 	if !api.Cfg.SchemaRegistry.Enabled {
 		return api.handleSchemaRegistryNotConfigured()
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		res, err := api.ConsoleSvc.GetSchemaRegistrySubjects(r.Context())
+		subjectPrefix := rest.GetQueryParam(r, "subjectPrefix")
+		res, err := api.ConsoleSvc.GetSchemaRegistrySubjects(r.Context(), subjectPrefix)
 		if err != nil {
 			rest.SendRESTError(w, r, api.Logger, &rest.Error{
 				Err:      err,
@@ -629,6 +805,7 @@ func getSubjectFromRequestPath(r *http.Request) string {
 	requestURI = strings.Replace(requestURI, r.Host, "", 1)
 	requestURI = strings.Replace(requestURI, "/api/schema-registry/subjects/", "", 1)
 	requestURI = strings.Replace(requestURI, "/api/schema-registry/config/", "", 1)
+	requestURI = strings.Replace(requestURI, "/api/schema-registry/mode/", "", 1)
 	if r.URL.RawQuery != "" {
 		requestURI = strings.TrimSuffix(requestURI, "?"+r.URL.RawQuery)
 	}

--- a/backend/pkg/api/handle_schema_registry_integration_test.go
+++ b/backend/pkg/api/handle_schema_registry_integration_test.go
@@ -427,3 +427,255 @@ func (s *APIIntegrationTestSuite) TestSchemaMetadata() {
 		assert.Nil(details.Schemas[0].Metadata, "metadata should be nil for schema without metadata")
 	})
 }
+
+func (s *APIIntegrationTestSuite) TestSchemaRegistryMode() {
+	t := s.T()
+	require := require.New(t)
+	assert := assert.New(t)
+
+	t.Run("get global mode", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer cancel()
+
+		res, body := s.apiRequest(ctx, http.MethodGet, "/api/schema-registry/mode", nil)
+		require.Equal(200, res.StatusCode)
+
+		var mode console.SchemaRegistryMode
+		err := json.Unmarshal(body, &mode)
+		require.NoError(err)
+		assert.Equal("READWRITE", mode.Mode)
+	})
+
+	t.Run("set and get global mode", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer cancel()
+
+		// Set to READONLY
+		setReq := struct {
+			Mode string `json:"mode"`
+		}{Mode: "READONLY"}
+		res, body := s.apiRequest(ctx, http.MethodPut, "/api/schema-registry/mode", setReq)
+		require.Equal(200, res.StatusCode)
+
+		var mode console.SchemaRegistryMode
+		err := json.Unmarshal(body, &mode)
+		require.NoError(err)
+		assert.Equal("READONLY", mode.Mode)
+
+		// Verify via GET
+		res, body = s.apiRequest(ctx, http.MethodGet, "/api/schema-registry/mode", nil)
+		require.Equal(200, res.StatusCode)
+
+		err = json.Unmarshal(body, &mode)
+		require.NoError(err)
+		assert.Equal("READONLY", mode.Mode)
+
+		// Restore to READWRITE
+		setReq.Mode = "READWRITE"
+		res, _ = s.apiRequest(ctx, http.MethodPut, "/api/schema-registry/mode", setReq)
+		require.Equal(200, res.StatusCode)
+	})
+
+	t.Run("set and get subject-level mode", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer cancel()
+
+		// Create a subject first
+		schemaStr := `{"type":"record","name":"ModeTest","fields":[{"name":"id","type":"int"}]}`
+		createReq := struct {
+			Schema string `json:"schema"`
+			Type   string `json:"schemaType"`
+		}{Schema: schemaStr, Type: sr.TypeAvro.String()}
+		res, _ := s.apiRequest(ctx, http.MethodPost, "/api/schema-registry/subjects/test-mode-subject/versions", createReq)
+		require.Equal(200, res.StatusCode)
+
+		// Set subject-level mode
+		setReq := struct {
+			Mode string `json:"mode"`
+		}{Mode: "READONLY"}
+		res, body := s.apiRequest(ctx, http.MethodPut, "/api/schema-registry/mode/test-mode-subject", setReq)
+		require.Equal(200, res.StatusCode)
+
+		var mode console.SchemaRegistryMode
+		err := json.Unmarshal(body, &mode)
+		require.NoError(err)
+		assert.Equal("READONLY", mode.Mode)
+
+		// Verify via GET
+		res, body = s.apiRequest(ctx, http.MethodGet, "/api/schema-registry/mode/test-mode-subject", nil)
+		require.Equal(200, res.StatusCode)
+
+		err = json.Unmarshal(body, &mode)
+		require.NoError(err)
+		assert.Equal("READONLY", mode.Mode)
+
+		// Delete subject-level mode
+		res, _ = s.apiRequest(ctx, http.MethodDelete, "/api/schema-registry/mode/test-mode-subject", nil)
+		require.Equal(200, res.StatusCode)
+	})
+}
+
+func (s *APIIntegrationTestSuite) TestSchemaRegistrySubjectConfig() {
+	t := s.T()
+	require := require.New(t)
+	assert := assert.New(t)
+
+	t.Run("get and set subject-level config", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer cancel()
+
+		// Create a subject first
+		schemaStr := `{"type":"record","name":"ConfigTest","fields":[{"name":"id","type":"int"}]}`
+		createReq := struct {
+			Schema string `json:"schema"`
+			Type   string `json:"schemaType"`
+		}{Schema: schemaStr, Type: sr.TypeAvro.String()}
+		res, _ := s.apiRequest(ctx, http.MethodPost, "/api/schema-registry/subjects/test-config-subject/versions", createReq)
+		require.Equal(200, res.StatusCode)
+
+		// Set subject-level config
+		configReq := struct {
+			Compatibility string `json:"compatibility"`
+		}{Compatibility: "FULL"}
+		res, body := s.apiRequest(ctx, http.MethodPut, "/api/schema-registry/config/test-config-subject", configReq)
+		require.Equal(200, res.StatusCode)
+
+		var cfg console.SchemaRegistryConfig
+		err := json.Unmarshal(body, &cfg)
+		require.NoError(err)
+		assert.Equal(sr.CompatFull, cfg.Compatibility)
+
+		// Verify via GET
+		res, body = s.apiRequest(ctx, http.MethodGet, "/api/schema-registry/config/test-config-subject", nil)
+		require.Equal(200, res.StatusCode)
+
+		err = json.Unmarshal(body, &cfg)
+		require.NoError(err)
+		assert.Equal(sr.CompatFull, cfg.Compatibility)
+
+		// Delete subject-level config
+		res, _ = s.apiRequest(ctx, http.MethodDelete, "/api/schema-registry/config/test-config-subject", nil)
+		require.Equal(200, res.StatusCode)
+	})
+}
+
+func (s *APIIntegrationTestSuite) TestSchemaRegistrySubjectPrefix() {
+	t := s.T()
+	require := require.New(t)
+	assert := assert.New(t)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	// Create two subjects with a common prefix
+	subjects := []struct {
+		subject    string
+		recordName string
+	}{
+		{"prefix-orders-value", "PrefixOrders"},
+		{"prefix-users-value", "PrefixUsers"},
+	}
+	for _, subj := range subjects {
+		schemaStr := fmt.Sprintf(`{"type":"record","name":"%s","fields":[{"name":"id","type":"int"}]}`, subj.recordName)
+		createReq := struct {
+			Schema string `json:"schema"`
+			Type   string `json:"schemaType"`
+		}{Schema: schemaStr, Type: sr.TypeAvro.String()}
+		res, _ := s.apiRequest(ctx, http.MethodPost, "/api/schema-registry/subjects/"+subj.subject+"/versions", createReq)
+		require.Equal(200, res.StatusCode)
+	}
+
+	t.Run("list subjects with matching prefix", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer cancel()
+
+		res, body := s.apiRequest(ctx, http.MethodGet, "/api/schema-registry/subjects?subjectPrefix=prefix-", nil)
+		require.Equal(200, res.StatusCode)
+
+		var subjects []console.SchemaRegistrySubject
+		err := json.Unmarshal(body, &subjects)
+		require.NoError(err)
+		assert.Len(subjects, 2)
+
+		names := make([]string, len(subjects))
+		for i, s := range subjects {
+			names[i] = s.Name
+		}
+		assert.Contains(names, "prefix-orders-value")
+		assert.Contains(names, "prefix-users-value")
+	})
+
+	t.Run("list subjects with non-matching prefix", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer cancel()
+
+		res, body := s.apiRequest(ctx, http.MethodGet, "/api/schema-registry/subjects?subjectPrefix=nonexistent-", nil)
+		require.Equal(200, res.StatusCode)
+
+		var subjects []console.SchemaRegistrySubject
+		err := json.Unmarshal(body, &subjects)
+		require.NoError(err)
+		assert.Empty(subjects)
+	})
+}
+
+func (s *APIIntegrationTestSuite) TestSchemaUsagesByIDSubjectFilter() {
+	t := s.T()
+	require := require.New(t)
+	assert := assert.New(t)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	// Create a schema so we have a known ID
+	schemaStr := `{"type":"record","name":"UsageTest","fields":[{"name":"id","type":"int"}]}`
+	createReq := struct {
+		Schema string `json:"schema"`
+		Type   string `json:"schemaType"`
+	}{Schema: schemaStr, Type: sr.TypeAvro.String()}
+	res, body := s.apiRequest(ctx, http.MethodPost, "/api/schema-registry/subjects/usage-test-value/versions", createReq)
+	require.Equal(200, res.StatusCode)
+
+	createResponse := struct {
+		ID int `json:"id"`
+	}{}
+	err := json.Unmarshal(body, &createResponse)
+	require.NoError(err)
+	schemaID := createResponse.ID
+
+	t.Run("get usages without subject filter", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer cancel()
+
+		res, body := s.apiRequest(ctx, http.MethodGet, fmt.Sprintf("/api/schema-registry/schemas/ids/%d/versions", schemaID), nil)
+		require.Equal(200, res.StatusCode)
+
+		type schemaVersion struct {
+			Subject string `json:"subject"`
+			Version int    `json:"version"`
+		}
+		var versions []schemaVersion
+		err := json.Unmarshal(body, &versions)
+		require.NoError(err)
+		require.NotEmpty(versions)
+		assert.Equal("usage-test-value", versions[0].Subject)
+	})
+
+	t.Run("get usages with matching subject filter", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer cancel()
+
+		res, body := s.apiRequest(ctx, http.MethodGet, fmt.Sprintf("/api/schema-registry/schemas/ids/%d/versions?subject=usage-test-value", schemaID), nil)
+		require.Equal(200, res.StatusCode)
+
+		type schemaVersion struct {
+			Subject string `json:"subject"`
+			Version int    `json:"version"`
+		}
+		var versions []schemaVersion
+		err := json.Unmarshal(body, &versions)
+		require.NoError(err)
+		require.Len(versions, 1)
+		assert.Equal("usage-test-value", versions[0].Subject)
+	})
+}

--- a/backend/pkg/api/handle_schema_registry_test.go
+++ b/backend/pkg/api/handle_schema_registry_test.go
@@ -47,6 +47,11 @@ func Test_getSubjectFromRequestPath(t *testing.T) {
 			expected: "asdf",
 		},
 		{
+			name:     "with qualified subject",
+			target:   "http://example.com/api/schema-registry/subjects/:.myctx:foobar",
+			expected: ":.myctx:foobar",
+		},
+		{
 			name:     "with slashes",
 			target:   "http://example.com/api/schema-registry/subjects/common%2Ffolder%2Fenvelope.proto/versions/last",
 			expected: "common/folder/envelope.proto",
@@ -105,6 +110,21 @@ func Test_getSubjectFromRequestPath(t *testing.T) {
 			name:     "with query",
 			target:   "https://console-123.cn456.fmc.ppd.cloud.redpanda.com/api/schema-registry/subjects/repro?permanent=false",
 			expected: "repro",
+		},
+		{
+			name:     "mode path no special characters",
+			target:   "http://example.com/api/schema-registry/mode/my-subject",
+			expected: "my-subject",
+		},
+		{
+			name:     "mode path with %252F",
+			target:   "http://example.com/api/schema-registry/mode/with%252Fslash",
+			expected: "with%2Fslash",
+		},
+		{
+			name:     "mode path qualified subject (context)",
+			target:   "http://example.com/api/schema-registry/mode/%3A.staging%3Atest-value",
+			expected: ":.staging:test-value",
 		},
 	}
 

--- a/backend/pkg/api/routes.go
+++ b/backend/pkg/api/routes.go
@@ -634,8 +634,13 @@ func (api *API) routes() *chi.Mux {
 
 				// Schema Registry
 				r.Get("/schema-registry/mode", api.handleGetSchemaRegistryMode())
+				r.Put("/schema-registry/mode", api.handlePutSchemaRegistryMode())
+				r.Get("/schema-registry/mode/{subject}", api.handleGetSchemaRegistrySubjectMode())
+				r.Put("/schema-registry/mode/{subject}", api.handlePutSchemaRegistrySubjectMode())
+				r.Delete("/schema-registry/mode/{subject}", api.handleDeleteSchemaRegistrySubjectMode())
 				r.Get("/schema-registry/config", api.handleGetSchemaRegistryConfig())
 				r.Put("/schema-registry/config", api.handlePutSchemaRegistryConfig())
+				r.Get("/schema-registry/config/{subject}", api.handleGetSchemaRegistrySubjectConfig())
 				r.Put("/schema-registry/config/{subject}", api.handlePutSchemaRegistrySubjectConfig())
 				r.Delete("/schema-registry/config/{subject}", api.handleDeleteSchemaRegistrySubjectConfig())
 				r.Get("/schema-registry/subjects", api.handleGetSchemaSubjects())

--- a/backend/pkg/console/schema_registry.go
+++ b/backend/pkg/console/schema_registry.go
@@ -43,19 +43,47 @@ type SchemaRegistrySubject struct {
 	IsSoftDeleted bool   `json:"isSoftDeleted"`
 }
 
-// GetSchemaRegistryMode retrieves the schema registry mode.
-func (s *Service) GetSchemaRegistryMode(ctx context.Context) (*SchemaRegistryMode, error) {
+// GetSchemaRegistryMode retrieves the schema registry mode. The global mode
+// can be retrieved by using an empty subject.
+func (s *Service) GetSchemaRegistryMode(ctx context.Context, subject string) (*SchemaRegistryMode, error) {
 	srClient, err := s.schemaClientFactory.GetSchemaRegistryClient(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	modeResult := srClient.Mode(ctx)
+	modeResult := srClient.Mode(ctx, subject)
 	mode := modeResult[0]
 	if err := mode.Err; err != nil {
 		return nil, fmt.Errorf("failed to get mode: %w", err)
 	}
 	return &SchemaRegistryMode{Mode: mode.Mode.String()}, nil
+}
+
+// PutSchemaRegistryMode sets the mode for the given subject or globally if
+// subject is empty.
+func (s *Service) PutSchemaRegistryMode(ctx context.Context, mode sr.Mode, subject string) (*SchemaRegistryMode, error) {
+	srClient, err := s.schemaClientFactory.GetSchemaRegistryClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	modeResult := srClient.SetMode(ctx, mode, subject)
+	result := modeResult[0]
+	if err := result.Err; err != nil {
+		return nil, fmt.Errorf("failed to set mode: %w", err)
+	}
+	return &SchemaRegistryMode{Mode: result.Mode.String()}, nil
+}
+
+// DeleteSchemaRegistrySubjectMode deletes the subject's or context's mode override.
+func (s *Service) DeleteSchemaRegistrySubjectMode(ctx context.Context, subject string) error {
+	srClient, err := s.schemaClientFactory.GetSchemaRegistryClient(ctx)
+	if err != nil {
+		return err
+	}
+	modeResult := srClient.ResetMode(ctx, subject)
+	result := modeResult[0]
+	return result.Err
 }
 
 // GetSchemaRegistryConfig returns the schema registry config which currently
@@ -106,8 +134,9 @@ func (s *Service) DeleteSchemaRegistrySubjectConfig(ctx context.Context, subject
 }
 
 // GetSchemaRegistrySubjects returns a list of all register subjects. The list includes
-// soft-deleted subjects.
-func (s *Service) GetSchemaRegistrySubjects(ctx context.Context) ([]SchemaRegistrySubject, error) {
+// soft-deleted subjects. If subjectPrefix is non-empty, only subjects matching
+// the prefix are returned (supports context-aware filtering, e.g. ":.prod:").
+func (s *Service) GetSchemaRegistrySubjects(ctx context.Context, subjectPrefix string) ([]SchemaRegistrySubject, error) {
 	srClient, err := s.schemaClientFactory.GetSchemaRegistryClient(ctx)
 	if err != nil {
 		return nil, err
@@ -116,9 +145,18 @@ func (s *Service) GetSchemaRegistrySubjects(ctx context.Context) ([]SchemaRegist
 	subjects := make(map[string]struct{})
 	subjectsWithDeleted := make(map[string]struct{})
 
+	var prefixParams []sr.Param
+	if subjectPrefix != "" {
+		prefixParams = append(prefixParams, sr.SubjectPrefix(subjectPrefix))
+	}
+
 	grp, grpCtx := errgroup.WithContext(ctx)
 	grp.Go(func() error {
-		res, err := srClient.Subjects(grpCtx)
+		callCtx := grpCtx
+		if len(prefixParams) > 0 {
+			callCtx = sr.WithParams(grpCtx, prefixParams...)
+		}
+		res, err := srClient.Subjects(callCtx)
 		if err != nil {
 			return err
 		}
@@ -128,7 +166,8 @@ func (s *Service) GetSchemaRegistrySubjects(ctx context.Context) ([]SchemaRegist
 		return nil
 	})
 	grp.Go(func() error {
-		res, err := srClient.Subjects(sr.WithParams(grpCtx, sr.ShowDeleted))
+		params := append([]sr.Param{sr.ShowDeleted}, prefixParams...)
+		res, err := srClient.Subjects(sr.WithParams(grpCtx, params...))
 		if err != nil {
 			return err
 		}
@@ -745,14 +784,18 @@ type SchemaVersion struct {
 	Version int    `json:"version"`
 }
 
-// GetSchemaUsagesByID registers a new schema for the given subject in the schema registry.
-func (s *Service) GetSchemaUsagesByID(ctx context.Context, schemaID int) ([]SchemaVersion, error) {
+// GetSchemaUsagesByID returns all subject-versions that use a given schema ID.
+func (s *Service) GetSchemaUsagesByID(ctx context.Context, schemaID int, subject string) ([]SchemaVersion, error) {
 	srClient, err := s.schemaClientFactory.GetSchemaRegistryClient(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	res, err := srClient.SchemaUsagesByID(ctx, schemaID)
+	callCtx := ctx
+	if subject != "" {
+		callCtx = sr.WithParams(ctx, sr.Subject(subject))
+	}
+	res, err := srClient.SchemaUsagesByID(callCtx, schemaID)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/console/servicer.go
+++ b/backend/pkg/console/servicer.go
@@ -90,11 +90,13 @@ type Servicer interface {
 
 // SchemaRegistryServicer is the interface for schema registry servicer
 type SchemaRegistryServicer interface {
-	GetSchemaRegistryMode(ctx context.Context) (*SchemaRegistryMode, error)
+	GetSchemaRegistryMode(ctx context.Context, subject string) (*SchemaRegistryMode, error)
+	PutSchemaRegistryMode(ctx context.Context, mode sr.Mode, subject string) (*SchemaRegistryMode, error)
+	DeleteSchemaRegistrySubjectMode(ctx context.Context, subject string) error
 	GetSchemaRegistryConfig(ctx context.Context, subject string) (*SchemaRegistryConfig, error)
 	PutSchemaRegistryConfig(ctx context.Context, subject string, compatibility sr.SetCompatibility) (*SchemaRegistryConfig, error)
 	DeleteSchemaRegistrySubjectConfig(ctx context.Context, subject string) error
-	GetSchemaRegistrySubjects(ctx context.Context) ([]SchemaRegistrySubject, error)
+	GetSchemaRegistrySubjects(ctx context.Context, subjectPrefix string) ([]SchemaRegistrySubject, error)
 	GetSchemaRegistrySubjectDetails(ctx context.Context, subjectName string, version string) (*SchemaRegistrySubjectDetails, error)
 	GetSchemaRegistrySchemaReferencedBy(ctx context.Context, subjectName string, version int) ([]SchemaReference, error)
 	DeleteSchemaRegistrySubject(ctx context.Context, subjectName string, deletePermanently bool) (*SchemaRegistryDeleteSubjectResponse, error)
@@ -102,7 +104,7 @@ type SchemaRegistryServicer interface {
 	GetSchemaRegistrySchemaTypes(ctx context.Context) (*SchemaRegistrySchemaTypes, error)
 	CreateSchemaRegistrySchema(ctx context.Context, subjectName string, schema sr.Schema, params CreateSchemaRequestParams) (*CreateSchemaResponse, error)
 	ValidateSchemaRegistrySchema(ctx context.Context, subjectName string, version int, schema sr.Schema) (*SchemaRegistrySchemaValidation, error)
-	GetSchemaUsagesByID(ctx context.Context, schemaID int) ([]SchemaVersion, error)
+	GetSchemaUsagesByID(ctx context.Context, schemaID int, subject string) ([]SchemaVersion, error)
 
 	// Custom Redpanda-only methods for managing ACLs within the schema registry.
 


### PR DESCRIPTION
This adds the backend support to the legacy endpoints for Schema Registry Context AND Schema Registry Mode. Also updates existing endpoints' behavior to receive query parameters and pass them down to the SR.

Summary of the changes:

### New Routes

| Route | Method | Description |
|-------|--------|-------------|
| `/api/schema-registry/mode` | `PUT` | Set global mode |
| `/api/schema-registry/mode/{subject}` | `GET` | Get mode for subject/context |
| `/api/schema-registry/mode/{subject}` | `PUT` | Set mode for subject/context |
| `/api/schema-registry/mode/{subject}` | `DELETE` | Delete mode override for subject |
| `/api/schema-registry/config/{subject}` | `GET` | Get config for subject/context |

### Modified Routes

| Route | Method | Change |
|-------|--------|--------|
| `/api/schema-registry/subjects` | `GET` | New query param: `subjectPrefix` (e.g. `:.staging:`, `:*:`) |
| `/api/schema-registry/schemas/ids/{id}/versions` | `GET` | New query param: `subject` |

### Existing Routes (no code changes needed)

| Route | Method | Notes |
|-------|--------|-------|
| `/api/schema-registry/config/{subject}` | `PUT` | Already handles qualified subjects |
| `/api/schema-registry/config/{subject}` | `DELETE` | Already handles qualified subjects |
| `/api/schema-registry/mode` | `GET` | Updated internally to pass `""` for global mode |
