### PR TITLE
fix: skip secret validation for hidden PASSWORD fields

### DIFF
--- a/frontend/src/state/connect/state.ts
+++ b/frontend/src/state/connect/state.ts
@@ -880,7 +880,7 @@ export class ConnectorPropertiesStore {
             | string[];
         }
 
-        if (p.definition.type === DataType.Password && !!this.secrets) {
+        if (p.definition.type === DataType.Password && !!this.secrets && p.value.visible) {
           const secret = this.secrets.getSecret(property.name);
           secret.extractSecretId(String(property.value));
 


### PR DESCRIPTION
## Summary

- Fixes MM2 connector creation failing with: `Secret value for key source.cluster.sasl.jaas.config is empty`
- Hidden PASSWORD fields (`visible: false`) are auto-generated by the backend hook (`ConsoleToKafkaConnectMirrorSourceHook`), but the frontend was registering them in the SecretsStore and requiring a non-empty value
- Only register visible PASSWORD fields in the SecretsStore, letting the backend generate hidden ones