### PR TITLE
fix(frontend): preserve \u00XX escapes in Avro JSON viewer

### DIFF
--- a/frontend/src/components/misc/kowl-json-view.test.tsx
+++ b/frontend/src/components/misc/kowl-json-view.test.tsx
@@ -161,4 +161,24 @@ describe('KowlJsonView', () => {
 
     expect(editorLayoutSpy).toHaveBeenLastCalledWith({ width: 800, height: 480 });
   });
+
+  test('escapeLatin1 re-escapes Latin-1 code points so copy-paste recovers the original byte', async () => {
+    render(<KowlJsonView escapeLatin1 srcObj={{ v: 'ÛN' }} />);
+
+    await waitFor(() => {
+      const value = editorPropsSpy.mock.lastCall?.[0].value as string;
+      expect(value).toContain('\\u00db');
+      expect(value).not.toContain('Û');
+    });
+  });
+
+  test('without escapeLatin1, Latin-1 glyphs pass through to the editor unchanged', async () => {
+    render(<KowlJsonView srcObj={{ v: 'ÛN' }} />);
+
+    await waitFor(() => {
+      const value = editorPropsSpy.mock.lastCall?.[0].value as string;
+      expect(value).toContain('Û');
+      expect(value).not.toContain('\\u00db');
+    });
+  });
 });

--- a/frontend/src/components/misc/kowl-json-view.tsx
+++ b/frontend/src/components/misc/kowl-json-view.tsx
@@ -49,15 +49,26 @@ const READ_ONLY_EDITOR_OPTIONS = {
   scrollBeyondLastLine: false,
 } as const;
 
-export const KowlJsonView = (props: { srcObj: object | string | null | undefined; style?: CSSProperties }) => {
+export const KowlJsonView = (props: {
+  srcObj: object | string | null | undefined;
+  style?: CSSProperties;
+  // escapeLatin1 re-escapes code points in 0x80-0xFF as \u00XX so bytes from
+  // Avro's JSON bytes encoding survive copy-paste out of the viewer. Without
+  // this, JSON.stringify emits the code point as a literal glyph and the
+  // clipboard receives the UTF-8 encoding, not the original byte.
+  escapeLatin1?: boolean;
+}) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const editorRef = useRef<IStandaloneCodeEditor | null>(null);
   const frameRef = useRef<number | null>(null);
   const lastSizeRef = useRef({ width: 0, height: 0 });
-  const str = useMemo(
-    () => (typeof props.srcObj === 'string' ? props.srcObj : JSON.stringify(props.srcObj, undefined, 4)),
-    [props.srcObj]
-  );
+  const str = useMemo(() => {
+    const raw = typeof props.srcObj === 'string' ? props.srcObj : JSON.stringify(props.srcObj, undefined, 4);
+    if (!props.escapeLatin1) {
+      return raw;
+    }
+    return raw.replace(/[\u0080-\u00ff]/g, (c) => `\\u00${c.charCodeAt(0).toString(16).padStart(2, '0')}`);
+  }, [props.srcObj, props.escapeLatin1]);
 
   const scheduleLayout = useCallback(() => {
     if (frameRef.current !== null) {

--- a/frontend/src/components/pages/topics/Tab.Messages/message-display/payload-component.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/message-display/payload-component.tsx
@@ -182,7 +182,10 @@ export const PayloadComponent = (p: { payload: Payload; loadLargeMessage: () => 
     );
   }
   if (renderData.type === 'json') {
-    return <KowlJsonView srcObj={renderData.content} />;
+    // Avro JSON encodes bytes fields as \u00XX escape sequences. Re-escape
+    // Latin-1 code points in the viewer so copy-paste yields the original
+    // bytes rather than their UTF-8 encoding.
+    return <KowlJsonView escapeLatin1={payload.encoding === 'avro'} srcObj={renderData.content} />;
   }
   return <span style={{ color: 'red' }}>Error in RenderExpandedMessage: {renderData.content}</span>;
 };


### PR DESCRIPTION
## Summary

- Fixes the copy-paste loss reported in #2421 for Avro `bytes` / `fixed` fields.
- Root cause: Avro JSON encodes bytes as ISO-8859-1 code points (`\u00XX`), but the frontend runs the payload through `JSON.parse` then `JSON.stringify` for display. `JSON.stringify` does not re-escape non-ASCII, so a byte like `0xDB` renders as the literal glyph `Û` and "Copy Value" places UTF-8 bytes on the clipboard instead of the original byte.
- Fix is frontend-only and scoped: `KowlJsonView` gains an optional `escapeLatin1` prop that re-escapes code points in `0x80-0xFF` back to `\u00XX` before display. `PayloadComponent` sets it only when `payload.encoding === 'avro'`, so non-avro payloads are unchanged.
- The transform is lossless for both Avro bytes fields (recovers the exact byte) and legitimate Latin-1 strings (valid JSON escape for the same Unicode character).

## Test plan

- [ ] Open an Avro topic with a `bytes` field (e.g. Debezium `VariableScaleDecimal.value`); confirm the value renders as `\u00XX` escapes and "Copy Value" yields the on-wire JSON.
- [ ] Confirm non-avro payloads (proto, json, text) render unchanged.
- [ ] `bun run type:check && bun run lint && bun run test` pass in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)