### PR TITLE
fix: fixed stale ACL check in add-user-step

### DIFF
--- a/frontend/src/components/pages/rp-connect/onboarding/add-topic-step.tsx
+++ b/frontend/src/components/pages/rp-connect/onboarding/add-topic-step.tsx
@@ -21,6 +21,7 @@ import { ToggleGroup, ToggleGroupItem } from 'components/redpanda-ui/components/
 import { Heading } from 'components/redpanda-ui/components/typography';
 import { ChevronDown, XIcon } from 'lucide-react';
 import type { MotionProps } from 'motion/react';
+import { listACLs } from 'protogen/redpanda/api/dataplane/v1/acl-ACLService_connectquery';
 import { ListTopicsRequestSchema } from 'protogen/redpanda/api/dataplane/v1/topic_pb';
 import { listTopics } from 'protogen/redpanda/api/dataplane/v1/topic-TopicService_connectquery';
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useState } from 'react';
@@ -348,6 +349,12 @@ export const AddTopicStep = forwardRef<BaseStepRef<AddTopicFormData>, AddTopicSt
                                   queryClient.invalidateQueries({
                                     queryKey: createConnectQueryKey({
                                       schema: listTopics,
+                                      cardinality: 'infinite',
+                                    }),
+                                  });
+                                  queryClient.invalidateQueries({
+                                    queryKey: createConnectQueryKey({
+                                      schema: listACLs,
                                       cardinality: 'finite',
                                     }),
                                   });

--- a/frontend/src/components/pages/rp-connect/onboarding/add-user-step.tsx
+++ b/frontend/src/components/pages/rp-connect/onboarding/add-user-step.tsx
@@ -491,6 +491,12 @@ export const AddUserStep = forwardRef<UserStepRef, AddUserStepProps & MotionProp
                                           cardinality: 'infinite',
                                         }),
                                       });
+                                      queryClient.invalidateQueries({
+                                        queryKey: createConnectQueryKey({
+                                          schema: listACLs,
+                                          cardinality: 'finite',
+                                        }),
+                                      });
                                     }}
                                     options={userOptions}
                                     placeholder="Select a user"
@@ -549,6 +555,7 @@ export const AddUserStep = forwardRef<UserStepRef, AddUserStepProps & MotionProp
                                 <TanStackRouterLink
                                   className="text-blue-800"
                                   params={{ userName: existingUserSelected.name }}
+                                  target="_blank"
                                   to="/security/users/$userName/details"
                                 >
                                   ACLs
@@ -698,8 +705,11 @@ export const AddUserStep = forwardRef<UserStepRef, AddUserStepProps & MotionProp
                                       <AlertDescription>
                                         <Text variant="small">
                                           You will need to configure{' '}
-                                          <TanStackRouterLink to="/security/acls">ACLs</TanStackRouterLink> for custom
-                                          user permissions if you want the user to be able to read from the topic.
+                                          <TanStackRouterLink target="_blank" to="/security/acls">
+                                            ACLs
+                                          </TanStackRouterLink>{' '}
+                                          for custom user permissions if you want the user to be able to read from the
+                                          topic.
                                         </Text>
                                       </AlertDescription>
                                     </Alert>
@@ -734,6 +744,14 @@ export const AddUserStep = forwardRef<UserStepRef, AddUserStepProps & MotionProp
                                     {...field}
                                     className="w-[300px]"
                                     disabled={isPending}
+                                    onFocus={() => {
+                                      queryClient.invalidateQueries({
+                                        queryKey: createConnectQueryKey({
+                                          schema: listACLs,
+                                          cardinality: 'finite',
+                                        }),
+                                      });
+                                    }}
                                     placeholder="Enter a consumer group name"
                                   />
                                 </FormControl>


### PR DESCRIPTION
[UX-832](https://redpandadata.atlassian.net/browse/UX-832)

Users who created a topic in `Console > Topics` and a user + ACLs in `Console > Security` saw the Connect pipeline wizard incorrectly insist the user lacked permissions for the topic. The wizard's permission check (`checkUserHasTopicReadWritePermissions`) was running against a stale `listACLs` cache, and a separate cardinality typo meant the topic combobox's `onOpen` invalidation never matched the legacy topic query.

Two stale-cache holes closed:

- **`add-topic-step.tsx`** — topic combobox `onOpen` was invalidating `listTopics` with `cardinality: 'finite'`, but `useLegacyListTopicsQuery` registers under `cardinality: 'infinite'`, so the invalidation hit nothing. Fixed the cardinality and also invalidate `listACLs` on open.
- **`add-user-step.tsx`** — user combobox `onOpen` now also invalidates `listACLs` so the topic permission alert reflects current ACLs the moment the user picks an existing user. Same fix applied to the consumer-group `Input` via `onFocus`, which drives the parallel `useListACLsQuery({ resourceType: GROUP })` check.

Same-tab edits already invalidate correctly via `useCreateACLMutation` / `useCreateAcls` / `useUpdateAclMutation` — they all target `listACLs` cardinality `'finite'`. The remaining hole was cross-tab edits (each tab has its own `queryClient`) and the broken topic cardinality, both of which this PR closes.


[UX-832]: https://redpandadata.atlassian.net/browse/UX-832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