### PR TITLE
fix(deps): bump protobufjs to 7.5.5 for GHSA-xq3m-2v4x-88gg

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -169,6 +169,7 @@
     "lodash": "^4.18.1",
     "lodash-es": "^4.18.1",
     "prismjs": "^1.30.0",
+    "protobufjs": "^7.5.5",
     "qs": "^6.14.2",
     "serialize-javascript": "^7.0.5",
     "yaml": "^2.8.3",
@@ -3170,7 +3171,7 @@
 
     "prosemirror-virtual-cursor": ["prosemirror-virtual-cursor@0.4.2", "", { "peerDependencies": { "prosemirror-model": "^1.0.0", "prosemirror-state": "^1.0.0", "prosemirror-view": "^1.0.0" }, "optionalPeers": ["prosemirror-model", "prosemirror-state", "prosemirror-view"] }, "sha512-pUMKnIuOhhnMcgIJUjhIQTVJruBEGxfMBVQSrK0g2qhGPDm1i12KdsVaFw15dYk+29tZcxjMeR7P5VDKwmbwJg=="],
 
-    "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
+    "protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,7 +61,8 @@
     "serialize-javascript": "^7.0.5",
     "@remix-run/router": "^1.23.2",
     "flatted": "^3.4.2",
-    "immutable": "^5.1.5"
+    "immutable": "^5.1.5",
+    "protobufjs": "^7.5.5"
   },
   "dependencies": {
     "@a2a-js/sdk": "^0.3.10",
@@ -233,6 +234,7 @@
     "serialize-javascript": "^7.0.5",
     "@remix-run/router": "^1.23.2",
     "flatted": "^3.4.2",
-    "immutable": "^5.1.5"
+    "immutable": "^5.1.5",
+    "protobufjs": "^7.5.5"
   }
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -13068,9 +13068,9 @@ prosemirror-virtual-cursor@^0.4.2:
   integrity sha512-pUMKnIuOhhnMcgIJUjhIQTVJruBEGxfMBVQSrK0g2qhGPDm1i12KdsVaFw15dYk+29tZcxjMeR7P5VDKwmbwJg==
 
 protobufjs@^7.2.5, protobufjs@^7.3.2, protobufjs@^7.5.3:
-  version "7.5.4"
-  resolved "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz"
-  integrity sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==
+  version "7.5.5"
+  resolved "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz"
+  integrity sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"


### PR DESCRIPTION
## Summary
- [GHSA-xq3m-2v4x-88gg](https://github.com/advisories/GHSA-xq3m-2v4x-88gg): protobufjs ≤7.5.4 / ≤8.0.0 generates JS functions by concatenating schema-derived identifiers and executing them via `Function()` without validation → RCE when processing untrusted schemas.
- Console has no direct `protobufjs` dependency, but a transitive `7.5.4` was present in `frontend/bun.lock` and `frontend/yarn.lock`.
- Pin `protobufjs: ^7.5.5` in both `overrides` and `resolutions` of `frontend/package.json` to kill the finding.

## Test plan
- [x] `bun i` + `bun i --yarn` produce clean lockfiles; every `protobufjs` reference resolves to 7.5.5.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)