### PR TITLE
feat(frontend): gate Remote MCP sidebar item behind LaunchDarkly flag

### DIFF
--- a/frontend/src/components/constants.ts
+++ b/frontend/src/components/constants.ts
@@ -7,6 +7,7 @@ export const BUILDER_API_KEY = '4abd0efa0759420b88149ada5c1eb216';
 // By default, most feature flags will be false when there's no embedded mode on.
 export const FEATURE_FLAGS = {
   enableKnowledgeBaseInConsoleUi: false,
+  enableRemoteMcpInConsole: false,
   enableRpcnTiles: false,
   enableServerlessOnboardingWizard: false,
   enableApiKeyConfigurationAgent: false,

--- a/frontend/src/utils/route-utils.tsx
+++ b/frontend/src/utils/route-utils.tsx
@@ -301,7 +301,7 @@ export const SIDEBAR_ITEMS: SidebarItem[] = [
     title: 'Remote MCP',
     icon: MCPIcon,
     group: SidebarSection.AGENTIC,
-    visibilityCheck: routeVisibility(() => isEmbedded()),
+    visibilityCheck: routeVisibility(() => isEmbedded() && isFeatureFlagEnabled('enableRemoteMcpInConsole')),
   },
   {
     path: '/agents',


### PR DESCRIPTION
## Summary

- Remote MCP is GA, but we need to temporarily restrict the Console sidebar entry to an allow-list while we migrate other customers off the old experience.
- Adds `enableRemoteMcpInConsole` to `FEATURE_FLAGS` in `frontend/src/components/constants.ts` so cloud-ui's forwarded LD value is typed and read inside Console.
- Gates the `/mcp-servers` sidebar entry in `frontend/src/utils/route-utils.tsx` on `isEmbedded() && isFeatureFlagEnabled('enableRemoteMcpInConsole')`, matching the pattern already used for `/knowledgebases` and `/observability`.
- cloud-ui already forwards this flag as of redpanda-data/cloudv2#25621 — after this Console release + cloud-ui bump, LD targeting becomes the single source of truth for sidebar visibility.

## Scope / non-goals

- This only hides the sidebar item. Direct URL access to `/mcp-servers/*` is unchanged (per product direction — allow-listed orgs still use those routes, and we don't want a hard block).
- No changes to route guards, API gating, or the MCP feature itself.

## Test plan

- [x] `bun run type:check && bun run lint && bun run test` pass locally.
- [x] In cloud-ui with `enable-remote-mcp-in-console = false`: Remote MCP item is hidden from the Agentic sidebar group.
- [x] In cloud-ui with the flag `true` (allow-listed org): Remote MCP item is visible and the existing page loads unchanged.
- [x] OSS / non-embedded Console: no regression — item was already hidden (`isEmbedded()` was false), still hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)