### PR TITLE
ci(frontend): remove coverage job

### DIFF
--- a/.github/workflows/frontend-verify.yml
+++ b/.github/workflows/frontend-verify.yml
@@ -135,27 +135,3 @@ jobs:
           name: integration-test-results-${{ matrix.shard }}
           path: frontend/test-results
           retention-days: 2
-
-  test-coverage:
-    needs: ["test-unit", "test-integration"]
-    timeout-minutes: 10
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    defaults:
-      run:
-        working-directory: frontend
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-      - name: Run coverage (unit + integration, merged)
-        run: bun run test:coverage
-      - name: Upload merged coverage HTML report
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: coverage-report
-          path: frontend/coverage-merged/
-          retention-days: 14


### PR DESCRIPTION
## Summary
- Remove the frontend `test-coverage` CI job.
- Keep local coverage tooling/scripts intact for ad-hoc use.

## Commits
- cb361ef19 ci(frontend): remove coverage job

## Test plan
- [x] Workflow YAML diff inspected.
- [x] Let GitHub Actions validate the updated workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)