### PR TITLE
feat: add Netlify deployment config for Console frontend

### DIFF
--- a/frontend/netlify.toml
+++ b/frontend/netlify.toml
@@ -1,0 +1,32 @@
+[build]
+  base = "frontend"
+  command = "bun install && NODE_OPTIONS=--max_old_space_size=16384 bun run build"
+  publish = "build"
+
+[build.environment]
+  NODE_VERSION = "22"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Access-Control-Allow-Origin = "*"
+    Access-Control-Allow-Methods = "GET, OPTIONS"
+    Access-Control-Allow-Headers = "*"
+    X-Content-Type-Options = "nosniff"
+
+# MF remote entry and manifest must never be cached
+[[headers]]
+  for = "/embedded.js"
+  [headers.values]
+    Cache-Control = "no-cache, no-store, must-revalidate"
+
+[[headers]]
+  for = "/mf-manifest.json"
+  [headers.values]
+    Cache-Control = "no-cache, no-store, must-revalidate"
+
+# Hashed static assets are immutable
+[[headers]]
+  for = "/static/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"

--- a/frontend/netlify.toml
+++ b/frontend/netlify.toml
@@ -1,5 +1,7 @@
 [build]
   base = "frontend"
+  # NODE_OPTIONS: 16 GB is a V8 heap ceiling guard, not actual memory usage.
+  # It prevents OOM kills during large builds; real RSS stays well below this.
   command = "bun install && NODE_OPTIONS=--max_old_space_size=16384 bun run build"
   publish = "build"
 
@@ -9,24 +11,34 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Access-Control-Allow-Origin = "*"
-    Access-Control-Allow-Methods = "GET, OPTIONS"
-    Access-Control-Allow-Headers = "*"
     X-Content-Type-Options = "nosniff"
 
-# MF remote entry and manifest must never be cached
+# MF remote entry — never cached, CORS required for cross-origin import
 [[headers]]
   for = "/embedded.js"
   [headers.values]
     Cache-Control = "no-cache, no-store, must-revalidate"
+    Access-Control-Allow-Origin = "*"
+    Access-Control-Allow-Methods = "GET, OPTIONS"
+    Access-Control-Allow-Headers = "*"
+    Access-Control-Max-Age = "86400"
 
+# MF manifest — never cached, CORS required for cross-origin fetch
 [[headers]]
   for = "/mf-manifest.json"
   [headers.values]
     Cache-Control = "no-cache, no-store, must-revalidate"
+    Access-Control-Allow-Origin = "*"
+    Access-Control-Allow-Methods = "GET, OPTIONS"
+    Access-Control-Allow-Headers = "*"
+    Access-Control-Max-Age = "86400"
 
-# Hashed static assets are immutable
+# Hashed static assets are immutable, CORS required for cross-origin import
 [[headers]]
   for = "/static/*"
   [headers.values]
     Cache-Control = "public, max-age=31536000, immutable"
+    Access-Control-Allow-Origin = "*"
+    Access-Control-Allow-Methods = "GET, OPTIONS"
+    Access-Control-Allow-Headers = "*"
+    Access-Control-Max-Age = "86400"

--- a/frontend/netlify.toml
+++ b/frontend/netlify.toml
@@ -7,7 +7,7 @@
 
 [build.environment]
   NODE_VERSION = "22"
-  BUN_VERSION = "1.3"
+  BUN_VERSION = "1.3.11"
 
 [[headers]]
   for = "/*"

--- a/frontend/netlify.toml
+++ b/frontend/netlify.toml
@@ -1,8 +1,8 @@
 [build]
   base = "frontend"
-  # NODE_OPTIONS: 16 GB is a V8 heap ceiling guard, not actual memory usage.
+  # NODE_OPTIONS: 4 GB is a V8 heap ceiling guard, not actual memory usage.
   # It prevents OOM kills during large builds; real RSS stays well below this.
-  command = "bun install && NODE_OPTIONS=--max_old_space_size=16384 bun run build"
+  command = "bun install && NODE_OPTIONS=--max_old_space_size=4096 bun run build"
   publish = "build"
 
 [build.environment]

