### PR TITLE
UX-1272 - Improving back button behavior

### DIFF
--- a/frontend/src/components/pages/rp-connect/pipeline/index.test.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/index.test.tsx
@@ -80,7 +80,7 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
   return {
     ...actual,
     useNavigate: () => mockNavigate,
-    useRouter: () => ({ history: { back: mockBack } }),
+    useRouter: () => ({ history: { back: mockBack, canGoBack: () => true } }),
     useSearch: () => mockSearch(),
   };
 });

--- a/frontend/src/components/pages/rp-connect/pipeline/index.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/index.tsx
@@ -838,8 +838,10 @@ export default function PipelinePage() {
     }
     if (mode === 'view') {
       navigate({ to: '/connect-clusters', search: {} as never });
-    } else {
+    } else if (router.history.canGoBack()) {
       router.history.back();
+    } else {
+      navigate({ to: '/connect-clusters', search: {} as never });
     }
   }, [mode, clearWizardStore, navigate, router]);
 


### PR DESCRIPTION
* UX-1272
* Occasionally on the connect create page, if you arrive via deep link, or a refresh after awhile, the back button would no longer work.
* This detects if we can use back, otherwise defaults to return to the main connect page.