### PR TITLE
ci(changelog): post Enterprise CI status so changelog PRs can merge

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      statuses: write
 
     steps:
       - name: Checkout repository
@@ -54,11 +55,13 @@ jobs:
             --allowedTools "Bash(git tag:*),Bash(git log:*),Bash(git status:*),Bash(git branch:*),Bash(head:*),Bash(pwd),Read,Edit"
 
       - name: Check for changes, commit, and create PR
+        id: changelog_pr
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           if git diff --quiet CHANGELOG.md; then
             echo "No changelog changes detected, skipping PR creation."
+            echo "created=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -68,6 +71,8 @@ jobs:
           git add CHANGELOG.md
           git commit -m "docs: update CHANGELOG.md for ${{ steps.tag.outputs.name }}"
           git push origin "changelog/${{ steps.tag.outputs.name }}"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "created=true" >> "$GITHUB_OUTPUT"
 
           gh pr create \
             --title "docs: update CHANGELOG.md for ${{ steps.tag.outputs.name }}" \
@@ -85,3 +90,23 @@ jobs:
           )" \
             --base master \
             --head "changelog/${{ steps.tag.outputs.name }}"
+
+      # The branch above is pushed with GITHUB_TOKEN, so GitHub does not trigger
+      # the push workflows (enterprise-ci-skip.yml / repository-dispatch.yml) that
+      # would normally post the required 'Enterprise CI' status. A changelog PR
+      # only touches CHANGELOG.md, so post the skip status directly here to keep
+      # the PR mergeable — mirrors enterprise-ci-skip.yml.
+      - name: Post Enterprise CI skip status
+        if: ${{ steps.changelog_pr.outputs.created == 'true' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ steps.changelog_pr.outputs.sha }}',
+              state: 'success',
+              description: 'Skipped — changelog-only change',
+              context: 'Enterprise CI'
+            });


### PR DESCRIPTION
## What

Makes auto-generated changelog PRs (e.g. #2473 "docs: update CHANGELOG.md for v3.7.4") mergeable by posting the required `Enterprise CI` commit status from the changelog workflow itself.

## Root cause

`changelog.yml` creates the `changelog/<tag>` branch and pushes it with `GH_TOKEN: ${{ github.token }}` (the default `GITHUB_TOKEN`). GitHub **does not trigger `push`/`pull_request` workflows for refs pushed by `GITHUB_TOKEN`** (recursion guard). So neither:

- `enterprise-ci-skip.yml` — which exists to post `Enterprise CI = success` for non-code pushes, nor
- `repository-dispatch.yml` — which posts the `pending` status and dispatches to console-enterprise

ever run on the changelog branch. The required `Enterprise CI` status is therefore never created, and the PR sits `BLOCKED` with no way to merge (Snyk still reports because it's a GitHub App, not an Actions push workflow).

## Fix

A changelog PR only ever touches `CHANGELOG.md`, so there is nothing to build or test. After creating the PR, post `Enterprise CI = success` ("Skipped — changelog-only change") directly from this workflow — mirroring `enterprise-ci-skip.yml`. Adds `statuses: write` to the job permissions.

## Alternative considered

Pushing the branch with a PAT/bot token instead of `GITHUB_TOKEN` would let `enterprise-ci-skip.yml` run naturally (and any future push-based required checks), but requires wiring the bot-token/AWS-OIDC plumbing into this workflow. Posting the status directly is the minimal change and matches the existing skip behavior.

## Related

`console#2473` was unblocked manually by posting the status; this makes it automatic for every future changelog PR.
