### PR TITLE
feat: improve api-patterns skill score (59% → 97%)

### DIFF
--- a/frontend/.claude/skills/api-patterns/SKILL.md
+++ b/frontend/.claude/skills/api-patterns/SKILL.md
@@ -1,35 +1,67 @@
 ---
 name: api-patterns
-description: Connect Query patterns for API calls. Use when working with mutations, queries, or data fetching.
+description: "Implement Connect Query (@connectrpc/connect-query) patterns for type-safe gRPC-Web API calls in React components — generate query hooks from protobuf services, create mutation handlers with cache invalidation, and wire toast error messages. Use when working with useQuery, useMutation, @connectrpc, protobuf services, gRPC-Web, .proto files, Connect Query hooks, cache invalidation after mutations, or formatToastErrorMessage."
 ---
 
 # API Patterns
 
-Make API calls with Connect Query and handle responses properly.
+Implement type-safe API calls using Connect Query with proper caching, error handling, and cache invalidation in Redpanda Console's React frontend.
 
 ## Activation Conditions
 
-- Making API calls
-- Using Connect Query hooks
-- Cache invalidation
-- Mutations and optimistic updates
-- Toast notifications for errors
+- Adding or modifying Connect Query `useQuery` / `useMutation` calls
+- Implementing cache invalidation after create/update/delete mutations
+- Wiring `formatToastErrorMessage` in mutation `onError` handlers
+- Importing from `@connectrpc/connect-query` or `src/protogen/`
+- Regenerating protobuf types or working with `.proto` schemas
 
 ## Quick Reference
 
 | Action | Rule |
 |--------|------|
-| Fetch data | `use-connect-query.md` |
-| After mutation | `api-invalidate-cache.md` |
-| Handle errors | `api-toast-errors.md` (use `formatToastErrorMessage` in onError) |
-| Protobuf files | `protobuf-no-edit.md` |
+| Fetch data | `rules/use-connect-query.md` — use `useQuery` with `enabled` guard |
+| After mutation | `rules/api-invalidate-cache.md` — invalidate related queries on success |
+| Handle errors | `rules/api-toast-errors.md` — use `formatToastErrorMessage` in `onError` |
+| Protobuf files | `rules/protobuf-no-edit.md` — never edit `src/protogen/`, extend outside |
+
+## Mutation Workflow
+
+Follow this sequence for every mutation:
+
+1. **Call mutation** — `useMutation(rpcMethod, { onSuccess, onError })`
+2. **Handle errors** — pass `formatToastErrorMessage({ error, action, entity })` to `toast.error` in `onError`
+3. **Invalidate cache** — call `queryClient.invalidateQueries({ queryKey })` in `onSuccess` for affected queries
+4. **Confirm success** — show `toast.success` after invalidation
+
+```tsx
+import { useMutation } from '@connectrpc/connect-query';
+import { useQueryClient } from '@tanstack/react-query';
+import { formatToastErrorMessage } from 'utils/toast.utils';
+
+const queryClient = useQueryClient();
+
+const mutation = useMutation(updateCluster, {
+  onSuccess: () => {
+    queryClient.invalidateQueries({ queryKey: ['getClusters'] });
+    toast.success('Cluster updated');
+  },
+  onError: (error) => {
+    toast.error(formatToastErrorMessage({
+      error: { reason: error.message, internalCode: error.code },
+      action: 'update',
+      entity: 'cluster',
+    }));
+  },
+});
+```
 
 ## Key Locations
 
 | Location | Purpose |
 |----------|---------|
-| `/src/react-query/` | Connect Query hooks |
-| `/src/protogen/` | Generated protos (DO NOT EDIT) |
+| `src/react-query/` | Connect Query hooks and utilities |
+| `src/protogen/` | Generated protobuf types (DO NOT EDIT) |
+| `src/utils/toast.utils.ts` | `formatToastErrorMessage` implementation |
 
 Regenerate protos: `task proto:generate` (from repo root)
 


### PR DESCRIPTION
Hey @malinskibeniamin 👋

ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| **api-patterns** | **59%** | **97%** | **+38%** |

<details>
<summary>Changes made to <code>api-patterns</code></summary>

**Description improvements (biggest impact - 32% → 100%):**
- Expanded from vague "Connect Query patterns for API calls" to a specific description listing concrete actions: generating query hooks from protobuf services, creating mutation handlers with cache invalidation, and wiring toast error messages
- Added an explicit "Use when..." clause with distinctive trigger terms (`useQuery`, `useMutation`, `@connectrpc`, `protobuf services`, `gRPC-Web`, `.proto files`, `formatToastErrorMessage`) to reduce false-positive activation and avoid overlap with generic data-fetching skills
- Wrapped description in a quoted string for standard frontmatter formatting

**Content improvements (65% → 92%):**
- Added a complete inline mutation workflow with explicit 4-step sequence: call mutation → handle errors with `formatToastErrorMessage` → invalidate cache → confirm success
- Included a copy-paste ready TSX code example showing the full pattern with proper imports from `@connectrpc/connect-query` and `@tanstack/react-query`
- Added `src/utils/toast.utils.ts` to key locations table for discoverability
- Updated activation conditions from generic terms to specific, actionable trigger scenarios
- Prefixed rule file references with `rules/` path for clarity

</details>

---

also stress-tested your `api-patterns` skill against [a few real-world task evals](https://tessl.io/registry/skills/github/redpanda-data/console/api-patterns/evals) and it held up really well on mutation-with-cache-invalidation workflows. The Connect Query + `formatToastErrorMessage` pattern guidance was solid. Kudos for that.

quick honest disclosure. I work at https://github.com/tesslio where we build tooling around skills like these. Not a pitch, just saw room for improvement and wanted to contribute.

if you want to self-improve your skills, or define your own scenarios to pressure test, just ask your agent (Claude Code, Codex, etc.) to evaluate and optimize your skill with Tessl. Ping me [@yogesh-tessl](https://github.com/yogesh-tessl), if you hit any snags.