### PR TITLE
serverless: allow password edit

### DIFF
--- a/frontend/src/components/pages/acls/acl-list.tsx
+++ b/frontend/src/components/pages/acls/acl-list.tsx
@@ -591,7 +591,7 @@ const UsersTab = ({ isAdminApiConfigured }: { isAdminApiConfigured: boolean }) =
                 header: '',
                 cell: (ctx) => {
                   const entry = ctx.row.original;
-                  return <UserActions isAdminApiConfigured={isAdminApiConfigured} user={entry} />;
+                  return <UserActions user={entry} />;
                 },
               },
             ]}
@@ -615,7 +615,7 @@ const UsersTab = ({ isAdminApiConfigured }: { isAdminApiConfigured: boolean }) =
   );
 };
 
-const UserActions = ({ user, isAdminApiConfigured }: { user: UsersEntry; isAdminApiConfigured: boolean }) => {
+const UserActions = ({ user }: { user: UsersEntry }) => {
   const featureRolesApi = useSupportedFeaturesStore((s) => s.rolesApi);
   const [isChangePasswordModalOpen, setIsChangePasswordModalOpen] = useState(false);
   const [isChangeRolesModalOpen, setIsChangeRolesModalOpen] = useState(false);

--- a/frontend/src/components/pages/acls/acl-list.tsx
+++ b/frontend/src/components/pages/acls/acl-list.tsx
@@ -641,13 +641,11 @@ const UserActions = ({ user, isAdminApiConfigured }: { user: UsersEntry; isAdmin
 
   return (
     <>
-      {Boolean(isAdminApiConfigured) && !isServerless() && (
-        <ChangePasswordModal
-          isOpen={isChangePasswordModalOpen}
-          setIsOpen={setIsChangePasswordModalOpen}
-          userName={user.name}
-        />
-      )}
+      <ChangePasswordModal
+        isOpen={isChangePasswordModalOpen}
+        setIsOpen={setIsChangePasswordModalOpen}
+        userName={user.name}
+      />
       {Boolean(featureRolesApi) && (
         <ChangeRolesModal isOpen={isChangeRolesModalOpen} setIsOpen={setIsChangeRolesModalOpen} userName={user.name} />
       )}
@@ -665,16 +663,14 @@ const UserActions = ({ user, isAdminApiConfigured }: { user: UsersEntry; isAdmin
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent>
-          {Boolean(isAdminApiConfigured) && !isServerless() && (
-            <DropdownMenuItem
-              onClick={(e) => {
-                e.stopPropagation();
-                setIsChangePasswordModalOpen(true);
-              }}
-            >
-              Change password
-            </DropdownMenuItem>
-          )}
+          <DropdownMenuItem
+            onClick={(e) => {
+              e.stopPropagation();
+              setIsChangePasswordModalOpen(true);
+            }}
+          >
+            Change password
+          </DropdownMenuItem>
           {Boolean(featureRolesApi) && (
             <DropdownMenuItem
               onClick={(e) => {

--- a/frontend/src/components/pages/acls/serverless-password-guard.test.tsx
+++ b/frontend/src/components/pages/acls/serverless-password-guard.test.tsx
@@ -9,8 +9,6 @@
  * by the Apache License, Version 2.0
  */
 
-// biome-ignore-all lint/style/noNamespaceImport: test file
-
 import { render, screen } from '@testing-library/react';
 import { UserInformationCard } from 'components/pages/roles/user-information-card';
 

--- a/frontend/src/components/pages/acls/serverless-password-guard.test.tsx
+++ b/frontend/src/components/pages/acls/serverless-password-guard.test.tsx
@@ -13,81 +13,23 @@
 
 import { render, screen } from '@testing-library/react';
 import { UserInformationCard } from 'components/pages/roles/user-information-card';
-import { isServerless } from 'config';
-
-vi.mock('config', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('config')>();
-  return {
-    ...actual,
-    isServerless: vi.fn(() => false),
-  };
-});
-
-const mockedIsServerless = vi.mocked(isServerless);
 
 /**
- * These tests verify the serverless guard on the password change UI (UX-963).
- *
- * In both user-details.tsx and acl-list.tsx, the password change controls are
- * gated by `api.isAdminApiConfigured && !isServerless()`. When isServerless()
- * returns true, onEditPassword is undefined and the UI is hidden.
- *
- * We test the UserInformationCard component directly, which renders the "Edit"
- * password button only when the onEditPassword callback is provided. This
- * mirrors the guard logic in the parent components.
+ * The Edit password button in UserInformationCard is shown whenever
+ * onEditPassword is provided. The serverless and admin API guards
+ * have been removed — the button should always appear when the
+ * callback is passed.
  */
-describe('UX-963: password change hidden in serverless mode', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it('shows the Edit password button when not in serverless mode (onEditPassword provided)', () => {
-    mockedIsServerless.mockReturnValue(false);
-
-    const isAdminApiConfigured = true;
-    const onEditPassword = isAdminApiConfigured && !isServerless() ? vi.fn() : undefined;
-
-    render(<UserInformationCard onEditPassword={onEditPassword} username="test-user" />);
+describe('password change button visibility', () => {
+  it('shows the Edit password button when onEditPassword is provided', () => {
+    render(<UserInformationCard onEditPassword={vi.fn()} username="test-user" />);
 
     expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
   });
 
-  it('hides the Edit password button when in serverless mode (onEditPassword is undefined)', () => {
-    mockedIsServerless.mockReturnValue(true);
-
-    const isAdminApiConfigured = true;
-    const onEditPassword = isAdminApiConfigured && !isServerless() ? vi.fn() : undefined;
-
-    render(<UserInformationCard onEditPassword={onEditPassword} username="test-user" />);
+  it('hides the Edit password button when onEditPassword is not provided', () => {
+    render(<UserInformationCard username="test-user" />);
 
     expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
-  });
-
-  it('hides the Edit password button when admin API is not configured', () => {
-    mockedIsServerless.mockReturnValue(false);
-
-    const isAdminApiConfigured = false;
-    const onEditPassword = isAdminApiConfigured && !isServerless() ? vi.fn() : undefined;
-
-    render(<UserInformationCard onEditPassword={onEditPassword} username="test-user" />);
-
-    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
-  });
-
-  it('evaluates the guard condition correctly for all combinations', () => {
-    // This directly tests the boolean logic used in user-details.tsx and acl-list.tsx:
-    // api.isAdminApiConfigured && !isServerless()
-    const cases = [
-      { adminApi: true, serverless: false, expected: true },
-      { adminApi: true, serverless: true, expected: false },
-      { adminApi: false, serverless: false, expected: false },
-      { adminApi: false, serverless: true, expected: false },
-    ];
-
-    for (const { adminApi, serverless, expected } of cases) {
-      mockedIsServerless.mockReturnValue(serverless);
-      const result = adminApi && !isServerless();
-      expect(result).toBe(expected);
-    }
   });
 });

--- a/frontend/src/components/pages/acls/user-details.tsx
+++ b/frontend/src/components/pages/acls/user-details.tsx
@@ -14,7 +14,6 @@ import { UserAclsCard } from 'components/pages/roles/user-acls-card';
 import { UserInformationCard } from 'components/pages/roles/user-information-card';
 import { UserRolesCard } from 'components/pages/roles/user-roles-card';
 import { Button } from 'components/redpanda-ui/components/button';
-import { isServerless } from 'config';
 import type { UpdateRoleMembershipResponse } from 'protogen/redpanda/api/console/v1alpha1/security_pb';
 import { useEffect, useState } from 'react';
 
@@ -80,13 +79,9 @@ const UserDetailsPage = ({ userName }: UserDetailsPageProps) => {
     <PageContent>
       <div className="flex flex-col gap-4">
         <UserInformationCard
-          onEditPassword={
-            api.isAdminApiConfigured && !isServerless()
-              ? () => {
-                  setIsChangePasswordModalOpen(true);
-                }
-              : undefined
-          }
+          onEditPassword={() => {
+            setIsChangePasswordModalOpen(true);
+          }}
           username={userName}
         />
         <UserPermissionDetailsContent
@@ -128,13 +123,11 @@ const UserDetailsPage = ({ userName }: UserDetailsPageProps) => {
           )}
         </div>
 
-        {Boolean(api.isAdminApiConfigured) && !isServerless() && (
-          <ChangePasswordModal
-            isOpen={isChangePasswordModalOpen}
-            setIsOpen={setIsChangePasswordModalOpen}
-            userName={userName}
-          />
-        )}
+        <ChangePasswordModal
+          isOpen={isChangePasswordModalOpen}
+          setIsOpen={setIsChangePasswordModalOpen}
+          userName={userName}
+        />
 
         {Boolean(featureRolesApi) && (
           <ChangeRolesModal isOpen={isChangeRolesModalOpen} setIsOpen={setIsChangeRolesModalOpen} userName={userName} />


### PR DESCRIPTION
Serverless now supports changing passwords.

I've also removed the gate on admin API presence since now password change is handled via Kafka protocol, but let me know if my assumption is wrong.