### PR TITLE
fix: fixed pipeline component names on pipelines list page

### DIFF
--- a/frontend/src/components/pages/rp-connect/utils/yaml.test.tsx
+++ b/frontend/src/components/pages/rp-connect/utils/yaml.test.tsx
@@ -722,6 +722,228 @@ output:
     });
   });
 
+  describe('label sibling handling', () => {
+    test('skips label on single input and returns component name', () => {
+      const yaml = `
+input:
+  label: ""
+  generate:
+    mapping: ""
+    interval: 1s
+    count: 0
+    batch_size: 0
+
+output:
+  drop: {}
+`;
+      const result = parseConfigComponents(yaml);
+      expect(result.inputs).toEqual(['generate']);
+    });
+
+    test('skips label on single output and returns component name', () => {
+      const yaml = `
+input:
+  generate:
+    mapping: 'root = {}'
+
+output:
+  label: ""
+  redpanda:
+    topic: test
+    key: ""
+`;
+      const result = parseConfigComponents(yaml);
+      expect(result.outputs).toEqual(['redpanda']);
+    });
+
+    test('skips label on both input and output', () => {
+      const yaml = `
+input:
+  label: ""
+  generate:
+    mapping: ""
+    interval: 1s
+    count: 0
+    batch_size: 0
+    auto_replay_nacks: false
+
+output:
+  label: ""
+  redpanda:
+    tls:
+      client_certs:
+        - key: ""
+          password: \${secrets.KAFKA_PASSWORD_USER}
+    sasl:
+      - mechanism: SCRAM-SHA-256
+        username: \${secrets.KAFKA_USER_USER}
+        password: \${secrets.KAFKA_PASSWORD_USER}
+    topic: test
+    key: ""
+    partition: ""
+    max_in_flight: 0
+`;
+      const result = parseConfigComponents(yaml);
+      expect(result.inputs).toEqual(['generate']);
+      expect(result.outputs).toEqual(['redpanda']);
+    });
+
+    test('skips label on processor items', () => {
+      const yaml = `
+input:
+  generate:
+    mapping: 'root = {}'
+
+pipeline:
+  processors:
+    - label: "enrichment"
+      branch:
+        request_map: 'root = this.doc.id'
+        processors:
+          - http:
+              url: http://example.com
+        result_map: 'root.enriched = this'
+    - label: "transform"
+      mapping: 'root.processed = true'
+
+output:
+  drop: {}
+`;
+      const result = parseConfigComponents(yaml);
+      expect(result.processors).toEqual(['branch', 'mapping']);
+    });
+
+    test('skips label on broker child inputs', () => {
+      const yaml = `
+input:
+  broker:
+    inputs:
+      - label: "source_a"
+        kafka:
+          addresses:
+            - localhost:9092
+          topics:
+            - events
+      - label: "source_b"
+        amqp_0_9:
+          urls:
+            - amqp://guest:guest@localhost:5672/
+          queue: orders
+
+output:
+  drop: {}
+`;
+      const result = parseConfigComponents(yaml);
+      expect(result.inputs).toEqual(['kafka', 'amqp_0_9']);
+    });
+
+    test('skips label on broker child outputs', () => {
+      const yaml = `
+output:
+  broker:
+    pattern: fan_out
+    outputs:
+      - label: "primary"
+        kafka:
+          addresses:
+            - localhost:9092
+          topic: topic_a
+      - label: "secondary"
+        http_client:
+          url: http://example.com/post
+`;
+      const result = parseConfigComponents(yaml);
+      expect(result.outputs).toEqual(['kafka', 'http_client']);
+    });
+
+    test('skips label on fallback child outputs', () => {
+      const yaml = `
+output:
+  fallback:
+    - label: "primary"
+      http_client:
+        url: http://foo:4195/post
+        retries: 3
+    - label: "backup"
+      file:
+        path: /usr/local/benthos/failed.jsonl
+`;
+      const result = parseConfigComponents(yaml);
+      expect(result.outputs).toEqual(['http_client', 'file']);
+    });
+
+    test('skips label on switch case outputs', () => {
+      const yaml = `
+output:
+  switch:
+    cases:
+      - check: this.type == "foo"
+        output:
+          label: "foo_output"
+          amqp_1:
+            urls:
+              - amqps://guest:guest@localhost:5672/
+            target_address: queue:/the_foos
+      - check: this.type == "bar"
+        output:
+          label: "bar_output"
+          gcp_pubsub:
+            project: dealing_with_mike
+            topic: mikes_bars
+`;
+      const result = parseConfigComponents(yaml);
+      expect(result.outputs).toEqual(['amqp_1', 'gcp_pubsub']);
+    });
+
+    test('full pipeline with labels everywhere', () => {
+      const yaml = `
+input:
+  label: "my_input"
+  broker:
+    inputs:
+      - label: "source_1"
+        kafka:
+          addresses:
+            - localhost:9092
+          topics:
+            - events
+      - label: "source_2"
+        generate:
+          mapping: 'root = {}'
+
+pipeline:
+  processors:
+    - label: "step_1"
+      mapping: 'root.processed = true'
+    - label: "step_2"
+      branch:
+        request_map: 'root = this.id'
+        processors:
+          - http:
+              url: http://example.com
+        result_map: 'root.enriched = this'
+
+output:
+  label: "my_output"
+  broker:
+    pattern: fan_out
+    outputs:
+      - label: "dest_1"
+        kafka:
+          addresses:
+            - localhost:9092
+          topic: processed_events
+      - label: "dest_2"
+        http_client:
+          url: http://example.com/webhook
+`;
+      const result = parseConfigComponents(yaml);
+      expect(result.inputs).toEqual(['kafka', 'generate']);
+      expect(result.processors).toEqual(['mapping', 'branch']);
+      expect(result.outputs).toEqual(['kafka', 'http_client']);
+    });
+  });
+
   describe('edge cases', () => {
     test('returns empty for empty string', () => {
       const result = parseConfigComponents('');

--- a/frontend/src/components/pages/rp-connect/utils/yaml.ts
+++ b/frontend/src/components/pages/rp-connect/utils/yaml.ts
@@ -519,9 +519,35 @@ export const getConnectTemplate = ({
 // Config Component Parsing (used by pipeline list)
 // ============================================================================
 
-/** Extract the first key from an object, or undefined if not a valid object. */
-const firstKey = (obj: unknown): string | undefined =>
-  obj && typeof obj === 'object' && !Array.isArray(obj) ? Object.keys(obj)[0] : undefined;
+/**
+ * Keys that can appear as siblings to the actual component name in a Connect
+ * component config object (e.g. `label` next to `generate` inside `input:`).
+ */
+const RESERVED_COMPONENT_KEYS = new Set(['label']);
+
+/**
+ * Processors whose configs contain nested child `processors` arrays.
+ * We intentionally do not recurse into these when extracting processor names
+ * for the pipeline list display.
+ */
+export const PROCESSORS_WITH_NESTED_STEPS = [
+  'branch',
+  'catch',
+  'for_each',
+  'parallel',
+  'switch',
+  'try',
+  'while',
+  'workflow',
+] as const;
+
+/** Extract the component name from an object, skipping reserved metadata keys like `label`. */
+const componentName = (obj: unknown): string | undefined => {
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) {
+    return;
+  }
+  return Object.keys(obj).find((k) => !RESERVED_COMPONENT_KEYS.has(k));
+};
 
 /** Extract child input names from a multi-input component (broker, sequence). */
 const parseMultiInputs = (inputKey: string, value: unknown): string[] | undefined => {
@@ -535,7 +561,7 @@ const parseMultiInputs = (inputKey: string, value: unknown): string[] | undefine
   ) {
     const items = (value as { inputs?: unknown[] }).inputs;
     if (Array.isArray(items)) {
-      return items.map(firstKey).filter((k): k is string => !!k);
+      return items.map(componentName).filter((k): k is string => !!k);
     }
   }
 
@@ -548,7 +574,7 @@ const parseMultiOutputs = (outputKey: string, value: unknown): string[] | undefi
   if (outputKey === 'broker' && value && typeof value === 'object' && !Array.isArray(value) && 'outputs' in value) {
     const items = (value as { outputs?: unknown[] }).outputs;
     if (Array.isArray(items)) {
-      return items.map(firstKey).filter((k): k is string => !!k);
+      return items.map(componentName).filter((k): k is string => !!k);
     }
   }
 
@@ -556,13 +582,13 @@ const parseMultiOutputs = (outputKey: string, value: unknown): string[] | undefi
   if (outputKey === 'switch' && value && typeof value === 'object' && !Array.isArray(value) && 'cases' in value) {
     const cases = (value as { cases?: { output?: unknown }[] }).cases;
     if (Array.isArray(cases)) {
-      return cases.map((c) => firstKey(c.output)).filter((k): k is string => !!k);
+      return cases.map((c) => componentName(c.output)).filter((k): k is string => !!k);
     }
   }
 
   // fallback: the value itself is an array of output objects
   if (outputKey === 'fallback' && Array.isArray(value)) {
-    return value.map(firstKey).filter((k): k is string => !!k);
+    return value.map(componentName).filter((k): k is string => !!k);
   }
 
   return;
@@ -594,13 +620,13 @@ export const parseConfigComponents = (configYaml: string): ParsedConfigComponent
     }
 
     const processors = Array.isArray(config.pipeline?.processors)
-      ? config.pipeline.processors.map(firstKey).filter((p): p is string => !!p)
+      ? config.pipeline.processors.map(componentName).filter((p): p is string => !!p)
       : [];
 
     const inputObj = config.input;
     let inputs: string[] = [];
     if (inputObj && typeof inputObj === 'object') {
-      const inputKey = firstKey(inputObj);
+      const inputKey = componentName(inputObj);
       if (inputKey) {
         inputs = parseMultiInputs(inputKey, inputObj[inputKey]) ?? [inputKey];
       }
@@ -609,7 +635,7 @@ export const parseConfigComponents = (configYaml: string): ParsedConfigComponent
     const outputObj = config.output;
     let outputs: string[] = [];
     if (outputObj && typeof outputObj === 'object') {
-      const outputKey = firstKey(outputObj);
+      const outputKey = componentName(outputObj);
       if (outputKey) {
         outputs = parseMultiOutputs(outputKey, outputObj[outputKey]) ?? [outputKey];
       }


### PR DESCRIPTION
Connect pipeline list was showing `label` for some component names because the config parsing logic was picking up the first key in a component config, but template output `label` as the first key, so needed to add an exclusion when parsing. 

Before
<img width="1494" height="659" alt="Screenshot 2026-03-04 at 8 46 14 AM" src="https://github.com/user-attachments/assets/392898e5-d861-4751-8af8-e071fc2683ab" />


After
<img width="1502" height="657" alt="Screenshot 2026-03-04 at 8 45 56 AM" src="https://github.com/user-attachments/assets/02ce3685-7391-4084-b332-61e21753507c" />
