### PR TITLE
chore(frontend): [release-2.8] dismiss 3 @remix-run/* HIGH vulns missed by #2413

### DIFF
--- a/frontend/.snyk
+++ b/frontend/.snyk
@@ -66,4 +66,37 @@ ignore:
           in this app.
         expires: '2027-04-22T00:00:00.000Z'
         created: '2026-04-22T00:00:00.000Z'
+  SNYK-JS-REMIXRUNNODE-14908858:
+    - '*':
+        reason: >-
+          Directory Traversal in @remix-run/node's file-system handler.
+          @remix-run/node is pulled only via @tanstack/react-form's optional
+          /start SSR utility. Frontend is a browser-only Module Federation
+          remote built with rsbuild/rspack; grep of frontend/src confirms
+          source imports only from '@tanstack/react-form' (browser entry),
+          never '@tanstack/react-form/start'. @remix-run/node never loads in
+          the browser and its file-system APIs are never invoked.
+        expires: '2027-04-22T00:00:00.000Z'
+        created: '2026-04-22T00:00:00.000Z'
+  SNYK-JS-REMIXRUNROUTER-14908287:
+    - '*':
+        reason: >-
+          Open Redirect in @remix-run/router. Pulled via the same
+          @tanstack/react-form /start SSR chain as the undici/remix-run-node
+          advisories. Frontend source imports only the browser entry of
+          @tanstack/react-form, never the /start subpath. @remix-run/router's
+          server-side redirect-handling code is never executed in this
+          browser-only MF remote.
+        expires: '2027-04-22T00:00:00.000Z'
+        created: '2026-04-22T00:00:00.000Z'
+  SNYK-JS-REMIXRUNROUTER-14908530:
+    - '*':
+        reason: >-
+          XSS in @remix-run/router. Pulled via the same
+          @tanstack/react-form /start SSR chain. Frontend source imports only
+          the browser entry of @tanstack/react-form, never the /start
+          subpath. The vulnerable server-side response-rendering code is
+          never executed in this browser-only MF remote.
+        expires: '2027-04-22T00:00:00.000Z'
+        created: '2026-04-22T00:00:00.000Z'
 patch: {}


### PR DESCRIPTION
## Summary

Follow-up to merged PR #2413. That sweep dismissed 4 HIGH-severity Snyk findings (SNYK-JS-LODASH-15869625 + 3 undici IDs) but missed 3 additional HIGH-severity findings that share the exact same unreachable dep chain:

- `SNYK-JS-REMIXRUNNODE-14908858` — Directory Traversal
- `SNYK-JS-REMIXRUNROUTER-14908287` — Open Redirect
- `SNYK-JS-REMIXRUNROUTER-14908530` — Cross-site Scripting (XSS)

All three are pulled in via `@tanstack/react-form`'s optional `/start` SSR utility. `grep -rn "@tanstack/react-form/start\|@remix-run" frontend/src` returns zero hits — the frontend is a browser-only Module Federation remote and never imports the `/start` subpath. The vulnerable server-side code is never loaded or executed.

Each dismissal includes a reachability analysis in `frontend/.snyk` with `expires: 2027-04-22`.

## Verification

- [x] `snyk test --file=yarn.lock --severity-threshold=high` — "no vulnerable paths found"
- [x] Scope: only `frontend/.snyk` touched (+33 / -0)

cc @redpanda-data/ux-console