### PR TITLE
[release-2.8] backend: bump golang.org/x/crypto to v0.52.0 to address Snyk findings

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -207,9 +207,9 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/crypto v0.51.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/mod v0.35.0 // indirect
-	golang.org/x/sys v0.44.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
 	gopkg.in/linkedin/goavro.v1 v1.0.5 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -738,8 +738,8 @@ golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
-golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
-golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f h1:W3F4c+6OLc6H2lb//N1q4WpJkhzJCK5J6kUi1NTVXfM=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aINzNzt2Bket5bjo9sdOYzOsU80=
@@ -844,8 +844,8 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
-golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=


### PR DESCRIPTION
## Summary

Backport of the master fix (https://github.com/redpanda-data/console/pull/2469) to release-2.8.

Bump `golang.org/x/crypto` from v0.51.0 to v0.52.0 to address 6 HIGH severity Snyk findings in `golang.org/x/crypto/ssh`.

### Vulnerabilities addressed

| CVE | Go vuln | Title |
|-----|---------|-------|
| CVE-2026-39831 | GO-2026-5019 | Improper Authentication |
| CVE-2026-39827 | GO-2026-5016 | Missing Release of Resource after Effective Lifetime |
| CVE-2026-42508 | GO-2026-5021 | Improper Check for Certificate Revocation (knownhosts) |
| CVE-2026-46597 | GO-2026-5013 | Incorrect Type Conversion or Cast |
| CVE-2026-46598 | GO-2026-5033 | Incorrect Type Conversion or Cast (ssh/agent) |
| CVE-2026-39835 | GO-2026-5015 | Uncaught Exception |

Snyk links:
- https://app.snyk.io/vuln/SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16795344
- https://app.snyk.io/vuln/SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16795342
- https://app.snyk.io/vuln/SNYK-GOLANG-GOLANGORGXCRYPTOSSHKNOWNHOSTS-16796449
- https://app.snyk.io/vuln/SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16796326
- https://app.snyk.io/vuln/SNYK-GOLANG-GOLANGORGXCRYPTOSSHAGENT-16796334
- https://app.snyk.io/vuln/SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16796332

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)