### PR TITLE
ci: dispatch to console-enterprise for fork PRs [UX-1222]

### DIFF
--- a/.github/workflows/fork-pr-dispatch.yml
+++ b/.github/workflows/fork-pr-dispatch.yml
@@ -1,0 +1,66 @@
+---
+name: Fork PR dispatch to enterprise
+on:
+  workflow_run:
+    workflows: ["PR verification (forks)"]
+    types: [completed]
+permissions:
+  id-token: write
+  contents: read
+  statuses: write
+jobs:
+  dispatch:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.fork == true
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ,sdlc/prod/github/actions_bot_token
+          parse-json-secrets: true
+      - name: Build dispatch payload
+        id: payload
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const payload = {
+              branch: process.env.HEAD_BRANCH,
+              commit_sha: process.env.HEAD_SHA,
+              head_repository: process.env.HEAD_REPO,
+              is_fork: true,
+            };
+            core.setOutput('json', JSON.stringify(payload));
+            core.setOutput('sha', process.env.HEAD_SHA);
+      - name: Repository dispatch for fork PR
+        uses: peter-evans/repository-dispatch@caebe2a7c967e9f927ff8780fea8e16e50b5ce40
+        with:
+          token: ${{ env.ACTIONS_BOT_TOKEN }}
+          repository: redpanda-data/console-enterprise
+          event-type: push
+          client-payload: ${{ steps.payload.outputs.json }}
+      - name: Set pending enterprise CI status
+        env:
+          HEAD_SHA: ${{ steps.payload.outputs.sha }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ env.ACTIONS_BOT_TOKEN }}
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: 'redpanda-data',
+              repo: 'console',
+              sha: process.env.HEAD_SHA,
+              state: 'pending',
+              description: 'Enterprise CI is running...',
+              context: 'Enterprise CI'
+            });


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/fork-pr-dispatch.yml`, a `workflow_run`-triggered workflow that fires after `PR verification (forks)` succeeds on fork `pull_request` runs.
- It dispatches the `push` event to `console-enterprise` and marks `Enterprise CI` as pending, matching the non-fork `repository-dispatch.yml` flow.
- Payload now includes `head_repository` + `is_fork` so the enterprise side can clone from the fork repo (the OSS SHA is not reachable from `redpanda-data/console` for fork PRs).

## Why not put it in `fork-pr-verify.yml`?
That workflow runs on `pull_request`, which strips secrets on fork triggers — the dispatch needs AWS creds + the bot token. `workflow_run` is GitHub's documented pattern for "wait for verify, then use secrets", and it runs on the base repo's default-branch workflow file (no fork code executes with secrets present).

## Security
- Fork-controlled values (`head_branch`, `head_sha`, `head_repository.full_name`) are passed through `env:` → `process.env.X` rather than `${{ }}` template expansion, closing the [classic Actions script-injection vector](https://securitylab.github.com/research/github-actions-untrusted-input/).
- Client payload is built via `JSON.stringify` so a malicious repo name can't escape JSON structure.

## Companion PR
Enterprise side: https://github.com/redpanda-data/console-enterprise/pull/new/jc/accept-oss-fork-dispatch — merge that one first (or together) so dispatches land somewhere that accepts `head_repository`.

## Ticket
UX-1222

## Test plan
- [ ] Merge companion enterprise PR first.
- [ ] Open a fork PR against master with a frontend/backend change.
- [ ] Confirm `PR verification (forks)` runs.
- [ ] Confirm `Fork PR dispatch to enterprise` fires on success, sets `Enterprise CI` to pending, and dispatches to `console-enterprise`.
- [ ] Confirm `report-status` on the enterprise side updates `Enterprise CI` to success/failure on the PR head SHA.