### PR TITLE
chore: bump twmb/avro to v1.4.1

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.38.0
 	github.com/testcontainers/testcontainers-go/modules/redpanda v0.38.0
-	github.com/twmb/avro v1.3.4
+	github.com/twmb/avro v1.4.1
 	github.com/twmb/franz-go v1.20.6
 	github.com/twmb/franz-go/pkg/kadm v1.17.2
 	github.com/twmb/franz-go/pkg/kfake v0.0.0-20251115002817-3affad808a82

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -454,8 +454,8 @@ github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYI
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
-github.com/twmb/avro v1.3.4 h1:4tTV207HOUHKTdAMv6fGPyqgwmGfMLUfnFg5R4cfIX0=
-github.com/twmb/avro v1.3.4/go.mod h1:TUQS96Ptl8tDRyK0Jw91FXIVCoPKz4sXxvUSShiG5FA=
+github.com/twmb/avro v1.4.1 h1:pzXZivLS0YkI7lntpxnu6aYkNJBUJ3vSp6uzEGLeQOI=
+github.com/twmb/avro v1.4.1/go.mod h1:X0fT1dY2xcbV4YuCE4mYro+qljHl4kUF5uA/2z1rgSk=
 github.com/twmb/franz-go v1.7.0/go.mod h1:PMze0jNfNghhih2XHbkmTFykbMF5sJqmNJB31DOOzro=
 github.com/twmb/franz-go v1.20.6 h1:TpQTt4QcixJ1cHEmQGPOERvTzo99s8jAutmS7rbSD6w=
 github.com/twmb/franz-go v1.20.6/go.mod h1:u+FzH2sInp7b9HNVv2cZN8AxdXy6y/AQ1Bkptu4c0FM=


### PR DESCRIPTION
## Summary

Routine maintenance bump from v1.3.4 to v1.4.1.

v1.4.1 release notes: https://github.com/twmb/avro/releases/tag/v1.4.1

v1.4.1 fixes an edge case where records with zero fields emitted as `{"type":"record","name":"x"}` (missing the required `fields` attribute), which strict Avro readers reject. Console is highly unlikely to hit this in practice — it parses schemas from schema registry and caches them, and empty-record schemas are rare in normal data. This is primarily a "stay current" bump.

v1.4.0 (also included in this jump from 1.3.4) added the `atype` subpackage, `SchemaNode` struct-literal schema construction, case-insensitive JSON parsing for janky encoders, duplicate-JSON-key tolerance, fixed-UUID reflect support, and named-type dedup. None of these change behavior for console's existing usage.

## Test plan

- [x] `go mod tidy` clean
- [x] `go build ./...` in backend
- [x] `go test ./pkg/schema/... ./pkg/serde/...` all pass