### PR TITLE
chore(frontend): [release-2.8] snyk sweep — critical/high + CVE-2026-4800 lodash

### DIFF
--- a/frontend/.snyk
+++ b/frontend/.snyk
@@ -1,0 +1,69 @@
+# Snyk (https://snyk.io) policy file
+version: v1.25.1
+ignore:
+  SNYK-JS-LODASH-15869625:
+    - '@redpanda-data/ui > @hookform/devtools > lodash':
+        reason: >-
+          CVE-2026-4800 / Arbitrary Code Injection in lodash _.template with
+          options.imports. Vulnerable surface is _.template. Reachability
+          analysis: @hookform/devtools only imports lodash/isUndefined,
+          lodash/isObject, and lodash/get (see
+          node_modules/@hookform/devtools/dist/index.esm.js). The vulnerable
+          _.template API is never loaded or invoked through this chain.
+          Additionally, @hookform/devtools is gated inside @redpanda-data/ui
+          behind a developerView flag and is not used anywhere in frontend/src.
+          No untrusted input reaches lodash through this path.
+        expires: '2027-04-22T00:00:00.000Z'
+        created: '2026-04-22T00:00:00.000Z'
+    - '@redpanda-data/ui > remark-emoji > node-emoji > lodash':
+        reason: >-
+          CVE-2026-4800 / Arbitrary Code Injection in lodash _.template with
+          options.imports. Vulnerable surface is _.template. Reachability
+          analysis: the legacy node-emoji@1.11.0 pulled transitively through
+          @redpanda-data/ui's bundled remark-emoji@3.1.2 only imports
+          lodash/toArray (see
+          node_modules/@redpanda-data/ui/node_modules/remark-emoji/node_modules/node-emoji/lib/emoji.js).
+          The vulnerable _.template API is never loaded or invoked. Frontend
+          source code does not call lodash directly and does not import
+          node-emoji directly. No untrusted input reaches _.template.
+        expires: '2027-04-22T00:00:00.000Z'
+        created: '2026-04-22T00:00:00.000Z'
+  SNYK-JS-UNDICI-15518064:
+    - '@tanstack/react-form > @remix-run/node > undici':
+        reason: >-
+          Uncaught Exception in undici WebSocket ByteParser. undici is pulled
+          only via @tanstack/react-form's optional /start SSR utility
+          (dist/esm/start/utils.js -> @remix-run/node). Frontend is a
+          browser-only Module Federation remote built with rsbuild/rspack;
+          source code imports only from '@tanstack/react-form' (browser entry),
+          never '@tanstack/react-form/start'. undici never loads in the
+          browser and its WebSocket client is never invoked from this app.
+        expires: '2027-04-22T00:00:00.000Z'
+        created: '2026-04-22T00:00:00.000Z'
+  SNYK-JS-UNDICI-15518068:
+    - '@tanstack/react-form > @remix-run/node > undici':
+        reason: >-
+          Improper Handling of Highly Compressed Data in undici
+          PerMessageDeflate.decompress (WebSocket extension). undici is pulled
+          only via @tanstack/react-form's optional /start SSR utility
+          (dist/esm/start/utils.js -> @remix-run/node). Frontend is a
+          browser-only Module Federation remote; source imports only from
+          '@tanstack/react-form' (browser entry), never
+          '@tanstack/react-form/start'. undici's WebSocket client never loads
+          or decompresses data in this app.
+        expires: '2027-04-22T00:00:00.000Z'
+        created: '2026-04-22T00:00:00.000Z'
+  SNYK-JS-UNDICI-15518070:
+    - '@tanstack/react-form > @remix-run/node > undici':
+        reason: >-
+          Uncaught Exception via server_max_window_bits in undici
+          permessage-deflate WebSocket extension. undici is pulled only via
+          @tanstack/react-form's optional /start SSR utility
+          (dist/esm/start/utils.js -> @remix-run/node). Frontend is a
+          browser-only Module Federation remote; source imports only from
+          '@tanstack/react-form' (browser entry), never
+          '@tanstack/react-form/start'. undici's WebSocket client never loads
+          in this app.
+        expires: '2027-04-22T00:00:00.000Z'
+        created: '2026-04-22T00:00:00.000Z'
+patch: {}


