### PR TITLE
fix(frontend): align lucide-react with Cloud UI (^1.8.0) to unbreak Console MF mount

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "dependencies": {
@@ -58,7 +57,7 @@
         "json-bigint": "^1.0.0",
         "jwt-decode": "^4.0.0",
         "lottie-react": "^2.4.1",
-        "lucide-react": "^0.563.0",
+        "lucide-react": "^1.8.0",
         "moment": "^2.30.1",
         "monaco-editor": "^0.55.0",
         "monaco-editor-webpack-plugin": "^7.1.1",
@@ -2744,7 +2743,7 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
-    "lucide-react": ["lucide-react@0.563.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA=="],
+    "lucide-react": ["lucide-react@1.8.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw=="],
 
     "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -115,7 +115,7 @@
     "json-bigint": "^1.0.0",
     "jwt-decode": "^4.0.0",
     "lottie-react": "^2.4.1",
-    "lucide-react": "^0.563.0",
+    "lucide-react": "^1.8.0",
     "moment": "^2.30.1",
     "monaco-editor": "^0.55.0",
     "monaco-editor-webpack-plugin": "^7.1.1",

--- a/frontend/src/components/icons/index.tsx
+++ b/frontend/src/components/icons/index.tsx
@@ -66,7 +66,6 @@ export {
   Layers as LayersIcon, // MdOutlineLayers
   LayoutGrid as CollectionIcon, // CollectionIcon (Heroicons) - Note: 3x3 grid → 2x2 grid
   Link as LinkIcon, // LinkIcon (Heroicons)
-  Linkedin as LinkedInIcon, // FaLinkedin (LinkedIn removed from simple-icons)
   Loader2 as LoaderIcon, // Loading spinner
   Lock as LockIcon, // LockIcon (Octicons)
   Menu as MenuIcon, // ThreeBarsIcon (Octicons)

--- a/frontend/src/components/layout/footer.tsx
+++ b/frontend/src/components/layout/footer.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useLocation, useMatchRoute } from '@tanstack/react-router';
-import { GitHubIcon, LinkedInIcon, SlackIcon, TwitterIcon } from 'components/icons';
+import { GitHubIcon, SlackIcon, TwitterIcon } from 'components/icons';
 
 import { isEmbedded } from '../../config';
 import env, { getBuildDate, IsCI, IsDev } from '../../utils/env';
@@ -87,14 +87,6 @@ export const AppFooter = () => {
         </a>
         <a href="https://twitter.com/redpandadata" rel="noopener noreferrer" target="_blank" title="Twitter">
           <TwitterIcon size={16} />
-        </a>
-        <a
-          href="https://www.linkedin.com/company/redpanda-data"
-          rel="noopener noreferrer"
-          target="_blank"
-          title="LinkedIn"
-        >
-          <LinkedInIcon size={16} />
         </a>
       </div>
 


### PR DESCRIPTION
## Summary

Cloud UI bumped `lucide-react` to `^1.8.0` in [cloudv2 `cfb8f9ff62`](https://github.com/redpanda-data/cloudv2/commit/cfb8f9ff62) (\"align ADP sidebar icons with ADP UI and upgrade lucide-react\"). Because **both** Cloud UI and Console declare `lucide-react` as `singleton: true` in their Module Federation config, MF must resolve to a single instance shared between host and remote. Cloud UI's `^1.8.0` and Console's `^0.563.0` are disjoint ranges, so the host's 1.8.0 wins and Console receives it at runtime.

The breaking change: `Linkedin` was removed from `lucide-react` v1 (trademark). Console's `components/layout/footer.tsx` still imported `Linkedin as LinkedInIcon`, so on every Console-embedded route in Cloud UI we were rendering an `undefined` component. React raised _\"Element type is invalid… Check the render method of v\"_, the `ConsoleLoader` error boundary caught it, and the whole cluster view collapsed to the \"Failed to load Console\" fallback.

Federation runtime warning observed in the browser confirming the mismatch:

> `[ Federation Runtime ] Version 1.8.0 from cloud_ui of shared singleton module lucide-react does not satisfy the requirement of rp_console which needs ^0.563.0`

### Changes

- `frontend/package.json`: `lucide-react ^0.563.0 → ^1.8.0` (matches Cloud UI)
- `frontend/bun.lock`: regenerated by `bun install`
- `frontend/src/components/icons/index.tsx`: remove the `Linkedin as LinkedInIcon` re-export (no replacement exists in lucide v1)
- `frontend/src/components/layout/footer.tsx`: drop the LinkedIn social link + its import

### Why this repo, not Cloud UI

Cloud UI's upgrade commit explicitly removed its own `LinkedInIcon` usage (described as \"unused\"). That was only true inside Cloud UI — Console was still consuming it via the shared singleton. Aligning Console is the right direction, since Cloud UI is the host and all MF consumers (current and future) need to track its lucide-react major.

## Test plan

- [x] `bun install` in `frontend/`
- [x] `bun run type:check` — clean
- [x] Built Console locally (via Cloudv2 Tilt `Build & deploy local Console`) and loaded it embedded in Cloud UI at `/clusters/:id/*`: sidebar, tabs, and footer render without the React element-type error
- [x] Verified served `mf-manifest.json` now declares `lucide-react { requiredVersion: \"^1.8.0\", singleton: true }` matching Cloud UI
- [ ] CI: unit + integration + e2e

cc @malinskibeniamin — flagging you since `cfb8f9ff62` in cloudv2 motivated this. No action needed on your side; posting so the singleton bump story is complete on both sides.