### PR TITLE
chore(frontend): remove vestigial AI Gateway v1 references

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -7,8 +7,6 @@
         "@a2a-js/sdk": "^0.3.13",
         "@autoform/react": "^4.0.0",
         "@autoform/zod": "^5.0.0",
-        "@buf/redpandadata_ai-gateway.bufbuild_es": "^2.11.0-20260313141452-dbbaece03f76.1",
-        "@buf/redpandadata_ai-gateway.connectrpc_query-es": "^2.2.0-20260313141452-dbbaece03f76.1",
         "@buf/redpandadata_cloud.connectrpc_query-es": "^2.2.0-20251128173054-b9f9fc6e5a70.1",
         "@buf/redpandadata_common.bufbuild_es": "^2.11.0-20260316210807-5d899910f714.1",
         "@bufbuild/protobuf": "^2.10.0",
@@ -290,21 +288,17 @@
 
     "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.1", "", {}, "sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw=="],
 
-    "@buf/bufbuild_protovalidate.bufbuild_es": ["@buf/bufbuild_protovalidate.bufbuild_es@2.11.0-20250912141014-52f32327d4b0.1", "https://buf.build/gen/npm/v1/@buf/bufbuild_protovalidate.bufbuild_es/-/bufbuild_protovalidate.bufbuild_es-2.11.0-20250912141014-52f32327d4b0.1.tgz", { "peerDependencies": { "@bufbuild/protobuf": "^2.11.0" } }, ""],
+    "@buf/bufbuild_protovalidate.bufbuild_es": ["@buf/bufbuild_protovalidate.bufbuild_es@2.7.0-20250912141014-52f32327d4b0.1", "https://buf.build/gen/npm/v1/@buf/bufbuild_protovalidate.bufbuild_es/-/bufbuild_protovalidate.bufbuild_es-2.7.0-20250912141014-52f32327d4b0.1.tgz", { "peerDependencies": { "@bufbuild/protobuf": "^2.7.0" } }, ""],
 
     "@buf/bufbuild_protovalidate.connectrpc_query-es": ["@buf/bufbuild_protovalidate.connectrpc_query-es@2.2.0-20250912141014-52f32327d4b0.1", "https://buf.build/gen/npm/v1/@buf/bufbuild_protovalidate.connectrpc_query-es/-/bufbuild_protovalidate.connectrpc_query-es-2.2.0-20250912141014-52f32327d4b0.1.tgz", { "dependencies": { "@buf/bufbuild_protovalidate.bufbuild_es": "2.7.0-20250912141014-52f32327d4b0.1" }, "peerDependencies": { "@bufbuild/protobuf": "^2.7.0", "@connectrpc/connect-query": "^2.2.0" } }, ""],
 
-    "@buf/googleapis_googleapis.bufbuild_es": ["@buf/googleapis_googleapis.bufbuild_es@2.11.0-20251009205305-72c8614f3bd0.1", "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-2.11.0-20251009205305-72c8614f3bd0.1.tgz", { "peerDependencies": { "@bufbuild/protobuf": "^2.11.0" } }, ""],
+    "@buf/googleapis_googleapis.bufbuild_es": ["@buf/googleapis_googleapis.bufbuild_es@2.11.0-20251126203132-004180b77378.1", "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-2.11.0-20251126203132-004180b77378.1.tgz", { "peerDependencies": { "@bufbuild/protobuf": "^2.11.0" } }, ""],
 
     "@buf/googleapis_googleapis.connectrpc_query-es": ["@buf/googleapis_googleapis.connectrpc_query-es@2.2.0-20251009205305-72c8614f3bd0.1", "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.connectrpc_query-es/-/googleapis_googleapis.connectrpc_query-es-2.2.0-20251009205305-72c8614f3bd0.1.tgz", { "dependencies": { "@buf/googleapis_googleapis.bufbuild_es": "2.7.0-20251009205305-72c8614f3bd0.1" }, "peerDependencies": { "@bufbuild/protobuf": "^2.7.0", "@connectrpc/connect-query": "^2.2.0" } }, ""],
 
     "@buf/grpc-ecosystem_grpc-gateway.bufbuild_es": ["@buf/grpc-ecosystem_grpc-gateway.bufbuild_es@2.7.0-20221127060915-a1ecdc58eccd.1", "https://buf.build/gen/npm/v1/@buf/grpc-ecosystem_grpc-gateway.bufbuild_es/-/grpc-ecosystem_grpc-gateway.bufbuild_es-2.7.0-20221127060915-a1ecdc58eccd.1.tgz", { "peerDependencies": { "@bufbuild/protobuf": "^2.7.0" } }, ""],
 
     "@buf/grpc-ecosystem_grpc-gateway.connectrpc_query-es": ["@buf/grpc-ecosystem_grpc-gateway.connectrpc_query-es@2.2.0-20221127060915-a1ecdc58eccd.1", "https://buf.build/gen/npm/v1/@buf/grpc-ecosystem_grpc-gateway.connectrpc_query-es/-/grpc-ecosystem_grpc-gateway.connectrpc_query-es-2.2.0-20221127060915-a1ecdc58eccd.1.tgz", { "dependencies": { "@buf/grpc-ecosystem_grpc-gateway.bufbuild_es": "2.7.0-20221127060915-a1ecdc58eccd.1" }, "peerDependencies": { "@bufbuild/protobuf": "^2.7.0", "@connectrpc/connect-query": "^2.2.0" } }, ""],
