### PR TITLE
frontend(topics): split retention into Retention Time and Retention Size (UX-1310)

### DIFF
--- a/frontend/src/components/pages/topics/quick-info.tsx
+++ b/frontend/src/components/pages/topics/quick-info.tsx
@@ -119,27 +119,28 @@ export const TopicQuickInfoStatistic = (p: { topic: Topic }) => {
           </>
         )}
 
-        {cleanupPolicy === 'delete' && (
+        {cleanupPolicy === 'delete' && retentionMs && retentionBytes && (
           <>
-            <Text as="dt" fontWeight="bold">
-              Retention:
-            </Text>
-            {retentionMs && retentionBytes ? (
-              <Text as="dd">
-                ~
-                {retentionMs.value === '-1' && retentionBytes.value === '-1' ? (
-                  'Unlimited'
-                ) : (
-                  <>
-                    {formatConfigValue(retentionMs.name, retentionMs.value, 'friendly')} or{' '}
-                    {formatConfigValue(retentionBytes.name, retentionBytes.value, 'friendly')}
-                    {Number.isFinite(Number(retentionBytes.value)) &&
-                      Number(retentionBytes.value) !== -1 &&
-                      ' / partition'}
-                  </>
-                )}
+            <Flex gap={2}>
+              <Text as="dt" fontWeight="bold">
+                Retention Time:
               </Text>
-            ) : null}
+              <Text as="dd">~{formatConfigValue(retentionMs.name, retentionMs.value, 'friendly')}</Text>
+            </Flex>
+            <Box>
+              <Divider orientation="vertical" />
+            </Box>
+            <Flex gap={2}>
+              <Text as="dt" fontWeight="bold">
+                Retention Size:
+              </Text>
+              <Text as="dd">
+                ~{formatConfigValue(retentionBytes.name, retentionBytes.value, 'friendly')}
+                {Number.isFinite(Number(retentionBytes.value)) &&
+                  Number(retentionBytes.value) !== -1 &&
+                  ' / partition'}
+              </Text>
+            </Flex>
           </>
         )}
       </Flex>

--- a/frontend/src/components/pages/topics/quick-info.tsx
+++ b/frontend/src/components/pages/topics/quick-info.tsx
@@ -125,7 +125,10 @@ export const TopicQuickInfoStatistic = (p: { topic: Topic }) => {
               <Text as="dt" fontWeight="bold">
                 Retention Time:
               </Text>
-              <Text as="dd">~{formatConfigValue(retentionMs.name, retentionMs.value, 'friendly')}</Text>
+              <Text as="dd">
+                {retentionMs.value !== '-1' && '~'}
+                {formatConfigValue(retentionMs.name, retentionMs.value, 'friendly')}
+              </Text>
             </Flex>
             <Box>
               <Divider orientation="vertical" />
@@ -135,7 +138,8 @@ export const TopicQuickInfoStatistic = (p: { topic: Topic }) => {
                 Retention Size:
               </Text>
               <Text as="dd">
-                ~{formatConfigValue(retentionBytes.name, retentionBytes.value, 'friendly')}
+                {retentionBytes.value !== '-1' && '~'}
+                {formatConfigValue(retentionBytes.name, retentionBytes.value, 'friendly')}
                 {Number.isFinite(Number(retentionBytes.value)) &&
                   Number(retentionBytes.value) !== -1 &&
                   ' / partition'}

--- a/frontend/src/components/pages/topics/quick-info.tsx
+++ b/frontend/src/components/pages/topics/quick-info.tsx
@@ -140,9 +140,7 @@ export const TopicQuickInfoStatistic = (p: { topic: Topic }) => {
               <Text as="dd">
                 {retentionBytes.value !== '-1' && '~'}
                 {formatConfigValue(retentionBytes.name, retentionBytes.value, 'friendly')}
-                {Number.isFinite(Number(retentionBytes.value)) &&
-                  Number(retentionBytes.value) !== -1 &&
-                  ' / partition'}
+                {Number.isFinite(Number(retentionBytes.value)) && Number(retentionBytes.value) !== -1 && ' / partition'}
               </Text>
             </Flex>
           </>


### PR DESCRIPTION
## Summary

- Splits the topic quick-info "Retention" field into two labelled columns: **Retention Time** and **Retention Size**.
- Both always render, so when one of `retention.ms` / `retention.bytes` is `-1` the user now sees an unambiguous `Infinite` against the correct metric instead of strings like `1 day or Infinite`.

Jira: https://redpandadata.atlassian.net/browse/UX-1310

### Before
`Retention: ~1 day or Infinite`

### After
`Retention Time: ~1 day` | `Retention Size: ~Infinite`

<img width="1074" height="82" alt="image" src="https://github.com/user-attachments/assets/70005fa3-ef22-437e-9ddc-884eef25e4be" />


## Test plan

- [ ] Topic with `retention.ms=86400000`, `retention.bytes=-1` → "Retention Time: ~1 day" and "Retention Size: ~Infinite".
- [ ] Topic with `retention.ms=-1`, `retention.bytes=10737418240` → "Retention Time: ~Infinite" and "Retention Size: ~10 GB / partition".
- [ ] Topic with both `-1` → both columns show "~Infinite".
- [ ] Compacted topic (`cleanup.policy=compact`) still shows the Segment column unchanged.