### PR DESCRIPTION
## Summary
Minimal Snyk sweep on `release-2.8`. Scope: **critical + high** severity, **plus** `SNYK-JS-LODASH-15869625` (CVE-2026-4800, lodash code injection) per explicit request.

Builds on the prior sweep merged in #2276.

**Methodology**: reachability check first → direct-dep bump → overrides only as last resort.

All five in-scope high findings were **unreachable** in the shipped browser bundle. Each is dismissed in `frontend/.snyk` with a per-path reachability justification (expires 2027-04-22). No dependency bumps, no overrides, no source churn.

After applying `.snyk`, `snyk test --severity-threshold=high` is clean.

## Disposition per finding

| Severity | Snyk / CVE | Package | Chain | Disposition | Reasoning |
| --- | --- | --- | --- | --- | --- |
| high | SNYK-JS-LODASH-15869625 (CVE-2026-4800) | lodash@4.17.21 | `@redpanda-data/ui > @hookform/devtools > lodash` | `.snyk` dismiss | Vulnerable surface is `_.template` with `options.imports`. `@hookform/devtools` only imports `lodash/isUndefined`, `lodash/isObject`, `lodash/get` (verified in node_modules). `_.template` is never loaded. Also, `@hookform/devtools` is gated behind a `developerView` flag inside `@redpanda-data/ui` and isn't referenced in `frontend/src`. |
| high | SNYK-JS-LODASH-15869625 (CVE-2026-4800) | lodash@4.17.21 | `@redpanda-data/ui > remark-emoji > node-emoji > lodash` | `.snyk` dismiss | Vulnerable surface is `_.template`. Legacy `node-emoji@1.11.0` (nested under `@redpanda-data/ui`'s bundled `remark-emoji@3.1.2`) only imports `lodash/toArray`. `_.template` is never loaded. Frontend source uses top-level `remark-emoji@5.0.1` which does not depend on lodash at all. |
| high | SNYK-JS-UNDICI-15518064 | undici@6.23.0 | `@tanstack/react-form > @remix-run/node > undici` | `.snyk` dismiss | undici WebSocket ByteParser. undici is pulled only via `@tanstack/react-form/dist/esm/start/utils.js` (Start SSR subpath). The frontend is a browser-only MF v2 remote built with rsbuild/rspack and only imports from `@tanstack/react-form` (browser entry); `react-form/start` is never imported. |
| high | SNYK-JS-UNDICI-15518068 | undici@6.23.0 | `@tanstack/react-form > @remix-run/node > undici` | `.snyk` dismiss | Same reachability argument as above (undici WebSocket `permessage-deflate` decompress). |
| high | SNYK-JS-UNDICI-15518070 | undici@6.23.0 | `@tanstack/react-form > @remix-run/node > undici` | `.snyk` dismiss | Same reachability argument (undici `server_max_window_bits` permessage-deflate handling). |

## SNYK-JS-LODASH-15869625 (CVE-2026-4800) — explicitly requested
**Disposition**: dismissed via `frontend/.snyk` on both dependency paths.

**Reachability**: the vulnerable API is `_.template` with `options.imports`. Neither caller of lodash in this tree exercises `_.template`:
- `@hookform/devtools` → only `lodash/isUndefined`, `lodash/isObject`, `lodash/get`.
- legacy `node-emoji@1.11.0` (nested under `@redpanda-data/ui`'s bundled `remark-emoji@3.1.2`) → only `lodash/toArray`.

No frontend source code imports lodash directly. No untrusted input ever reaches `_.template` through any reachable path.

## React 18 pin
No bump affects React peers (no bumps were required).

## Verification
- [x] `snyk test --severity-threshold=high` — clean (0 issues, all 5 dismissed)
- [x] `bun audit` run — additional dev-only findings are out of scope for this minimal release-branch sweep
- [x] `bun.lock` unchanged; `yarn.lock` unchanged — `.snyk` is the only new file
- [x] Scope: only `frontend/.snyk` touched

## Release-branch discipline
This is a maintained release branch. Diff is one new file (`frontend/.snyk`). No lockfile churn, no speculative overrides, no unrelated cleanup. All dismissals carry a per-path reachability reason that references the actual node_modules file evidence.

cc @redpanda-data/ux-console