### PR TITLE
fix(agents): preserve bedrock region on AI agent edit

### DIFF
--- a/frontend/src/components/pages/agents/details/ai-agent-configuration-tab.tsx
+++ b/frontend/src/components/pages/agents/details/ai-agent-configuration-tab.tsx
@@ -191,6 +191,10 @@ const extractProviderInfo = (provider: AIAgent_Provider): { apiKeyTemplate: stri
       apiKeyTemplate = provider.provider.value.apiKey;
       baseUrl = provider.provider.value.baseUrl;
       break;
+    case 'bedrock':
+      // Bedrock has no apiKey/baseUrl; region is stored via the baseUrl field
+      baseUrl = provider.provider.value.region || '';
+      break;
     default:
       break;
   }
@@ -1252,9 +1256,19 @@ export const AIAgentConfigurationTab = () => {
                               : displayData.provider?.provider.case || 'openai'
                           ) as 'openai' | 'anthropic' | 'google' | 'openaiCompatible' | 'bedrock';
 
+                          // When switching to a bedrock provider, update the region from the LLM provider config
+                          let baseUrl = displayData.baseUrl || '';
+                          if (formTypeId === 'bedrock' && providersData?.llmProviders) {
+                            const fullProvider = providersData.llmProviders.find((p) => p.name === value);
+                            if (fullProvider?.providerConfig?.case === 'bedrockConfig') {
+                              baseUrl = fullProvider.providerConfig.value.region || '';
+                            }
+                          }
+
                           updateField({
                             llmProvider: value,
-                            provider: createUpdatedProvider(formTypeId, '', displayData.baseUrl || ''),
+                            provider: createUpdatedProvider(formTypeId, '', baseUrl),
+                            baseUrl,
                             model: '',
                           });
                         }}

--- a/frontend/src/components/pages/agents/details/ai-agent-configuration-tab.tsx
+++ b/frontend/src/components/pages/agents/details/ai-agent-configuration-tab.tsx
@@ -1261,7 +1261,7 @@ export const AIAgentConfigurationTab = () => {
                           if (formTypeId === 'bedrock' && providersData?.llmProviders) {
                             const fullProvider = providersData.llmProviders.find((p) => p.name === value);
                             if (fullProvider?.providerConfig?.case === 'bedrockConfig') {
-                              baseUrl = fullProvider.providerConfig.value.region || '';
+                              baseUrl = fullProvider.providerConfig.value?.region || '';
                             }
                           }
 


### PR DESCRIPTION
## Summary

- `extractProviderInfo` was missing the `bedrock` case, so the region was always lost when editing an AI agent with a Bedrock provider. This caused a validation error ("region has to be provided") on save.
- When switching `llmProvider` to a Bedrock provider on the edit page, the region is now resolved from the AIGW LLM provider config (matching the create page behavior).

Related backend fix: https://github.com/redpanda-data/cloudv2/pull/25896

## Test plan

- [ ] Edit a Bedrock+gateway AI agent without changing provider — region should be preserved, save should succeed
- [ ] Edit a Bedrock+gateway AI agent and switch `llmProvider` to a different Bedrock provider — region should update to the new provider's region
- [ ] Create a new Bedrock+gateway AI agent — region should still be fetched from the LLM provider (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)