### PR TITLE
fix(agents): allow bedrock in agent form provider enum

### DIFF
--- a/frontend/src/components/pages/agents/create/schemas.ts
+++ b/frontend/src/components/pages/agents/create/schemas.ts
@@ -50,7 +50,7 @@ export const FormSchema = z
       ),
     triggerType: z.enum(['http', 'slack', 'kafka']).default('http'),
     llmProvider: z.string().optional().or(z.literal('')),
-    provider: z.enum(['openai', 'anthropic', 'google', 'openaiCompatible']).default('openai'),
+    provider: z.enum(['openai', 'anthropic', 'google', 'openaiCompatible', 'bedrock']).default('openai'),
     apiKeySecret: z.string(),
     model: z.string().min(1, 'Model is required'),
     baseUrl: z.string().url('Must be a valid URL').optional().or(z.literal('')),


### PR DESCRIPTION
## What

Add `'bedrock'` to the Zod enum for the agent form's provider field.

## Why

34be39ede added Bedrock to the provider TS unions, to `LLM_PROVIDER_TYPE_TO_FORM_ID`, and to the aigw dropdown pipeline, but missed the Zod schema. Selecting a Bedrock provider from the aigw dropdown set `provider: 'bedrock'` and the form blew up with:

> Invalid enum value. Expected 'openai' | 'anthropic' | 'google' | 'openaiCompatible', received 'bedrock'

## Implementation details

One-line widen of the enum in `frontend/src/components/pages/agents/create/schemas.ts`.

Bedrock-specific field validation (region, credentials) is intentionally not added. In aigw mode that config lives on the gateway provider, not on the agent form. The non-gateway path doesn't render Bedrock fields yet anyway.

## References

Introduced by 34be39ede (feat(agents): add Bedrock provider to AIAgent proto).