### PR TITLE
fix(agents): wire bedrock provider in create form submit

### DIFF
--- a/frontend/src/components/pages/agents/create/ai-agent-create-page.tsx
+++ b/frontend/src/components/pages/agents/create/ai-agent-create-page.tsx
@@ -41,6 +41,7 @@ import {
   AIAgent_MCPServerSchema,
   type AIAgent_Provider,
   AIAgent_Provider_AnthropicSchema,
+  AIAgent_Provider_BedrockSchema,
   AIAgent_Provider_GoogleSchema,
   AIAgent_Provider_OpenAICompatibleSchema,
   AIAgent_Provider_OpenAISchema,
@@ -53,6 +54,7 @@ import {
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Controller, useFieldArray, useForm, useWatch } from 'react-hook-form';
 import { useCreateAIAgentMutation } from 'react-query/api/ai-agent';
+import { useListLLMProvidersQuery } from 'react-query/api/aigw/llm-providers';
 import { useListAigwMCPServersQuery } from 'react-query/api/aigw/mcp-servers';
 import { useCreateSecretMutation, useListSecretsQuery } from 'react-query/api/secret';
 import { toast } from 'sonner';
@@ -70,6 +72,7 @@ export const AIAgentCreatePage = () => {
   const { mutateAsync: createAgent, isPending: isCreateAgentPending } = useCreateAIAgentMutation();
   const { data: secretsData } = useListSecretsQuery();
   const { data: mcpServersData } = useListAigwMCPServersQuery(undefined, { enabled: !!config.aigwUrl });
+  const { data: llmProvidersData } = useListLLMProvidersQuery(undefined, { enabled: !!config.aigwUrl });
   const { mutateAsync: createSecret, isPending: isCreateSecretPending } = useCreateSecretMutation({
     skipInvalidation: true,
   });
@@ -344,6 +347,22 @@ export const AIAgentCreatePage = () => {
           },
         });
         break;
+      case 'bedrock': {
+        // Region lives on the gateway's LLMProvider config; mirror it into the
+        // agent's Bedrock config so proto validation (region required) passes.
+        const selectedGwProvider = llmProvidersData?.llmProviders?.find((p) => p.name === values.llmProvider);
+        const region =
+          selectedGwProvider?.providerConfig?.case === 'bedrockConfig'
+            ? selectedGwProvider.providerConfig.value.region
+            : '';
+        providerConfig = create(AIAgent_ProviderSchema, {
+          provider: {
+            case: 'bedrock',
+            value: create(AIAgent_Provider_BedrockSchema, { region }),
+          },
+        });
+        break;
+      }
       default: // openai
         providerConfig = create(AIAgent_ProviderSchema, {
           provider: {


### PR DESCRIPTION
## What

Add a `case 'bedrock':` branch to the AI agent create-page submit switch so the UI actually ships a Bedrock provider config when the user picks a Bedrock-typed LLM gateway provider.

## Why

PR #2402 added Bedrock to the dataplane `AIAgent.Provider` oneof and to the provider dropdown, but the create-page `onSubmit` switch was never updated. The form's `provider` field gets set to `'bedrock'` via `LLM_PROVIDER_TYPE_TO_FORM_ID` in `llm-config-section.tsx`, then falls through to `default // openai` in `ai-agent-create-page.tsx`. The request on the wire is `provider:{openai:{}}` with a Bedrock model ID, and the aiagent pod crashes on startup with:

```
failed to create models: failed to create OpenAI model: unsupported OpenAI model: anthropic.claude-opus-4-7
```

## Implementation details

The dataplane proto marks `AIAgent.Provider.Bedrock.region` as required (pattern `^[a-z]{2}(-[a-z]+-\\d+)?$`), but in gateway mode the region lives on the `LLMProvider.bedrockConfig` resource in aigw. Pull it from there at submit time and mirror it onto the agent's Bedrock oneof variant so validation passes. Credentials stay on the gateway.

Gateway-only for now. Direct (non-gateway) Bedrock would need a region form field.

## References

- redpanda-data/console#2402 - proto + dropdown support
- redpanda-data/console#2415 - zod enum fix

Requires matching backend work in cloudv2: CRD type, proto-to-CRD mapper, controller env-var mapping, ai-agent ProviderConfig + `createModel` branch. Filed separately.