-
-    "@buf/redpandadata_ai-gateway.bufbuild_es": ["@buf/redpandadata_ai-gateway.bufbuild_es@2.11.0-20260313141452-dbbaece03f76.1", "https://buf.build/gen/npm/v1/@buf/redpandadata_ai-gateway.bufbuild_es/-/redpandadata_ai-gateway.bufbuild_es-2.11.0-20260313141452-dbbaece03f76.1.tgz", { "dependencies": { "@buf/bufbuild_protovalidate.bufbuild_es": "2.11.0-20250912141014-52f32327d4b0.1", "@buf/googleapis_googleapis.bufbuild_es": "2.11.0-20251009205305-72c8614f3bd0.1" }, "peerDependencies": { "@bufbuild/protobuf": "^2.11.0" } }, ""],
-
-    "@buf/redpandadata_ai-gateway.connectrpc_query-es": ["@buf/redpandadata_ai-gateway.connectrpc_query-es@2.2.0-20260313141452-dbbaece03f76.1", "https://buf.build/gen/npm/v1/@buf/redpandadata_ai-gateway.connectrpc_query-es/-/redpandadata_ai-gateway.connectrpc_query-es-2.2.0-20260313141452-dbbaece03f76.1.tgz", { "dependencies": { "@buf/bufbuild_protovalidate.connectrpc_query-es": "2.2.0-20250912141014-52f32327d4b0.1", "@buf/googleapis_googleapis.connectrpc_query-es": "2.2.0-20251009205305-72c8614f3bd0.1", "@buf/redpandadata_ai-gateway.bufbuild_es": "2.7.0-20260313141452-dbbaece03f76.1" }, "peerDependencies": { "@bufbuild/protobuf": "^2.7.0", "@connectrpc/connect-query": "^2.2.0" } }, ""],
 
     "@buf/redpandadata_cloud.bufbuild_es": ["@buf/redpandadata_cloud.bufbuild_es@2.7.0-20251128173054-b9f9fc6e5a70.1", "https://buf.build/gen/npm/v1/@buf/redpandadata_cloud.bufbuild_es/-/redpandadata_cloud.bufbuild_es-2.7.0-20251128173054-b9f9fc6e5a70.1.tgz", { "dependencies": { "@buf/bufbuild_protovalidate.bufbuild_es": "2.7.0-20250912141014-52f32327d4b0.1", "@buf/googleapis_googleapis.bufbuild_es": "2.7.0-20251009205305-72c8614f3bd0.1", "@buf/grpc-ecosystem_grpc-gateway.bufbuild_es": "2.7.0-20221127060915-a1ecdc58eccd.1", "@buf/redpandadata_common.bufbuild_es": "2.7.0-20250904135917-9feeb2588236.1", "@buf/redpandadata_core.bufbuild_es": "2.7.0-20251024023333-e0f79c48b9f0.1" }, "peerDependencies": { "@bufbuild/protobuf": "^2.7.0" } }, ""],
 
@@ -3928,19 +3922,11 @@
 
     "@babel/traverse/@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
 
-    "@buf/bufbuild_protovalidate.connectrpc_query-es/@buf/bufbuild_protovalidate.bufbuild_es": ["@buf/bufbuild_protovalidate.bufbuild_es@2.7.0-20250912141014-52f32327d4b0.1", "https://buf.build/gen/npm/v1/@buf/bufbuild_protovalidate.bufbuild_es/-/bufbuild_protovalidate.bufbuild_es-2.7.0-20250912141014-52f32327d4b0.1.tgz", { "peerDependencies": { "@bufbuild/protobuf": "^2.7.0" } }, ""],
-
     "@buf/googleapis_googleapis.connectrpc_query-es/@buf/googleapis_googleapis.bufbuild_es": ["@buf/googleapis_googleapis.bufbuild_es@2.7.0-20251009205305-72c8614f3bd0.1", "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-2.7.0-20251009205305-72c8614f3bd0.1.tgz", { "peerDependencies": { "@bufbuild/protobuf": "^2.7.0" } }, ""],
-
-    "@buf/redpandadata_ai-gateway.connectrpc_query-es/@buf/redpandadata_ai-gateway.bufbuild_es": ["@buf/redpandadata_ai-gateway.bufbuild_es@2.7.0-20260313141452-dbbaece03f76.1", "https://buf.build/gen/npm/v1/@buf/redpandadata_ai-gateway.bufbuild_es/-/redpandadata_ai-gateway.bufbuild_es-2.7.0-20260313141452-dbbaece03f76.1.tgz", { "dependencies": { "@buf/bufbuild_protovalidate.bufbuild_es": "2.7.0-20250912141014-52f32327d4b0.1", "@buf/googleapis_googleapis.bufbuild_es": "2.7.0-20251009205305-72c8614f3bd0.1" }, "peerDependencies": { "@bufbuild/protobuf": "^2.7.0" } }, ""],
-
-    "@buf/redpandadata_cloud.bufbuild_es/@buf/bufbuild_protovalidate.bufbuild_es": ["@buf/bufbuild_protovalidate.bufbuild_es@2.7.0-20250912141014-52f32327d4b0.1", "https://buf.build/gen/npm/v1/@buf/bufbuild_protovalidate.bufbuild_es/-/bufbuild_protovalidate.bufbuild_es-2.7.0-20250912141014-52f32327d4b0.1.tgz", { "peerDependencies": { "@bufbuild/protobuf": "^2.7.0" } }, ""],
 
     "@buf/redpandadata_cloud.bufbuild_es/@buf/googleapis_googleapis.bufbuild_es": ["@buf/googleapis_googleapis.bufbuild_es@2.7.0-20251009205305-72c8614f3bd0.1", "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-2.7.0-20251009205305-72c8614f3bd0.1.tgz", { "peerDependencies": { "@bufbuild/protobuf": "^2.7.0" } }, ""],
 
     "@buf/redpandadata_cloud.bufbuild_es/@buf/redpandadata_common.bufbuild_es": ["@buf/redpandadata_common.bufbuild_es@2.7.0-20250904135917-9feeb2588236.1", "https://buf.build/gen/npm/v1/@buf/redpandadata_common.bufbuild_es/-/redpandadata_common.bufbuild_es-2.7.0-20250904135917-9feeb2588236.1.tgz", { "dependencies": { "@buf/googleapis_googleapis.bufbuild_es": "2.7.0-20250411203938-61b203b9a916.1" }, "peerDependencies": { "@bufbuild/protobuf": "^2.7.0" } }, ""],
-
-    "@buf/redpandadata_common.bufbuild_es/@buf/googleapis_googleapis.bufbuild_es": ["@buf/googleapis_googleapis.bufbuild_es@2.11.0-20251126203132-004180b77378.1", "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-2.11.0-20251126203132-004180b77378.1.tgz", { "peerDependencies": { "@bufbuild/protobuf": "^2.11.0" } }, ""],
 
     "@buf/redpandadata_common.connectrpc_query-es/@buf/googleapis_googleapis.connectrpc_query-es": ["@buf/googleapis_googleapis.connectrpc_query-es@2.2.0-20250411203938-61b203b9a916.1", "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.connectrpc_query-es/-/googleapis_googleapis.connectrpc_query-es-2.2.0-20250411203938-61b203b9a916.1.tgz", { "dependencies": { "@buf/googleapis_googleapis.bufbuild_es": "2.7.0-20250411203938-61b203b9a916.1" }, "peerDependencies": { "@bufbuild/protobuf": "^2.7.0", "@connectrpc/connect-query": "^2.2.0" } }, ""],
 
@@ -4597,10 +4583,6 @@
     "@babel/helper-skip-transparent-expression-wrappers/@babel/traverse/@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
 
     "@babel/helpers/@babel/template/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
