### PR TITLE
ci: fetch BUF_TOKEN from AWS Secrets Manager in proto-generate workflow

### DIFF
--- a/.github/workflows/proto-generate.yml
+++ b/.github/workflows/proto-generate.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write  # OIDC to assume AWS role for Secrets Manager
 
 jobs:
   proto-generate:
@@ -22,6 +23,17 @@ jobs:
       CI: "true"
     steps:
       - uses: actions/checkout@v5
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ,sdlc/prod/github/buf_token
+          parse-json-secrets: true
 
       - uses: actions/setup-go@v6
         with:
@@ -41,6 +53,4 @@ jobs:
           key: proto-tools-${{ runner.os }}-go${{ hashFiles('backend/go.mod') }}-${{ hashFiles('taskfiles/proto.yaml') }}
 
       - name: Generate protos
-        env:
-          BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
         run: task proto:generate


### PR DESCRIPTION
## Summary

Migrates `proto-generate.yml` off the repo-level `BUF_TOKEN` GitHub secret and onto AWS Secrets Manager, mirroring the pattern already used by `buf.yml` in this same repo.

After this lands, the `BUF_TOKEN` repo secret can be deleted — the buf.build vbot token is sourced canonically from `sdlc/prod/github/buf_token` in AWS SM (managed by the DevProd Secret Maintainer).

## Context

- A recent rotation of the buf.build vbot token updated only the AWS SM copy of the secret; this workflow's stale GH-secret copy would have started failing the next time the upstream token was revoked. See [DEVPROD-3054](https://redpandadata.atlassian.net/browse/DEVPROD-3054).
- Same OIDC role / region wiring as the existing `buf.yml` in this repo — `RP_AWS_CRED_BASE_ROLE_NAME` and `RP_AWS_CRED_REGION` are already provisioned for `redpanda-data/console`.
- `parse-json-secrets: true` exports the SM JSON keys as env vars, so `BUF_TOKEN` is set automatically for the `task proto:generate` step — the explicit `env:` block becomes redundant.

## Test plan

- [x] PR's own `Proto generate check` run succeeds against the new auth path.
- [ ] After merge, run `gh secret delete BUF_TOKEN --repo redpanda-data/console` and confirm a subsequent proto-touching PR still passes `Proto generate check`.


[DEVPROD-3054]: https://redpandadata.atlassian.net/browse/DEVPROD-3054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