### PR TITLE
fix(topics): hide Infinite button for capped configs + fix Custom SELECT width (UX-1235)

### DIFF
--- a/backend/pkg/console/config_extensions.go
+++ b/backend/pkg/console/config_extensions.go
@@ -52,6 +52,12 @@ type ConfigEntryExtension struct {
 	// the user the available compression methods for `compression.type`.
 	// The presented values may be dependent on the target Kafka cluster version.
 	EnumValues []string `json:"enumValues,omitempty"`
+
+	// NoInfiniteValue opts a config out of the "Infinite" button in the config
+	// editor. BYTE_SIZE and DURATION configs show Infinite by default; set this
+	// to true for configs where the broker rejects the infinite sentinel (e.g.
+	// max.message.bytes, segment.bytes, which have hard server-side caps).
+	NoInfiniteValue bool `json:"noInfiniteValue,omitempty"`
 }
 
 func loadConfigExtensions() (map[string]ConfigEntryExtension, error) {

--- a/backend/pkg/embed/kafka/apache_kafka_configs.json
+++ b/backend/pkg/embed/kafka/apache_kafka_configs.json
@@ -60,7 +60,8 @@
     "type": "INT",
     "documentation": "This configuration controls the segment file size for the log. Retention and cleaning is always done a file at a time so a larger segment size means fewer files but less granular control over retention.",
     "category": "Storage Internals",
-    "frontendFormat": "BYTE_SIZE"
+    "frontendFormat": "BYTE_SIZE",
+    "noInfiniteValue": true
   },
   {
     "name": "retention.ms",
@@ -102,7 +103,8 @@
     "type": "INT",
     "documentation": "The largest record batch size allowed by Kafka (after compression if compression is enabled). If this is increased and there are consumers older than 0.10.2, the consumers' fetch size must also be increased so that they can fetch record batches this large. In the latest message format version, records are always grouped into batches for efficiency. In previous message format versions, uncompressed records are not grouped into batches and this limit only applies to a single record in that case.",
     "category": "Message Handling",
-    "frontendFormat": "BYTE_SIZE"
+    "frontendFormat": "BYTE_SIZE",
+    "noInfiniteValue": true
   },
   {
     "name": "min.compaction.lag.ms",

--- a/frontend/src/components/pages/topics/topic-configuration.tsx
+++ b/frontend/src/components/pages/topics/topic-configuration.tsx
@@ -442,6 +442,7 @@ export const ConfigEntryEditorController = <T extends string | number>(p: {
     case 'SELECT':
       return (
         <SingleSelect
+          chakraStyles={{ container: (base) => ({ ...base, minWidth: '240px' }) }}
           className={p.className}
           onChange={onChange}
           options={

--- a/frontend/src/components/pages/topics/topic-configuration.tsx
+++ b/frontend/src/components/pages/topics/topic-configuration.tsx
@@ -79,7 +79,10 @@ const ConfigEditorForm: FC<{
     },
   });
 
-  const hasInfiniteValue = editedEntry.frontendFormat && ['BYTE_SIZE', 'DURATION'].includes(editedEntry.frontendFormat);
+  const hasInfiniteValue =
+    editedEntry.frontendFormat &&
+    ['BYTE_SIZE', 'DURATION'].includes(editedEntry.frontendFormat) &&
+    !editedEntry.noInfiniteValue;
   const valueTypeOptions: Array<{
     label: string;
     value: Inputs['valueType'];

--- a/frontend/src/state/rest-interfaces.ts
+++ b/frontend/src/state/rest-interfaces.ts
@@ -277,6 +277,7 @@ export type ConfigEntryExtended = ConfigEntry & {
     | 'DECIMAL'
     | 'INTEGER';
   enumValues?: string[];
+  noInfiniteValue?: boolean;
 
   // added by frontend
   currentValue: string | number | null | undefined;


### PR DESCRIPTION
## Summary
Two fixes to the topic config editor, both filed under [UX-1235](https://redpandadata.atlassian.net/browse/UX-1235).

### 1. Infinite button on capped configs
The editor offered an **Infinite** button for every `BYTE_SIZE`/`DURATION` config. For configs with a hard server-side cap (`max.message.bytes`, `segment.bytes`), clicking it sent `-1`, which the broker reinterpreted as `4294967295` and rejected with `INVALID_CONFIG: max.message.bytes 4294967295 is outside of the allowed range [1, 104857600]`.

- Added an opt-out field `noInfiniteValue` to the config extension schema (`ConfigEntryExtension` in Go, `ConfigEntryExtended` in TS).
- Applied the opt-out to `max.message.bytes` and `segment.bytes` in `apache_kafka_configs.json`.
- Other `BYTE_SIZE`/`DURATION` configs continue to show the button by default.

### 2. Custom SELECT width
For SELECT configs like `message.timestamp.type`, the Custom editor wrapper used `maxW="fit-content"` only. `DataSizeSelect`/`DurationSelect` have intrinsic width from their number+unit inputs, but a bare `SingleSelect` collapsed to the width of the current selection — rendering as just an arrow icon, with opened options truncated (`CreateTime` → `Creat`, `LogAppendTime` → `LogA`).

- Added `minW="240px"` on the Custom value Box so any control has room for its labels.

> Note: the first commit message on this branch still says `UX-1222` (wrong ticket, was the active pointer at commit time). The second commit uses the correct key. Fix on squash-merge — canonical ticket is `UX-1235`.

## Test plan
- [ ] Edit `max.message.bytes`: shows only **Default** / **Custom**; KB/MB/GB unit picker still works under Custom.
- [ ] Edit `segment.bytes`: same — no **Infinite** button.
- [ ] Edit `retention.bytes` and `retention.ms`: unchanged — **Infinite** still shown and applies `-1`.
- [ ] Edit `message.timestamp.type`, click **Custom**: dropdown is wide enough to show `CreateTime` / `LogAppendTime` without truncation.
- [ ] Regression: `cleanup.policy` and other non-BYTE/DURATION configs render as before.

## Follow-up
The JSON config-extension dictionary is hand-curated and drifts from broker truth. Proper fix is to have `DescribeConfigs` return valid range + `supports_infinite` per config. Scoped in the UX-1235 description for a separate ticket.

[UX-1235]: https://redpandadata.atlassian.net/browse/UX-1235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="639" height="332" alt="Screenshot 2026-04-23 at 11 58 45" src="https://github.com/user-attachments/assets/058a7908-fe3e-41c0-afc3-2f028a72510e" />


Before on Select Dropdown:
<img width="371" height="170" alt="Screenshot 2026-04-23 at 12 00 12" src="https://github.com/user-attachments/assets/a83f91b8-51c1-419c-bcb3-f105727d7cf2" />
After on Select Dropdown:
<img width="585" height="343" alt="image" src="https://github.com/user-attachments/assets/eda9df67-1c6c-4721-9a54-082436bb1e58" />