-
-    "@buf/redpandadata_ai-gateway.connectrpc_query-es/@buf/redpandadata_ai-gateway.bufbuild_es/@buf/bufbuild_protovalidate.bufbuild_es": ["@buf/bufbuild_protovalidate.bufbuild_es@2.7.0-20250912141014-52f32327d4b0.1", "https://buf.build/gen/npm/v1/@buf/bufbuild_protovalidate.bufbuild_es/-/bufbuild_protovalidate.bufbuild_es-2.7.0-20250912141014-52f32327d4b0.1.tgz", { "peerDependencies": { "@bufbuild/protobuf": "^2.7.0" } }, ""],
-
-    "@buf/redpandadata_ai-gateway.connectrpc_query-es/@buf/redpandadata_ai-gateway.bufbuild_es/@buf/googleapis_googleapis.bufbuild_es": ["@buf/googleapis_googleapis.bufbuild_es@2.7.0-20251009205305-72c8614f3bd0.1", "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-2.7.0-20251009205305-72c8614f3bd0.1.tgz", { "peerDependencies": { "@bufbuild/protobuf": "^2.7.0" } }, ""],
 
     "@buf/redpandadata_cloud.bufbuild_es/@buf/redpandadata_common.bufbuild_es/@buf/googleapis_googleapis.bufbuild_es": ["@buf/googleapis_googleapis.bufbuild_es@2.7.0-20250411203938-61b203b9a916.1", "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-2.7.0-20250411203938-61b203b9a916.1.tgz", { "peerDependencies": { "@bufbuild/protobuf": "^2.7.0" } }, ""],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,8 +67,6 @@
     "@a2a-js/sdk": "^0.3.13",
     "@autoform/react": "^4.0.0",
     "@autoform/zod": "^5.0.0",
-    "@buf/redpandadata_ai-gateway.bufbuild_es": "^2.11.0-20260313141452-dbbaece03f76.1",
-    "@buf/redpandadata_ai-gateway.connectrpc_query-es": "^2.2.0-20260313141452-dbbaece03f76.1",
     "@buf/redpandadata_cloud.connectrpc_query-es": "^2.2.0-20251128173054-b9f9fc6e5a70.1",
     "@buf/redpandadata_common.bufbuild_es": "^2.11.0-20260316210807-5d899910f714.1",
     "@bufbuild/protobuf": "^2.10.0",

