### PR TITLE
fix(agents): auto-expand TaskStatusUpdate on error states

### DIFF
--- a/frontend/src/components/pages/agents/details/a2a/chat/components/message-blocks/task-status-update-block.tsx
+++ b/frontend/src/components/pages/agents/details/a2a/chat/components/message-blocks/task-status-update-block.tsx
@@ -65,6 +65,7 @@ export const TaskStatusUpdateBlock = ({
   const showBadge = validState && taskState !== previousState;
   const hasPreviousState = previousState && previousState !== taskState;
 
+  const isErrorState = validState === 'failed' || validState === 'rejected';
   const hasTokens = (inputTokens && inputTokens > 0) || (outputTokens && outputTokens > 0);
 
   // Metadata component (reused in both cases)
@@ -142,7 +143,7 @@ export const TaskStatusUpdateBlock = ({
   }
 
   return (
-    <Collapsible defaultOpen={false}>
+    <Collapsible defaultOpen={isErrorState}>
       <Artifact className="mb-4">
         <CollapsibleTrigger asChild>
           <ArtifactHeader className="cursor-pointer hover:bg-muted/50">


### PR DESCRIPTION
## What

Auto-expand the collapsible TaskStatusUpdate block when the task state is `failed` or `rejected`.

## Why

Error details were hidden behind a collapsed section, forcing users to manually click to see what went wrong. Errors should be immediately visible.

## Implementation details

Added an `isErrorState` flag derived from the task state. The `Collapsible` component's `defaultOpen` prop now uses this flag instead of a hardcoded `false`, so error states expand on render while normal states remain collapsed.