### PR TITLE
fix(topics): clamp default replication factor to broker count

### DIFF
--- a/frontend/src/components/pages/mcp-servers/details/remote-mcp-inspector-tab.tsx
+++ b/frontend/src/components/pages/mcp-servers/details/remote-mcp-inspector-tab.tsx
@@ -36,7 +36,6 @@ import {
 } from 'protogen/redpanda/api/dataplane/v1/topic_pb';
 import { MCPServer_State, MCPServer_Tool_ComponentType } from 'protogen/redpanda/api/dataplane/v1alpha3/mcp_pb';
 import { useEffect, useRef, useState } from 'react';
-import { useGetKafkaInfoQuery } from 'react-query/api/cluster-status';
 import {
   type MCPStreamProgress,
   useGetMCPServerQuery,
@@ -202,13 +201,6 @@ export const RemoteMCPInspectorTab = () => {
     hideInternalTopics: true,
   });
   const { mutateAsync: createTopic } = useCreateTopicMutation();
-  // Clamp RF to broker count so single-broker clusters (e.g. local-byoc) don't
-  // fail CreateTopic with "not enough replicas". Fall back to the default if
-  // the KafkaInfo query hasn't resolved yet.
-  const { data: kafkaInfo } = useGetKafkaInfoQuery();
-  const brokersOnline = kafkaInfo?.brokersOnline ?? 0;
-  const effectiveReplicationFactor =
-    brokersOnline > 0 ? Math.min(DEFAULT_TOPIC_REPLICATION_FACTOR, brokersOnline) : DEFAULT_TOPIC_REPLICATION_FACTOR;
 
   useEffect(() => {
     if (!selectedTool && mcpServerTools?.tools && mcpServerTools.tools.length === 1) {
@@ -572,7 +564,7 @@ export const RemoteMCPInspectorTab = () => {
                                             topic: create(CreateTopicRequest_TopicSchema, {
                                               name: newTopicName,
                                               partitionCount: DEFAULT_TOPIC_PARTITION_COUNT,
-                                              replicationFactor: effectiveReplicationFactor,
+                                              replicationFactor: DEFAULT_TOPIC_REPLICATION_FACTOR,
                                               configs: [
                                                 create(CreateTopicRequest_Topic_ConfigSchema, {
                                                   name: 'cleanup.policy',

--- a/frontend/src/components/pages/mcp-servers/details/remote-mcp-inspector-tab.tsx
+++ b/frontend/src/components/pages/mcp-servers/details/remote-mcp-inspector-tab.tsx
@@ -36,6 +36,7 @@ import {
 } from 'protogen/redpanda/api/dataplane/v1/topic_pb';
 import { MCPServer_State, MCPServer_Tool_ComponentType } from 'protogen/redpanda/api/dataplane/v1alpha3/mcp_pb';
 import { useEffect, useRef, useState } from 'react';
+import { useGetKafkaInfoQuery } from 'react-query/api/cluster-status';
 import {
   type MCPStreamProgress,
   useGetMCPServerQuery,
@@ -201,6 +202,13 @@ export const RemoteMCPInspectorTab = () => {
     hideInternalTopics: true,
   });
   const { mutateAsync: createTopic } = useCreateTopicMutation();
+  // Clamp RF to broker count so single-broker clusters (e.g. local-byoc) don't
+  // fail CreateTopic with "not enough replicas". Fall back to the default if
+  // the KafkaInfo query hasn't resolved yet.
+  const { data: kafkaInfo } = useGetKafkaInfoQuery();
+  const brokersOnline = kafkaInfo?.brokersOnline ?? 0;
+  const effectiveReplicationFactor =
+    brokersOnline > 0 ? Math.min(DEFAULT_TOPIC_REPLICATION_FACTOR, brokersOnline) : DEFAULT_TOPIC_REPLICATION_FACTOR;
 
   useEffect(() => {
     if (!selectedTool && mcpServerTools?.tools && mcpServerTools.tools.length === 1) {
@@ -564,7 +572,7 @@ export const RemoteMCPInspectorTab = () => {
                                             topic: create(CreateTopicRequest_TopicSchema, {
                                               name: newTopicName,
                                               partitionCount: DEFAULT_TOPIC_PARTITION_COUNT,
-                                              replicationFactor: DEFAULT_TOPIC_REPLICATION_FACTOR,
+                                              replicationFactor: effectiveReplicationFactor,
                                               configs: [
                                                 create(CreateTopicRequest_Topic_ConfigSchema, {
                                                   name: 'cleanup.policy',

--- a/frontend/src/components/pages/rp-connect/onboarding/add-topic-step.tsx
+++ b/frontend/src/components/pages/rp-connect/onboarding/add-topic-step.tsx
@@ -166,7 +166,10 @@ export const AddTopicStep = forwardRef<BaseStepRef<AddTopicFormData>, AddTopicSt
       }
       if (topicConfig && !topicConfig.error) {
         const allTopicValues = parseTopicConfigFromExisting(existingTopicSelected, topicConfig);
-        form.reset(allTopicValues, { keepDefaultValues: false });
+        // Override the form-level `keepDirtyValues: true` default — when a user
+        // selects an existing topic, its config must fully replace any partial
+        // input they've made.
+        form.reset(allTopicValues, { keepDefaultValues: false, keepDirtyValues: false });
       } else {
         form.setValue('topicName', existingTopicSelected.topicName, {
           shouldDirty: false,

--- a/frontend/src/components/pages/rp-connect/onboarding/add-topic-step.tsx
+++ b/frontend/src/components/pages/rp-connect/onboarding/add-topic-step.tsx
@@ -25,6 +25,7 @@ import { ListTopicsRequestSchema } from 'protogen/redpanda/api/dataplane/v1/topi
 import { listTopics } from 'protogen/redpanda/api/dataplane/v1/topic-TopicService_connectquery';
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
+import { useGetKafkaInfoQuery } from 'react-query/api/cluster-status';
 import { useLegacyListTopicsQuery } from 'react-query/api/topic';
 import { LONG_LIVED_CACHE_STALE_TIME } from 'react-query/react-query.utils';
 import { isFalsy } from 'utils/falsy';
@@ -104,12 +105,23 @@ export const AddTopicStep = forwardRef<BaseStepRef<AddTopicFormData>, AddTopicSt
 
     const isPending = createTopicMutation.isPending;
 
+    // The RF field is readOnly in advanced-topic-settings, so the default is
+    // also the final value. Clamp to broker count so single-broker clusters
+    // (e.g. local-byoc) don't hit "not enough replicas" on CreateTopic.
+    const { data: kafkaInfo } = useGetKafkaInfoQuery();
+    const brokersOnline = kafkaInfo?.brokersOnline ?? 0;
+    const defaultReplicationFactor =
+      brokersOnline > 0
+        ? Math.min(TOPIC_FORM_DEFAULTS.replicationFactor, brokersOnline)
+        : TOPIC_FORM_DEFAULTS.replicationFactor;
+
     const defaultValues = useMemo(
       () => ({
         ...TOPIC_FORM_DEFAULTS,
+        replicationFactor: defaultReplicationFactor,
         topicName: defaultTopicName || TOPIC_FORM_DEFAULTS.topicName,
       }),
-      [defaultTopicName]
+      [defaultTopicName, defaultReplicationFactor]
     );
 
     const form = useForm<AddTopicFormData>({

--- a/frontend/src/components/pages/rp-connect/onboarding/add-topic-step.tsx
+++ b/frontend/src/components/pages/rp-connect/onboarding/add-topic-step.tsx
@@ -124,10 +124,17 @@ export const AddTopicStep = forwardRef<BaseStepRef<AddTopicFormData>, AddTopicSt
       [defaultTopicName, defaultReplicationFactor]
     );
 
+    // Pass defaultValues AND values so react-hook-form reactively updates
+    // replicationFactor when the KafkaInfo query resolves after mount. The
+    // `values` prop is rhf's built-in mechanism for external reactive state;
+    // `keepDirtyValues` prevents fields the user has already touched from
+    // being overwritten when kafkaInfo lands late.
     const form = useForm<AddTopicFormData>({
       resolver: zodResolver(addTopicFormSchema),
       mode: 'onChange',
       defaultValues,
+      values: defaultValues,
+      resetOptions: { keepDirtyValues: true },
     });
 
     const watchedTopicName = useWatch({

--- a/frontend/src/components/pages/topics/create-topic-modal.tsx
+++ b/frontend/src/components/pages/topics/create-topic-modal.tsx
@@ -46,8 +46,9 @@ export const CreateTopicModal = ({ isOpen, onClose }: CreateTopicModalProps) => 
   });
   const { mutateAsync: createTopic, isPending: isCreateTopicPending } = useCreateTopicMutation();
   // Clamp RF to broker count so single-broker clusters (e.g. local-byoc) don't
-  // fail CreateTopic with "not enough replicas". Fall back to the default if
-  // the KafkaInfo query hasn't resolved yet.
+  // fail CreateTopic with "not enough replicas". When `brokersOnline` is 0
+  // (KafkaInfo still loading, or every broker is offline) keep the default —
+  // a degraded cluster will reject CreateTopic regardless of what we send.
   const { data: kafkaInfo } = useGetKafkaInfoQuery();
   const brokersOnline = kafkaInfo?.brokersOnline ?? 0;
   const replicationFactor =

--- a/frontend/src/components/pages/topics/create-topic-modal.tsx
+++ b/frontend/src/components/pages/topics/create-topic-modal.tsx
@@ -20,6 +20,7 @@ import {
   CreateTopicRequestSchema,
   ListTopicsRequestSchema,
 } from 'protogen/redpanda/api/dataplane/v1/topic_pb';
+import { useGetKafkaInfoQuery } from 'react-query/api/cluster-status';
 import { useCreateTopicMutation, useLegacyListTopicsQuery } from 'react-query/api/topic';
 import { z } from 'zod';
 
@@ -44,6 +45,13 @@ export const CreateTopicModal = ({ isOpen, onClose }: CreateTopicModalProps) => 
     hideInternalTopics: true,
   });
   const { mutateAsync: createTopic, isPending: isCreateTopicPending } = useCreateTopicMutation();
+  // Clamp RF to broker count so single-broker clusters (e.g. local-byoc) don't
+  // fail CreateTopic with "not enough replicas". Fall back to the default if
+  // the KafkaInfo query hasn't resolved yet.
+  const { data: kafkaInfo } = useGetKafkaInfoQuery();
+  const brokersOnline = kafkaInfo?.brokersOnline ?? 0;
+  const replicationFactor =
+    brokersOnline > 0 ? Math.min(DEFAULT_TOPIC_REPLICATION_FACTOR, brokersOnline) : DEFAULT_TOPIC_REPLICATION_FACTOR;
 
   const formOpts = formOptions({
     defaultValues: {
@@ -57,7 +65,7 @@ export const CreateTopicModal = ({ isOpen, onClose }: CreateTopicModalProps) => 
         topic: create(CreateTopicRequest_TopicSchema, {
           name: value.name,
           partitionCount: DEFAULT_TOPIC_PARTITION_COUNT,
-          replicationFactor: DEFAULT_TOPIC_REPLICATION_FACTOR,
+          replicationFactor,
           configs: [
             create(CreateTopicRequest_Topic_ConfigSchema, {
               name: 'cleanup.policy',


### PR DESCRIPTION
## Summary

Three topic-create surfaces in Console hardcoded \`replicationFactor: 3\`. On single-broker clusters (local-byoc dev environments, degraded prod edges) that caused CreateTopic to fail with \"not enough replicas\". The RPCN onboarding form was the most visible case because the RF input is rendered \`readOnly\` — users could see the \`3\` but had no way to change it.

Files changed:
- \`pages/rp-connect/onboarding/add-topic-step.tsx\` — override \`TOPIC_FORM_DEFAULTS.replicationFactor\` at form init with \`min(3, brokersOnline)\`. **This is the user-visible fix**: the readOnly field now shows the correct value for single-broker clusters.
- \`pages/topics/create-topic-modal.tsx\` — new topic-create modal; clamp RF inline.
- \`pages/mcp-servers/details/remote-mcp-inspector-tab.tsx\` — MCP inspector's inline topic-create flow; clamp RF inline.

All three use \`useGetKafkaInfoQuery\` to read \`brokersOnline\` and fall back to the original \`3\` while the query is loading. On 3+ broker clusters the behavior is unchanged.

Note: the legacy \`pages/topics/CreateTopicModal/create-topic-modal.tsx\` already reads the default from the broker's \`default.replication.factor\` config, so it's already correct provided the broker config is correct.

## Test plan

- [x] \`bun run test:ci\` (unit): 755/755 passed on the branch
- [x] \`bun run lint\` auto-sorted imports; no new lint findings introduced by this change
- [ ] Manual verification on a 1-broker local-byoc cluster: RPCN onboarding → Add Topic should show RF=1 (readOnly), CreateTopic succeeds
- [ ] Manual verification on a 3-broker cluster: RPCN onboarding shows RF=3 as before