### PR TITLE
fix(frontend): replace axios with fetch in hubspot helper

### DIFF
--- a/frontend/src/hubspot/hubspot.helper.ts
+++ b/frontend/src/hubspot/hubspot.helper.ts
@@ -78,6 +78,9 @@ export const hubspotSubmit = ({
     }),
   })
     .then((response) => {
+      if (!response.ok) {
+        throw new Error(`HubSpot submit failed: ${response.status}`);
+      }
       if (onSuccess) {
         onSuccess(response);
       }

--- a/frontend/src/hubspot/hubspot.helper.ts
+++ b/frontend/src/hubspot/hubspot.helper.ts
@@ -9,7 +9,6 @@
  * by the Apache License, Version 2.0
  */
 
-import axios from 'axios';
 // biome-ignore lint/performance/noNamespaceImport: part of es-cookie
 import * as Cookies from 'es-cookie';
 
@@ -66,15 +65,18 @@ export const hubspotSubmit = ({
       value,
     }));
 
-  axios
-    .post(`https://api.hsforms.com/submissions/v3/integration/submit/${portalId}/${formId}`, {
+  fetch(`https://api.hsforms.com/submissions/v3/integration/submit/${portalId}/${formId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
       fields: prepareFields(fields),
       context: {
         hutk: Cookies.get(HUBSPOT_TRACKING_COOKIE_TOKEN),
         pageUri: window?.location?.href,
         pageName: document?.title,
       },
-    })
+    }),
+  })
     .then((response) => {
       if (onSuccess) {
         onSuccess(response);


### PR DESCRIPTION
## Summary
- `axios` was never a direct dependency — it was resolved transitively
- After the dep bump in #2380 regenerated `bun.lock`, axios disappeared from the lockfile
- This broke the `build-unstable` Docker image build in console-enterprise ([failed run](https://github.com/redpanda-data/console-enterprise/actions/runs/24509496376/job/71637633598))
- Replace with native `fetch` which requires no external dependencies

## Test plan
- [ ] `bun run build` succeeds
- [ ] `bun run type:check` passes
- [ ] console-enterprise `build-unstable` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)