--- a/frontend/netlify.toml
+++ b/frontend/netlify.toml
@@ -7,6 +7,7 @@
 
 [build.environment]
   NODE_VERSION = "22"
+  BUN_VERSION = "1.3"
 
 [[headers]]
   for = "/*"

--- a/frontend/public/_redirects
+++ b/frontend/public/_redirects
@@ -1,0 +1,3 @@
+# SPA fallback for standalone mode. In embedded (MF) mode, only
+# remoteEntry.js/embedded.js and chunks are fetched.
+/*    /index.html   200

--- a/frontend/src/federation/console-app.tsx
+++ b/frontend/src/federation/console-app.tsx
@@ -289,7 +289,11 @@ function ConsoleAppInner({
     if (navigateTo !== currentPath) {
       // Update ref to prevent echo back to host
       lastNotifiedPathRef.current = navigateTo;
-      router.navigate({ to: navigateTo });
+      const [toPath, toSearch] = navigateTo.split('?');
+      router.navigate({
+        to: toPath,
+        search: toSearch ? Object.fromEntries(new URLSearchParams(toSearch)) : undefined,
+      });
     }
   }, [navigateTo, isInitialized, router]);
 

--- a/frontend/src/federation/console-app.tsx
+++ b/frontend/src/federation/console-app.tsx
@@ -289,7 +289,9 @@ function ConsoleAppInner({
     if (navigateTo !== currentPath) {
       // Update ref to prevent echo back to host
       lastNotifiedPathRef.current = navigateTo;
-      const [toPath, toSearch] = navigateTo.split('?');
+      const qIdx = navigateTo.indexOf('?');
+      const toPath = qIdx >= 0 ? navigateTo.slice(0, qIdx) : navigateTo;
+      const toSearch = qIdx >= 0 ? navigateTo.slice(qIdx + 1) : undefined;
       router.navigate({
         to: toPath,
         search: toSearch ? Object.fromEntries(new URLSearchParams(toSearch)) : undefined,


### PR DESCRIPTION
## Summary

Add Netlify deployment configuration for Console frontend, enabling it to be deployed as a static site alongside the existing Go HTTP server deployment.

## What's included

- **`frontend/netlify.toml`** — Build config, CORS headers for cross-origin MF loading, cache control
- **`frontend/public/_redirects`** — SPA fallback for standalone mode

## How it works

Console frontend assets can now be deployed to a Netlify site (e.g., `redpanda-console-ui`). Cloud UI loads the assets from Netlify when `REACT_APP_CONSOLE_FRONTEND_URL` is set, with automatic fallback to the cluster's Go HTTP server when Netlify is unreachable.

### Deployment modes

| Mode | Source | When |
|------|--------|------|
| Netlify (new) | `REACT_APP_CONSOLE_FRONTEND_URL/mf-manifest.json` | Env var set + MF v2 enabled |
| Cluster pod (existing) | `cluster.redpandaConsole.url/embedded.js` | Fallback or no env var |
| Local dev | `REACT_APP_CONSOLE_FRONTEND_URL_OVERRIDE/embedded.js` | Dev override |

### Fallback chain (implemented in Cloud UI)

1. Try Netlify URL (MF v2 manifest)
2. If unreachable → try cluster URL (MF v2 embedded.js)
3. If MF v2 unavailable → load legacy Injector (MF v1)
4. Private-only clusters skip Netlify entirely

## Prerequisites

- Console MF v2 search params fix: #2361
- Cloud UI support: redpanda-data/cloudv2#25386
- `enable-console-mf-v2` feature flag enabled in LaunchDarkly

## Test plan

- [x] `bun run build` produces correct output in `build/` (embedded.js, mf-manifest.json, static assets)
- [x] Netlify deploy preview builds successfully
- [x] CORS headers present on `embedded.js` and `mf-manifest.json`
- [x] `_redirects` SPA fallback works for standalone navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)