### PR TITLE
Show unconsumed partitions in consumer groups

### DIFF
--- a/backend/pkg/console/consumer_group_offsets.go
+++ b/backend/pkg/console/consumer_group_offsets.go
@@ -35,7 +35,7 @@ type PartitionOffsets struct {
 	// Error will be set when the high water mark could not be fetched
 	Error         string `json:"error,omitempty"`
 	PartitionID   int32  `json:"partitionId"`
-	GroupOffset   int64  `json:"groupOffset"`
+	GroupOffset   *int64 `json:"groupOffset"` // nil when no committed offset exists for this partition
 	HighWaterMark int64  `json:"highWaterMark"`
 	Lag           int64  `json:"lag"`
 }
@@ -183,6 +183,10 @@ func (s *Service) getConsumerGroupOffsets(ctx context.Context, adminCl *kadm.Cli
 
 				groupOffset, hasGroupOffset := partitionOffsets[pID]
 				if !hasGroupOffset {
+					t.PartitionOffsets = append(t.PartitionOffsets, PartitionOffsets{
+						PartitionID:   pID,
+						HighWaterMark: watermark.HighWaterMark,
+					})
 					continue
 				}
 				t.PartitionsWithOffset++
@@ -193,7 +197,7 @@ func (s *Service) getConsumerGroupOffsets(ctx context.Context, adminCl *kadm.Cli
 				t.SummedLag += lag
 				t.PartitionOffsets = append(t.PartitionOffsets, PartitionOffsets{
 					PartitionID:   pID,
-					GroupOffset:   groupOffset,
+					GroupOffset:   &groupOffset,
 					HighWaterMark: watermark.HighWaterMark,
 					Lag:           lag,
 				})

--- a/backend/pkg/console/consumer_group_offsets_test.go
+++ b/backend/pkg/console/consumer_group_offsets_test.go
@@ -184,6 +184,7 @@ func TestGetConsumerGroupOffsets_NonExistentTopicInMetadata(t *testing.T) {
 	req.NoError(err, "Should not error when one topic is deleted")
 
 	// Expected result: only the existing topic, with 1 partition and offset at position 1
+	groupOffset := int64(1)
 	expected := map[string][]GroupTopicOffsets{
 		groupID: {
 			{
@@ -194,7 +195,7 @@ func TestGetConsumerGroupOffsets_NonExistentTopicInMetadata(t *testing.T) {
 				PartitionOffsets: []PartitionOffsets{
 					{
 						PartitionID:   0,
-						GroupOffset:   1,
+						GroupOffset:   &groupOffset,
 						HighWaterMark: 1,
 						Lag:           0,
 					},

--- a/backend/pkg/console/consumer_group_offsets_test.go
+++ b/backend/pkg/console/consumer_group_offsets_test.go
@@ -184,7 +184,6 @@ func TestGetConsumerGroupOffsets_NonExistentTopicInMetadata(t *testing.T) {
 	req.NoError(err, "Should not error when one topic is deleted")
 
 	// Expected result: only the existing topic, with 1 partition and offset at position 1
-	groupOffset := int64(1)
 	expected := map[string][]GroupTopicOffsets{
 		groupID: {
 			{
@@ -195,7 +194,7 @@ func TestGetConsumerGroupOffsets_NonExistentTopicInMetadata(t *testing.T) {
 				PartitionOffsets: []PartitionOffsets{
 					{
 						PartitionID:   0,
-						GroupOffset:   &groupOffset,
+						GroupOffset:   new(int64(1)),
 						HighWaterMark: 1,
 						Lag:           0,
 					},

--- a/frontend/src/components/pages/consumers/group-details.test.tsx
+++ b/frontend/src/components/pages/consumers/group-details.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { screen, waitFor } from 'test-utils';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const { refreshConsumerGroupMock, refreshConsumerGroupAclsMock } = vi.hoisted(() => ({
+  refreshConsumerGroupMock: vi.fn(),
+  refreshConsumerGroupAclsMock: vi.fn(),
+}));
+
+vi.mock('state/ui-state', () => ({
+  setPageHeader: vi.fn(),
+  uiState: {
+    pageTitle: '',
+    pageBreadcrumbs: [],
+  },
+}));
+
+vi.mock('state/app-global', () => ({
+  appGlobal: {
+    onRefresh: null,
+    historyPush: vi.fn(),
+  },
+}));
+
+vi.mock('state/backend-api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('state/backend-api')>();
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      refreshConsumerGroup: refreshConsumerGroupMock,
+      refreshConsumerGroupAcls: refreshConsumerGroupAclsMock,
+      refreshPartitionsForTopic: vi.fn(),
+    },
+  };
+});
+
+vi.mock('config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('config')>();
+  return {
+    ...actual,
+    config: { jwt: '' },
+    isFeatureFlagEnabled: vi.fn(() => false),
+  };
+});
+
+import { useApiStore } from 'state/backend-api';
+import type { GroupDescription } from 'state/rest-interfaces';
+import { useSupportedFeaturesStore } from 'state/supported-features';
+import { renderWithFileRoutes } from 'test-utils';
+
+import GroupDetails from './group-details';
+
+const TOPIC = 'test-topic';
+const GROUP_ID = 'test-group';
+
+// Backend now returns all partitions in partitionOffsets.
+// Partition 0: committed offset 5. Partitions 1 and 2: no committed offset (groupOffset: null).
+const mockGroup: GroupDescription = {
+  groupId: GROUP_ID,
+  state: 'Empty',
+  protocol: '',
+  protocolType: 'consumer',
+  members: [],
+  coordinatorId: 0,
+  topicOffsets: [
+    {
+      topic: TOPIC,
+      summedLag: 1,
+      partitionCount: 3,
+      partitionsWithOffset: 1,
+      partitionOffsets: [
+        { partitionId: 0, groupOffset: 5, error: undefined, highWaterMark: 6, lag: 1 },
+        { partitionId: 1, groupOffset: null, error: undefined, highWaterMark: 5, lag: 0 },
+        { partitionId: 2, groupOffset: null, error: undefined, highWaterMark: 3, lag: 0 },
+      ],
+    },
+  ],
+  allowedActions: null,
+  lagSum: 1,
+  isInUse: false,
+  noEditPerms: false,
+  noDeletePerms: false,
+};
+
+const renderGroupDetails = () =>
+  renderWithFileRoutes(
+    <GroupDetails groupId={GROUP_ID} matchedPath={`/groups/${GROUP_ID}`} onSearchChange={() => {}} search={{}} />
+  );
+
+describe('GroupDetails - unconsumed partitions', () => {
+  beforeEach(() => {
+    useApiStore.setState({
+      consumerGroups: new Map([[GROUP_ID, mockGroup]]),
+      consumerGroupAcls: new Map(),
+    });
+    useSupportedFeaturesStore.setState({ patchGroup: true, deleteGroup: true, deleteGroupOffsets: true });
+  });
+
+  afterEach(() => {
+    useApiStore.setState({ consumerGroups: new Map(), consumerGroupAcls: new Map() });
+  });
+
+  test('edit button is enabled for consumed partition and disabled for unconsumed partitions', async () => {
+    renderGroupDetails();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('partition-edit-0')).toBeInTheDocument();
+    });
+
+    // Partition 0 has a committed offset → edit button renders as <button>
+    expect(screen.getByTestId('partition-edit-0').tagName).toBe('BUTTON');
+
+    // Partitions 1 and 2 have no committed offset → edit button renders as disabled <span>
+    expect(screen.getByTestId('partition-edit-1').tagName).toBe('SPAN');
+    expect(screen.getByTestId('partition-edit-2').tagName).toBe('SPAN');
+  });
+
+  test('unconsumed partitions render "—" for group offset and lag', async () => {
+    renderGroupDetails();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('partition-edit-1')).toBeInTheDocument();
+    });
+
+    // Each unconsumed partition (1 and 2) shows "—" for both group offset and lag = 4 dashes minimum
+    const dashes = screen.getAllByText('—');
+    expect(dashes.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/frontend/src/components/pages/consumers/group-details.tsx
+++ b/frontend/src/components/pages/consumers/group-details.tsx
@@ -357,7 +357,7 @@ const GroupByTopics = (groupProps: {
     const partitionsAssigned = g.partitions.filter((c) => c.assignedMember).length;
 
     const partitions = groupProps.onlyShowPartitionsWithLag
-      ? g.partitions.filter((e) => e.lag !== 0 || e.isUnconsumed)
+      ? g.partitions.filter((e) => e.isUnconsumed || (e.lag !== null && e.lag !== 0))
       : g.partitions;
 
     if (partitions.length === 0) {
@@ -377,7 +377,7 @@ const GroupByTopics = (groupProps: {
 
             <Flex gap={2}>
               <IconButton
-                disabledReason={cannotEditGroupReason(groupProps.group, featurePatchGroup)}
+                disabledReason={cannotEditGroupReason(groupProps.group, featurePatchGroup, consumedPartitions)}
                 onClick={(e) => {
                   groupProps.onEditOffsets(consumedPartitions);
                   e.stopPropagation();
@@ -386,7 +386,11 @@ const GroupByTopics = (groupProps: {
                 <EditIcon />
               </IconButton>
               <IconButton
-                disabledReason={cannotDeleteGroupOffsetsReason(groupProps.group, featureDeleteGroupOffsets)}
+                disabledReason={cannotDeleteGroupOffsetsReason(
+                  groupProps.group,
+                  featureDeleteGroupOffsets,
+                  consumedPartitions
+                )}
                 onClick={(e) => {
                   groupProps.onDeleteOffsets(consumedPartitions, 'topic');
                   e.stopPropagation();
@@ -488,22 +492,22 @@ const GroupByTopics = (groupProps: {
                 <Flex gap={1} pr={2}>
                   <IconButton
                     data-testid={`partition-edit-${original.partitionId}`}
-                    disabledReason={
-                      original.isUnconsumed
-                        ? 'No committed offset'
-                        : cannotEditGroupReason(groupProps.group, featurePatchGroup)
-                    }
+                    disabledReason={cannotEditGroupReason(
+                      groupProps.group,
+                      featurePatchGroup,
+                      original.isUnconsumed ? [] : undefined
+                    )}
                     onClick={() => groupProps.onEditOffsets([original])}
                   >
                     <EditIcon />
                   </IconButton>
                   <IconButton
                     data-testid={`partition-delete-${original.partitionId}`}
-                    disabledReason={
-                      original.isUnconsumed
-                        ? 'No committed offset'
-                        : cannotDeleteGroupOffsetsReason(groupProps.group, featureDeleteGroupOffsets)
-                    }
+                    disabledReason={cannotDeleteGroupOffsetsReason(
+                      groupProps.group,
+                      featureDeleteGroupOffsets,
+                      original.isUnconsumed ? [] : undefined
+                    )}
                     onClick={() => groupProps.onDeleteOffsets([original], 'partition')}
                   >
                     <TrashIcon />
@@ -630,7 +634,14 @@ const ProtocolType = (p: { group: GroupDescription }) => {
   return <Statistic title="Protocol" value={protocol} />;
 };
 
-function cannotEditGroupReason(group: GroupDescription, featurePatchGroup: boolean): string | undefined {
+function cannotEditGroupReason(
+  group: GroupDescription,
+  featurePatchGroup: boolean,
+  consumedPartitions?: readonly unknown[]
+): string | undefined {
+  if (consumedPartitions !== undefined && consumedPartitions.length === 0) {
+    return 'No committed offsets';
+  }
   if (group.noEditPerms) {
     return "You don't have 'editConsumerGroup' permissions for this group";
   }
@@ -656,8 +667,12 @@ function cannotDeleteGroupReason(group: GroupDescription, featureDeleteGroup: bo
 
 function cannotDeleteGroupOffsetsReason(
   group: GroupDescription,
-  featureDeleteGroupOffsets: boolean
+  featureDeleteGroupOffsets: boolean,
+  consumedPartitions?: readonly unknown[]
 ): string | undefined {
+  if (consumedPartitions !== undefined && consumedPartitions.length === 0) {
+    return 'No committed offsets';
+  }
   if (group.noEditPerms) {
     return "You don't have 'deleteConsumerGroup' permissions for this group";
   }

--- a/frontend/src/components/pages/consumers/group-details.tsx
+++ b/frontend/src/components/pages/consumers/group-details.tsx
@@ -330,18 +330,18 @@ const GroupByTopics = (groupProps: {
       const assignedMember = allAssignments.find(
         (e) => e.topicName === topicLag.topic && e.partitions.includes(partLag.partitionId)
       );
-
+      const isUnconsumed = partLag.groupOffset === null;
       return {
         topicName: topicLag.topic,
         partitionId: partLag.partitionId,
         groupOffset: partLag.groupOffset,
-        highWaterMark: partLag.highWaterMark,
-        lag: partLag.lag,
-
+        highWaterMark: partLag.highWaterMark as number | null,
+        lag: isUnconsumed ? null : (partLag.lag as number | null),
         assignedMember: assignedMember?.member,
         id: assignedMember?.member.id,
         clientId: assignedMember?.member.clientId,
         host: assignedMember?.member.clientHost,
+        isUnconsumed,
       };
     })
   );
@@ -356,11 +356,15 @@ const GroupByTopics = (groupProps: {
     const totalLagAll = g.partitions.sum((c) => c.lag ?? 0);
     const partitionsAssigned = g.partitions.filter((c) => c.assignedMember).length;
 
-    const partitions = groupProps.onlyShowPartitionsWithLag ? g.partitions.filter((e) => e.lag !== 0) : g.partitions;
+    const partitions = groupProps.onlyShowPartitionsWithLag
+      ? g.partitions.filter((e) => e.lag !== 0 || e.isUnconsumed)
+      : g.partitions;
 
     if (partitions.length === 0) {
       return null;
     }
+
+    const consumedPartitions = g.partitions.filter((p) => !p.isUnconsumed);
 
     return {
       heading: (
@@ -375,7 +379,7 @@ const GroupByTopics = (groupProps: {
               <IconButton
                 disabledReason={cannotEditGroupReason(groupProps.group, featurePatchGroup)}
                 onClick={(e) => {
-                  groupProps.onEditOffsets(g.partitions);
+                  groupProps.onEditOffsets(consumedPartitions);
                   e.stopPropagation();
                 }}
               >
@@ -384,7 +388,7 @@ const GroupByTopics = (groupProps: {
               <IconButton
                 disabledReason={cannotDeleteGroupOffsetsReason(groupProps.group, featureDeleteGroupOffsets)}
                 onClick={(e) => {
-                  groupProps.onDeleteOffsets(g.partitions, 'topic');
+                  groupProps.onDeleteOffsets(consumedPartitions, 'topic');
                   e.stopPropagation();
                 }}
               >
@@ -409,13 +413,14 @@ const GroupByTopics = (groupProps: {
         <DataTable<{
           topicName: string;
           partitionId: number;
-          groupOffset: number;
-          highWaterMark: number;
-          lag: number;
+          groupOffset: number | null;
+          highWaterMark: number | null;
+          lag: number | null;
           assignedMember: GroupMemberDescription | undefined;
           id: string | undefined;
           clientId: string | undefined;
           host: string | undefined;
+          isUnconsumed: boolean;
         }>
           columns={[
             {
@@ -458,19 +463,22 @@ const GroupByTopics = (groupProps: {
               size: 120,
               header: 'Log End Offset',
               accessorKey: 'highWaterMark',
-              cell: ({ row: { original } }) => numberToThousandsString(original.highWaterMark),
+              cell: ({ row: { original } }) =>
+                original.highWaterMark !== null ? numberToThousandsString(original.highWaterMark) : '—',
             },
             {
               size: 120,
               header: 'Group Offset',
               accessorKey: 'groupOffset',
-              cell: ({ row: { original } }) => numberToThousandsString(original.groupOffset),
+              cell: ({ row: { original } }) =>
+                original.groupOffset !== null ? numberToThousandsString(original.groupOffset) : '—',
             },
             {
               size: 80,
               header: 'Lag',
               accessorKey: 'lag',
-              cell: ({ row: { original } }) => ShortNum({ value: original.lag, tooltip: true }),
+              cell: ({ row: { original } }) =>
+                original.lag !== null ? ShortNum({ value: original.lag, tooltip: true }) : '—',
             },
             {
               size: 1,
@@ -479,13 +487,23 @@ const GroupByTopics = (groupProps: {
               cell: ({ row: { original } }) => (
                 <Flex gap={1} pr={2}>
                   <IconButton
-                    disabledReason={cannotEditGroupReason(groupProps.group, featurePatchGroup)}
+                    data-testid={`partition-edit-${original.partitionId}`}
+                    disabledReason={
+                      original.isUnconsumed
+                        ? 'No committed offset'
+                        : cannotEditGroupReason(groupProps.group, featurePatchGroup)
+                    }
                     onClick={() => groupProps.onEditOffsets([original])}
                   >
                     <EditIcon />
                   </IconButton>
                   <IconButton
-                    disabledReason={cannotDeleteGroupOffsetsReason(groupProps.group, featureDeleteGroupOffsets)}
+                    data-testid={`partition-delete-${original.partitionId}`}
+                    disabledReason={
+                      original.isUnconsumed
+                        ? 'No committed offset'
+                        : cannotDeleteGroupOffsetsReason(groupProps.group, featureDeleteGroupOffsets)
+                    }
                     onClick={() => groupProps.onDeleteOffsets([original], 'partition')}
                   >
                     <TrashIcon />

--- a/frontend/src/components/pages/consumers/modals.tsx
+++ b/frontend/src/components/pages/consumers/modals.tsx
@@ -537,7 +537,7 @@ export class EditOffsetsModal extends Component<{
           const getOffset = (topicName: string, partitionId: number): number | undefined =>
             other.topicOffsets
               .first((t) => t.topic === topicName)
-              ?.partitionOffsets.first((p) => p.partitionId === partitionId)?.groupOffset;
+              ?.partitionOffsets.first((p) => p.partitionId === partitionId)?.groupOffset ?? undefined;
 
           const currentOffsets = this.props.offsets;
           const alreadyExists = (topicName: string, partitionId: number): boolean =>
@@ -553,11 +553,13 @@ export class EditOffsetsModal extends Component<{
           // Extend our offsets with any offsets that our group currently doesn't have
           if (this.state.otherGroupCopyMode === 'all') {
             const otherFlat = other.topicOffsets.flatMap((x) =>
-              x.partitionOffsets.flatMap((p) => ({
-                topicName: x.topic,
-                partitionId: p.partitionId,
-                offset: p.groupOffset,
-              }))
+              x.partitionOffsets
+                .filter((p) => p.groupOffset !== null)
+                .flatMap((p) => ({
+                  topicName: x.topic,
+                  partitionId: p.partitionId,
+                  offset: p.groupOffset as number,
+                }))
             );
 
             for (const o of otherFlat) {

--- a/frontend/src/state/rest-interfaces.ts
+++ b/frontend/src/state/rest-interfaces.ts
@@ -366,7 +366,7 @@ export type GroupTopicOffsets = {
 // PartitionOffset describes the kafka lag for a partition for a single consumer group
 export type GroupPartitionOffset = {
   partitionId: number;
-  groupOffset: number;
+  groupOffset: number | null; // null when no committed offset exists for this partition
 
   error: string | undefined; // Error will be set when the high water mark could not be fetched
   highWaterMark: number;

--- a/frontend/src/utils/tsx-utils.tsx
+++ b/frontend/src/utils/tsx-utils.tsx
@@ -665,10 +665,11 @@ export function IconButton(p: {
   onClick?: React.MouseEventHandler<HTMLElement>;
   children?: React.ReactNode;
   disabledReason?: string;
+  'data-testid'?: string;
 }) {
   if (!p.disabledReason) {
     return (
-      <button className="iconButton" onClick={p.onClick} type="button">
+      <button className="iconButton" data-testid={p['data-testid']} onClick={p.onClick} type="button">
         {p.children}
       </button>
     );
@@ -676,7 +677,9 @@ export function IconButton(p: {
 
   return (
     <Tooltip hasArrow label={p.disabledReason} placement="top">
-      <span className="iconButton disabled">{p.children}</span>
+      <span className="iconButton disabled" data-testid={p['data-testid']}>
+        {p.children}
+      </span>
     </Tooltip>
   );
 }

--- a/frontend/tests/test-variant-console/consumers/consumer-group-unconsumed-partitions.spec.ts
+++ b/frontend/tests/test-variant-console/consumers/consumer-group-unconsumed-partitions.spec.ts
@@ -1,0 +1,148 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+
+import { execRpk, getRedpandaContainerId } from '../../shared/rpk.utils';
+
+/**
+ * E2E tests for consumer group details page: unconsumed partition behaviour.
+ *
+ * Setup:
+ *   1. Create a topic with 3 partitions.
+ *   2. Produce one message to each partition (0, 1, 2).
+ *   3. Consume 2 messages with a test group — committing offsets for
+ *      partitions 0 and 1 (rpk consume reads in order).
+ *   4. Delete the committed offset for partition 1 via `rpk group offset-delete`.
+ *
+ * Result:
+ *   - Partition 0: has a committed offset  → shows numeric Group Offset / Lag
+ *   - Partition 1: offset deleted          → shows "—" for Group Offset and Lag
+ *   - Partition 2: never consumed          → shows "—" for Group Offset and Lag
+ *   - Edit / Delete buttons on rows 1 and 2 are disabled with tooltip
+ *     "No committed offset".
+ */
+
+const TOPIC_NAME = `e2e-unconsumed-${Date.now()}`;
+const GROUP_NAME = `e2e-unconsumed-group-${Date.now()}`;
+
+/** Column indices (0-based td positions within a data row) */
+const COL = {
+  PARTITION: 0,
+  ASSIGNED_MEMBER: 1,
+  HOST: 2,
+  LOG_END_OFFSET: 3,
+  GROUP_OFFSET: 4,
+  LAG: 5,
+  // index 6 is the actions cell
+} as const;
+
+/**
+ * Find a table row whose PARTITION cell exactly matches `partitionId`.
+ * Uses positional td matching so we don't accidentally match a row
+ * because a different column (e.g. Log End Offset) also contains the number.
+ */
+function rowByPartition(page: Page, partitionId: number) {
+  return page
+    .locator('tr')
+    .filter({
+      has: page.locator(`td:nth-child(${COL.PARTITION + 1})`).filter({ hasText: new RegExp(`^${partitionId}$`) }),
+    })
+    .first();
+}
+
+test.describe('Consumer Group Details - Unconsumed Partitions', () => {
+  test.beforeAll(async () => {
+    const { exec } = await import('node:child_process');
+    const { promisify } = await import('node:util');
+    const execAsync = promisify(exec);
+
+    const containerId = getRedpandaContainerId();
+    const authFlags = '-X user=e2euser -X pass=very-secret -X sasl.mechanism=SCRAM-SHA-256';
+
+    // 1. Create topic with 3 partitions
+    await execRpk(`topic create ${TOPIC_NAME} --partitions 3`);
+
+    // 2. Produce one message to each partition (stdin pipe requires docker exec -i)
+    for (const partition of [0, 1, 2]) {
+      await execAsync(
+        `echo "msg-p${partition}" | docker exec -i ${containerId} rpk topic produce ${TOPIC_NAME} -p ${partition} ${authFlags}`
+      );
+    }
+
+    // 3. Consume 2 messages — commits offsets on partitions 0 and 1 (in order)
+    await execAsync(
+      `docker exec ${containerId} rpk topic consume ${TOPIC_NAME} -n 2 --group ${GROUP_NAME} ${authFlags}`
+    );
+
+    // 4. Delete offset for partition 1 → it becomes an "unconsumed" partition
+    await execRpk(`group offset-delete ${GROUP_NAME} -t ${TOPIC_NAME}:1`);
+  });
+
+  test.afterAll(async () => {
+    // Best-effort cleanup: remove remaining offsets, then delete topic
+    await execRpk(`group offset-delete ${GROUP_NAME} -t ${TOPIC_NAME}:0`).catch(() => {});
+    await execRpk(`topic delete ${TOPIC_NAME}`).catch(() => {});
+  });
+
+  test('shows all 3 partitions with correct Group Offset and Lag values', async ({ page }) => {
+    await test.step('Navigate to consumer group details page', async () => {
+      await page.goto(`/groups/${GROUP_NAME}`);
+      // Wait for the group name heading to appear
+      await expect(page.getByText(GROUP_NAME).first()).toBeVisible({ timeout: 15_000 });
+    });
+
+    await test.step('Ensure the topic accordion is expanded', async () => {
+      // With a single topic the accordion auto-expands, but click if collapsed
+      const accordionButton = page.getByRole('button', { name: new RegExp(TOPIC_NAME) });
+      await accordionButton.waitFor({ state: 'visible', timeout: 15_000 });
+
+      const isExpanded = await accordionButton.getAttribute('aria-expanded');
+      if (isExpanded !== 'true') {
+        await accordionButton.click();
+      }
+
+      // Wait for the data table to appear
+      await expect(page.getByRole('table').first()).toBeVisible({ timeout: 10_000 });
+    });
+
+    await test.step('All 3 partitions are visible in the table', async () => {
+      for (const partitionId of [0, 1, 2]) {
+        await expect(rowByPartition(page, partitionId)).toBeVisible({ timeout: 10_000 });
+      }
+    });
+
+    await test.step('Partition 0 shows a numeric Group Offset (committed)', async () => {
+      const row = rowByPartition(page, 0);
+      const groupOffsetCell = row.locator(`td:nth-child(${COL.GROUP_OFFSET + 1})`);
+      const text = await groupOffsetCell.textContent();
+      expect(text?.trim()).not.toBe('—');
+      expect(Number(text?.trim())).toBeGreaterThanOrEqual(0);
+    });
+
+    await test.step('Partition 1 shows "—" for Group Offset (offset deleted)', async () => {
+      const row = rowByPartition(page, 1);
+      await expect(row.locator(`td:nth-child(${COL.GROUP_OFFSET + 1})`)).toHaveText('—', { timeout: 5000 });
+      await expect(row.locator(`td:nth-child(${COL.LAG + 1})`)).toHaveText('—', { timeout: 5000 });
+    });
+
+    await test.step('Partition 2 shows "—" for Group Offset (never consumed)', async () => {
+      const row = rowByPartition(page, 2);
+      await expect(row.locator(`td:nth-child(${COL.GROUP_OFFSET + 1})`)).toHaveText('—', { timeout: 5000 });
+      await expect(row.locator(`td:nth-child(${COL.LAG + 1})`)).toHaveText('—', { timeout: 5000 });
+    });
+
+    await test.step('Edit button on partition 1 (offset deleted) is disabled with tooltip', async () => {
+      const btn = page.getByTestId('partition-edit-1');
+      await expect(btn).toBeVisible({ timeout: 5000 });
+      await btn.hover();
+      await expect(page.getByRole('tooltip', { name: 'No committed offset' }).first()).toBeVisible({ timeout: 5000 });
+      await page.mouse.move(0, 0);
+    });
+
+    await test.step('Edit button on partition 2 (never consumed) is disabled with tooltip', async () => {
+      const btn = page.getByTestId('partition-edit-2');
+      await expect(btn).toBeVisible({ timeout: 5000 });
+      await btn.hover();
+      await expect(page.getByRole('tooltip', { name: 'No committed offset' }).first()).toBeVisible({ timeout: 5000 });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

  Previously, consumer group details only showed partitions that had a committed offset.
  This PR extends the backend and frontend so all partitions are visible — including those
  that have never been consumed or whose offset was deleted.

  **Backend**
  - `PartitionOffsets.GroupOffset` changed from `int64` to `*int64` — `nil` signals no committed offset
  - Partitions without a committed offset are now included in the response (previously skipped with `continue`)

  **Frontend**
  - `GroupPartitionOffset.groupOffset` typed as `number | null`
  - Unconsumed partitions show `—` for Group Offset and Lag columns
  - Edit / Delete buttons on unconsumed partition rows are disabled with tooltip "No committed offset"
  - Topic-level Edit / Delete buttons disabled when all partitions are unconsumed
  - `onEditOffsets` / `onDeleteOffsets` at topic level only receive consumed partitions, preventing crashes in downstream modal handlers
  - Lag filter (`onlyShowPartitionsWithLag`) updated to explicitly include unconsumed partitions rather than relying on `null !== 0`
  - `cannotEditGroupReason` / `cannotDeleteGroupOffsetsReason` accept an optional `consumedPartitions` array and own the "No committed offsets" check, removing inline ternaries at call sites

  **Tests**
  - Unit test (`group-details.test.tsx`) covers: edit button enabled/disabled state, `—` rendering for unconsumed partitions
  - E2E test (`consumer-group-unconsumed-partitions.spec.ts`) covers the full flow: produce messages, consume partially, delete an offset, verify all 3 partitions appear with correct values and button states
