### PR TITLE
config: add SQL connection and auth knobs

### DIFF
--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	Kafka          Kafka        `yaml:"kafka"`
 	Serde          Serde        `yaml:"serde"`
 	SchemaRegistry Schema       `yaml:"schemaRegistry"`
+	SQL            SQL          `yaml:"sql"`
 	Logger         Logging      `yaml:"logger"`
 	Analytics      Analytics    `yaml:"analytics"`
 }
@@ -57,6 +58,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	c.Console.RegisterFlags(f)
 	c.KafkaConnect.RegisterFlags(f)
 	c.SchemaRegistry.RegisterFlags(f)
+	c.SQL.RegisterFlags(f)
 }
 
 // Validate all root and child config structs
@@ -96,6 +98,11 @@ func (c *Config) Validate() error {
 		return err
 	}
 
+	err = c.SQL.Validate()
+	if err != nil {
+		return fmt.Errorf("failed to validate SQL config: %w", err)
+	}
+
 	err = c.Analytics.Validate()
 	if err != nil {
 		return fmt.Errorf("failed to validate Analytics config: %w", err)
@@ -117,6 +124,7 @@ func (c *Config) SetDefaults() {
 	c.Redpanda.SetDefaults()
 	c.Console.SetDefaults()
 	c.KafkaConnect.SetDefaults()
+	c.SQL.SetDefaults()
 	c.Analytics.SetDefaults()
 }
 

--- a/backend/pkg/config/sql.go
+++ b/backend/pkg/config/sql.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package config
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+)
+
+// SQL holds the configuration for connecting to Redpanda SQL over the
+// Postgres wire protocol.
+type SQL struct {
+	Enabled bool `yaml:"enabled"`
+	// URL is the Postgres-wire endpoint in host:port form (e.g. "rpsql:5432").
+	URL string `yaml:"url"`
+
+	Authentication HTTPAuthentication `yaml:"authentication"`
+	TLS            TLS                `yaml:"tls"`
+}
+
+// RegisterFlags registers flags for sensitive SQL authentication inputs.
+func (c *SQL) RegisterFlags(f *flag.FlagSet) {
+	c.Authentication.RegisterFlags(f, "sql.")
+}
+
+// SetDefaults for the SQL configuration.
+func (c *SQL) SetDefaults() {
+	c.Enabled = false
+	c.TLS.SetDefaults()
+}
+
+// Validate the SQL configuration.
+func (c *SQL) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+
+	if c.URL == "" {
+		return errors.New("sql is enabled but no URL is configured")
+	}
+
+	if err := c.TLS.Validate(); err != nil {
+		return fmt.Errorf("invalid sql tls config: %w", err)
+	}
+
+	// Mutual exclusion: impersonation forwards the user's session bearer as the
+	// upstream credential, so static credentials must not also be set.
+	isAuthSet := c.Authentication.BearerToken != "" || c.Authentication.BasicAuth.Username != "" || c.Authentication.BasicAuth.Password != ""
+	if c.Authentication.ImpersonateUser && isAuthSet {
+		return errors.New("sql authentication cannot set impersonateUser together with static basic/bearer credentials")
+	}
+
+	return nil
+}

--- a/backend/pkg/config/sql_test.go
+++ b/backend/pkg/config/sql_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSQL_SetDefaults(t *testing.T) {
+	var c SQL
+	c.Enabled = true // ensure SetDefaults resets it
+	c.SetDefaults()
+
+	if c.Enabled {
+		t.Error("expected Enabled to default to false, got true")
+	}
+	if c.TLS.RefreshInterval == 0 {
+		t.Error("expected TLS defaults to be applied")
+	}
+}
+
+func TestSQL_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     SQL
+		wantErr bool
+	}{
+		{
+			name: "disabled is always valid",
+			cfg:  SQL{Enabled: false},
+		},
+		{
+			name:    "enabled without url is invalid",
+			cfg:     SQL{Enabled: true},
+			wantErr: true,
+		},
+		{
+			name: "enabled with url is valid",
+			cfg:  SQL{Enabled: true, URL: "rpsql:5432"},
+		},
+		{
+			name: "impersonateUser with static bearer is invalid",
+			cfg: SQL{
+				Enabled:        true,
+				URL:            "rpsql:5432",
+				Authentication: HTTPAuthentication{ImpersonateUser: true, BearerToken: "tok"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "impersonateUser with basic auth username is invalid",
+			cfg: SQL{
+				Enabled:        true,
+				URL:            "rpsql:5432",
+				Authentication: HTTPAuthentication{ImpersonateUser: true, BasicAuth: HTTPBasicAuth{Username: "user"}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "impersonateUser alone is valid",
+			cfg: SQL{
+				Enabled:        true,
+				URL:            "rpsql:5432",
+				Authentication: HTTPAuthentication{ImpersonateUser: true},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Console will connect to Redpanda SQL over the
Postgres wire protocol, but there is no way to
express where that endpoint lives or how to
authenticate. Add a SQL config block, reusing the
existing HTTPAuthentication type so the
impersonateUser path (forwarding the session
bearer upstream) works as it does for Kafka and
the Admin API, with static basic or bearer
credentials as the fallback. The two are mutually
exclusive and rejected together at validation.

Only the configuration surface is added here; no
client or factory wiring yet.