### PR TITLE
fix(backend): make operation timeouts configurable

### DIFF
--- a/backend/pkg/config/console.go
+++ b/backend/pkg/config/console.go
@@ -22,12 +22,14 @@ const DefaultMaxDeserializationPayloadSize = 20_480 // 20 KB
 type Console struct {
 	TopicDocumentation ConsoleTopicDocumentation `yaml:"topicDocumentation"`
 	API                ConsoleAPI                `yaml:"api"`
+	OperationTimeouts  OperationTimeouts         `yaml:"operationTimeouts"`
 }
 
 // SetDefaults for Console configs.
 func (c *Console) SetDefaults() {
 	c.TopicDocumentation.SetDefaults()
 	c.API.SetDefaults()
+	c.OperationTimeouts.SetDefaults()
 }
 
 // RegisterFlags for sensitive Console configurations.
@@ -43,6 +45,10 @@ func (c *Console) Validate() error {
 
 	if err := c.API.Validate(); err != nil {
 		return fmt.Errorf("failed to validate API config: %w", err)
+	}
+
+	if err := c.OperationTimeouts.Validate(); err != nil {
+		return fmt.Errorf("failed to validate timeouts config: %w", err)
 	}
 
 	return nil

--- a/backend/pkg/config/operation_timeouts.go
+++ b/backend/pkg/config/operation_timeouts.go
@@ -1,0 +1,48 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package config
+
+import (
+	"errors"
+	"time"
+)
+
+// OperationTimeouts contains timeout configurations for various Kafka operations
+// performed by the console service.
+type OperationTimeouts struct {
+	// ClusterInfo is the timeout applied when fetching broker metadata and log dir
+	// information to build the cluster overview. A shorter timeout avoids long
+	// response times when a single broker is temporarily unreachable, but may
+	// cause incomplete results on slow clusters.
+	ClusterInfo time.Duration `yaml:"clusterInfo"`
+
+	// TopicsOverview is the timeout applied when fetching topic metadata and per-topic
+	// log dir sizes to build the topics list. A shorter timeout avoids long response
+	// times when a single broker is temporarily unreachable, but may cause incomplete
+	// results on slow clusters.
+	TopicsOverview time.Duration `yaml:"topicsOverview"`
+}
+
+// SetDefaults for ConsoleTimeouts.
+func (c *OperationTimeouts) SetDefaults() {
+	c.ClusterInfo = 6 * time.Second
+	c.TopicsOverview = 5 * time.Second
+}
+
+// Validate ConsoleTimeouts.
+func (c *OperationTimeouts) Validate() error {
+	if c.ClusterInfo <= 0 {
+		return errors.New("console.operationTimeouts.clusterInfo must be a positive duration")
+	}
+	if c.TopicsOverview <= 0 {
+		return errors.New("console.operationTimeouts.topicsOverview must be a positive duration")
+	}
+	return nil
+}

--- a/backend/pkg/console/cluster_info.go
+++ b/backend/pkg/console/cluster_info.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"log/slog"
 	"sort"
-	"time"
 
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"golang.org/x/sync/errgroup"
@@ -53,7 +52,7 @@ func (s *Service) GetClusterInfo(ctx context.Context) (*ClusterInfo, error) {
 
 	// We use a child context with a shorter timeout because otherwise we'll potentially have very long response
 	// times in case of a single broker being down.
-	childCtx, cancel := context.WithTimeout(egCtx, 6*time.Second)
+	childCtx, cancel := context.WithTimeout(egCtx, s.cfg.Console.OperationTimeouts.ClusterInfo)
 	defer cancel()
 
 	eg.Go(func() error {

--- a/backend/pkg/console/topic_overview.go
+++ b/backend/pkg/console/topic_overview.go
@@ -15,7 +15,6 @@ import (
 	"log/slog"
 	"sort"
 	"sync"
-	"time"
 )
 
 // DocumentationState denotes whether topic documentation is available for a certain
@@ -77,7 +76,7 @@ func (s *Service) GetTopicsOverview(ctx context.Context) ([]*TopicSummary, error
 
 	// 3. Get log dir sizes & configs for each topic concurrently
 	// Use a shorter ctx timeout so that we don't wait for too long if one broker is currently down.
-	childCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	childCtx, cancel := context.WithTimeout(ctx, s.cfg.Console.OperationTimeouts.TopicsOverview)
 	defer cancel()
 
 	configs := make(map[string]*TopicConfig)

--- a/docs/config/console.yaml
+++ b/docs/config/console.yaml
@@ -270,6 +270,12 @@ serde:
 # Console settings
 #----------------------------------------------------------------------------
 console:
+  # Optional: Configure timeouts for Kafka admin operations.
+  # operationTimeouts:
+    # Timeout for fetching broker metadata and log dir sizes (cluster overview).
+    # clusterInfo: 6s
+    # Timeout for fetching topic metadata and per-topic log dir sizes (topics list).
+    # topicsOverview: 5s
   topicDocumentation:
     enabled: false
     # git:


### PR DESCRIPTION
Fixes #2410

On large clusters (e.g. AWS MSK with thousands of partitions and IAM authentication), the hardcoded 6s timeout in GetClusterInfo and 5s timeout in GetTopicsOverview lead to errors such as "context deadline exceeded" and broken broker connections.

This patch introduces a new `OperationTimeouts` config block under `console.operationTimeouts` with `clusterInfo` and `topicsOverview` duration fields. The original values (6s / 5s) are default.

Example configuration:
```
  console:
    operationTimeouts:
      clusterInfo: 30s
      topicsOverview: 30s
```

I'm not sure if the configuration should be under console or under kafka