--- a/frontend/rsbuild.config.ts
+++ b/frontend/rsbuild.config.ts
@@ -87,22 +87,6 @@ export default defineConfig({
       credentials: true,
     },
     proxy: [
-      // AI Gateway API - proxy to separate AI Gateway service
-      // Matches: /.redpanda/api/redpanda.api.aigateway.v1.*
-      // Proto package is: redpanda.api.aigateway.v1 (includes .api)
-      // AI Gateway now expects the full path with .api
-      ...(process.env.AI_GATEWAY_URL
-        ? [
-            {
-              context: ['/.redpanda/api/redpanda.api.aigateway.v1'],
-              target: process.env.AI_GATEWAY_URL,
-              changeOrigin: true,
-              secure: false,
-              logLevel: 'debug',
-              // No pathRewrite - AI Gateway expects full path with .api
-            },
-          ]
-        : []),
       // AIGW v2 API - proxy to new AI Gateway management API (LLMProviderService, ModelService)
       ...(process.env.AIGW_URL
         ? [

--- a/frontend/rsbuild.config.ts
+++ b/frontend/rsbuild.config.ts
@@ -87,8 +87,20 @@ export default defineConfig({
       credentials: true,
     },
     proxy: [
-      // All APIs - proxy to Console backend. AI Gateway (v1 and v2) is not
-      // proxied here; Console consumes AIGW via ADP UI in Cloud UI instead.
+      // AIGW v2 API - proxy to new AI Gateway management API (LLMProviderService, ModelService)
+      ...(process.env.AIGW_URL
+        ? [
+            {
+              context: ['/.aigw/api'],
+              target: process.env.AIGW_URL,
+              changeOrigin: true,
+              secure: false,
+              logLevel: 'debug',
+              pathRewrite: { '^/\\.aigw/api': '' },
+            },
+          ]
+        : []),
+      // All other APIs - proxy to Console backend
       {
         context: ['/api', '/redpanda.api', '/auth', '/logout'],
         target: process.env.PROXY_TARGET || 'http://localhost:9090',

--- a/frontend/rsbuild.config.ts
+++ b/frontend/rsbuild.config.ts
@@ -87,20 +87,8 @@ export default defineConfig({
       credentials: true,
     },
     proxy: [
-      // AIGW v2 API - proxy to new AI Gateway management API (LLMProviderService, ModelService)
-      ...(process.env.AIGW_URL
-        ? [
-            {
-              context: ['/.aigw/api'],
-              target: process.env.AIGW_URL,
-              changeOrigin: true,
-              secure: false,
-              logLevel: 'debug',
-              pathRewrite: { '^/\\.aigw/api': '' },
-            },
-          ]
-        : []),
-      // All other APIs - proxy to Console backend
+      // All APIs - proxy to Console backend. AI Gateway (v1 and v2) is not
+      // proxied here; Console consumes AIGW via ADP UI in Cloud UI instead.
       {
         context: ['/api', '/redpanda.api', '/auth', '/logout'],
         target: process.env.PROXY_TARGET || 'http://localhost:9090',

--- a/frontend/start-cloud.sh
+++ b/frontend/start-cloud.sh
@@ -26,15 +26,7 @@ if [ -z "$BACKEND_URL" ]; then
   exit 1
 fi
 
-# Extract cluster ID from backend URL
-# Example: https://console-2fd2fedf.d5mst2vnnfekmiescdb0.fmc.ign.cloud.redpanda.com
-# Example: https://console-2498fb74.d5tp5kntujt599ksadgg.byoc.ign.cloud.redpanda.com
-# Example: https://console-xxx.d5xxx.ppd.ign.cloud.redpanda.com (preprod)
-# Extracts: d5mst2vnnfekmiescdb0 or d5tp5kntujt599ksadgg
-CLUSTER_ID=$(echo "$BACKEND_URL" | sed -E 's/.*\.([a-z0-9]+)\.(fmc\.ign|byoc\.ign|ppd\.ign|rpd)\.cloud\.redpanda\.com.*/\1/')
-
 export PROXY_TARGET="$BACKEND_URL"
-export AI_GATEWAY_URL="https://ai-gateway.${CLUSTER_ID}.clusters.ign.rdpa.co"
 export REACT_APP_ENABLED_FEATURES=SINGLE_SIGN_ON,REASSIGN_PARTITIONS
 
 echo "Starting frontend dev server..."

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3,10 +3,10 @@
 # bun ./bun.lockb --hash: 0000000000000000-0000000000000000-0000000000000000-0000000000000000
 
 
-"@a2a-js/sdk@^0.3.10":
-  version "0.3.10"
-  resolved "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-0.3.10.tgz"
-  integrity sha512-t6w5ctnwJkSOMRl6M9rn95C1FTHCPqixxMR0yWXtzhZXEnF6mF1NAK0CfKlG3cz+tcwTxkmn287QZC3t9XPgrA==
+"@a2a-js/sdk@^0.3.13":
+  version "0.3.13"
+  resolved "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-0.3.13.tgz"
+  integrity sha512-BZr0f9JVNQs3GKOM9xINWCh6OKIJWZFPyqqVqTym5mxO2Eemc6I/0zL7zWnljHzGdaf5aZQyQN5xa6PSH62q+A==
   dependencies:
     uuid "^11.1.0"
 
@@ -15,29 +15,29 @@
   resolved "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz"
   integrity sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==
 
-"@ai-sdk/gateway@2.0.15":
-  version "2.0.15"
-  resolved "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.15.tgz"
-  integrity sha512-i1YVKzC1dg9LGvt+GthhD7NlRhz9J4+ZRj3KELU14IZ/MHPsOBiFeEoCCIDLR+3tqT8/+5nIsK3eZ7DFRfMfdw==
+"@ai-sdk/gateway@3.0.104":
+  version "3.0.104"
+  resolved "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.104.tgz"
+  integrity sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==
   dependencies:
-    "@ai-sdk/provider" "2.0.0"
-    "@ai-sdk/provider-utils" "3.0.17"
-    "@vercel/oidc" "3.0.5"
+    "@ai-sdk/provider" "3.0.8"
+    "@ai-sdk/provider-utils" "4.0.23"
+    "@vercel/oidc" "3.2.0"
 
-"@ai-sdk/provider@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0.tgz"
-  integrity sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==
+"@ai-sdk/provider@3.0.8":
+  version "3.0.8"
+  resolved "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz"
+  integrity sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==
   dependencies:
     json-schema "^0.4.0"
 
-"@ai-sdk/provider-utils@3.0.17":
-  version "3.0.17"
-  resolved "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.17.tgz"
-  integrity sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw==
+"@ai-sdk/provider-utils@4.0.23":
+  version "4.0.23"
+  resolved "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz"
+  integrity sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==
   dependencies:
-    "@ai-sdk/provider" "2.0.0"
-    "@standard-schema/spec" "^1.0.0"
+    "@ai-sdk/provider" "3.0.8"
+    "@standard-schema/spec" "^1.1.0"
     eventsource-parser "^3.0.6"
 
 "@alloc/quick-lru@^5.2.0":
@@ -569,10 +569,6 @@
   version "2.7.0-20250912141014-52f32327d4b0.1"
   resolved "https://buf.build/gen/npm/v1/@buf/bufbuild_protovalidate.bufbuild_es/-/bufbuild_protovalidate.bufbuild_es-2.7.0-20250912141014-52f32327d4b0.1.tgz"
 
-"@buf/bufbuild_protovalidate.bufbuild_es@2.11.0-20250912141014-52f32327d4b0.1":
-  version "2.11.0-20250912141014-52f32327d4b0.1"
-  resolved "https://buf.build/gen/npm/v1/@buf/bufbuild_protovalidate.bufbuild_es/-/bufbuild_protovalidate.bufbuild_es-2.11.0-20250912141014-52f32327d4b0.1.tgz"
-
 "@buf/bufbuild_protovalidate.connectrpc_query-es@2.2.0-20250912141014-52f32327d4b0.1":
   version "2.2.0-20250912141014-52f32327d4b0.1"
   resolved "https://buf.build/gen/npm/v1/@buf/bufbuild_protovalidate.connectrpc_query-es/-/bufbuild_protovalidate.connectrpc_query-es-2.2.0-20250912141014-52f32327d4b0.1.tgz"
@@ -586,10 +582,6 @@
 "@buf/googleapis_googleapis.bufbuild_es@2.7.0-20251009205305-72c8614f3bd0.1":
   version "2.7.0-20251009205305-72c8614f3bd0.1"
   resolved "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-2.7.0-20251009205305-72c8614f3bd0.1.tgz"
-
-"@buf/googleapis_googleapis.bufbuild_es@2.11.0-20251009205305-72c8614f3bd0.1":
-  version "2.11.0-20251009205305-72c8614f3bd0.1"
-  resolved "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-2.11.0-20251009205305-72c8614f3bd0.1.tgz"
 
 "@buf/googleapis_googleapis.bufbuild_es@2.11.0-20251126203132-004180b77378.1":
   version "2.11.0-20251126203132-004180b77378.1"
@@ -616,28 +608,6 @@
   resolved "https://buf.build/gen/npm/v1/@buf/grpc-ecosystem_grpc-gateway.connectrpc_query-es/-/grpc-ecosystem_grpc-gateway.connectrpc_query-es-2.2.0-20221127060915-a1ecdc58eccd.1.tgz"
   dependencies:
     "@buf/grpc-ecosystem_grpc-gateway.bufbuild_es" "2.7.0-20221127060915-a1ecdc58eccd.1"
-
-"@buf/redpandadata_ai-gateway.bufbuild_es@2.7.0-20260313141452-dbbaece03f76.1":
-  version "2.7.0-20260313141452-dbbaece03f76.1"
-  resolved "https://buf.build/gen/npm/v1/@buf/redpandadata_ai-gateway.bufbuild_es/-/redpandadata_ai-gateway.bufbuild_es-2.7.0-20260313141452-dbbaece03f76.1.tgz"
-  dependencies:
-    "@buf/bufbuild_protovalidate.bufbuild_es" "2.7.0-20250912141014-52f32327d4b0.1"
-    "@buf/googleapis_googleapis.bufbuild_es" "2.7.0-20251009205305-72c8614f3bd0.1"
-
-"@buf/redpandadata_ai-gateway.bufbuild_es@^2.11.0-20260313141452-dbbaece03f76.1":
-  version "2.11.0-20260313141452-dbbaece03f76.1"
-  resolved "https://buf.build/gen/npm/v1/@buf/redpandadata_ai-gateway.bufbuild_es/-/redpandadata_ai-gateway.bufbuild_es-2.11.0-20260313141452-dbbaece03f76.1.tgz"
-  dependencies:
-    "@buf/bufbuild_protovalidate.bufbuild_es" "2.11.0-20250912141014-52f32327d4b0.1"
-    "@buf/googleapis_googleapis.bufbuild_es" "2.11.0-20251009205305-72c8614f3bd0.1"
-
-"@buf/redpandadata_ai-gateway.connectrpc_query-es@^2.2.0-20260313141452-dbbaece03f76.1":
-  version "2.2.0-20260313141452-dbbaece03f76.1"
-  resolved "https://buf.build/gen/npm/v1/@buf/redpandadata_ai-gateway.connectrpc_query-es/-/redpandadata_ai-gateway.connectrpc_query-es-2.2.0-20260313141452-dbbaece03f76.1.tgz"
-  dependencies:
-    "@buf/bufbuild_protovalidate.connectrpc_query-es" "2.2.0-20250912141014-52f32327d4b0.1"
-    "@buf/googleapis_googleapis.connectrpc_query-es" "2.2.0-20251009205305-72c8614f3bd0.1"
-    "@buf/redpandadata_ai-gateway.bufbuild_es" "2.7.0-20260313141452-dbbaece03f76.1"
 
 "@buf/redpandadata_cloud.bufbuild_es@2.7.0-20251128173054-b9f9fc6e5a70.1":
   version "2.7.0-20251128173054-b9f9fc6e5a70.1"
@@ -957,37 +927,35 @@
     "@types/lodash.mergewith" "4.6.9"
     lodash.mergewith "4.6.2"
 
-"@chevrotain/cst-dts-gen@11.0.3":
-  version "11.0.3"
-  resolved "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz"
-  integrity sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==
+"@chevrotain/cst-dts-gen@12.0.0":
+  version "12.0.0"
+  resolved "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz"
+  integrity sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==
   dependencies:
-    "@chevrotain/gast" "11.0.3"
-    "@chevrotain/types" "11.0.3"
-    lodash-es "4.17.21"
+    "@chevrotain/gast" "12.0.0"
+    "@chevrotain/types" "12.0.0"
 
-"@chevrotain/gast@11.0.3":
-  version "11.0.3"
-  resolved "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz"
-  integrity sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==
+"@chevrotain/gast@12.0.0":
+  version "12.0.0"
+  resolved "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz"
+  integrity sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==
   dependencies:
-    "@chevrotain/types" "11.0.3"
-    lodash-es "4.17.21"
+    "@chevrotain/types" "12.0.0"
 
-"@chevrotain/regexp-to-ast@11.0.3":
-  version "11.0.3"
-  resolved "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz"
-  integrity sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==
+"@chevrotain/regexp-to-ast@12.0.0", "@chevrotain/regexp-to-ast@~12.0.0":
+  version "12.0.0"
+  resolved "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz"
+  integrity sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==
 
-"@chevrotain/types@11.0.3":
-  version "11.0.3"
-  resolved "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz"
-  integrity sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==
+"@chevrotain/types@12.0.0":
+  version "12.0.0"
+  resolved "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz"
+  integrity sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==
 
-"@chevrotain/utils@11.0.3":
-  version "11.0.3"
-  resolved "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz"
-  integrity sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==
+"@chevrotain/utils@12.0.0":
+  version "12.0.0"
+  resolved "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz"
+  integrity sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==
 
 "@clack/core@0.5.0":
   version "0.5.0"
@@ -1992,7 +1960,7 @@
   resolved "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz"
   integrity sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==
 
-"@iconify/utils@^3.0.1":
+"@iconify/utils@^3.0.2":
   version "3.0.2"
   resolved "https://registry.npmjs.org/@iconify/utils/-/utils-3.0.2.tgz"
   integrity sha512-EfJS0rLfVuRuJRn4psJHtK2A9TqVnkxPpHY6lYHiB9+8eSuudsxbwMiavocG45ujOo6FJ+CIRlRnlOGinzkaGQ==
@@ -2289,12 +2257,12 @@
   resolved "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz"
   integrity sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==
 
-"@mermaid-js/parser@^0.6.3":
-  version "0.6.3"
-  resolved "https://registry.npmjs.org/@mermaid-js/parser/-/parser-0.6.3.tgz"
-  integrity sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==
+"@mermaid-js/parser@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.0.tgz"
+  integrity sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==
   dependencies:
-    langium "3.3.1"
+    langium "^4.0.0"
 
 "@milkdown/components@7.18.0":
   version "7.18.0"
@@ -4644,7 +4612,7 @@
   resolved "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz"
   integrity sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==
 
-"@standard-schema/spec@1.0.0", "@standard-schema/spec@^1.0.0":
+"@standard-schema/spec@1.0.0":
   version "1.0.0"
   resolved "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz"
   integrity sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==
@@ -5961,10 +5929,18 @@
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
-"@vercel/oidc@3.0.5":
-  version "3.0.5"
-  resolved "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.0.5.tgz"
-  integrity sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==
+"@upsetjs/venn.js@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz"
+  integrity sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==
+  optionalDependencies:
+    d3-selection "^3.0.0"
+    d3-transition "^3.0.1"
+
+"@vercel/oidc@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz"
+  integrity sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==
 
 "@vitejs/plugin-react@^5.1.2":
   version "5.1.2"
@@ -6434,14 +6410,14 @@ agent-base@6:
   dependencies:
     debug "4"
 
-ai@^5.0.101:
-  version "5.0.101"
-  resolved "https://registry.npmjs.org/ai/-/ai-5.0.101.tgz"
-  integrity sha512-/P4fgs2PGYTBaZi192YkPikOudsl9vccA65F7J7LvoNTOoP5kh1yAsJPsKAy6FXU32bAngai7ft1UDyC3u7z5g==
+ai@^6.0.168:
+  version "6.0.168"
+  resolved "https://registry.npmjs.org/ai/-/ai-6.0.168.tgz"
+  integrity sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==
   dependencies:
-    "@ai-sdk/gateway" "2.0.15"
-    "@ai-sdk/provider" "2.0.0"
-    "@ai-sdk/provider-utils" "3.0.17"
+    "@ai-sdk/gateway" "3.0.104"
+    "@ai-sdk/provider" "3.0.8"
+    "@ai-sdk/provider-utils" "4.0.23"
     "@opentelemetry/api" "1.9.0"
 
 ajv@^6.14.0, ajv@^8.0.0, ajv@^8.17.1, ajv@^8.8.2, ajv@^8.9.0:
@@ -6816,7 +6792,7 @@ bn.js@^5.2.1, bn.js@^5.2.2:
   resolved "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz"
   integrity sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==
 
-body-parser@1.20.3, body-parser@^2.2.0, body-parser@^2.2.1:
+body-parser@1.20.3, body-parser@^2.2.1:
   version "2.2.2"
   resolved "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz"
   integrity sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==
@@ -7137,22 +7113,21 @@ character-reference-invalid@^2.0.0:
   resolved "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz"
   integrity sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==
 
-chevrotain@^11.0.0, chevrotain@~11.0.3:
-  version "11.0.3"
-  resolved "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz"
-  integrity sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==
+chevrotain@^12.0.0, chevrotain@~12.0.0:
+  version "12.0.0"
+  resolved "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz"
+  integrity sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==
   dependencies:
-    "@chevrotain/cst-dts-gen" "11.0.3"
-    "@chevrotain/gast" "11.0.3"
-    "@chevrotain/regexp-to-ast" "11.0.3"
-    "@chevrotain/types" "11.0.3"
-    "@chevrotain/utils" "11.0.3"
-    lodash-es "4.17.21"
+    "@chevrotain/cst-dts-gen" "12.0.0"
+    "@chevrotain/gast" "12.0.0"
+    "@chevrotain/regexp-to-ast" "12.0.0"
+    "@chevrotain/types" "12.0.0"
+    "@chevrotain/utils" "12.0.0"
 
-chevrotain-allstar@~0.3.0:
-  version "0.3.1"
-  resolved "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz"
-  integrity sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==
+chevrotain-allstar@~0.4.1:
+  version "0.4.1"
+  resolved "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.1.tgz"
+  integrity sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA==
   dependencies:
     lodash-es "^4.17.21"
 
@@ -7708,7 +7683,7 @@ csstype@^3.2.3:
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz"
   integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
 
-cytoscape@^3.2.0, cytoscape@^3.29.3:
+cytoscape@^3.2.0, cytoscape@^3.33.1:
   version "3.33.1"
   resolved "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz"
   integrity sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==
@@ -7976,7 +7951,7 @@ d3-shape@3, d3-shape@^3.1.0:
   resolved "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz"
   integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
 
-"d3-transition@2 - 3", d3-transition@3:
+"d3-transition@2 - 3", d3-transition@3, d3-transition@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz"
   integrity sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==
@@ -7998,10 +7973,10 @@ d3-zoom@3, d3-zoom@^3.0.0:
     d3-selection "2 - 3"
     d3-transition "2 - 3"
 
-dagre-d3-es@7.0.13:
-  version "7.0.13"
-  resolved "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.13.tgz"
-  integrity sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==
+dagre-d3-es@7.0.14:
+  version "7.0.14"
+  resolved "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz"
+  integrity sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==
   dependencies:
     d3 "^7.9.0"
     lodash-es "^4.17.21"
@@ -8042,7 +8017,7 @@ date-fns-tz@^2.0.0:
   resolved "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.1.tgz"
   integrity sha512-fJCG3Pwx8HUoLhkepdsP7Z5RsucUi+ZBOxyM5d0ZZ6c4SdYustq0VMmOu6Wf7bli+yS/Jwp91TOCqn9jMcVrUA==
 
-dayjs@^1.11.18:
+dayjs@^1.11.19:
   version "1.11.19"
   resolved "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz"
   integrity sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==
@@ -8334,7 +8309,7 @@ domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@3.2.7, dompurify@^3.2.5:
+dompurify@3.2.7, dompurify@^3.2.5, dompurify@^3.3.1:
   version "3.3.3"
   resolved "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz"
   integrity sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==
@@ -8911,40 +8886,7 @@ express@^4.21.2:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
-"express@>= 4.11", "express@^4.21.2 || ^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.npmjs.org/express/-/express-5.1.0.tgz"
-  integrity sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==
-  dependencies:
-    accepts "^2.0.0"
-    body-parser "^2.2.0"
-    content-disposition "^1.0.0"
-    content-type "^1.0.5"
-    cookie "^0.7.1"
-    cookie-signature "^1.2.1"
-    debug "^4.4.0"
-    encodeurl "^2.0.0"
-    escape-html "^1.0.3"
-    etag "^1.8.1"
-    finalhandler "^2.1.0"
-    fresh "^2.0.0"
-    http-errors "^2.0.0"
-    merge-descriptors "^2.0.0"
-    mime-types "^3.0.0"
-    on-finished "^2.4.1"
-    once "^1.4.0"
-    parseurl "^1.3.3"
-    proxy-addr "^2.0.7"
-    qs "^6.14.0"
-    range-parser "^1.2.1"
-    router "^2.2.0"
-    send "^1.1.0"
-    serve-static "^2.2.0"
-    statuses "^2.0.1"
-    type-is "^2.0.1"
-    vary "^1.1.2"
-
-express@^5.2.1:
+"express@>= 4.11", "express@^4.21.2 || ^5.1.0", express@^5.2.1:
   version "5.2.1"
   resolved "https://registry.npmjs.org/express/-/express-5.2.1.tgz"
   integrity sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==
@@ -9574,37 +9516,6 @@ hast@^1.0.0:
   resolved "https://registry.npmjs.org/hast/-/hast-1.0.0.tgz"
   integrity sha512-vFUqlRV5C+xqP76Wwq2SrM0kipnmpxJm7OfvVXpB35Fp+Fn4MV+ozr+JZr5qFvyR1q/U+Foim2x+3P+x9S1PLA==
 
-hast-util-from-dom@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz"
-  integrity sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==
-  dependencies:
-    "@types/hast" "^3.0.0"
-    hastscript "^9.0.0"
-    web-namespaces "^2.0.0"
-
-hast-util-from-html@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz"
-  integrity sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==
-  dependencies:
-    "@types/hast" "^3.0.0"
-    devlop "^1.1.0"
-    hast-util-from-parse5 "^8.0.0"
-    parse5 "^7.0.0"
-    vfile "^6.0.0"
-    vfile-message "^4.0.0"
-
-hast-util-from-html-isomorphic@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz"
-  integrity sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==
-  dependencies:
-    "@types/hast" "^3.0.0"
-    hast-util-from-dom "^5.0.0"
-    hast-util-from-html "^2.0.0"
-    unist-util-remove-position "^5.0.0"
-
 hast-util-from-parse5@^8.0.0:
   version "8.0.3"
   resolved "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz"
@@ -9618,13 +9529,6 @@ hast-util-from-parse5@^8.0.0:
     vfile "^6.0.0"
     vfile-location "^5.0.0"
     web-namespaces "^2.0.0"
-
-hast-util-is-element@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz"
-  integrity sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==
-  dependencies:
-    "@types/hast" "^3.0.0"
 
 hast-util-parse-selector@^2.0.0:
   version "2.2.5"
@@ -9656,6 +9560,15 @@ hast-util-raw@^9.0.0:
     vfile "^6.0.0"
     web-namespaces "^2.0.0"
     zwitch "^2.0.0"
+
+hast-util-sanitize@^5.0.0:
+  version "5.0.2"
+  resolved "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz"
+  integrity sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@ungap/structured-clone" "^1.0.0"
+    unist-util-position "^5.0.0"
 
 hast-util-to-html@^9.0.5:
   version "9.0.5"
@@ -9707,16 +9620,6 @@ hast-util-to-parse5@^8.0.0:
     space-separated-tokens "^2.0.0"
     web-namespaces "^2.0.0"
     zwitch "^2.0.0"
-
-hast-util-to-text@^4.0.0:
-  version "4.0.2"
-  resolved "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz"
-  integrity sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==
-  dependencies:
-    "@types/hast" "^3.0.0"
-    "@types/unist" "^3.0.0"
-    hast-util-is-element "^3.0.0"
-    unist-util-find-after "^5.0.0"
 
 hast-util-whitespace@^2.0.0:
   version "2.0.1"
@@ -9834,7 +9737,7 @@ html-escaper@^2.0.0, html-escaper@^2.0.2:
   resolved "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
-html-url-attributes@^3.0.0:
+html-url-attributes@^3.0.0, html-url-attributes@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz"
   integrity sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==
@@ -10459,7 +10362,7 @@ jwt-decode@^4.0.0:
   resolved "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz"
   integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
 
-katex@^0.16.0, katex@^0.16.22:
+katex@^0.16.0, katex@^0.16.25:
   version "0.16.25"
   resolved "https://registry.npmjs.org/katex/-/katex-0.16.25.tgz"
   integrity sha512-woHRUZ/iF23GBP1dkDQMh1QBad9dmr8/PAwNA54VrSOVYgI12MAcE14TqnDdQOdzyEonGzMepYnqBMYdsoAr8Q==
@@ -10512,16 +10415,17 @@ kolorist@^1.8.0:
   resolved "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz"
   integrity sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==
 
-langium@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.npmjs.org/langium/-/langium-3.3.1.tgz"
-  integrity sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==
+langium@^4.0.0:
+  version "4.2.2"
+  resolved "https://registry.npmjs.org/langium/-/langium-4.2.2.tgz"
+  integrity sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ==
   dependencies:
-    chevrotain "~11.0.3"
-    chevrotain-allstar "~0.3.0"
+    "@chevrotain/regexp-to-ast" "~12.0.0"
+    chevrotain "~12.0.0"
+    chevrotain-allstar "~0.4.1"
     vscode-languageserver "~9.0.1"
     vscode-languageserver-textdocument "~1.0.11"
-    vscode-uri "~3.0.8"
+    vscode-uri "~3.1.0"
 
 launch-editor@^2.6.1:
   version "2.12.0"
@@ -10759,7 +10663,7 @@ lodash@^4.17.15, lodash@^4.17.21, lodash@^4.7.0:
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz"
   integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
-lodash-es@4.17.21, lodash-es@^4.17.21:
+lodash-es@^4.17.21, lodash-es@^4.17.23:
   version "4.18.1"
   resolved "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz"
   integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
@@ -10853,11 +10757,6 @@ lru-cache@^11.0.0:
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz"
   integrity sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==
 
-lucide-react@^0.542.0:
-  version "0.542.0"
-  resolved "https://registry.npmjs.org/lucide-react/-/lucide-react-0.542.0.tgz"
-  integrity sha512-w3hD8/SQB7+lzU2r4VdFyzzOzKnUjTZIF/MQJGSSvni7Llewni4vuViRppfRAa2guOsY5k4jZyxw/i9DQHv+dw==
-
 lucide-react@^1.8.0:
   version "1.8.0"
   resolved "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz"
@@ -10911,10 +10810,15 @@ marked@14.0.0:
   resolved "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz"
   integrity sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==
 
-marked@^16.2.1:
+marked@^16.3.0:
   version "16.4.2"
   resolved "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz"
   integrity sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==
+
+marked@^17.0.1:
+  version "17.0.6"
+  resolved "https://registry.npmjs.org/marked/-/marked-17.0.6.tgz"
+  integrity sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==
 
 math-intrinsics@^1.1.0:
   version "1.1.0"
@@ -11337,27 +11241,28 @@ merge2@^1.3.0:
   resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-mermaid@^11.11.0:
-  version "11.12.1"
-  resolved "https://registry.npmjs.org/mermaid/-/mermaid-11.12.1.tgz"
-  integrity sha512-UlIZrRariB11TY1RtTgUWp65tphtBv4CSq7vyS2ZZ2TgoMjs2nloq+wFqxiwcxlhHUvs7DPGgMjs2aeQxz5h9g==
+mermaid@^11.12.2:
+  version "11.14.0"
+  resolved "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz"
+  integrity sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==
   dependencies:
     "@braintree/sanitize-url" "^7.1.1"
-    "@iconify/utils" "^3.0.1"
-    "@mermaid-js/parser" "^0.6.3"
+    "@iconify/utils" "^3.0.2"
+    "@mermaid-js/parser" "^1.1.0"
     "@types/d3" "^7.4.3"
-    cytoscape "^3.29.3"
+    "@upsetjs/venn.js" "^2.0.0"
+    cytoscape "^3.33.1"
     cytoscape-cose-bilkent "^4.1.0"
     cytoscape-fcose "^2.2.0"
     d3 "^7.9.0"
     d3-sankey "^0.12.3"
-    dagre-d3-es "7.0.13"
-    dayjs "^1.11.18"
-    dompurify "^3.2.5"
-    katex "^0.16.22"
+    dagre-d3-es "7.0.14"
+    dayjs "^1.11.19"
+    dompurify "^3.3.1"
+    katex "^0.16.25"
     khroma "^2.1.0"
-    lodash-es "^4.17.21"
-    marked "^16.2.1"
+    lodash-es "^4.17.23"
+    marked "^16.3.0"
     roughjs "^4.6.6"
     stylis "^4.3.6"
     ts-dedent "^2.2.0"
@@ -13762,23 +13667,12 @@ regex-utilities@^2.3.0:
   resolved "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz"
   integrity sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==
 
-rehype-harden@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.npmjs.org/rehype-harden/-/rehype-harden-1.1.5.tgz"
-  integrity sha512-JrtBj5BVd/5vf3H3/blyJatXJbzQfRT9pJBmjafbTaPouQCAKxHwRyCc7dle9BXQKxv4z1OzZylz/tNamoiG3A==
-
-rehype-katex@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz"
-  integrity sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==
+rehype-harden@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.npmjs.org/rehype-harden/-/rehype-harden-1.1.8.tgz"
+  integrity sha512-Qn7vR1xrf6fZCrkm9TDWi/AB4ylrHy+jqsNm1EHOAmbARYA6gsnVJBq/sdBh6kmT4NEZxH5vgIjrscefJAOXcw==
   dependencies:
-    "@types/hast" "^3.0.0"
-    "@types/katex" "^0.16.0"
-    hast-util-from-html-isomorphic "^2.0.0"
-    hast-util-to-text "^4.0.0"
-    katex "^0.16.0"
-    unist-util-visit-parents "^6.0.0"
-    vfile "^6.0.0"
+    unist-util-visit "^5.0.0"
 
 rehype-raw@^7.0.0:
   version "7.0.0"
@@ -13788,6 +13682,14 @@ rehype-raw@^7.0.0:
     "@types/hast" "^3.0.0"
     hast-util-raw "^9.0.0"
     vfile "^6.0.0"
+
+rehype-sanitize@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz"
+  integrity sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-sanitize "^5.0.0"
 
 remark@^15.0.1:
   version "15.0.1"
@@ -13889,7 +13791,7 @@ remark-rehype@^10.0.0:
     mdast-util-to-hast "^12.1.0"
     unified "^10.0.0"
 
-remark-rehype@^11.0.0:
+remark-rehype@^11.0.0, remark-rehype@^11.1.2:
   version "11.1.2"
   resolved "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz"
   integrity sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==
@@ -13908,6 +13810,11 @@ remark-stringify@^11.0.0:
     "@types/mdast" "^4.0.0"
     mdast-util-to-markdown "^2.0.0"
     unified "^11.0.0"
+
+remend@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/remend/-/remend-1.3.0.tgz"
+  integrity sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw==
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -14468,7 +14375,7 @@ shell-quote@^1.8.3:
   resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz"
   integrity sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==
 
-shiki@^3.12.2, shiki@^3.15.0:
+shiki@^3.15.0:
   version "3.15.0"
   resolved "https://registry.npmjs.org/shiki/-/shiki-3.15.0.tgz"
   integrity sha512-kLdkY6iV3dYbtPwS9KXU7mjfmDm25f5m0IPNFnaXO7TBPcvbUOY72PYXSuSqDzwp+vlH/d7MXpHlKO/x+QoLXw==
@@ -14814,24 +14721,27 @@ stream-http@^3.2.0:
     readable-stream "^3.6.0"
     xtend "^4.0.2"
 
-streamdown@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/streamdown/-/streamdown-1.4.0.tgz"
-  integrity sha512-ylhDSQ4HpK5/nAH9v7OgIIdGJxlJB2HoYrYkJNGrO8lMpnWuKUcrz/A8xAMwA6eILA27469vIavcOTjmxctrKg==
+streamdown@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.npmjs.org/streamdown/-/streamdown-2.5.0.tgz"
+  integrity sha512-/tTnURfIOxZK/pqJAxsfCvETG/XCJHoWnk3jq9xLcuz6CSpnjjuxSRBTTL4PKGhxiZQf0lqPxGhImdpwcZ2XwA==
   dependencies:
     clsx "^2.1.1"
-    katex "^0.16.22"
-    lucide-react "^0.542.0"
-    marked "^16.2.1"
-    mermaid "^11.11.0"
-    react-markdown "^10.1.0"
-    rehype-harden "^1.1.5"
-    rehype-katex "^7.0.1"
+    hast-util-to-jsx-runtime "^2.3.6"
+    html-url-attributes "^3.0.1"
+    marked "^17.0.1"
+    mermaid "^11.12.2"
+    rehype-harden "^1.1.8"
     rehype-raw "^7.0.0"
+    rehype-sanitize "^6.0.0"
     remark-gfm "^4.0.1"
-    remark-math "^6.0.0"
-    shiki "^3.12.2"
-    tailwind-merge "^3.3.1"
+    remark-parse "^11.0.0"
+    remark-rehype "^11.1.2"
+    remend "1.3.0"
+    tailwind-merge "^3.4.0"
+    unified "^11.0.5"
+    unist-util-visit "^5.0.0"
+    unist-util-visit-parents "^6.0.0"
 
 streamx@^2.15.0, streamx@^2.21.0:
   version "2.23.0"
@@ -15016,7 +14926,7 @@ sync-message-port@^1.0.0:
   resolved "https://registry.npmjs.org/sync-message-port/-/sync-message-port-1.1.3.tgz"
   integrity sha512-GTt8rSKje5FilG+wEdfCkOcLL7LWqpMlr2c3LRuKt/YXxcJ52aGSbGBAdI4L3aaqfrBt6y711El53ItyH1NWzg==
 
-tailwind-merge@^3.3.1, tailwind-merge@^3.4.0:
+tailwind-merge@^3.4.0:
   version "3.4.0"
   resolved "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz"
   integrity sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==
@@ -15473,7 +15383,7 @@ unified@^10.0.0:
     trough "^2.0.0"
     vfile "^5.0.0"
 
-unified@^11.0.0, unified@^11.0.3, unified@^11.0.4:
+unified@^11.0.0, unified@^11.0.3, unified@^11.0.4, unified@^11.0.5:
   version "11.0.5"
   resolved "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz"
   integrity sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==
@@ -15485,14 +15395,6 @@ unified@^11.0.0, unified@^11.0.3, unified@^11.0.4:
     is-plain-obj "^4.0.0"
     trough "^2.0.0"
     vfile "^6.0.0"
-
-unist-util-find-after@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz"
-  integrity sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==
-  dependencies:
-    "@types/unist" "^3.0.0"
-    unist-util-is "^6.0.0"
 
 unist-util-generated@^2.0.0:
   version "2.0.1"
@@ -15912,12 +15814,7 @@ vscode-languageserver-types@3.17.5, vscode-languageserver-types@^3.0.0:
   resolved "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz"
   integrity sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==
 
-vscode-uri@~3.0.8:
-  version "3.0.8"
-  resolved "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz"
-  integrity sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==
-
-vscode-uri@^3.0.0:
+vscode-uri@^3.0.0, vscode-uri@~3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz"
   integrity sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==


### PR DESCRIPTION
## Summary

- Remove the old AI Gateway **v1** references from Console frontend (dev proxy, buf-generated npm packages, `AI_GATEWAY_URL` env helper).
- AI Gateway **v2** (aigw) wiring is fully preserved: `/.aigw/api` dev proxy, v2 transport hook, v2 query hooks, and the agent pages that depend on them all stay.
- Old AI Gateway v1 UI was removed in #2155 (Jan 2026); this PR finishes the job by deleting the last vestigial references.

## What's removed

- Dev proxy block for `/.redpanda/api/redpanda.api.aigateway.v1` in `frontend/rsbuild.config.ts` (v1 only)
- `AI_GATEWAY_URL` env var export in `frontend/start-cloud.sh` (plus the cluster-id regex helper it fed)
- `@buf/redpandadata_ai-gateway.bufbuild_es` and `@buf/redpandadata_ai-gateway.connectrpc_query-es` dependencies
- Lockfile entries regenerated (`bun.lock`, `yarn.lock`)

## What's preserved

- AIGW **v2** proxy block (`/.aigw/api`) in `rsbuild.config.ts` — still gated on `AIGW_URL` env var
- `useAigwTransport`, `useListLLMProvidersQuery`, `useListAigwMCPServersQuery` and the agent-page call sites
- `Scope.AI_GATEWAY` secret scope label — semantically refers to stored credentials scoped to AIGW access
- Deprecated `virtualGatewayId` field in `AIAgent.GatewayConfig` proto — backend contract stays

## Companion PR

cloudv2 cleanup (kills the old AI Gateway front-end embedded under `/clusters/:id/ai-gateway` in Cloud UI): https://github.com/redpanda-data/cloudv2/pull/25788

## Test plan

- [x] `bun i && bun i --yarn` in `frontend/` — lockfiles stay clean
- [x] `bun run start:cloud <backend-url>` — dev server starts; aigw v2 proxy still routes when `AIGW_URL` is set
- [x] `bun run test` — existing agent/secret suites still pass

Generated with [Claude Code](https://claude.com/claude-code)
