### PR TITLE
UX-1322 - feat(connect): prepare pipeline pages for editor enhancements

### DIFF
--- a/frontend/src/components/pages/rp-connect/onboarding/onboarding-wizard.tsx
+++ b/frontend/src/components/pages/rp-connect/onboarding/onboarding-wizard.tsx
@@ -29,6 +29,7 @@ import {
 } from '../types/constants';
 import type { ExtendedConnectComponentSpec } from '../types/schema';
 import type { AddTopicFormData, BaseStepRef, ConnectTilesListFormData, UserStepRef } from '../types/wizard';
+import { navigateToConnectClusters } from '../utils/navigation';
 import { parseSchema } from '../utils/schema';
 import { handleStepResult, regenerateYamlForTopicUserComponents } from '../utils/wizard';
 import { getConnectTemplate } from '../utils/yaml';
@@ -300,7 +301,7 @@ export const ConnectOnboardingWizard = ({
       navigate({ to: '/overview' });
       window.location.reload(); // Required because we want to load Cloud UI's overview, not Console UI.
     } else {
-      navigate({ to: '/connect-clusters', search: {} as never });
+      navigateToConnectClusters(navigate);
     }
   }, [onCancelProp, navigate, resetRpcnWizardStore, search.serverless]);
 

--- a/frontend/src/components/pages/rp-connect/onboarding/onboarding-wizard.tsx
+++ b/frontend/src/components/pages/rp-connect/onboarding/onboarding-wizard.tsx
@@ -12,13 +12,7 @@ import { AnimatePresence } from 'motion/react';
 import { ComponentSpecSchema } from 'protogen/redpanda/api/dataplane/v1/pipeline_pb';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useListComponentsQuery } from 'react-query/api/connect';
-import {
-  useOnboardingTopicDataStore,
-  useOnboardingUserDataStore,
-  useOnboardingWizardDataStore,
-  useOnboardingYamlContentStore,
-  useResetOnboardingWizardStore,
-} from 'state/onboarding-wizard-store';
+import { useResetRpcnWizardStore, useRpcnWizardStore } from 'state/rpcn-wizard-store';
 import { useShallow } from 'zustand/react/shallow';
 
 import { AddTopicStep } from './add-topic-step';
@@ -72,18 +66,16 @@ export const ConnectOnboardingWizard = ({
     [componentListResponse]
   );
 
-  const persistedInputConnectionName = useOnboardingWizardDataStore(useShallow((state) => state.input?.connectionName));
-  const persistedOutputConnectionName = useOnboardingWizardDataStore(
-    useShallow((state) => state.output?.connectionName)
-  );
-  const persistedTopicName = useOnboardingTopicDataStore(useShallow((state) => state.topicName));
-  const persistedUserSaslMechanism = useOnboardingUserDataStore(useShallow((state) => state.saslMechanism));
-  const persistedUsername = useOnboardingUserDataStore(useShallow((state) => state.username));
-  const persistedConsumerGroup = useOnboardingUserDataStore(useShallow((state) => state.consumerGroup));
-  const resetOnboardingWizardStore = useResetOnboardingWizardStore();
-  const setWizardData = useOnboardingWizardDataStore(useShallow((state) => state.setWizardData));
-  const setTopicData = useOnboardingTopicDataStore(useShallow((state) => state.setTopicData));
-  const setUserData = useOnboardingUserDataStore(useShallow((state) => state.setUserData));
+  const persistedInputConnectionName = useRpcnWizardStore(useShallow((state) => state.input?.connectionName));
+  const persistedOutputConnectionName = useRpcnWizardStore(useShallow((state) => state.output?.connectionName));
+  const persistedTopicName = useRpcnWizardStore(useShallow((state) => state.topicName));
+  const persistedUserSaslMechanism = useRpcnWizardStore(useShallow((state) => state.saslMechanism));
+  const persistedUsername = useRpcnWizardStore(useShallow((state) => state.username));
+  const persistedConsumerGroup = useRpcnWizardStore(useShallow((state) => state.consumerGroup));
+  const resetRpcnWizardStore = useResetRpcnWizardStore();
+  const setWizardData = useRpcnWizardStore(useShallow((state) => state.setWizardData));
+  const setTopicData = useRpcnWizardStore(useShallow((state) => state.setTopicData));
+  const setUserData = useRpcnWizardStore(useShallow((state) => state.setUserData));
 
   const persistedInputIsRedpandaComponent = useMemo<boolean>(
     () =>
@@ -93,7 +85,7 @@ export const ConnectOnboardingWizard = ({
   );
 
   useEffect(() => {
-    const store = useOnboardingWizardDataStore;
+    const store = useRpcnWizardStore;
     store.persist.rehydrate();
   }, []);
 
@@ -102,10 +94,10 @@ export const ConnectOnboardingWizard = ({
       // Only clear if we're navigating away from the wizard
       const currentPath = window.location.pathname;
       if (!currentPath.includes('/rp-connect/wizard')) {
-        resetOnboardingWizardStore();
+        resetRpcnWizardStore();
       }
     };
-  }, [resetOnboardingWizardStore]);
+  }, [resetRpcnWizardStore]);
 
   const search = routeApi.useSearch();
 
@@ -144,7 +136,7 @@ export const ConnectOnboardingWizard = ({
 
   const handleSkipToCreatePipeline = (methods: WizardStepperSteps) => {
     if (methods.current.id === WizardStep.ADD_INPUT) {
-      resetOnboardingWizardStore();
+      resetRpcnWizardStore();
     } else if (methods.current.id === WizardStep.ADD_OUTPUT) {
       setTopicData({});
       setUserData({});
@@ -169,11 +161,11 @@ export const ConnectOnboardingWizard = ({
             connectionName,
             connectionType,
             components,
-            existingYaml: useOnboardingYamlContentStore.getState().yamlContent,
+            existingYaml: useRpcnWizardStore.getState().yamlContent,
           });
 
           if (yamlContent) {
-            useOnboardingYamlContentStore.getState().setYamlContent({ yamlContent });
+            useRpcnWizardStore.getState().setYamlContent({ yamlContent });
           }
 
           if (connectionName === 'redpanda_common') {
@@ -189,7 +181,7 @@ export const ConnectOnboardingWizard = ({
             });
             methods.goTo(WizardStep.ADD_TOPIC);
           } else {
-            const { setWizardData: _, ...currentWizardData } = useOnboardingWizardDataStore.getState();
+            const { setWizardData: _, ...currentWizardData } = useRpcnWizardStore.getState();
             setWizardData({
               input: {
                 connectionName,
@@ -218,11 +210,11 @@ export const ConnectOnboardingWizard = ({
             connectionName,
             connectionType,
             components,
-            existingYaml: useOnboardingYamlContentStore.getState().yamlContent,
+            existingYaml: useRpcnWizardStore.getState().yamlContent,
           });
 
           if (yamlContent) {
-            useOnboardingYamlContentStore.getState().setYamlContent({ yamlContent });
+            useRpcnWizardStore.getState().setYamlContent({ yamlContent });
           }
 
           if (connectionName === 'redpanda_common') {
@@ -237,7 +229,7 @@ export const ConnectOnboardingWizard = ({
               },
             });
           } else {
-            const { setWizardData: _, ...currentWizardData } = useOnboardingWizardDataStore.getState();
+            const { setWizardData: _, ...currentWizardData } = useRpcnWizardStore.getState();
             setWizardData({
               output: {
                 connectionName,
@@ -301,7 +293,7 @@ export const ConnectOnboardingWizard = ({
   };
 
   const handleCancel = useCallback(() => {
-    resetOnboardingWizardStore();
+    resetRpcnWizardStore();
     if (onCancelProp) {
       onCancelProp();
     } else if (search.serverless === 'true') {
@@ -310,7 +302,7 @@ export const ConnectOnboardingWizard = ({
     } else {
       navigate({ to: '/connect-clusters', search: {} as never });
     }
-  }, [onCancelProp, navigate, resetOnboardingWizardStore, search.serverless]);
+  }, [onCancelProp, navigate, resetRpcnWizardStore, search.serverless]);
 
   // Callbacks to update validity for each step
   const handleInputValidityChange = useCallback((isValid: boolean) => {

--- a/frontend/src/components/pages/rp-connect/pipeline/index.test.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/index.test.tsx
@@ -183,23 +183,11 @@ vi.mock('./pipeline-command-menu', async () => ({
 }));
 
 // 7. Mock Zustand stores
-vi.mock('state/onboarding-wizard-store', () => ({
-  useOnboardingYamlContentStore: Object.assign(
+vi.mock('state/rpcn-wizard-store', () => ({
+  useRpcnWizardStore: Object.assign(
     vi.fn(() => ''),
     {
-      getState: () => ({ setYamlContent: vi.fn(), yamlContent: '' }),
-    }
-  ),
-  useOnboardingWizardDataStore: Object.assign(
-    vi.fn(() => ({ hasHydrated: true })),
-    {
-      getState: () => ({ setWizardData: vi.fn() }),
-    }
-  ),
-  useOnboardingUserDataStore: Object.assign(
-    vi.fn(() => ({})),
-    {
-      getState: () => ({ reset: vi.fn() }),
+      getState: () => ({ setYamlContent: vi.fn(), yamlContent: '', setWizardData: vi.fn(), reset: vi.fn() }),
     }
   ),
   getWizardConnectionData: () => ({ input: undefined, output: undefined }),

--- a/frontend/src/components/pages/rp-connect/pipeline/index.test.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/index.test.tsx
@@ -594,6 +594,22 @@ describe('PipelinePage', () => {
     });
   });
 
+  it('view page exposes Monitor and Configuration lanes; Configuration shows the YAML read-only', async () => {
+    const user = userEvent.setup();
+    mockUsePipelineMode.mockReturnValue({ mode: 'view', pipelineId: 'test-pipeline' });
+
+    render(<PipelinePage />, { transport: createTransport() });
+
+    // Monitor is the default lane — no YAML editor shown yet.
+    expect(await screen.findByText('Configuration')).toBeInTheDocument();
+    expect(screen.queryByTestId('yaml-editor')).not.toBeInTheDocument();
+
+    // Switching to Configuration shows the pipeline YAML.
+    await user.click(screen.getByText('Configuration'));
+    const yaml = (await screen.findByTestId('yaml-editor')) as HTMLTextAreaElement;
+    expect(yaml.value).toBe('input:\n  stdin: {}\noutput:\n  stdout: {}');
+  });
+
   it('confirms before stopping a running pipeline', async () => {
     const user = userEvent.setup();
     mockUsePipelineMode.mockReturnValue({ mode: 'view', pipelineId: 'test-pipeline' });

--- a/frontend/src/components/pages/rp-connect/pipeline/index.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/index.tsx
@@ -709,8 +709,7 @@ function SidebarPanel({
 export default function PipelinePage() {
   const { mode, pipelineId } = usePipelineMode();
   const isSlashMenuEnabled = isFeatureFlagEnabled('enableConnectSlashMenu');
-  // Key by pipeline id so navigating between pipelines remounts a clean editor
-  // store instead of carrying the previous lane / YAML / selection over.
+  // Keyed by pipeline id so each pipeline gets a fresh editor store.
   return (
     <PipelineEditorProvider initialSlashTipVisible={isSlashMenuEnabled && mode !== 'view'} key={pipelineId ?? 'create'}>
       <PipelinePageContent />
@@ -718,7 +717,7 @@ export default function PipelinePage() {
   );
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: top-level page wiring; state now lives in the editor store
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: top-level page wiring across many concerns
 function PipelinePageContent() {
   const { mode, pipelineId } = usePipelineMode();
   const navigate = useNavigate();
@@ -822,9 +821,8 @@ function PipelinePageContent() {
     setAllowNavigation(false);
   }, [mode, setAllowNavigation]);
 
-  // Side effects for any document change — typing, dialog patches, or templates.
-  // Centralized here (rather than per call site) so every mutation path, including
-  // a future visual editor, clears stale lint and mirrors create-mode drafts.
+  // Runs on any document change so every mutation path clears stale lint and
+  // mirrors the create-mode draft to the wizard store.
   useEffect(
     () =>
       editorStore.subscribe((state, prev) => {

--- a/frontend/src/components/pages/rp-connect/pipeline/index.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/index.tsx
@@ -108,12 +108,7 @@ import { navigateToConnectClusters } from '../utils/navigation';
 import { parseSchema } from '../utils/schema';
 import { useCreateModeInitialYaml } from '../utils/use-create-mode-initial-yaml';
 import { usePipelineMode } from '../utils/use-pipeline-mode';
-import {
-  extractConnectorTopics,
-  getConnectTemplate,
-  type RedpandaSetupResultLike,
-  tryPatchRedpandaYaml,
-} from '../utils/yaml';
+import { extractConnectorTopics, getConnectTemplate, type RedpandaSetupResultLike } from '../utils/yaml';
 
 function getConnectorDialogTitle(type: ConnectComponentType | 'resource' | null): string | undefined {
   if (type === 'input') {
@@ -388,20 +383,19 @@ function usePipelineSave({
 
 type DiagramDialogTarget = { section: 'input' | 'output'; componentName: string };
 
-function useDiagramDialogs(yamlContent: string, handleConnectorYamlChange: (yaml: string) => void) {
+function useDiagramDialogs(
+  yamlContent: string,
+  patchComponent: (section: 'input' | 'output', componentName: string, patch: RedpandaSetupResultLike) => boolean,
+  focusEditorEnd: () => void
+) {
   const topicStepRef = useRef<BaseStepRef<AddTopicFormData>>(null);
   const userStepRef = useRef<UserStepRef>(null);
 
   const topicDialog = useRefFormDialog<AddTopicFormData, DiagramDialogTarget>({
     ref: topicStepRef,
     onSuccess: (data, target) => {
-      if (data.topicName) {
-        const patched = tryPatchRedpandaYaml(yamlContent, target.section, target.componentName, {
-          topicName: data.topicName,
-        });
-        if (patched) {
-          handleConnectorYamlChange(patched);
-        }
+      if (data.topicName && patchComponent(target.section, target.componentName, { topicName: data.topicName })) {
+        focusEditorEnd();
       }
     },
   });
@@ -422,9 +416,8 @@ function useDiagramDialogs(yamlContent: string, handleConnectorYamlChange: (yaml
           saslMechanism: (data as AddUserFormData).saslMechanism,
         };
       }
-      const patched = tryPatchRedpandaYaml(yamlContent, target.section, target.componentName, setupResult);
-      if (patched) {
-        handleConnectorYamlChange(patched);
+      if (patchComponent(target.section, target.componentName, setupResult)) {
+        focusEditorEnd();
       }
     },
   });
@@ -714,10 +707,12 @@ function SidebarPanel({
 }
 
 export default function PipelinePage() {
-  const { mode } = usePipelineMode();
+  const { mode, pipelineId } = usePipelineMode();
   const isSlashMenuEnabled = isFeatureFlagEnabled('enableConnectSlashMenu');
+  // Key by pipeline id so navigating between pipelines remounts a clean editor
+  // store instead of carrying the previous lane / YAML / selection over.
   return (
-    <PipelineEditorProvider initialSlashTipVisible={isSlashMenuEnabled && mode !== 'view'}>
+    <PipelineEditorProvider initialSlashTipVisible={isSlashMenuEnabled && mode !== 'view'} key={pipelineId ?? 'create'}>
       <PipelinePageContent />
     </PipelineEditorProvider>
   );
@@ -739,6 +734,7 @@ function PipelinePageContent() {
   const editorStore = usePipelineEditorStoreApi();
   const {
     setYamlContent,
+    patchComponent,
     setEditorInstance,
     hydrateFromServer,
     resolveInitialYaml,
@@ -826,38 +822,43 @@ function PipelinePageContent() {
     setAllowNavigation(false);
   }, [mode, setAllowNavigation]);
 
-  const handleYamlChange = useCallback(
-    (value: string) => {
-      clearErrorLintHints();
-      setYamlContent(value);
-      if (mode === 'create' && !isPipelineDiagramsEnabled) {
-        useRpcnWizardStore.getState().setYamlContent({ yamlContent: value });
-      }
-    },
-    [mode, isPipelineDiagramsEnabled, clearErrorLintHints, setYamlContent]
+  // Side effects for any document change — typing, dialog patches, or templates.
+  // Centralized here (rather than per call site) so every mutation path, including
+  // a future visual editor, clears stale lint and mirrors create-mode drafts.
+  useEffect(
+    () =>
+      editorStore.subscribe((state, prev) => {
+        if (state.yamlContent === prev.yamlContent) {
+          return;
+        }
+        clearErrorLintHints();
+        if (mode === 'create' && !isPipelineDiagramsEnabled) {
+          useRpcnWizardStore.getState().setYamlContent({ yamlContent: state.yamlContent });
+        }
+      }),
+    [editorStore, clearErrorLintHints, mode, isPipelineDiagramsEnabled]
   );
 
-  const handleConnectorYamlChange = useCallback(
-    (yaml: string) => {
-      handleYamlChange(yaml);
-      setTimeout(() => {
-        if (editorInstance) {
-          const model = editorInstance.getModel();
-          if (model) {
-            const lastLine = model.getLineCount();
-            const lastColumn = model.getLineMaxColumn(lastLine);
-            editorInstance.setPosition({ lineNumber: lastLine, column: lastColumn });
-            editorInstance.revealLine(lastLine);
-          }
-          editorInstance.focus();
-        }
-      }, 0);
-    },
-    [handleYamlChange, editorInstance]
-  );
+  // Move the caret to the end of the editor after a programmatic edit (dialog
+  // patch / template insert) so the user sees what changed.
+  const focusEditorEnd = useCallback(() => {
+    setTimeout(() => {
+      const ed = editorStore.getState().editorInstance;
+      if (!ed) {
+        return;
+      }
+      const model = ed.getModel();
+      if (model) {
+        const lastLine = model.getLineCount();
+        ed.setPosition({ lineNumber: lastLine, column: model.getLineMaxColumn(lastLine) });
+        ed.revealLine(lastLine);
+      }
+      ed.focus();
+    }, 0);
+  }, [editorStore]);
 
   const { topicDialog, userDialog, topicStepRef, userStepRef, connectorTopics, handleAddTopic, handleAddSasl } =
-    useDiagramDialogs(yamlContent, handleConnectorYamlChange);
+    useDiagramDialogs(yamlContent, patchComponent, focusEditorEnd);
 
   const handleConnectorSelected = useCallback(
     (connectionName: string, connectionType: ConnectComponentType) => {
@@ -870,10 +871,11 @@ function PipelinePageContent() {
         existingYaml: yamlContent,
       });
       if (newYaml) {
-        handleConnectorYamlChange(newYaml);
+        setYamlContent(newYaml);
+        focusEditorEnd();
       }
     },
-    [components, yamlContent, handleConnectorYamlChange, setAddConnectorType]
+    [components, yamlContent, setYamlContent, focusEditorEnd, setAddConnectorType]
   );
 
   // Hydrate from the loaded pipeline once per id, so re-renders don't clobber edits.
@@ -995,7 +997,7 @@ function PipelinePageContent() {
               lintHints={lintHints}
               onDismissSlashTip={() => setSlashTipVisible(false)}
               onEditorMount={setEditorInstance}
-              onYamlChange={handleYamlChange}
+              onYamlChange={setYamlContent}
               slashTipVisible={slashTipVisible}
               yamlContent={yamlContent}
               yamlEditorSchema={yamlEditorSchema}
@@ -1181,12 +1183,12 @@ function PipelinePageContent() {
         <TemplateGalleryDialog
           onClose={(stashedYaml) => {
             if (stashedYaml) {
-              handleYamlChange(stashedYaml);
+              setYamlContent(stashedYaml);
             }
             setIsTemplateDialogOpen(false);
           }}
           onSubmit={({ pipelineName: suggestedName, yaml }) => {
-            handleYamlChange(yaml);
+            setYamlContent(yaml);
             if (!form.getValues('name')) {
               form.setValue('name', suggestedName, { shouldDirty: true, shouldValidate: true });
             }

--- a/frontend/src/components/pages/rp-connect/pipeline/index.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/index.tsx
@@ -34,6 +34,7 @@ import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from 'components
 import { Separator } from 'components/redpanda-ui/components/separator';
 import { Skeleton } from 'components/redpanda-ui/components/skeleton';
 import { Spinner } from 'components/redpanda-ui/components/spinner';
+import { Tabs, TabsList, TabsTrigger } from 'components/redpanda-ui/components/tabs';
 import { Heading } from 'components/redpanda-ui/components/typography';
 import { LogExplorer } from 'components/ui/connect/log-explorer';
 import { DeleteResourceAlertDialog } from 'components/ui/delete-resource-alert-dialog';
@@ -89,6 +90,7 @@ import { PipelineCommandMenu } from './pipeline-command-menu';
 import { PipelineFlowDiagram } from './pipeline-flow-diagram';
 import { PipelineEditHeader, PipelineViewHeader } from './pipeline-header';
 import { PipelineThroughputCard } from './pipeline-throughput-card';
+import { PipelineEditorProvider, usePipelineEditorStore, usePipelineEditorStoreApi } from './use-pipeline-editor-store';
 import { useSlashCommand } from './use-slash-command';
 import { extractLintHintsFromError } from '../errors';
 import { AddConnectorDialog } from '../onboarding/add-connector-dialog';
@@ -264,10 +266,7 @@ function usePipelineSave({
   pipelineId: string | undefined;
   pipeline: Pipeline | undefined;
   isPipelineDiagramsEnabled: boolean;
-  /**
-   * Called right before a successful save navigates away, so the unsaved-changes
-   * guard doesn't block the post-save navigation.
-   */
+  // Called right before a successful save navigates away, so the unsaved-changes guard doesn't block it.
   onBeforeSaveNavigate?: () => void;
 }) {
   const navigate = useNavigate();
@@ -478,6 +477,27 @@ function EditorSkeleton() {
       <Skeleton variant="text" width="md" />
       <Skeleton variant="text" width="lg" />
       <Skeleton variant="text" width="sm" />
+    </div>
+  );
+}
+
+// Read-only YAML viewer for the view page: reuses the editor with all editable
+// cues (caret, text cursor, active-line highlight) suppressed.
+function YamlViewPanel({
+  configYaml,
+  schema,
+}: {
+  configYaml: string;
+  schema: ReturnType<typeof parseYamlEditorSchema>;
+}) {
+  return (
+    <div className="relative h-full overflow-hidden p-2 [&_.cursors-layer]:opacity-0">
+      <YamlEditor
+        options={{ readOnly: true, domReadOnly: true, renderLineHighlight: 'none', mouseStyle: 'default' }}
+        schema={schema}
+        transparentBackground
+        value={configYaml}
+      />
     </div>
   );
 }
@@ -697,6 +717,17 @@ function SidebarPanel({
 }
 
 export default function PipelinePage() {
+  const { mode } = usePipelineMode();
+  const isSlashMenuEnabled = isFeatureFlagEnabled('enableConnectSlashMenu');
+  return (
+    <PipelineEditorProvider initialSlashTipVisible={isSlashMenuEnabled && mode !== 'view'}>
+      <PipelinePageContent />
+    </PipelineEditorProvider>
+  );
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: top-level page wiring; state now lives in the editor store
+function PipelinePageContent() {
   const { mode, pipelineId } = usePipelineMode();
   const navigate = useNavigate();
   const router = useRouter();
@@ -704,19 +735,39 @@ export default function PipelinePage() {
   const isSlashMenuEnabled = isFeatureFlagEnabled('enableConnectSlashMenu');
   const isServerlessMode = search.serverless === 'true';
   const isPipelineDiagramsEnabled = isFeatureFlagEnabled('enablePipelineDiagrams') && isEmbedded();
-
-  const [editorInstance, setEditorInstance] = useState<null | editor.IStandaloneCodeEditor>(null);
-  const [yamlContent, setYamlContent] = useState('');
-  const [commandMenuFilter, setCommandMenuFilter] = useState<
-    'all' | 'variables' | 'secrets' | 'topics' | 'users' | null
-  >(null);
-  const [isConfigDialogOpen, setIsConfigDialogOpen] = useState(false);
-  const [isViewConfigDialogOpen, setIsViewConfigDialogOpen] = useState(false);
-  const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState(false);
-  const [addConnectorType, setAddConnectorType] = useState<ConnectComponentType | 'resource' | null>(null);
-  const [slashTipVisible, setSlashTipVisible] = useState(isSlashMenuEnabled && mode !== 'view');
-  const [isTemplateDialogOpen, setIsTemplateDialogOpen] = useState(false);
   const isTemplateGalleryEnabled = isFeatureFlagEnabled('enableRpcnTemplateGallery');
+
+  // Editor session state lives in a context-scoped Zustand store. Actions are
+  // stable, so we read them once; values use selectors.
+  const editorStore = usePipelineEditorStoreApi();
+  const {
+    setYamlContent,
+    setEditorInstance,
+    hydrateFromServer,
+    resolveInitialYaml,
+    setAllowNavigation,
+    setActiveViewLane,
+    setCommandMenuFilter,
+    setAddConnectorType,
+    setSlashTipVisible,
+    setIsConfigDialogOpen,
+    setIsViewConfigDialogOpen,
+    setIsDeleteAlertOpen,
+    setIsTemplateDialogOpen,
+  } = editorStore.getState();
+
+  const yamlContent = usePipelineEditorStore((s) => s.yamlContent);
+  const initialYaml = usePipelineEditorStore((s) => s.initialYaml);
+  const editorInstance = usePipelineEditorStore((s) => s.editorInstance);
+  const hydratedPipelineId = usePipelineEditorStore((s) => s.hydratedPipelineId);
+  const activeViewLane = usePipelineEditorStore((s) => s.activeViewLane);
+  const commandMenuFilter = usePipelineEditorStore((s) => s.commandMenuFilter);
+  const addConnectorType = usePipelineEditorStore((s) => s.addConnectorType);
+  const slashTipVisible = usePipelineEditorStore((s) => s.slashTipVisible);
+  const isConfigDialogOpen = usePipelineEditorStore((s) => s.isConfigDialogOpen);
+  const isViewConfigDialogOpen = usePipelineEditorStore((s) => s.isViewConfigDialogOpen);
+  const isDeleteAlertOpen = usePipelineEditorStore((s) => s.isDeleteAlertOpen);
+  const isTemplateDialogOpen = usePipelineEditorStore((s) => s.isTemplateDialogOpen);
 
   const form = useForm<PipelineFormValues>({
     resolver: zodResolver(pipelineFormSchema) as Resolver<PipelineFormValues>,
@@ -724,7 +775,7 @@ export default function PipelinePage() {
     defaultValues: { name: '', description: '', computeUnits: MIN_TASKS, tags: [] },
   });
 
-  const handleSlashOpen = useCallback(() => setCommandMenuFilter(null), []);
+  const handleSlashOpen = useCallback(() => setCommandMenuFilter(null), [setCommandMenuFilter]);
   const slashCommand = useSlashCommand(mode !== 'view' ? editorInstance : null, isSlashMenuEnabled, handleSlashOpen);
 
   const handleCommandMenuOpen = useCallback(
@@ -732,7 +783,7 @@ export default function PipelinePage() {
       slashCommand.close();
       setCommandMenuFilter(filter);
     },
-    [slashCommand]
+    [slashCommand, setCommandMenuFilter]
   );
 
   const { data: pipelineResponse } = useGetPipelineQuery(
@@ -751,13 +802,7 @@ export default function PipelinePage() {
   const yamlEditorSchema = useMemo(() => parseYamlEditorSchema(schemaResponse?.configSchema), [schemaResponse]);
 
   // Lets a successful save navigate away without tripping the unsaved-changes guard.
-  const allowNavigationRef = useRef(false);
-  const markNavigationAllowed = useCallback(() => {
-    allowNavigationRef.current = true;
-  }, []);
-  // Baseline YAML to diff against for the unsaved-changes guard: the server config
-  // in edit mode, or the first resolved template in create mode.
-  const initialYamlRef = useRef<string | null>(null);
+  const markNavigationAllowed = useCallback(() => setAllowNavigation(true), [setAllowNavigation]);
 
   const { handleSave, handleDelete, clearWizardStore, errorLintHints, clearErrorLintHints, isSaving, isDeleting } =
     usePipelineSave({
@@ -772,17 +817,17 @@ export default function PipelinePage() {
   const { lintHints, isLintPending } = usePipelineLint(yamlContent, errorLintHints, mode !== 'view');
 
   // Guard against losing unsaved edits when navigating away from the editor (edit or create).
-  const yamlDirty = initialYamlRef.current !== null && yamlContent !== initialYamlRef.current;
+  const yamlDirty = initialYaml !== null && yamlContent !== initialYaml;
   const hasUnsavedChanges = mode !== 'view' && (form.formState.isDirty || yamlDirty);
   const blocker = useBlocker({
-    shouldBlockFn: () => hasUnsavedChanges && !allowNavigationRef.current,
+    shouldBlockFn: () => hasUnsavedChanges && !editorStore.getState().allowNavigation,
     enableBeforeUnload: () => hasUnsavedChanges,
     withResolver: true,
   });
   // Re-arm the guard whenever the mode changes (e.g. after the post-save nav to view).
   useEffect(() => {
-    allowNavigationRef.current = false;
-  }, [mode]);
+    setAllowNavigation(false);
+  }, [mode, setAllowNavigation]);
 
   const handleYamlChange = useCallback(
     (value: string) => {
@@ -792,7 +837,7 @@ export default function PipelinePage() {
         useOnboardingYamlContentStore.getState().setYamlContent({ yamlContent: value });
       }
     },
-    [mode, isPipelineDiagramsEnabled, clearErrorLintHints]
+    [mode, isPipelineDiagramsEnabled, clearErrorLintHints, setYamlContent]
   );
 
   const handleConnectorYamlChange = useCallback(
@@ -831,15 +876,15 @@ export default function PipelinePage() {
         handleConnectorYamlChange(newYaml);
       }
     },
-    [components, yamlContent, handleConnectorYamlChange]
+    [components, yamlContent, handleConnectorYamlChange, setAddConnectorType]
   );
 
-  const [hydratedPipelineId, setHydratedPipelineId] = useState<string | null>(null);
-  if (pipeline && mode !== 'create' && pipeline.id !== hydratedPipelineId) {
-    setHydratedPipelineId(pipeline.id);
-    setYamlContent(pipeline.configYaml);
-    initialYamlRef.current = pipeline.configYaml;
-  }
+  // Hydrate from the loaded pipeline once per id, so re-renders don't clobber edits.
+  useEffect(() => {
+    if (pipeline && mode !== 'create' && pipeline.id !== hydratedPipelineId) {
+      hydrateFromServer(pipeline.id, pipeline.configYaml);
+    }
+  }, [pipeline, mode, hydratedPipelineId, hydrateFromServer]);
 
   useEffect(() => {
     if (pipeline && mode === 'edit') {
@@ -852,12 +897,7 @@ export default function PipelinePage() {
     }
   }, [pipeline, mode, form]);
 
-  const handleInitialYamlResolved = useCallback((yaml: string) => {
-    setYamlContent(yaml);
-    if (initialYamlRef.current === null) {
-      initialYamlRef.current = yaml;
-    }
-  }, []);
+  const handleInitialYamlResolved = useCallback((yaml: string) => resolveInitialYaml(yaml), [resolveInitialYaml]);
 
   const { isInitializing: isServerlessInitializing } = useCreateModeInitialYaml({
     enabled: mode === 'create',
@@ -918,6 +958,19 @@ export default function PipelinePage() {
           url={pipeline?.url}
         />
       ) : null}
+      {/* View-mode lanes: Monitor (throughput/logs) vs Configuration (read-only YAML). */}
+      {mode === 'view' && pipeline ? (
+        <Tabs value={activeViewLane}>
+          <TabsList className="w-fit" variant="underline">
+            <TabsTrigger onClick={() => setActiveViewLane('monitor')} value="monitor" variant="underline">
+              Monitor
+            </TabsTrigger>
+            <TabsTrigger onClick={() => setActiveViewLane('configuration')} value="configuration" variant="underline">
+              Configuration
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+      ) : null}
       {/* Grows to fill a tall viewport but keeps a usable minimum so the editor /
           flow panels aren't squished when the summary card is tall. */}
       <div className="flex min-h-[640px] flex-1 rounded-lg border border-border!">
@@ -934,9 +987,11 @@ export default function PipelinePage() {
           yamlContent={yamlContent}
         />
         <div className="min-w-0 flex-1">
-          {mode === 'view' ? (
-            <ViewModePanel pipeline={pipeline} />
-          ) : (
+          {mode === 'view' && activeViewLane === 'monitor' ? <ViewModePanel pipeline={pipeline} /> : null}
+          {mode === 'view' && pipeline && activeViewLane === 'configuration' ? (
+            <YamlViewPanel configYaml={pipeline.configYaml} schema={yamlEditorSchema} />
+          ) : null}
+          {mode === 'view' ? null : (
             <EditorPanel
               isLintPending={isLintPending}
               isServerlessInitializing={isServerlessInitializing}

--- a/frontend/src/components/pages/rp-connect/pipeline/index.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/index.tsx
@@ -104,6 +104,7 @@ import type {
   ServiceAccountSubmissionData,
   UserStepRef,
 } from '../types/wizard';
+import { navigateToConnectClusters } from '../utils/navigation';
 import { parseSchema } from '../utils/schema';
 import { useCreateModeInitialYaml } from '../utils/use-create-mode-initial-yaml';
 import { usePipelineMode } from '../utils/use-pipeline-mode';
@@ -362,7 +363,7 @@ function usePipelineSave({
       deleteMutation(deleteRequest, {
         onSuccess: () => {
           toast.success('Pipeline deleted');
-          navigate({ to: '/connect-clusters', search: {} as never });
+          navigateToConnectClusters(navigate);
         },
         onError: (err) => {
           toast.error(
@@ -913,14 +914,14 @@ function PipelinePageContent() {
       return;
     }
     if (mode === 'view') {
-      navigate({ to: '/connect-clusters', search: {} as never });
+      navigateToConnectClusters(navigate);
       return;
     }
     // Create: return to wherever the user came from.
     if (router.history.canGoBack()) {
       router.history.back();
     } else {
-      navigate({ to: '/connect-clusters', search: {} as never });
+      navigateToConnectClusters(navigate);
     }
   }, [mode, clearWizardStore, navigate, pipelineId, router]);
 

--- a/frontend/src/components/pages/rp-connect/pipeline/index.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/index.tsx
@@ -258,7 +258,7 @@ function usePipelineSave({
   pipelineId: string | undefined;
   pipeline: Pipeline | undefined;
   isPipelineDiagramsEnabled: boolean;
-  // Called right before a successful save navigates away, so the unsaved-changes guard doesn't block it.
+  /** Called right before a successful save navigates away, so the guard doesn't block it. */
   onBeforeSaveNavigate?: () => void;
 }) {
   const navigate = useNavigate();
@@ -279,8 +279,7 @@ function usePipelineSave({
   const handleSave = useCallback(async () => {
     const isValid = await form.trigger();
     if (!isValid) {
-      // The editable settings (name especially) live in the header/dialog, so a
-      // silent no-op is confusing — surface why the save was blocked.
+      // Settings live in the header/dialog, so surface why the save was blocked.
       const fieldErrors = form.formState.errors;
       const firstError = fieldErrors.name?.message ?? fieldErrors.computeUnits?.message ?? fieldErrors.tags?.message;
       toast.error(typeof firstError === 'string' ? firstError : 'Fix the highlighted pipeline settings before saving.');
@@ -471,8 +470,7 @@ function EditorSkeleton() {
   );
 }
 
-// Read-only YAML viewer for the view page: reuses the editor with all editable
-// cues (caret, text cursor, active-line highlight) suppressed.
+/** Read-only YAML viewer for the view page — reuses the editor with editing cues suppressed. */
 function YamlViewPanel({
   configYaml,
   schema,
@@ -728,8 +726,7 @@ function PipelinePageContent() {
   const isPipelineDiagramsEnabled = isFeatureFlagEnabled('enablePipelineDiagrams') && isEmbedded();
   const isTemplateGalleryEnabled = isFeatureFlagEnabled('enableRpcnTemplateGallery');
 
-  // Editor session state lives in a context-scoped Zustand store. Actions are
-  // stable, so we read them once; values use selectors.
+  // Actions are stable, so read them once via getState; values use selectors.
   const editorStore = usePipelineEditorStoreApi();
   const {
     setYamlContent,
@@ -837,8 +834,7 @@ function PipelinePageContent() {
     [editorStore, clearErrorLintHints, mode, isPipelineDiagramsEnabled]
   );
 
-  // Move the caret to the end of the editor after a programmatic edit (dialog
-  // patch / template insert) so the user sees what changed.
+  // Move the caret to the end after a programmatic edit so the user sees the change.
   const focusEditorEnd = useCallback(() => {
     setTimeout(() => {
       const ed = editorStore.getState().editorInstance;
@@ -917,7 +913,6 @@ function PipelinePageContent() {
       navigateToConnectClusters(navigate);
       return;
     }
-    // Create: return to wherever the user came from.
     if (router.history.canGoBack()) {
       router.history.back();
     } else {

--- a/frontend/src/components/pages/rp-connect/pipeline/index.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/index.tsx
@@ -75,11 +75,7 @@ import {
   useUpdatePipelineMutation,
 } from 'react-query/api/pipeline';
 import { toast } from 'sonner';
-import {
-  useOnboardingUserDataStore,
-  useOnboardingWizardDataStore,
-  useOnboardingYamlContentStore,
-} from 'state/onboarding-wizard-store';
+import { useRpcnWizardStore } from 'state/rpcn-wizard-store';
 import { addServiceAccountTags } from 'utils/service-account.utils';
 import { formatToastErrorMessageGRPC } from 'utils/toast.utils';
 import { z } from 'zod';
@@ -186,7 +182,7 @@ function buildCreateRequest(opts: {
   userTags: Record<string, string>;
   yamlContent: string;
 }) {
-  const userData = useOnboardingUserDataStore.getState();
+  const userData = useRpcnWizardStore.getState();
   const tags: Record<string, string> = {
     __redpanda_cloud_pipeline_type: 'pipeline',
   };
@@ -279,9 +275,9 @@ function usePipelineSave({
 
   const clearWizardStore = useCallback(() => {
     if (!isPipelineDiagramsEnabled) {
-      useOnboardingYamlContentStore.getState().setYamlContent({ yamlContent: '' });
+      useRpcnWizardStore.getState().setYamlContent({ yamlContent: '' });
     }
-    useOnboardingWizardDataStore.getState().setWizardData({ input: undefined, output: undefined });
+    useRpcnWizardStore.getState().setWizardData({ input: undefined, output: undefined });
   }, [isPipelineDiagramsEnabled]);
 
   const handleSave = useCallback(async () => {
@@ -834,7 +830,7 @@ function PipelinePageContent() {
       clearErrorLintHints();
       setYamlContent(value);
       if (mode === 'create' && !isPipelineDiagramsEnabled) {
-        useOnboardingYamlContentStore.getState().setYamlContent({ yamlContent: value });
+        useRpcnWizardStore.getState().setYamlContent({ yamlContent: value });
       }
     },
     [mode, isPipelineDiagramsEnabled, clearErrorLintHints, setYamlContent]

--- a/frontend/src/components/pages/rp-connect/pipeline/list.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/list.tsx
@@ -65,7 +65,7 @@ import {
   useStopPipelineMutation,
 } from 'react-query/api/pipeline';
 import { toast } from 'sonner';
-import { useResetOnboardingWizardStore } from 'state/onboarding-wizard-store';
+import { useResetRpcnWizardStore } from 'state/rpcn-wizard-store';
 import { formatToastErrorMessageGRPC } from 'utils/toast.utils';
 
 import { TabKafkaConnect } from '../../connect/overview';
@@ -500,7 +500,7 @@ const createColumns = ({
 
 const PipelineListPageContent = () => {
   const navigate = useNavigate();
-  const resetOnboardingWizardStore = useResetOnboardingWizardStore();
+  const resetRpcnWizardStore = useResetRpcnWizardStore();
 
   const {
     data: pipelinesData,
@@ -621,7 +621,7 @@ const PipelineListPageContent = () => {
   });
 
   const handleCreateClick = useCallback(() => {
-    resetOnboardingWizardStore();
+    resetRpcnWizardStore();
     // enablePipelineDiagrams: skip wizard, go straight to pipeline editor
     // otherwise: go through wizard (master behavior)
     if (isFeatureFlagEnabled('enablePipelineDiagrams') && isEmbedded()) {
@@ -629,7 +629,7 @@ const PipelineListPageContent = () => {
     } else {
       navigate({ to: '/rp-connect/wizard', search: { step: undefined, serverless: undefined } });
     }
-  }, [resetOnboardingWizardStore, navigate]);
+  }, [resetRpcnWizardStore, navigate]);
 
   if (isLoading) {
     return <PipelineListSkeleton />;

--- a/frontend/src/components/pages/rp-connect/pipeline/pipeline-header.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/pipeline-header.tsx
@@ -240,7 +240,7 @@ export function PipelineViewHeader({
           </Button>
           {/* self-center! overrides the registry's data-[orientation=vertical]:self-stretch,
               which would otherwise top-align a fixed-height (h-6) vertical separator. */}
-          <Separator className="mx-1 h-6 self-center!" orientation="vertical" />
+          <Separator className="self-center! mx-1 h-6" orientation="vertical" />
           <PipelineStatusToggle pipelineId={pipeline.id} pipelineState={pipeline.state} />
         </div>
       </div>

--- a/frontend/src/components/pages/rp-connect/pipeline/pipeline-header.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/pipeline-header.tsx
@@ -154,8 +154,7 @@ const BackButton = ({ onClick }: { onClick: () => void }) => (
   </Button>
 );
 
-// Inline-editable pipeline name. Bound to the same form field as the settings
-// dialog, so editing either keeps both in sync.
+// Inline-editable pipeline name, bound to the same form field as the settings dialog.
 const EditableTitle = ({ form, placeholder }: { form: UseFormReturn<PipelineFormValues>; placeholder: string }) => (
   <Controller
     control={form.control}

--- a/frontend/src/components/pages/rp-connect/pipeline/pipeline-header.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/pipeline-header.tsx
@@ -16,6 +16,7 @@ import { Badge } from 'components/redpanda-ui/components/badge';
 import { BadgeGroup } from 'components/redpanda-ui/components/badge-group';
 import { Button } from 'components/redpanda-ui/components/button';
 import { CopyButton } from 'components/redpanda-ui/components/copy-button';
+import { Separator } from 'components/redpanda-ui/components/separator';
 import { Spinner } from 'components/redpanda-ui/components/spinner';
 import { Tooltip, TooltipContent, TooltipTrigger } from 'components/redpanda-ui/components/tooltip';
 import { Heading, List, ListItem } from 'components/redpanda-ui/components/typography';
@@ -153,8 +154,8 @@ const BackButton = ({ onClick }: { onClick: () => void }) => (
   </Button>
 );
 
-// Inline-editable pipeline name, styled as the page title. Bound to the same
-// form field as the settings dialog, so editing either keeps both in sync.
+// Inline-editable pipeline name. Bound to the same form field as the settings
+// dialog, so editing either keeps both in sync.
 const EditableTitle = ({ form, placeholder }: { form: UseFormReturn<PipelineFormValues>; placeholder: string }) => (
   <Controller
     control={form.control}
@@ -237,7 +238,7 @@ export function PipelineViewHeader({
           >
             Edit pipeline
           </Button>
-          <div aria-hidden className="mx-1 h-6 w-px bg-border" />
+          <Separator className="mx-1 h-6" orientation="vertical" />
           <PipelineStatusToggle pipelineId={pipeline.id} pipelineState={pipeline.state} />
         </div>
       </div>

--- a/frontend/src/components/pages/rp-connect/pipeline/pipeline-header.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/pipeline-header.tsx
@@ -238,7 +238,9 @@ export function PipelineViewHeader({
           >
             Edit pipeline
           </Button>
-          <Separator className="mx-1 h-6" orientation="vertical" />
+          {/* self-center! overrides the registry's data-[orientation=vertical]:self-stretch,
+              which would otherwise top-align a fixed-height (h-6) vertical separator. */}
+          <Separator className="mx-1 h-6 self-center!" orientation="vertical" />
           <PipelineStatusToggle pipelineId={pipeline.id} pipelineState={pipeline.state} />
         </div>
       </div>

--- a/frontend/src/components/pages/rp-connect/pipeline/pipeline-throughput-card.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/pipeline-throughput-card.tsx
@@ -29,6 +29,7 @@ import {
   SelectValue,
 } from 'components/redpanda-ui/components/select';
 import { Heading, Text } from 'components/redpanda-ui/components/typography';
+import { cn } from 'components/redpanda-ui/lib/utils';
 import { ChartSkeleton } from 'components/ui/chart-skeleton';
 import type { FC } from 'react';
 import { useCallback, useId, useMemo, useState } from 'react';
@@ -40,9 +41,11 @@ import {
   type MergedPoint,
   mergeTimeSeries,
 } from 'utils/pipeline-throughput.utils';
-import { calculateTimeRange, getTimeRanges, type TimeRange } from 'utils/time-range';
+import { calculateTimeRange, getEvenlySpacedTimeTicks, getTimeRanges, type TimeRange } from 'utils/time-range';
 
-const TIME_RANGES = getTimeRanges(24 * 60 * 60 * 1000);
+// Cap at 12h (matching observability): the range-query backend has no step param
+// and can't serve a 24h window at its default resolution (Prometheus' 11k-point limit).
+const TIME_RANGES = getTimeRanges(12 * 60 * 60 * 1000);
 
 const chartConfig = {
   ingress: { label: 'Ingress', color: 'var(--color-primary)' },
@@ -55,9 +58,11 @@ type ThroughputContentProps = {
   hasData: boolean;
   chartData: MergedPoint[];
   id: string;
+  // Full selected window [start, end] in ms, so the axis spans it even when data is sparse.
+  domain: [number, number];
 };
 
-const ThroughputContent: FC<ThroughputContentProps> = ({ isLoading, isError, hasData, chartData, id }) => {
+const ThroughputContent: FC<ThroughputContentProps> = ({ isLoading, isError, hasData, chartData, id, domain }) => {
   if (isLoading) {
     return <ChartSkeleton className="h-40 w-full" variant="area" />;
   }
@@ -91,9 +96,13 @@ const ThroughputContent: FC<ThroughputContentProps> = ({ isLoading, isError, has
         <XAxis
           axisLine={false}
           dataKey="timestamp"
+          domain={domain}
+          scale="time"
           tickFormatter={formatChartTimestamp}
           tickLine={false}
           tickMargin={8}
+          ticks={getEvenlySpacedTimeTicks(domain[0], domain[1])}
+          type="number"
         />
         <YAxis axisLine={false} tickLine={false} tickMargin={8} width={40} />
         <ChartTooltip
@@ -198,6 +207,10 @@ export const PipelineThroughputCard: FC<PipelineThroughputCardProps> = ({ pipeli
   const isFetching = isFetchingIngress || isFetchingEgress;
   const hasData = chartData.length > 0;
 
+  // Anchor the axis to the full selected window so the graph spans the whole
+  // range even when data only covers part of it.
+  const domain: [number, number] = [timeRange.start.getTime(), timeRange.end.getTime()];
+
   return (
     <section className="flex flex-col gap-3">
       <div className="flex items-center justify-between gap-2">
@@ -216,11 +229,18 @@ export const PipelineThroughputCard: FC<PipelineThroughputCardProps> = ({ pipeli
             </SelectContent>
           </Select>
           <Button aria-label="Refresh" disabled={isFetching} onClick={handleRefresh} size="icon" variant="ghost">
-            <RefreshIcon className={isFetching ? 'size-4 animate-spin' : 'size-4'} />
+            <RefreshIcon className={cn('size-4', isFetching && 'animate-spin')} />
           </Button>
         </div>
       </div>
-      <ThroughputContent chartData={chartData} hasData={hasData} id={id} isError={isError} isLoading={isLoading} />
+      <ThroughputContent
+        chartData={chartData}
+        domain={domain}
+        hasData={hasData}
+        id={id}
+        isError={isError}
+        isLoading={isLoading}
+      />
     </section>
   );
 };

--- a/frontend/src/components/pages/rp-connect/pipeline/pipeline-throughput-card.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/pipeline-throughput-card.tsx
@@ -10,9 +10,7 @@
  */
 
 import { timestampFromMs } from '@bufbuild/protobuf/wkt';
-import { RefreshIcon } from 'components/icons';
 import { Alert, AlertDescription } from 'components/redpanda-ui/components/alert';
-import { Button } from 'components/redpanda-ui/components/button';
 import {
   type ChartConfig,
   ChartContainer,
@@ -29,8 +27,8 @@ import {
   SelectValue,
 } from 'components/redpanda-ui/components/select';
 import { Heading, Text } from 'components/redpanda-ui/components/typography';
-import { cn } from 'components/redpanda-ui/lib/utils';
 import { ChartSkeleton } from 'components/ui/chart-skeleton';
+import { RefreshButton } from 'components/ui/refresh-button';
 import type { FC } from 'react';
 import { useCallback, useId, useMemo, useState } from 'react';
 import { useExecuteRangeQuery, useListQueries } from 'react-query/api/observability';
@@ -228,9 +226,7 @@ export const PipelineThroughputCard: FC<PipelineThroughputCardProps> = ({ pipeli
               ))}
             </SelectContent>
           </Select>
-          <Button aria-label="Refresh" disabled={isFetching} onClick={handleRefresh} size="icon" variant="ghost">
-            <RefreshIcon className={cn('size-4', isFetching && 'animate-spin')} />
-          </Button>
+          <RefreshButton loading={isFetching} onClick={handleRefresh} />
         </div>
       </div>
       <ThroughputContent

--- a/frontend/src/components/pages/rp-connect/pipeline/pipeline-throughput-card.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/pipeline-throughput-card.tsx
@@ -205,8 +205,7 @@ export const PipelineThroughputCard: FC<PipelineThroughputCardProps> = ({ pipeli
   const isFetching = isFetchingIngress || isFetchingEgress;
   const hasData = chartData.length > 0;
 
-  // Anchor the axis to the full selected window so the graph spans the whole
-  // range even when data only covers part of it.
+  // Anchor the axis to the full selected window, not just the data extent.
   const domain: [number, number] = [timeRange.start.getTime(), timeRange.end.getTime()];
 
   return (

--- a/frontend/src/components/pages/rp-connect/pipeline/use-pipeline-editor-store.ts
+++ b/frontend/src/components/pages/rp-connect/pipeline/use-pipeline-editor-store.ts
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import type { editor } from 'monaco-editor';
+import { createContext, createElement, type ReactNode, useContext, useRef } from 'react';
+import { useStore } from 'zustand';
+import { createStore, type StoreApi } from 'zustand/vanilla';
+
+import type { ConnectComponentType } from '../types/schema';
+
+type CommandMenuFilter = 'all' | 'variables' | 'secrets' | 'topics' | 'users' | null;
+type AddConnectorType = ConnectComponentType | 'resource' | null;
+// View-page lanes. A future 'visual' lane (full react-flow editor) slots in here.
+export type ViewLane = 'monitor' | 'configuration';
+
+type PipelineEditorState = {
+  // Canonical editor content + the baseline used for the unsaved-changes guard.
+  yamlContent: string;
+  initialYaml: string | null;
+  // Monaco instance (for slash commands + imperative focus/scroll).
+  editorInstance: editor.IStandaloneCodeEditor | null;
+  // Tracks which loaded pipeline the content was hydrated from, so re-renders
+  // don't clobber edits.
+  hydratedPipelineId: string | null;
+  // Lets a successful save navigate away without tripping the guard.
+  allowNavigation: boolean;
+  activeViewLane: ViewLane;
+  // Transient UI.
+  commandMenuFilter: CommandMenuFilter;
+  addConnectorType: AddConnectorType;
+  slashTipVisible: boolean;
+  isConfigDialogOpen: boolean;
+  isViewConfigDialogOpen: boolean;
+  isDeleteAlertOpen: boolean;
+  isTemplateDialogOpen: boolean;
+};
+
+type PipelineEditorActions = {
+  setYamlContent: (yamlContent: string) => void;
+  setEditorInstance: (editorInstance: editor.IStandaloneCodeEditor | null) => void;
+  // Hydrate from a freshly-loaded server pipeline (sets content + baseline + id).
+  hydrateFromServer: (pipelineId: string, configYaml: string) => void;
+  // Resolve the create-mode starting YAML; only seeds the baseline once.
+  resolveInitialYaml: (yaml: string) => void;
+  setAllowNavigation: (allowNavigation: boolean) => void;
+  setActiveViewLane: (activeViewLane: ViewLane) => void;
+  setCommandMenuFilter: (commandMenuFilter: CommandMenuFilter) => void;
+  setAddConnectorType: (addConnectorType: AddConnectorType) => void;
+  setSlashTipVisible: (slashTipVisible: boolean) => void;
+  setIsConfigDialogOpen: (open: boolean) => void;
+  setIsViewConfigDialogOpen: (open: boolean) => void;
+  setIsDeleteAlertOpen: (open: boolean) => void;
+  setIsTemplateDialogOpen: (open: boolean) => void;
+};
+
+export type PipelineEditorStore = PipelineEditorState & PipelineEditorActions;
+
+const createInitialState = (overrides?: Partial<PipelineEditorState>): PipelineEditorState => ({
+  yamlContent: '',
+  initialYaml: null,
+  editorInstance: null,
+  hydratedPipelineId: null,
+  allowNavigation: false,
+  activeViewLane: 'monitor',
+  commandMenuFilter: null,
+  addConnectorType: null,
+  slashTipVisible: false,
+  isConfigDialogOpen: false,
+  isViewConfigDialogOpen: false,
+  isDeleteAlertOpen: false,
+  isTemplateDialogOpen: false,
+  ...overrides,
+});
+
+export function createPipelineEditorStore(overrides?: Partial<PipelineEditorState>): StoreApi<PipelineEditorStore> {
+  return createStore<PipelineEditorStore>()((set) => ({
+    ...createInitialState(overrides),
+    setYamlContent: (yamlContent) => set({ yamlContent }),
+    setEditorInstance: (editorInstance) => set({ editorInstance }),
+    hydrateFromServer: (pipelineId, configYaml) =>
+      set({ hydratedPipelineId: pipelineId, yamlContent: configYaml, initialYaml: configYaml }),
+    resolveInitialYaml: (yaml) => set((state) => ({ yamlContent: yaml, initialYaml: state.initialYaml ?? yaml })),
+    setAllowNavigation: (allowNavigation) => set({ allowNavigation }),
+    setActiveViewLane: (activeViewLane) => set({ activeViewLane }),
+    setCommandMenuFilter: (commandMenuFilter) => set({ commandMenuFilter }),
+    setAddConnectorType: (addConnectorType) => set({ addConnectorType }),
+    setSlashTipVisible: (slashTipVisible) => set({ slashTipVisible }),
+    setIsConfigDialogOpen: (open) => set({ isConfigDialogOpen: open }),
+    setIsViewConfigDialogOpen: (open) => set({ isViewConfigDialogOpen: open }),
+    setIsDeleteAlertOpen: (open) => set({ isDeleteAlertOpen: open }),
+    setIsTemplateDialogOpen: (open) => set({ isTemplateDialogOpen: open }),
+  }));
+}
+
+const PipelineEditorContext = createContext<StoreApi<PipelineEditorStore> | null>(null);
+
+// Context-scoped so each PipelinePage mount gets its own store — no state leaks
+// across navigations between pipelines/modes.
+export function PipelineEditorProvider({
+  children,
+  initialSlashTipVisible,
+}: {
+  children: ReactNode;
+  initialSlashTipVisible: boolean;
+}) {
+  const storeRef = useRef<StoreApi<PipelineEditorStore>>();
+  if (!storeRef.current) {
+    storeRef.current = createPipelineEditorStore({ slashTipVisible: initialSlashTipVisible });
+  }
+  return createElement(PipelineEditorContext.Provider, { value: storeRef.current }, children);
+}
+
+function usePipelineEditorStoreContext(): StoreApi<PipelineEditorStore> {
+  const store = useContext(PipelineEditorContext);
+  if (!store) {
+    throw new Error('usePipelineEditorStore must be used within a PipelineEditorProvider');
+  }
+  return store;
+}
+
+export function usePipelineEditorStore<T>(selector: (state: PipelineEditorStore) => T): T {
+  return useStore(usePipelineEditorStoreContext(), selector);
+}
+
+// Imperative handle for reading/writing without subscribing (callbacks, guards).
+export function usePipelineEditorStoreApi(): StoreApi<PipelineEditorStore> {
+  return usePipelineEditorStoreContext();
+}

--- a/frontend/src/components/pages/rp-connect/pipeline/use-pipeline-editor-store.ts
+++ b/frontend/src/components/pages/rp-connect/pipeline/use-pipeline-editor-store.ts
@@ -12,28 +12,42 @@
 import type { editor } from 'monaco-editor';
 import { createContext, createElement, type ReactNode, useContext, useRef } from 'react';
 import { useStore } from 'zustand';
-import { createStore, type StoreApi } from 'zustand/vanilla';
+import { createStore, type StateCreator, type StoreApi } from 'zustand/vanilla';
 
 import type { ConnectComponentType } from '../types/schema';
+import { type RedpandaSetupResultLike, tryPatchRedpandaYaml } from '../utils/yaml';
 
 type CommandMenuFilter = 'all' | 'variables' | 'secrets' | 'topics' | 'users' | null;
 type AddConnectorType = ConnectComponentType | 'resource' | null;
+type ConnectorSection = 'input' | 'output';
 // View-page lanes. A future 'visual' lane (full react-flow editor) slots in here.
 export type ViewLane = 'monitor' | 'configuration';
 
-type PipelineEditorState = {
-  // Canonical editor content + the baseline used for the unsaved-changes guard.
+// The pipeline document: the config YAML that every view (editor, diagram, and a
+// future visual lane) reads from and mutates, plus the baseline + hydration
+// bookkeeping. Semantic edits go through the actions here so all consumers share
+// one parse/patch/serialize path.
+type DocumentSlice = {
   yamlContent: string;
   initialYaml: string | null;
-  // Monaco instance (for slash commands + imperative focus/scroll).
-  editorInstance: editor.IStandaloneCodeEditor | null;
-  // Tracks which loaded pipeline the content was hydrated from, so re-renders
-  // don't clobber edits.
   hydratedPipelineId: string | null;
-  // Lets a successful save navigate away without tripping the guard.
+  // Lets a successful save navigate away without tripping the unsaved-changes guard.
   allowNavigation: boolean;
+  setYamlContent: (yamlContent: string) => void;
+  // Patch a single redpanda component in the current config; returns false if the
+  // YAML couldn't be parsed/patched (so callers can skip follow-up side effects).
+  patchComponent: (section: ConnectorSection, componentName: string, patch: RedpandaSetupResultLike) => boolean;
+  // Hydrate from a freshly-loaded server pipeline (sets content + baseline + id).
+  hydrateFromServer: (pipelineId: string, configYaml: string) => void;
+  // Resolve the create-mode starting YAML; only seeds the baseline once.
+  resolveInitialYaml: (yaml: string) => void;
+  setAllowNavigation: (allowNavigation: boolean) => void;
+};
+
+// Transient editor-page UI: the Monaco handle, the active lane, and dialog/menu flags.
+type UiSlice = {
+  editorInstance: editor.IStandaloneCodeEditor | null;
   activeViewLane: ViewLane;
-  // Transient UI.
   commandMenuFilter: CommandMenuFilter;
   addConnectorType: AddConnectorType;
   slashTipVisible: boolean;
@@ -41,16 +55,7 @@ type PipelineEditorState = {
   isViewConfigDialogOpen: boolean;
   isDeleteAlertOpen: boolean;
   isTemplateDialogOpen: boolean;
-};
-
-type PipelineEditorActions = {
-  setYamlContent: (yamlContent: string) => void;
   setEditorInstance: (editorInstance: editor.IStandaloneCodeEditor | null) => void;
-  // Hydrate from a freshly-loaded server pipeline (sets content + baseline + id).
-  hydrateFromServer: (pipelineId: string, configYaml: string) => void;
-  // Resolve the create-mode starting YAML; only seeds the baseline once.
-  resolveInitialYaml: (yaml: string) => void;
-  setAllowNavigation: (allowNavigation: boolean) => void;
   setActiveViewLane: (activeViewLane: ViewLane) => void;
   setCommandMenuFilter: (commandMenuFilter: CommandMenuFilter) => void;
   setAddConnectorType: (addConnectorType: AddConnectorType) => void;
@@ -61,14 +66,30 @@ type PipelineEditorActions = {
   setIsTemplateDialogOpen: (open: boolean) => void;
 };
 
-export type PipelineEditorStore = PipelineEditorState & PipelineEditorActions;
+export type PipelineEditorStore = DocumentSlice & UiSlice;
 
-const createInitialState = (overrides?: Partial<PipelineEditorState>): PipelineEditorState => ({
+const createDocumentSlice: StateCreator<PipelineEditorStore, [], [], DocumentSlice> = (set, get) => ({
   yamlContent: '',
   initialYaml: null,
-  editorInstance: null,
   hydratedPipelineId: null,
   allowNavigation: false,
+  setYamlContent: (yamlContent) => set({ yamlContent }),
+  patchComponent: (section, componentName, patch) => {
+    const patched = tryPatchRedpandaYaml(get().yamlContent, section, componentName, patch);
+    if (patched === null) {
+      return false;
+    }
+    set({ yamlContent: patched });
+    return true;
+  },
+  hydrateFromServer: (pipelineId, configYaml) =>
+    set({ hydratedPipelineId: pipelineId, yamlContent: configYaml, initialYaml: configYaml }),
+  resolveInitialYaml: (yaml) => set((state) => ({ yamlContent: yaml, initialYaml: state.initialYaml ?? yaml })),
+  setAllowNavigation: (allowNavigation) => set({ allowNavigation }),
+});
+
+const createUiSlice: StateCreator<PipelineEditorStore, [], [], UiSlice> = (set) => ({
+  editorInstance: null,
   activeViewLane: 'monitor',
   commandMenuFilter: null,
   addConnectorType: null,
@@ -77,33 +98,30 @@ const createInitialState = (overrides?: Partial<PipelineEditorState>): PipelineE
   isViewConfigDialogOpen: false,
   isDeleteAlertOpen: false,
   isTemplateDialogOpen: false,
-  ...overrides,
+  setEditorInstance: (editorInstance) => set({ editorInstance }),
+  setActiveViewLane: (activeViewLane) => set({ activeViewLane }),
+  setCommandMenuFilter: (commandMenuFilter) => set({ commandMenuFilter }),
+  setAddConnectorType: (addConnectorType) => set({ addConnectorType }),
+  setSlashTipVisible: (slashTipVisible) => set({ slashTipVisible }),
+  setIsConfigDialogOpen: (open) => set({ isConfigDialogOpen: open }),
+  setIsViewConfigDialogOpen: (open) => set({ isViewConfigDialogOpen: open }),
+  setIsDeleteAlertOpen: (open) => set({ isDeleteAlertOpen: open }),
+  setIsTemplateDialogOpen: (open) => set({ isTemplateDialogOpen: open }),
 });
 
-export function createPipelineEditorStore(overrides?: Partial<PipelineEditorState>): StoreApi<PipelineEditorStore> {
-  return createStore<PipelineEditorStore>()((set) => ({
-    ...createInitialState(overrides),
-    setYamlContent: (yamlContent) => set({ yamlContent }),
-    setEditorInstance: (editorInstance) => set({ editorInstance }),
-    hydrateFromServer: (pipelineId, configYaml) =>
-      set({ hydratedPipelineId: pipelineId, yamlContent: configYaml, initialYaml: configYaml }),
-    resolveInitialYaml: (yaml) => set((state) => ({ yamlContent: yaml, initialYaml: state.initialYaml ?? yaml })),
-    setAllowNavigation: (allowNavigation) => set({ allowNavigation }),
-    setActiveViewLane: (activeViewLane) => set({ activeViewLane }),
-    setCommandMenuFilter: (commandMenuFilter) => set({ commandMenuFilter }),
-    setAddConnectorType: (addConnectorType) => set({ addConnectorType }),
-    setSlashTipVisible: (slashTipVisible) => set({ slashTipVisible }),
-    setIsConfigDialogOpen: (open) => set({ isConfigDialogOpen: open }),
-    setIsViewConfigDialogOpen: (open) => set({ isViewConfigDialogOpen: open }),
-    setIsDeleteAlertOpen: (open) => set({ isDeleteAlertOpen: open }),
-    setIsTemplateDialogOpen: (open) => set({ isTemplateDialogOpen: open }),
+export function createPipelineEditorStore(overrides?: Partial<PipelineEditorStore>): StoreApi<PipelineEditorStore> {
+  return createStore<PipelineEditorStore>()((...args) => ({
+    ...createDocumentSlice(...args),
+    ...createUiSlice(...args),
+    ...overrides,
   }));
 }
 
 const PipelineEditorContext = createContext<StoreApi<PipelineEditorStore> | null>(null);
 
-// Context-scoped so each PipelinePage mount gets its own store — no state leaks
-// across navigations between pipelines/modes.
+// Context-scoped so each PipelinePage mount gets its own store. Callers should
+// key the provider by pipeline id (`key={pipelineId}`) so navigating between
+// pipelines starts a clean store rather than carrying lane/selection/YAML over.
 export function PipelineEditorProvider({
   children,
   initialSlashTipVisible,

--- a/frontend/src/components/pages/rp-connect/pipeline/use-pipeline-editor-store.ts
+++ b/frontend/src/components/pages/rp-connect/pipeline/use-pipeline-editor-store.ts
@@ -23,10 +23,9 @@ type ConnectorSection = 'input' | 'output';
 // View-page lanes. A future 'visual' lane (full react-flow editor) slots in here.
 export type ViewLane = 'monitor' | 'configuration';
 
-// The pipeline document: the config YAML that every view (editor, diagram, and a
-// future visual lane) reads from and mutates, plus the baseline + hydration
-// bookkeeping. Semantic edits go through the actions here so all consumers share
-// one parse/patch/serialize path.
+// The pipeline document: the canonical config YAML all views read and mutate,
+// plus its baseline. Semantic edits go through these actions so every consumer
+// shares one parse/patch/serialize path.
 type DocumentSlice = {
   yamlContent: string;
   initialYaml: string | null;
@@ -119,9 +118,8 @@ export function createPipelineEditorStore(overrides?: Partial<PipelineEditorStor
 
 const PipelineEditorContext = createContext<StoreApi<PipelineEditorStore> | null>(null);
 
-// Context-scoped so each PipelinePage mount gets its own store. Callers should
-// key the provider by pipeline id (`key={pipelineId}`) so navigating between
-// pipelines starts a clean store rather than carrying lane/selection/YAML over.
+// Context-scoped: each mount gets its own store. Key the provider by pipeline id
+// so navigating between pipelines starts clean instead of carrying state over.
 export function PipelineEditorProvider({
   children,
   initialSlashTipVisible,

--- a/frontend/src/components/pages/rp-connect/pipeline/use-pipeline-editor-store.ts
+++ b/frontend/src/components/pages/rp-connect/pipeline/use-pipeline-editor-store.ts
@@ -23,9 +23,8 @@ type ConnectorSection = 'input' | 'output';
 // View-page lanes. A future 'visual' lane (full react-flow editor) slots in here.
 export type ViewLane = 'monitor' | 'configuration';
 
-// The pipeline document: the canonical config YAML all views read and mutate,
-// plus its baseline. Semantic edits go through these actions so every consumer
-// shares one parse/patch/serialize path.
+// The canonical config YAML all views read and mutate, plus its baseline.
+// Semantic edits go through these actions so consumers share one patch path.
 type DocumentSlice = {
   yamlContent: string;
   initialYaml: string | null;

--- a/frontend/src/components/pages/rp-connect/utils/navigation.ts
+++ b/frontend/src/components/pages/rp-connect/utils/navigation.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import type { useNavigate } from '@tanstack/react-router';
+
+type NavigateFn = ReturnType<typeof useNavigate>;
+
+// '/connect-clusters' takes no search params; centralize the empty-search cast
+// TanStack requires so the route name + cast live in one place.
+export function navigateToConnectClusters(navigate: NavigateFn) {
+  navigate({ to: '/connect-clusters', search: {} as never });
+}

--- a/frontend/src/components/pages/rp-connect/utils/navigation.ts
+++ b/frontend/src/components/pages/rp-connect/utils/navigation.ts
@@ -13,8 +13,7 @@ import type { useNavigate } from '@tanstack/react-router';
 
 type NavigateFn = ReturnType<typeof useNavigate>;
 
-// '/connect-clusters' takes no search params; centralize the empty-search cast
-// TanStack requires so the route name + cast live in one place.
+/** Navigate to the connect-clusters list, centralizing the empty-search cast TanStack requires. */
 export function navigateToConnectClusters(navigate: NavigateFn) {
   navigate({ to: '/connect-clusters', search: {} as never });
 }

--- a/frontend/src/components/pages/rp-connect/utils/schema.test.tsx
+++ b/frontend/src/components/pages/rp-connect/utils/schema.test.tsx
@@ -1,6 +1,6 @@
 import { create } from '@bufbuild/protobuf';
 import { ComponentStatus, FieldSpecSchema } from 'protogen/redpanda/api/dataplane/v1/pipeline_pb';
-import { onboardingWizardStore } from 'state/onboarding-wizard-store';
+import { rpcnWizardStore } from 'state/rpcn-wizard-store';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { mockComponents } from './__fixtures__/component-schemas';
@@ -16,7 +16,7 @@ describe('generateDefaultValue', () => {
 
   describe('SASL visibility for Redpanda components', () => {
     test('SASL shown for Redpanda components when wizard user data exists', () => {
-      onboardingWizardStore.setUserData({
+      rpcnWizardStore.setUserData({
         username: 'testuser',
         saslMechanism: 'SCRAM-SHA-256',
         consumerGroup: '',
@@ -46,11 +46,11 @@ describe('generateDefaultValue', () => {
       expect(result).toBeDefined();
       expect((result as Record<string, unknown>).mechanism).toBe('SCRAM-SHA-256');
 
-      onboardingWizardStore.setUserData({ username: '', consumerGroup: '' });
+      rpcnWizardStore.setUserData({ username: '', consumerGroup: '' });
     });
 
     test('SASL NOT shown for Redpanda components without wizard user data', () => {
-      onboardingWizardStore.setUserData({ username: '', consumerGroup: '' });
+      rpcnWizardStore.setUserData({ username: '', consumerGroup: '' });
 
       const spec = {
         name: 'sasl',
@@ -160,8 +160,8 @@ describe('generateDefaultValue', () => {
 
   describe('Wizard data population', () => {
     beforeEach(() => {
-      onboardingWizardStore.setTopicData({ topicName: 'example' });
-      onboardingWizardStore.setUserData({
+      rpcnWizardStore.setTopicData({ topicName: 'example' });
+      rpcnWizardStore.setUserData({
         username: 'admin',
         saslMechanism: 'SCRAM-SHA-256',
         consumerGroup: 'my-consumer-group',
@@ -201,7 +201,7 @@ describe('generateDefaultValue', () => {
     });
 
     test('topics array field without wizard data returns sentinel for required field', () => {
-      onboardingWizardStore.setTopicData({ topicName: undefined });
+      rpcnWizardStore.setTopicData({ topicName: undefined });
 
       const spec = {
         name: 'topics',
@@ -444,7 +444,7 @@ describe('generateDefaultValue', () => {
 
   describe('SASL critical field behavior', () => {
     test('SASL populates with wizard data (user, password as secrets)', () => {
-      onboardingWizardStore.setUserData({
+      rpcnWizardStore.setUserData({
         username: 'admin',
         saslMechanism: 'SCRAM-SHA-256',
         consumerGroup: '',
@@ -570,8 +570,8 @@ describe('generateDefaultValue', () => {
 
   describe('Full component integration', () => {
     beforeEach(() => {
-      onboardingWizardStore.setTopicData({ topicName: 'example' });
-      onboardingWizardStore.setUserData({
+      rpcnWizardStore.setTopicData({ topicName: 'example' });
+      rpcnWizardStore.setUserData({
         username: 'admin',
         saslMechanism: 'SCRAM-SHA-256',
         consumerGroup: '',

--- a/frontend/src/components/pages/rp-connect/utils/schema.ts
+++ b/frontend/src/components/pages/rp-connect/utils/schema.ts
@@ -6,7 +6,7 @@ import {
   type FieldSpec,
 } from 'protogen/redpanda/api/dataplane/v1/pipeline_pb';
 import { toast } from 'sonner';
-import { onboardingWizardStore } from 'state/onboarding-wizard-store';
+import { rpcnWizardStore } from 'state/rpcn-wizard-store';
 import { formatToastErrorMessageGRPC } from 'utils/toast.utils';
 
 import { isConsumerGroupField, isPasswordField, isSchemaRegistryUrlField, isTopicField, isUserField } from './wizard';
@@ -133,7 +133,7 @@ export function parseSchema(componentList: ComponentList): ConnectComponentSpec[
 }
 
 const generateRedpandaTopLevelConfig = (): Record<string, unknown> => {
-  const userData = onboardingWizardStore.getUserData();
+  const userData = rpcnWizardStore.getUserData();
   const redpandaConfig: Record<string, unknown> = {};
 
   if (userData?.username) {
@@ -255,8 +255,8 @@ function populateWizardFields(
     return;
   }
 
-  const topicData = onboardingWizardStore.getTopicData();
-  const userData = onboardingWizardStore.getUserData();
+  const topicData = rpcnWizardStore.getTopicData();
+  const userData = rpcnWizardStore.getUserData();
 
   if (isTopicField(spec.name) && topicData?.topicName) {
     return spec.kind === 'array' ? [topicData.topicName] : topicData.topicName;
@@ -341,7 +341,7 @@ function populateConnectionDefaults(
   // SASL mechanism from session storage or default to SCRAM-SHA-256
   const isMechanismField = spec.name.toLowerCase() === 'mechanism' && parentName?.toLowerCase() === 'sasl';
   if (isMechanismField) {
-    const userData = onboardingWizardStore.getUserData();
+    const userData = rpcnWizardStore.getUserData();
     return userData?.saslMechanism || 'SCRAM-SHA-256';
   }
 
@@ -359,7 +359,7 @@ function shouldShowField(params: {
 
   // Redpanda SASL: show when wizard has user data (even though it's advanced)
   if (isRedpandaComponent(componentName) && spec.name === 'sasl') {
-    const userData = onboardingWizardStore.getUserData();
+    const userData = rpcnWizardStore.getUserData();
     return !!userData?.username;
   }
 

--- a/frontend/src/components/pages/rp-connect/utils/use-create-mode-initial-yaml.test.tsx
+++ b/frontend/src/components/pages/rp-connect/utils/use-create-mode-initial-yaml.test.tsx
@@ -18,8 +18,8 @@ import type { ConnectComponentSpec } from '../types/schema';
 const mockStoreSetYamlContent = vi.fn();
 let mockPersistedYaml: string | undefined;
 
-vi.mock('state/onboarding-wizard-store', () => ({
-  useOnboardingYamlContentStore: Object.assign(
+vi.mock('state/rpcn-wizard-store', () => ({
+  useRpcnWizardStore: Object.assign(
     vi.fn((selector: (s: { yamlContent: string | undefined }) => unknown) =>
       selector({ yamlContent: mockPersistedYaml })
     ),

--- a/frontend/src/components/pages/rp-connect/utils/use-create-mode-initial-yaml.ts
+++ b/frontend/src/components/pages/rp-connect/utils/use-create-mode-initial-yaml.ts
@@ -10,7 +10,7 @@
  */
 
 import { useEffect, useRef, useState } from 'react';
-import { getWizardConnectionData, useOnboardingYamlContentStore } from 'state/onboarding-wizard-store';
+import { getWizardConnectionData, useRpcnWizardStore } from 'state/rpcn-wizard-store';
 
 import { generateYamlFromWizardData } from './yaml';
 import type { ConnectComponentSpec } from '../types/schema';
@@ -40,7 +40,7 @@ export function useCreateModeInitialYaml(opts: {
   isInitializing: boolean;
 } {
   const { enabled, isServerlessMode, components, isPipelineDiagramsEnabled, timeoutMs = DEFAULT_TIMEOUT_MS } = opts;
-  const persistedYamlContent = useOnboardingYamlContentStore((s) => s.yamlContent);
+  const persistedYamlContent = useRpcnWizardStore((s) => s.yamlContent);
   const onResolvedRef = useRef(opts.onResolved);
   onResolvedRef.current = opts.onResolved;
 
@@ -66,7 +66,7 @@ export function useCreateModeInitialYaml(opts: {
     const yaml = generateYamlFromWizardData(input, output, components);
 
     if (yaml && !isPipelineDiagramsEnabled) {
-      useOnboardingYamlContentStore.getState().setYamlContent({ yamlContent: yaml });
+      useRpcnWizardStore.getState().setYamlContent({ yamlContent: yaml });
     }
 
     if (yaml) {

--- a/frontend/src/components/pages/rp-connect/utils/wizard.ts
+++ b/frontend/src/components/pages/rp-connect/utils/wizard.ts
@@ -1,5 +1,5 @@
 import { toast } from 'sonner';
-import { useOnboardingWizardDataStore, useOnboardingYamlContentStore } from 'state/onboarding-wizard-store';
+import { useRpcnWizardStore } from 'state/rpcn-wizard-store';
 
 import { getConnectTemplate } from './yaml';
 import { REDPANDA_TOPIC_AND_USER_COMPONENTS } from '../types/constants';
@@ -46,7 +46,7 @@ export const handleStepResult = <T>(result: StepSubmissionResult<T> | undefined,
  * Used at ADD_TOPIC and ADD_USER steps to update YAML with new context
  */
 export const regenerateYamlForTopicUserComponents = (components: ConnectComponentSpec[]): void => {
-  const { setWizardData: _, ...wizardData } = useOnboardingWizardDataStore.getState();
+  const { setWizardData: _, ...wizardData } = useRpcnWizardStore.getState();
 
   const inputNeedsTopicUser =
     wizardData.input?.connectionName && REDPANDA_TOPIC_AND_USER_COMPONENTS.includes(wizardData.input.connectionName);
@@ -54,7 +54,7 @@ export const regenerateYamlForTopicUserComponents = (components: ConnectComponen
     wizardData.output?.connectionName && REDPANDA_TOPIC_AND_USER_COMPONENTS.includes(wizardData.output.connectionName);
 
   if (inputNeedsTopicUser || outputNeedsTopicUser) {
-    let yamlContent = useOnboardingYamlContentStore.getState().yamlContent || '';
+    let yamlContent = useRpcnWizardStore.getState().yamlContent || '';
 
     if (inputNeedsTopicUser && wizardData.input?.connectionName && wizardData.input?.connectionType) {
       yamlContent =
@@ -76,7 +76,7 @@ export const regenerateYamlForTopicUserComponents = (components: ConnectComponen
         }) || yamlContent;
     }
 
-    useOnboardingYamlContentStore.getState().setYamlContent({ yamlContent });
+    useRpcnWizardStore.getState().setYamlContent({ yamlContent });
   }
 };
 

--- a/frontend/src/components/redpanda-ui/components/checkbox.tsx
+++ b/frontend/src/components/redpanda-ui/components/checkbox.tsx
@@ -153,4 +153,66 @@ const Checkbox = React.forwardRef<HTMLButtonElement, CheckboxProps>(
 
 Checkbox.displayName = 'Checkbox';
 
-export { Checkbox, checkboxVariants, type CheckboxProps };
+/**
+ * Presentational, non-interactive sibling of `Checkbox` — same visual, no
+ * Base UI primitive, no internal state. Use for row-selection surfaces where
+ * many controlled `Checkbox` instances under a re-rendering parent would
+ * otherwise feed enough updates to hit React's max-update-depth limit.
+ */
+export interface CheckboxViewProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'>,
+    VariantProps<typeof checkboxVariants> {
+  checked: boolean | 'indeterminate';
+}
+
+const CheckboxView = React.forwardRef<HTMLDivElement, CheckboxViewProps>(
+  ({ checked, className, variant, ...divProps }, ref) => {
+    const isIndeterminate = checked === 'indeterminate';
+    const dataState = isIndeterminate ? 'indeterminate' : checked ? 'checked' : 'unchecked';
+    const showCheckmark = checked === true;
+
+    return (
+      <div
+        aria-checked={isIndeterminate ? 'mixed' : checked}
+        className={cn(checkboxVariants({ variant, className }), 'cursor-default')}
+        data-slot="checkbox-view"
+        data-state={dataState}
+        ref={ref}
+        role="checkbox"
+        {...divProps}
+      >
+        <svg
+          className="size-3.5"
+          data-slot="checkbox-view-indicator"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="3.5"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>Checkbox</title>
+          <path
+            className={pathDrawClassName}
+            d="M4.5 12.75l6 6 9-13.5"
+            data-visible={showCheckmark}
+            pathLength={1}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <path
+            className={pathDrawClassName}
+            d="M5 12h14"
+            data-visible={isIndeterminate}
+            pathLength={1}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+CheckboxView.displayName = 'CheckboxView';
+
+export { Checkbox, CheckboxView, checkboxVariants, type CheckboxProps };

--- a/frontend/src/components/redpanda-ui/components/combobox/index.tsx
+++ b/frontend/src/components/redpanda-ui/components/combobox/index.tsx
@@ -290,9 +290,19 @@ export const Combobox = memo(
     );
 
     const handleEnterKey = useCallback(
+      // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: creatable Enter requires open + closed branches
       (event: React.KeyboardEvent) => {
         if (!open) {
-          return; // Let Enter propagate to form when closed
+          // In creatable mode, prevent Enter from bubbling to a parent <form>
+          // and triggering submit while the user is committing a new option.
+          // Without this, typing a new value + Enter in a creatable combobox
+          // both commits AND submits the form.
+          if (creatable && canCreate) {
+            event.preventDefault();
+            event.stopPropagation();
+            handleCreatableSubmit();
+          }
+          return; // Otherwise let Enter propagate to form when closed
         }
         event.preventDefault();
         event.stopPropagation();

--- a/frontend/src/components/redpanda-ui/components/data-table-filter.tsx
+++ b/frontend/src/components/redpanda-ui/components/data-table-filter.tsx
@@ -56,7 +56,7 @@ export type FilterColumnConfig = {
   icon?: React.ComponentType<{ className?: string }>;
 } & (
   | { type: 'text'; placeholder?: string }
-  | { type: 'option'; options?: FilterOption[] }
+  | { type: 'option'; options?: FilterOption[]; mode?: 'single' | 'multiple' }
   | { type: 'multiOption'; options?: FilterOption[] }
 );
 
@@ -102,6 +102,19 @@ function renderIcon(icon: React.ComponentType<{ className?: string }> | undefine
   }
   const Icon = icon;
   return isValidElement(Icon) ? Icon : <Icon className={className} />;
+}
+
+function RadioIndicator({ checked }: { checked: boolean }) {
+  return (
+    <span
+      className={cn(
+        'mr-1 flex size-4 shrink-0 items-center justify-center rounded-full border border-primary',
+        checked ? 'opacity-100' : 'opacity-0 group-data-[selected=true]:opacity-100'
+      )}
+    >
+      {checked && <span className="size-2 rounded-full bg-primary" />}
+    </span>
+  );
 }
 
 // ── DataTableFilter (root) ─────────────────────────────────────────────
@@ -154,10 +167,12 @@ function MatchingOptionItem({
   match,
   isSelected,
   onSelect,
+  singleMode,
 }: {
   match: MatchingOption;
   isSelected: boolean;
   onSelect: () => void;
+  singleMode?: boolean;
 }) {
   const { icon: MatchIcon } = match.option;
   const ColIcon = match.columnIcon;
@@ -168,10 +183,14 @@ function MatchingOptionItem({
       onSelect={onSelect}
       value={`${match.columnId}:${match.option.value}`}
     >
-      <Checkbox
-        checked={isSelected}
-        className="mr-1 opacity-0 data-[state=checked]:opacity-100 group-data-[selected=true]:opacity-100"
-      />
+      {singleMode ? (
+        <RadioIndicator checked={isSelected} />
+      ) : (
+        <Checkbox
+          checked={isSelected}
+          className="mr-1 opacity-0 data-[state=checked]:opacity-100 group-data-[selected=true]:opacity-100"
+        />
+      )}
       <span className="inline-flex items-center gap-1 text-muted-foreground">
         {ColIcon ? <ColIcon className="size-3.5" /> : null}
         <span>{match.columnDisplayName}</span>
@@ -288,6 +307,8 @@ const FilterSelector = memo(function FilterSelectorImpl<TData>({
                 <CommandSeparator />
                 <CommandGroup>
                   {matchingOptions.map((match) => {
+                    const col = columns.find((c) => c.id === match.columnId);
+                    const singleMode = col?.type === 'option' && col.mode === 'single';
                     const selectedValues = filters.find((f) => f.columnId === match.columnId)?.values ?? [];
                     const isSelected = selectedValues.includes(match.option.value);
                     return (
@@ -296,13 +317,18 @@ const FilterSelector = memo(function FilterSelectorImpl<TData>({
                         key={`${match.columnId}:${match.option.value}`}
                         match={match}
                         onSelect={() => {
-                          if (isSelected) {
+                          if (singleMode) {
+                            if (!isSelected) {
+                              actions.setFilterValues(match.columnId, [match.option.value]);
+                            }
+                          } else if (isSelected) {
                             actions.removeFilterValue(match.columnId, match.option.value);
                           } else {
                             actions.addFilterValue(match.columnId, match.option.value);
                           }
                           setOpen(false);
                         }}
+                        singleMode={singleMode}
                       />
                     );
                   })}
@@ -640,21 +666,29 @@ function TextValueController({
 type OptionItemProps = {
   option: FilterOption & { selected: boolean; count?: number };
   onToggle: (value: string, checked: boolean) => void;
+  singleMode?: boolean;
 };
 
-const OptionItem = memo(function OptionItemImpl({ option, onToggle }: OptionItemProps) {
+const OptionItem = memo(function OptionItemImpl({ option, onToggle, singleMode }: OptionItemProps) {
   const { value, label, icon: ItemIcon, selected, count } = option;
 
   const handleSelect = useCallback(() => {
+    if (singleMode && selected) {
+      return;
+    }
     onToggle(value, !selected);
-  }, [onToggle, value, selected]);
+  }, [onToggle, value, selected, singleMode]);
 
   return (
     <CommandItem className="group flex items-center gap-1.5" onSelect={handleSelect}>
-      <Checkbox
-        checked={selected}
-        className="mr-1 opacity-0 data-[state=checked]:opacity-100 group-data-[selected=true]:opacity-100"
-      />
+      {singleMode ? (
+        <RadioIndicator checked={selected} />
+      ) : (
+        <Checkbox
+          checked={selected}
+          className="mr-1 opacity-0 data-[state=checked]:opacity-100 group-data-[selected=true]:opacity-100"
+        />
+      )}
       {ItemIcon ? renderIcon(ItemIcon, 'size-4 text-primary') : null}
       <span>
         {label}
@@ -687,6 +721,7 @@ function OptionValueController<TData>({
   actions: DataTableFilterActions;
   table?: Table<TData>;
 }) {
+  const singleMode = filterColumn.type === 'option' && filterColumn.mode === 'single';
   const baseOptions = filterColumn.options ?? [];
   const facetedCounts = table?.getColumn(columnId)?.getFacetedUniqueValues();
 
@@ -702,13 +737,15 @@ function OptionValueController<TData>({
 
   const handleToggle = useCallback(
     (val: string, checked: boolean) => {
-      if (checked) {
+      if (singleMode && checked) {
+        actions.setFilterValues(columnId, [val]);
+      } else if (checked) {
         actions.addFilterValue(columnId, val);
       } else {
         actions.removeFilterValue(columnId, val);
       }
     },
-    [actions, columnId]
+    [actions, columnId, singleMode]
   );
 
   return (
@@ -718,7 +755,7 @@ function OptionValueController<TData>({
       <CommandList className="max-h-fit">
         <CommandGroup>
           {enrichedOptions.map((option) => (
-            <OptionItem key={option.value} onToggle={handleToggle} option={option} />
+            <OptionItem key={option.value} onToggle={handleToggle} option={option} singleMode={singleMode} />
           ))}
         </CommandGroup>
       </CommandList>

--- a/frontend/src/components/redpanda-ui/components/drawer.tsx
+++ b/frontend/src/components/redpanda-ui/components/drawer.tsx
@@ -50,7 +50,8 @@ function DrawerContent({
       {showOverlay ? <DrawerOverlay /> : null}
       <DrawerPrimitive.Content
         className={cn(
-          'group/drawer-content fixed z-50 flex h-auto flex-col bg-background',
+          // z-[60] keeps the panel above its own overlay (z-50) even if vaul flips DOM order on a fast toggle.
+          'group/drawer-content fixed z-[60] flex h-auto flex-col bg-background',
           'data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b',
           'data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t',
           'data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm',

--- a/frontend/src/components/redpanda-ui/components/dropdown-menu.tsx
+++ b/frontend/src/components/redpanda-ui/components/dropdown-menu.tsx
@@ -253,7 +253,6 @@ function DropdownMenuContent({
                 }
           }
           key="dropdown-menu-content"
-          style={{ willChange: 'opacity, transform' }}
           transition={keepMounted ? undefined : transition}
           {...props}
         >

--- a/frontend/src/components/redpanda-ui/components/multi-select.tsx
+++ b/frontend/src/components/redpanda-ui/components/multi-select.tsx
@@ -193,8 +193,8 @@ const MultiSelectTrigger = React.forwardRef<React.ComponentRef<'button'>, MultiS
             data-testid={testId}
             {...props}
             className={cn(
-              "!border-input flex min-h-9 w-fit items-start justify-between gap-2 rounded-md border bg-transparent px-3 py-1.5 text-base shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 md:text-sm dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:hover:bg-input/50 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
-              disabled ? 'cursor-not-allowed opacity-50' : 'cursor-text',
+              "!border-input flex min-h-9 w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-1.5 text-base shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 md:text-sm dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:hover:bg-input/50 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
+              disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
               className
             )}
             onClick={disabled ? PreventClick : props.onClick}
@@ -335,10 +335,42 @@ const MultiSelectContent = React.forwardRef<React.ComponentRef<typeof PopoverPri
     const context = useMultiSelect();
 
     const fragmentRef = React.useRef<DocumentFragment | null>(null);
+    const popupRef = React.useRef<HTMLDivElement | null>(null);
 
     if (!fragmentRef.current && typeof window !== 'undefined') {
       fragmentRef.current = document.createDocumentFragment();
     }
+
+    const setPopupRef = React.useCallback(
+      (node: HTMLDivElement | null) => {
+        popupRef.current = node;
+        if (typeof ref === 'function') {
+          ref(node);
+        } else if (ref) {
+          ref.current = node;
+        }
+      },
+      [ref]
+    );
+
+    // Focus the search input (or popup) with `preventScroll`, otherwise Base UI's
+    // FloatingFocusManager focuses the first tabbable element without it — which
+    // scrolls the page when the popup flips above the trigger.
+    const initialFocus = React.useCallback((openType: string) => {
+      const popup = popupRef.current;
+      if (!popup) {
+        return false;
+      }
+      if (openType === 'touch') {
+        return popup;
+      }
+      const input = popup.querySelector<HTMLElement>('[cmdk-input]');
+      if (input) {
+        input.focus({ preventScroll: true });
+        return false;
+      }
+      return popup;
+    }, []);
 
     if (!context.open) {
       return fragmentRef.current ? createPortal(<Command>{children}</Command>, fragmentRef.current) : null;
@@ -346,14 +378,21 @@ const MultiSelectContent = React.forwardRef<React.ComponentRef<typeof PopoverPri
 
     return (
       <PopoverPrimitive.Portal container={container as HTMLElement | undefined} keepMounted>
-        <PopoverPrimitive.Positioner align="start" className="z-50" collisionPadding={10} sideOffset={4}>
+        <PopoverPrimitive.Positioner
+          align="start"
+          className="z-50"
+          collisionPadding={10}
+          positionMethod="fixed"
+          sideOffset={4}
+        >
           <PopoverPrimitive.Popup
             className={cn(
               'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative max-h-(--available-height) min-w-[8rem] origin-(--transform-origin) overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=bottom]:translate-y-1 data-[side=top]:-translate-y-1 data-[state=closed]:animate-out data-[state=open]:animate-in',
               className
             )}
             data-testid={testId}
-            ref={ref}
+            initialFocus={initialFocus}
+            ref={setPopupRef}
             render={renderWithDataState('div')}
             {...props}
           >
@@ -537,6 +576,7 @@ function renderMultiSelectOptions(list: MultiSelectOption[]) {
 // Simplified API for backend developers
 type SimpleMultiSelectProps = PortalRootProps &
   SharedProps &
+  Pick<React.AriaAttributes, 'aria-describedby' | 'aria-invalid'> &
   Pick<PortalContentProps, 'container' | 'onOpenAutoFocus'> & {
     id?: string;
     options: MultiSelectOption[] | string[];
@@ -578,6 +618,8 @@ function SimpleMultiSelect({
   defaultOpen,
   onOpenChange,
   testId,
+  'aria-describedby': ariaDescribedBy,
+  'aria-invalid': ariaInvalid,
 }: SimpleMultiSelectProps) {
   // Convert simple string array to option objects
   const normalizedOptions: MultiSelectOption[] = React.useMemo(
@@ -603,6 +645,8 @@ function SimpleMultiSelect({
       value={value}
     >
       <MultiSelectTrigger
+        aria-describedby={ariaDescribedBy}
+        aria-invalid={ariaInvalid}
         className={cn(widthClasses[width], className)}
         id={id}
         testId={testId ? `${testId}-control` : undefined}

--- a/frontend/src/components/redpanda-ui/components/separator.tsx
+++ b/frontend/src/components/redpanda-ui/components/separator.tsx
@@ -4,33 +4,29 @@ import React from 'react';
 
 import { cn, type SharedProps } from '../lib/utils';
 
-const separatorVariants = cva(
-  'shrink-0 data-[orientation=horizontal]:h-px data-[orientation=vertical]:h-full data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px',
-  {
-    variants: {
-      variant: {
-        default: 'bg-divider-default',
-        subtle: 'bg-divider-subtle',
-        strong: 'bg-divider-strong',
-      },
+const separatorVariants = cva('shrink-0', {
+  variants: {
+    variant: {
+      default: 'bg-divider-default',
+      subtle: 'bg-divider-subtle',
+      strong: 'bg-divider-strong',
     },
-    defaultVariants: {
-      variant: 'default',
-    },
-  }
-);
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
+
+const orientationClasses = (orientation: 'horizontal' | 'vertical') =>
+  orientation === 'vertical' ? 'h-full w-px' : 'h-px w-full';
 
 export type SeparatorVariant = VariantProps<typeof separatorVariants>['variant'];
 
 type SeparatorProps = React.ComponentProps<typeof SeparatorPrimitive> &
   SharedProps & {
     variant?: SeparatorVariant;
-    /**
-     * When `true` (the Radix default), the separator is purely decorative and
-     * will not be announced to assistive tech (`role="none"` + `aria-hidden`).
-     * When `false`, the native Base UI `role="separator"` with an orientation
-     * is used. Honored faithfully — this is not a compat no-op.
-     */
+    // When `true` (default), the separator is decorative (`role="none"` +
+    // `aria-hidden`); when `false`, it uses the native `role="separator"`.
     decorative?: boolean;
   };
 
@@ -45,7 +41,7 @@ function Separator({
   const a11yProps = decorative ? { 'aria-hidden': true, role: 'none' as const } : {};
   return (
     <SeparatorPrimitive
-      className={cn(separatorVariants({ variant }), className)}
+      className={cn(separatorVariants({ variant }), orientationClasses(orientation), className)}
       data-orientation={orientation}
       data-slot="separator"
       data-testid={testId}

--- a/frontend/src/components/redpanda-ui/components/separator.tsx
+++ b/frontend/src/components/redpanda-ui/components/separator.tsx
@@ -4,29 +4,33 @@ import React from 'react';
 
 import { cn, type SharedProps } from '../lib/utils';
 
-const separatorVariants = cva('shrink-0', {
-  variants: {
-    variant: {
-      default: 'bg-divider-default',
-      subtle: 'bg-divider-subtle',
-      strong: 'bg-divider-strong',
+const separatorVariants = cva(
+  'shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px data-[orientation=vertical]:self-stretch',
+  {
+    variants: {
+      variant: {
+        default: 'bg-divider-default',
+        subtle: 'bg-divider-subtle',
+        strong: 'bg-divider-strong',
+      },
     },
-  },
-  defaultVariants: {
-    variant: 'default',
-  },
-});
-
-const orientationClasses = (orientation: 'horizontal' | 'vertical') =>
-  orientation === 'vertical' ? 'h-full w-px' : 'h-px w-full';
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
 
 export type SeparatorVariant = VariantProps<typeof separatorVariants>['variant'];
 
 type SeparatorProps = React.ComponentProps<typeof SeparatorPrimitive> &
   SharedProps & {
     variant?: SeparatorVariant;
-    // When `true` (default), the separator is decorative (`role="none"` +
-    // `aria-hidden`); when `false`, it uses the native `role="separator"`.
+    /**
+     * When `true` (the Radix default), the separator is purely decorative and
+     * will not be announced to assistive tech (`role="none"` + `aria-hidden`).
+     * When `false`, the native Base UI `role="separator"` with an orientation
+     * is used. Honored faithfully — this is not a compat no-op.
+     */
     decorative?: boolean;
   };
 
@@ -41,7 +45,7 @@ function Separator({
   const a11yProps = decorative ? { 'aria-hidden': true, role: 'none' as const } : {};
   return (
     <SeparatorPrimitive
-      className={cn(separatorVariants({ variant }), orientationClasses(orientation), className)}
+      className={cn(separatorVariants({ variant }), className)}
       data-orientation={orientation}
       data-slot="separator"
       data-testid={testId}

--- a/frontend/src/components/redpanda-ui/components/stepper.tsx
+++ b/frontend/src/components/redpanda-ui/components/stepper.tsx
@@ -43,7 +43,7 @@ const defineStepper = <const Steps extends Step[]>(...steps: Steps): Stepper.Def
     const renderedChildren = typeof children === 'function' ? children({ methods }) : children;
 
     return (
-      <div className={cn('w-full', className)} data-testid={testId} date-component="stepper" {...props}>
+      <div className={cn('w-full', className)} data-component="stepper" data-testid={testId} {...props}>
         {renderedChildren}
       </div>
     );
@@ -74,8 +74,8 @@ const defineStepper = <const Steps extends Step[]>(...steps: Steps): Stepper.Def
       Navigation: ({ children, 'aria-label': ariaLabel = 'Stepper Navigation', testId, ...props }) => {
         const { variant } = useStepperProvider();
         return (
-          <nav aria-label={ariaLabel} data-testid={testId} date-component="stepper-navigation" {...props}>
-            <ol className={classForNavigationList({ variant })} date-component="stepper-navigation-list">
+          <nav aria-label={ariaLabel} data-component="stepper-navigation" data-testid={testId} {...props}>
+            <ol className={classForNavigationList({ variant })} data-component="stepper-navigation-list">
               {children}
             </ol>
           </nav>
@@ -109,10 +109,10 @@ const defineStepper = <const Steps extends Step[]>(...steps: Steps): Stepper.Def
           return (
             <li
               className={cn('flex shrink-0 items-center gap-4 rounded-md transition-colors', className)}
-              date-component="stepper-step"
+              data-component="stepper-step"
             >
               <CircleStepIndicator currentStep={stepIndex + 1} totalSteps={steps.length} />
-              <div className="flex flex-col items-start gap-1" date-component="stepper-step-content">
+              <div className="flex flex-col items-start gap-1" data-component="stepper-step-content">
                 {title}
                 {description}
               </div>
@@ -130,11 +130,11 @@ const defineStepper = <const Steps extends Step[]>(...steps: Steps): Stepper.Def
                 'data-[label-orientation=vertical]:flex-col',
                 'data-[label-orientation=vertical]:justify-center',
               ])}
+              data-component="stepper-step"
               data-disabled={props.disabled}
               data-label-orientation={labelOrientation}
               data-state={dataState}
               data-variant={variant}
-              date-component="stepper-step"
             >
               <Button
                 aria-controls={`step-panel-${props.of}`}
@@ -143,8 +143,8 @@ const defineStepper = <const Steps extends Step[]>(...steps: Steps): Stepper.Def
                 aria-selected={isActive}
                 aria-setsize={steps.length}
                 className={cn('rounded-full', isActive && 'ring-3 ring-secondary/20')}
+                data-component="stepper-step-indicator"
                 data-testid={testId}
-                date-component="stepper-step-indicator"
                 id={`step-${step.id}`}
                 onKeyDown={(e) => onStepKeyDown(e, utils.getNext(props.of), utils.getPrev(props.of))}
                 role="tab"
@@ -165,7 +165,7 @@ const defineStepper = <const Steps extends Step[]>(...steps: Steps): Stepper.Def
                   state={dataState}
                 />
               )}
-              <div className="flex flex-col items-start" date-component="stepper-step-content">
+              <div className="flex flex-col items-start" data-component="stepper-step-content">
                 {title}
                 {description}
               </div>
@@ -201,7 +201,7 @@ const defineStepper = <const Steps extends Step[]>(...steps: Steps): Stepper.Def
 
         return (
           <Comp
-            date-component="stepper-step-panel"
+            data-component="stepper-step-panel"
             ref={(node: HTMLDivElement | null) => scrollIntoStepperPanel(node, tracking)}
             {...props}
           >
@@ -212,7 +212,7 @@ const defineStepper = <const Steps extends Step[]>(...steps: Steps): Stepper.Def
       Controls: ({ children, className, asChild, ...props }) => {
         const Comp = asChild ? Slot : 'div';
         return (
-          <Comp className={cn('flex justify-end gap-4', className)} date-component="stepper-controls" {...props}>
+          <Comp className={cn('flex justify-end gap-4', className)} data-component="stepper-controls" {...props}>
             {children}
           </Comp>
         );
@@ -227,7 +227,7 @@ const Title = ({ children, className, asChild, ...props }: React.ComponentProps<
   return (
     <Comp
       className={cn('font-medium text-base selection:bg-selected selection:text-selected-foreground', className)}
-      date-component="stepper-step-title"
+      data-component="stepper-step-title"
       level={asChild ? undefined : 4}
       {...props}
     >
@@ -245,7 +245,7 @@ const Description = ({ children, className, asChild, ...props }: React.Component
         'text-muted-foreground text-sm selection:bg-selected selection:text-selected-foreground',
         className
       )}
-      date-component="stepper-step-description"
+      data-component="stepper-step-description"
       {...props}
     >
       {children}
@@ -271,10 +271,10 @@ const StepperSeparator = ({
     <div
       aria-hidden="true"
       className={classForSeparator({ orientation, labelOrientation })}
+      data-component="stepper-separator"
       data-disabled={disabled}
       data-orientation={orientation}
       data-state={state}
-      date-component="stepper-separator"
     />
   );
 };
@@ -295,7 +295,7 @@ const CircleStepIndicator = ({
       aria-valuemin={1}
       aria-valuenow={currentStep}
       className="relative inline-flex items-center justify-center"
-      date-component="stepper-step-indicator"
+      data-component="stepper-step-indicator"
       role="progressbar"
       tabIndex={-1}
     >

--- a/frontend/src/components/redpanda-ui/components/tabs.tsx
+++ b/frontend/src/components/redpanda-ui/components/tabs.tsx
@@ -29,10 +29,8 @@ type TabsRenderFn = any;
 
 type TabsRenderProp = React.ReactElement | TabsRenderFn | undefined;
 
-/**
- * Build the data-state attribute from Base UI's render-prop state so Radix-era
- * CSS selectors (`data-[state=active]:...`) keep working.
- */
+// Build the data-state attribute from Base UI's state so Radix-era CSS selectors
+// (`data-[state=active]:...`) keep working.
 function dataStateFromBaseUi(state: { active?: boolean; hidden?: boolean }): Record<string, unknown> {
   const attrs: Record<string, unknown> = {};
   if (typeof state?.active === 'boolean') {
@@ -43,12 +41,8 @@ function dataStateFromBaseUi(state: { active?: boolean; hidden?: boolean }): Rec
   return attrs;
 }
 
-/**
- * Render prop factory. When no user-supplied render is provided, render the
- * given element tag with injected `data-state`. When the user supplies a
- * render (JSX element or function), compose it with `data-state` so router
- * links / anchors keep working as Tabs triggers.
- */
+// Render prop factory: inject `data-state` onto the default element, or compose
+// it onto a user-supplied render so router links/anchors keep working as triggers.
 function renderTabWithActiveState(Element: 'button' | 'div', userRender?: TabsRenderProp): TabsRenderFn {
   return ((props: Record<string, unknown>, state: { active?: boolean; hidden?: boolean }) => {
     const mergedProps = { ...props, ...dataStateFromBaseUi(state) };
@@ -141,7 +135,7 @@ const tabsListActiveVariants = cva('rounded-sm bg-background shadow-sm', {
     variant: {
       default: '',
       underline:
-        "rounded-none bg-transparent shadow-none after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:rounded-t-full after:bg-selected after:content-['']",
+        "rounded-none bg-transparent shadow-none after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:bg-selected after:content-['']",
     },
   },
   defaultVariants: {
@@ -245,9 +239,8 @@ const TabsList = React.forwardRef<HTMLDivElement, TabsListProps>(
 
     const prefersReducedMotion = useReducedMotion();
     const isHorizontal = orientation !== 'vertical';
-    // Lock the perpendicular axis: when the active tab moves to a different
-    // row (horizontal) or column (vertical), the highlight should snap on that
-    // axis instead of animating in 2D, which looks amateur.
+    // Lock the perpendicular axis so the highlight snaps (not animates) when the
+    // active tab moves to a different row/column.
     const axisLockedTransition: Transition = React.useMemo(() => {
       if (prefersReducedMotion) {
         return { duration: 0 };
@@ -318,20 +311,14 @@ const tabsTriggerVariants = cva(
 type TabsTriggerProps = Omit<React.ComponentProps<typeof TabsPrimitive.Tab>, 'render'> &
   SharedProps & {
     variant?: VariantProps<typeof tabsTriggerVariants>['variant'];
-    /**
-     * Base UI render prop. Pass a JSX element (e.g. a router `<Link />`) or a
-     * function to swap the rendered element while keeping Tab keyboard and
-     * active-state behavior. Defaults to a native `<button>`.
-     */
+    // Base UI render prop: swap the rendered element (e.g. a router `<Link />`)
+    // while keeping Tab behavior. Defaults to a native `<button>`.
     render?: TabsRenderProp;
   };
 
 function TabsTrigger({ className, value, variant, testId, disabled, render, ...props }: TabsTriggerProps) {
-  // If the consumer's render is a non-button intrinsic (e.g. `<a href>` for
-  // link-style tabs), tell Base UI to polyfill button semantics instead of
-  // asserting a native button. Function-form renders and component children
-  // are assumed to render a <button>; consumers can pass nativeButton={false}
-  // explicitly otherwise.
+  // Non-button intrinsic renders (e.g. `<a href>`) need Base UI's button-semantics
+  // polyfill; function/component renders are assumed to render a <button>.
   const nativeButton =
     React.isValidElement(render) && typeof render.type === 'string' && render.type !== 'button' ? false : undefined;
 

--- a/frontend/src/components/redpanda-ui/components/tags.tsx
+++ b/frontend/src/components/redpanda-ui/components/tags.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
   useContext,
   useEffect,
+  useId,
   useRef,
   useState,
 } from 'react';
@@ -24,6 +25,7 @@ type TagsContextType = {
   onOpenChange: (open: boolean) => void;
   width?: number;
   setWidth?: (width: number) => void;
+  listboxId: string;
 };
 const TagsContext = createContext<TagsContextType>({
   value: undefined,
@@ -34,6 +36,7 @@ const TagsContext = createContext<TagsContextType>({
   },
   width: undefined,
   setWidth: undefined,
+  listboxId: 'tags-listbox',
 });
 
 const useTagsContext = () => {
@@ -64,6 +67,7 @@ export const Tags = ({
 }: TagsProps) => {
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
   const [width, setWidth] = useState<number>();
+  const listboxId = useId();
   const ref = useRef<HTMLDivElement>(null);
   const open = controlledOpen ?? uncontrolledOpen;
   const onOpenChange = controlledOnOpenChange ?? setUncontrolledOpen;
@@ -80,7 +84,7 @@ export const Tags = ({
     };
   }, []);
   return (
-    <TagsContext.Provider value={{ value, setValue, open, onOpenChange, width, setWidth }}>
+    <TagsContext.Provider value={{ value, setValue, open, onOpenChange, width, setWidth, listboxId }}>
       <Popover onOpenChange={onOpenChange} open={open}>
         <div className={cn('relative w-full', className)} data-testid={testId} ref={ref}>
           {children}
@@ -90,25 +94,30 @@ export const Tags = ({
   );
 };
 export type TagsTriggerProps = ComponentProps<typeof Button> & { testId?: string };
-export const TagsTrigger = ({ className, children, testId, ...props }: TagsTriggerProps) => (
-  <PopoverTrigger asChild>
-    <Button
-      className={cn(
-        'h-auto w-full justify-between p-2 hover:bg-surface-inverse-hover active:bg-surface-default-hover',
-        className
-      )}
-      data-testid={testId}
-      role="combobox"
-      variant="outline"
-      {...props}
-    >
-      <div className="flex flex-wrap items-center gap-1">
-        {children}
-        <span className="px-2 py-px text-muted-foreground">Select a tag...</span>
-      </div>
-    </Button>
-  </PopoverTrigger>
-);
+export const TagsTrigger = ({ className, children, testId, ...props }: TagsTriggerProps) => {
+  const { open, listboxId } = useTagsContext();
+  return (
+    <PopoverTrigger asChild>
+      <Button
+        aria-controls={listboxId}
+        aria-expanded={open}
+        className={cn(
+          'h-auto w-full justify-between p-2 hover:bg-surface-inverse-hover active:bg-surface-default-hover',
+          className
+        )}
+        data-testid={testId}
+        role="combobox"
+        variant="outline"
+        {...props}
+      >
+        <div className="flex flex-wrap items-center gap-1">
+          {children}
+          <span className="px-2 py-px text-muted-foreground">Select a tag...</span>
+        </div>
+      </Button>
+    </PopoverTrigger>
+  );
+};
 export type TagsValueProps = ComponentProps<'span'> & { testId?: string };
 export const TagsValue = ({
   className,
@@ -161,9 +170,10 @@ export const TagsInput = ({ className, ...props }: TagsInputProps) => (
   <CommandInput className={cn('h-9', className)} {...props} />
 );
 export type TagsListProps = ComponentProps<typeof CommandList>;
-export const TagsList = ({ className, ...props }: TagsListProps) => (
-  <CommandList className={cn('max-h-[200px]', className)} {...props} />
-);
+export const TagsList = ({ className, ...props }: TagsListProps) => {
+  const { listboxId } = useTagsContext();
+  return <CommandList className={cn('max-h-[200px]', className)} id={listboxId} {...props} />;
+};
 
 export type TagsEmptyProps = ComponentProps<typeof CommandEmpty>;
 export const TagsEmpty = ({ children, className, ...props }: TagsEmptyProps) => (

--- a/frontend/src/components/redpanda-ui/components/textarea.tsx
+++ b/frontend/src/components/redpanda-ui/components/textarea.tsx
@@ -1,6 +1,7 @@
 import { cva, type VariantProps } from 'class-variance-authority';
 import React from 'react';
 
+import { useFieldContext } from './field';
 import { cn, type SharedProps } from '../lib/utils';
 
 const textareaVariants = cva(
@@ -30,15 +31,20 @@ const textareaVariants = cva(
 interface TextareaProps extends React.ComponentProps<'textarea'>, VariantProps<typeof textareaVariants>, SharedProps {}
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, size, resize, testId, ...props }, ref) => (
-    <textarea
-      className={cn(textareaVariants({ size, resize }), className)}
-      data-slot="textarea"
-      data-testid={testId}
-      ref={ref}
-      {...props}
-    />
-  )
+  ({ className, size, resize, testId, ...props }, ref) => {
+    const fieldCtx = useFieldContext();
+    return (
+      <textarea
+        {...props}
+        aria-describedby={props['aria-describedby'] ?? fieldCtx.errorId}
+        aria-invalid={props['aria-invalid'] ?? (fieldCtx.invalid || undefined)}
+        className={cn(textareaVariants({ size, resize }), className)}
+        data-slot="textarea"
+        data-testid={testId}
+        ref={ref}
+      />
+    );
+  }
 );
 
 Textarea.displayName = 'Textarea';

--- a/frontend/src/components/redpanda-ui/components/typography.tsx
+++ b/frontend/src/components/redpanda-ui/components/typography.tsx
@@ -145,28 +145,34 @@ interface TextProps extends React.HTMLAttributes<HTMLElement>, VariantProps<type
 // Defaults to <div> so Text can safely wrap block-level children (lists, inputs, etc.)
 // without emitting React `validateDOMNesting` warnings. Consumers that need paragraph
 // semantics can opt in via `as="p"`.
-export function Text({ variant, align, as = 'div', className, children, testId, ...props }: TextProps) {
-  const Component = as;
+// Uses forwardRef so Text can serve as a Slot/asChild child (e.g. TooltipTrigger asChild).
+export const Text = forwardRef<HTMLElement, TextProps>((componentProps, ref) => {
+  const { variant, align, as = 'div', className, children, testId, ...props } = componentProps;
 
-  return (
-    <Component className={cn(textVariants({ variant, align }), className)} data-testid={testId} {...props}>
-      {children}
-    </Component>
+  return React.createElement(
+    as,
+    {
+      ref,
+      className: cn(textVariants({ variant, align }), className),
+      'data-testid': testId,
+      ...props,
+    },
+    children
   );
-}
+});
 
 // Blockquote Component
 interface BlockquoteProps extends React.HTMLAttributes<HTMLQuoteElement>, SharedProps {
   children: React.ReactNode;
 }
 
-export function Blockquote({ className, children, testId, ...props }: BlockquoteProps) {
-  return (
-    <blockquote className={cn('border-l-2 pl-6 italic', className)} data-testid={testId} {...props}>
+export const Blockquote = forwardRef<HTMLQuoteElement, BlockquoteProps>(
+  ({ className, children, testId, ...props }, ref) => (
+    <blockquote className={cn('border-l-2 pl-6 italic', className)} data-testid={testId} ref={ref} {...props}>
       {children}
     </blockquote>
-  );
-}
+  )
+);
 
 // List Component
 interface ListProps extends React.HTMLAttributes<HTMLUListElement | HTMLOListElement>, SharedProps {
@@ -174,59 +180,62 @@ interface ListProps extends React.HTMLAttributes<HTMLUListElement | HTMLOListEle
   ordered?: boolean;
 }
 
-export function List({ ordered = false, className, children, testId, ...props }: ListProps) {
+export const List = forwardRef<HTMLUListElement | HTMLOListElement, ListProps>((componentProps, ref) => {
+  const { ordered = false, className, children, testId, ...props } = componentProps;
   const ListTag = ordered ? 'ol' : 'ul';
   const listClass = ordered ? 'mt-1 mb-3 ml-6 list-decimal [&>li]:mt-1' : 'mt-1 mb-3 ml-6 list-disc [&>li]:mt-0.5';
 
-  return (
-    <ListTag className={cn(listClass, className)} data-testid={testId} {...props}>
-      {children}
-    </ListTag>
+  return React.createElement(
+    ListTag,
+    {
+      ref,
+      className: cn(listClass, className),
+      'data-testid': testId,
+      ...props,
+    },
+    children
   );
-}
+});
 
 // List Item Component
 interface ListItemProps extends React.HTMLAttributes<HTMLLIElement>, SharedProps {
   children: React.ReactNode;
 }
 
-export function ListItem({ className, children, testId, ...props }: ListItemProps) {
-  return (
-    <li className={className} data-testid={testId} {...props}>
-      {children}
-    </li>
-  );
-}
+export const ListItem = forwardRef<HTMLLIElement, ListItemProps>(({ className, children, testId, ...props }, ref) => (
+  <li className={className} data-testid={testId} ref={ref} {...props}>
+    {children}
+  </li>
+));
 
 // Optional List Item Text component to emulate prose p-in-li behavior
 interface ListItemTextProps extends React.HTMLAttributes<HTMLParagraphElement>, SharedProps {
   children: React.ReactNode;
 }
 
-export function ListItemText({ className, children, testId, ...props }: ListItemTextProps) {
-  return (
-    <p className={cn('my-0 inline', className)} data-testid={testId} {...props}>
+export const ListItemText = forwardRef<HTMLParagraphElement, ListItemTextProps>(
+  ({ className, children, testId, ...props }, ref) => (
+    <p className={cn('my-0 inline', className)} data-testid={testId} ref={ref} {...props}>
       {children}
     </p>
-  );
-}
+  )
+);
 
 // Inline Code Component
 interface InlineCodeProps extends React.HTMLAttributes<HTMLElement>, SharedProps {
   children: React.ReactNode;
 }
 
-export function InlineCode({ className, children, testId, ...props }: InlineCodeProps) {
-  return (
-    <code
-      className={cn('relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono font-semibold text-sm', className)}
-      data-testid={testId}
-      {...props}
-    >
-      {children}
-    </code>
-  );
-}
+export const InlineCode = forwardRef<HTMLElement, InlineCodeProps>(({ className, children, testId, ...props }, ref) => (
+  <code
+    className={cn('relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono font-semibold text-sm', className)}
+    data-testid={testId}
+    ref={ref}
+    {...props}
+  >
+    {children}
+  </code>
+));
 
 // Base props shared by both link types
 type BaseLinkProps = SharedProps & {
@@ -258,12 +267,16 @@ type LinkProps =
 const linkStyles =
   'font-medium text-primary decoration-dotted underline underline-offset-[3px] hover:text-primary/80 transition-colors';
 
-export function Link({ className, children, testId, ...props }: LinkProps) {
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>((componentProps, ref) => {
+  // Re-assert the discriminated union: forwardRef's PropsWithoutRef collapses the
+  // index-signature branch, widening className/children to `unknown`.
+  const { className, children, testId, ...props } = componentProps as LinkProps;
+
   if ('as' in props && props.as === TanStackLink) {
     // Render as TanStack Router Link when explicitly specified
     const { as: _, ...routerProps } = props;
     return (
-      <TanStackLink className={cn(linkStyles, className)} data-testid={testId} {...routerProps}>
+      <TanStackLink className={cn(linkStyles, className)} data-testid={testId} ref={ref} {...routerProps}>
         {children}
       </TanStackLink>
     );
@@ -271,120 +284,132 @@ export function Link({ className, children, testId, ...props }: LinkProps) {
   // Render as anchor tag (default)
 
   return (
-    <a className={cn(linkStyles, className)} data-testid={testId} {...props}>
+    <a className={cn(linkStyles, className)} data-testid={testId} ref={ref} {...props}>
       {children}
     </a>
   );
-}
+});
 
 // Preformatted Code Block Component
 interface PreProps extends React.HTMLAttributes<HTMLPreElement>, SharedProps {
   children: React.ReactNode;
 }
 
-export function Pre({ className, children, testId, ...props }: PreProps) {
-  return (
-    <pre
-      className={cn('my-6 overflow-y-auto rounded-md bg-muted p-4 text-sm', className)}
-      data-testid={testId}
-      {...props}
-    >
-      {children}
-    </pre>
-  );
-}
+export const Pre = forwardRef<HTMLPreElement, PreProps>(({ className, children, testId, ...props }, ref) => (
+  <pre
+    className={cn('my-6 overflow-y-auto rounded-md bg-muted p-4 text-sm', className)}
+    data-testid={testId}
+    ref={ref}
+    {...props}
+  >
+    {children}
+  </pre>
+));
 
 // Horizontal Rule Component
 interface HrProps extends React.HTMLAttributes<HTMLHRElement>, SharedProps {}
 
-export function Hr({ className, testId, ...props }: HrProps) {
-  return <hr className={cn('my-10', className)} data-testid={testId} {...props} />;
-}
+export const Hr = forwardRef<HTMLHRElement, HrProps>(({ className, testId, ...props }, ref) => (
+  <hr className={cn('my-10', className)} data-testid={testId} ref={ref} {...props} />
+));
 
 // Description List Components
 interface DlProps extends React.HTMLAttributes<HTMLDListElement>, SharedProps {
   children: React.ReactNode;
 }
 
-export function Dl({ className, children, testId, ...props }: DlProps) {
-  return (
-    <dl className={cn('my-6', className)} data-testid={testId} {...props}>
-      {children}
-    </dl>
-  );
-}
+export const Dl = forwardRef<HTMLDListElement, DlProps>(({ className, children, testId, ...props }, ref) => (
+  <dl className={cn('my-6', className)} data-testid={testId} ref={ref} {...props}>
+    {children}
+  </dl>
+));
 
 interface DtProps extends React.HTMLAttributes<HTMLElement>, SharedProps {
   children: React.ReactNode;
 }
 
-export function Dt({ className, children, testId, ...props }: DtProps) {
-  return (
-    <dt className={cn('font-semibold tracking-tight', className)} data-testid={testId} {...props}>
-      {children}
-    </dt>
-  );
-}
+export const Dt = forwardRef<HTMLElement, DtProps>(({ className, children, testId, ...props }, ref) => (
+  <dt className={cn('font-semibold tracking-tight', className)} data-testid={testId} ref={ref} {...props}>
+    {children}
+  </dt>
+));
 
 interface DdProps extends React.HTMLAttributes<HTMLElement>, SharedProps {
   children: React.ReactNode;
 }
 
-export function Dd({ className, children, testId, ...props }: DdProps) {
-  return (
-    <dd className={className} data-testid={testId} {...props}>
-      {children}
-    </dd>
-  );
-}
+export const Dd = forwardRef<HTMLElement, DdProps>(({ className, children, testId, ...props }, ref) => (
+  <dd className={className} data-testid={testId} ref={ref} {...props}>
+    {children}
+  </dd>
+));
 
 // Details/Summary Components
 interface DetailsProps extends React.DetailsHTMLAttributes<HTMLDetailsElement>, SharedProps {
   children: React.ReactNode;
 }
 
-export function Details({ className, children, testId, ...props }: DetailsProps) {
-  return (
-    <details className={className} data-testid={testId} {...props}>
+export const Details = forwardRef<HTMLDetailsElement, DetailsProps>(
+  ({ className, children, testId, ...props }, ref) => (
+    <details className={className} data-testid={testId} ref={ref} {...props}>
       {children}
     </details>
-  );
-}
+  )
+);
 
 interface SummaryProps extends React.HTMLAttributes<HTMLElement>, SharedProps {
   children: React.ReactNode;
 }
 
-export function Summary({ className, children, testId, ...props }: SummaryProps) {
-  return (
-    <summary className={cn('cursor-pointer font-semibold tracking-tight', className)} data-testid={testId} {...props}>
-      {children}
-    </summary>
-  );
-}
+export const Summary = forwardRef<HTMLElement, SummaryProps>(({ className, children, testId, ...props }, ref) => (
+  <summary
+    className={cn('cursor-pointer font-semibold tracking-tight', className)}
+    data-testid={testId}
+    ref={ref}
+    {...props}
+  >
+    {children}
+  </summary>
+));
 
 // Marked/Highlight Component
 interface MarkProps extends React.HTMLAttributes<HTMLElement>, SharedProps {
   children: React.ReactNode;
 }
 
-export function Mark({ className, children, testId, ...props }: MarkProps) {
-  return (
-    <mark className={cn('bg-yellow-200', className)} data-testid={testId} {...props}>
-      {children}
-    </mark>
-  );
-}
+export const Mark = forwardRef<HTMLElement, MarkProps>(({ className, children, testId, ...props }, ref) => (
+  <mark className={cn('bg-yellow-200', className)} data-testid={testId} ref={ref} {...props}>
+    {children}
+  </mark>
+));
 
 // Small text Component
 interface SmallProps extends React.HTMLAttributes<HTMLElement>, SharedProps {
   children: React.ReactNode;
 }
 
-export function Small({ className, children, testId, ...props }: SmallProps) {
-  return (
-    <small className={cn('text-xs leading-none', className)} data-testid={testId} {...props}>
-      {children}
-    </small>
-  );
-}
+export const Small = forwardRef<HTMLElement, SmallProps>(({ className, children, testId, ...props }, ref) => (
+  <small className={cn('text-xs leading-none', className)} data-testid={testId} ref={ref} {...props}>
+    {children}
+  </small>
+));
+
+// Set displayName on every forwardRef component so they show their real name in React
+// DevTools, error boundaries, and component stacks instead of an anonymous "ForwardRef".
+Heading.displayName = 'Heading';
+Text.displayName = 'Text';
+Blockquote.displayName = 'Blockquote';
+List.displayName = 'List';
+ListItem.displayName = 'ListItem';
+ListItemText.displayName = 'ListItemText';
+InlineCode.displayName = 'InlineCode';
+Link.displayName = 'Link';
+Pre.displayName = 'Pre';
+Hr.displayName = 'Hr';
+Dl.displayName = 'Dl';
+Dt.displayName = 'Dt';
+Dd.displayName = 'Dd';
+Details.displayName = 'Details';
+Summary.displayName = 'Summary';
+Mark.displayName = 'Mark';
+Small.displayName = 'Small';

--- a/frontend/src/components/redpanda-ui/lib/use-controllable-state.ts
+++ b/frontend/src/components/redpanda-ui/lib/use-controllable-state.ts
@@ -36,26 +36,23 @@ export function useControllableState<T>({
   const isControlled = prop !== undefined;
   const value = isControlled ? prop : uncontrolledProp;
 
-  // OK to disable conditionally calling hooks here because they will always run
-  // consistently in the same environment. Bundlers should be able to remove the
-  // code block entirely in production.
-  if (process.env.NODE_ENV !== 'production') {
-    // biome-ignore lint/correctness/useHookAtTopLevel: see comment above
-    const isControlledRef = React.useRef(prop !== undefined);
-    // biome-ignore lint/correctness/useHookAtTopLevel: see comment above
-    React.useEffect(() => {
-      const wasControlled = isControlledRef.current;
-      if (wasControlled !== isControlled) {
-        const from = wasControlled ? 'controlled' : 'uncontrolled';
-        const to = isControlled ? 'controlled' : 'uncontrolled';
-        // biome-ignore lint/suspicious/noConsole: needed for controllable state implementation
-        console.warn(
-          `${caller} is changing from ${from} to ${to}. Components should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled value for the lifetime of the component.`
-        );
-      }
-      isControlledRef.current = isControlled;
-    }, [isControlled, caller]);
-  }
+  const isControlledRef = React.useRef(prop !== undefined);
+
+  React.useEffect(() => {
+    if (process.env.NODE_ENV === 'production') {
+      return;
+    }
+    const wasControlled = isControlledRef.current;
+    if (wasControlled !== isControlled) {
+      const from = wasControlled ? 'controlled' : 'uncontrolled';
+      const to = isControlled ? 'controlled' : 'uncontrolled';
+      // biome-ignore lint/suspicious/noConsole: needed for controllable state implementation
+      console.warn(
+        `${caller} is changing from ${from} to ${to}. Components should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled value for the lifetime of the component.`
+      );
+    }
+    isControlledRef.current = isControlled;
+  }, [isControlled, caller]);
 
   const setValue = React.useCallback<SetStateFn<T>>(
     (nextValue) => {

--- a/frontend/src/components/ui/connect/log-explorer.test.tsx
+++ b/frontend/src/components/ui/connect/log-explorer.test.tsx
@@ -79,7 +79,7 @@ describe('LogExplorer', () => {
 
   test('shows history empty state when no messages and search complete', () => {
     renderExplorer();
-    expect(screen.getByText('No logs found in the last 5 hours for this pipeline.')).toBeInTheDocument();
+    expect(screen.getByText('No logs found for this pipeline.')).toBeInTheDocument();
   });
 
   test('shows live empty state when live mode enabled and no messages', async () => {

--- a/frontend/src/components/ui/connect/log-explorer.test.tsx
+++ b/frontend/src/components/ui/connect/log-explorer.test.tsx
@@ -205,7 +205,7 @@ describe('LogExplorer', () => {
 
   test('table has expected column headers', () => {
     renderExplorer();
-    expect(screen.getByText('Timestamp')).toBeInTheDocument();
+    expect(screen.getByText('Time')).toBeInTheDocument();
     expect(screen.getByText('Level')).toBeInTheDocument();
     expect(screen.getByText('Component')).toBeInTheDocument();
     expect(screen.getByText('Message')).toBeInTheDocument();

--- a/frontend/src/components/ui/connect/log-explorer.test.tsx
+++ b/frontend/src/components/ui/connect/log-explorer.test.tsx
@@ -192,6 +192,23 @@ describe('LogExplorer', () => {
     expect(rows.length).toBe(11); // 1 header + 10 data
   });
 
+  test('resets to the first page when switching to live mode', async () => {
+    const user = userEvent.setup();
+    mockReturn.messages = Array.from({ length: 15 }, (_, i) =>
+      makeMessage({ offset: i, valuePayload: { message: `Log ${i}`, level: 'INFO', path: 'x' } }),
+    );
+    renderExplorer({ enableLiveView: true });
+
+    // Page 2 shows the later logs.
+    await user.click(screen.getByRole('button', { name: /go to next page/i }));
+    expect(screen.getByText('Log 10')).toBeInTheDocument();
+    expect(screen.queryByText('Log 0')).not.toBeInTheDocument();
+
+    // Toggling live must jump back to page 1 so new logs are visible.
+    await user.click(screen.getByTestId('log-live-toggle'));
+    expect(screen.getByText('Log 0')).toBeInTheDocument();
+  });
+
   test('table has expected column headers', () => {
     renderExplorer();
     expect(screen.getByText('Time')).toBeInTheDocument();

--- a/frontend/src/components/ui/connect/log-explorer.test.tsx
+++ b/frontend/src/components/ui/connect/log-explorer.test.tsx
@@ -67,25 +67,14 @@ describe('LogExplorer', () => {
     mockReturn.progress = { bytesConsumed: 0, messagesConsumed: 0 };
     renderExplorer();
     expect(screen.getByTestId('log-loading-spinner')).toBeInTheDocument();
-    expect(screen.queryByTestId('log-progress-bar')).not.toBeInTheDocument();
   });
 
-  test('shows progress bar (no spinner) when backend provides progress data', () => {
+  test('shows progress text (no spinner) when backend provides progress data', () => {
     mockReturn.phase = 'Searching...';
     mockReturn.progress = { bytesConsumed: 2_500_000, messagesConsumed: 150 };
     renderExplorer();
     expect(screen.queryByTestId('log-loading-spinner')).not.toBeInTheDocument();
-    expect(screen.getByTestId('log-progress-bar')).toBeInTheDocument();
     expect(screen.getByTestId('log-search-progress')).toHaveTextContent('150 messages checked');
-  });
-
-  test('progress bar renders above the table, not inside a table cell', () => {
-    mockReturn.phase = 'Searching...';
-    mockReturn.progress = { bytesConsumed: 1_000, messagesConsumed: 10 };
-    renderExplorer();
-    const progressBar = screen.getByTestId('log-progress-bar');
-    // Progress bar should be a sibling/overlay of the table, not inside a <td>
-    expect(progressBar.closest('td')).toBeNull();
   });
 
   test('shows history empty state when no messages and search complete', () => {

--- a/frontend/src/components/ui/connect/log-explorer.tsx
+++ b/frontend/src/components/ui/connect/log-explorer.tsx
@@ -20,6 +20,7 @@ import {
   useReactTable,
 } from '@tanstack/react-table';
 import { Alert, AlertDescription, AlertTitle } from 'components/redpanda-ui/components/alert';
+import { Button } from 'components/redpanda-ui/components/button';
 import { Badge } from 'components/redpanda-ui/components/badge';
 import { Label } from 'components/redpanda-ui/components/label';
 import { SimpleCodeBlock } from 'components/redpanda-ui/components/code-block';
@@ -279,7 +280,7 @@ export function LogExplorer({ pipeline, serverless, enableLiveView = false, titl
           // Time is the scannable field; date sits muted above, full date/time on hover.
           return (
             <div className="flex flex-col leading-tight" title={d.toLocaleString()}>
-              <span className="text-[11px] text-muted-foreground tabular-nums">{d.toLocaleDateString()}</span>
+              <span className="text-xs text-muted-foreground tabular-nums">{d.toLocaleDateString()}</span>
               <span className="font-medium text-sm tabular-nums">{d.toLocaleTimeString()}</span>
             </div>
           );
@@ -492,12 +493,11 @@ export function LogExplorer({ pipeline, serverless, enableLiveView = false, titl
                     <TableCell className="p-4" colSpan={table.getVisibleFlatColumns().length}>
                       <Alert data-testid="pipeline-stopped-banner" variant="info">
                         <AlertTitle>Pipeline is not running</AlertTitle>
-                        <AlertDescription>
-                          Live logs require a running pipeline.{' '}
-                          <button className="font-medium underline" onClick={() => setLiveView(false)} type="button">
+                        <AlertDescription className="flex flex-col items-start gap-2">
+                          Live logs require a running pipeline. Switch to recent logs to view historical logs.
+                          <Button onClick={() => setLiveView(false)} size="sm" variant="secondary-outline">
                             Switch to Recent Logs
-                          </button>{' '}
-                          to view historical logs.
+                          </Button>
                         </AlertDescription>
                       </Alert>
                     </TableCell>
@@ -550,7 +550,7 @@ export function LogExplorer({ pipeline, serverless, enableLiveView = false, titl
                           {/* Mirror the Time cell's two-line height so placeholder rows match data rows. */}
                           {columnIndex === 0 ? (
                             <div className="flex flex-col leading-tight">
-                              <span className="text-[11px]">&nbsp;</span>
+                              <span className="text-xs">&nbsp;</span>
                               <span className="text-sm">&nbsp;</span>
                             </div>
                           ) : null}

--- a/frontend/src/components/ui/connect/log-explorer.tsx
+++ b/frontend/src/components/ui/connect/log-explorer.tsx
@@ -212,6 +212,18 @@ interface LogExplorerProps {
 
 export function LogExplorer({ pipeline, serverless, enableLiveView = false, title }: LogExplorerProps) {
   const [liveViewEnabled, setLiveViewEnabled] = useState(false);
+  const [pageIndex, setPageIndex] = useState(0);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [selectedMessage, setSelectedMessage] = useState<TopicMessage | null>(null);
+
+  // Switching live/history swaps the dataset (and its ordering), so reset to the
+  // first page and drop sorting — otherwise a stale page index hides new logs.
+  const setLiveView = (enabled: boolean) => {
+    setLiveViewEnabled(enabled);
+    setPageIndex(0);
+    setSorting([]);
+  };
 
   // Sync live mode when the pipeline's enableLiveView prop changes (start/stop transitions).
   // Skip mount — always start in history mode; only react to subsequent transitions.
@@ -219,14 +231,11 @@ export function LogExplorer({ pipeline, serverless, enableLiveView = false, titl
   useEffect(() => {
     if (mountedRef.current) {
       setLiveViewEnabled(enableLiveView);
+      setPageIndex(0);
+      setSorting([]);
     }
     mountedRef.current = true;
   }, [enableLiveView]);
-
-  const [pageIndex, setPageIndex] = useState(0);
-  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
-  const [sorting, setSorting] = useState<SortingState>([]);
-  const [selectedMessage, setSelectedMessage] = useState<TopicMessage | null>(null);
 
   const { messages, phase, error, progress, refresh } = useLogSearch({
     pipelineId: pipeline.id,
@@ -372,6 +381,15 @@ export function LogExplorer({ pipeline, serverless, enableLiveView = false, titl
   const hasProgress = progress.bytesConsumed > 0 || progress.messagesConsumed > 0;
   const pipelineNotRunning = pipeline.state !== Pipeline_State.RUNNING;
 
+  // Clamp back to the first page if filtering (or a smaller dataset) leaves the
+  // current page out of range — otherwise the user is stranded on a blank page.
+  useEffect(() => {
+    const pageCount = Math.ceil(filteredRowCount / pageSize);
+    if (pageCount > 0 && pageIndex > pageCount - 1) {
+      setPageIndex(0);
+    }
+  }, [filteredRowCount, pageSize, pageIndex]);
+
   return (
     <div className="flex min-h-0 flex-col gap-4">
       <div className="flex items-center justify-between gap-2">
@@ -408,8 +426,7 @@ export function LogExplorer({ pipeline, serverless, enableLiveView = false, titl
             disabled={!enableLiveView}
             id="live-view-toggle"
             onCheckedChange={(checked) => {
-              setLiveViewEnabled(checked);
-              setSorting([]);
+              setLiveView(checked);
               if (checked) {
                 actions.removeAllFilters();
               }
@@ -480,11 +497,7 @@ export function LogExplorer({ pipeline, serverless, enableLiveView = false, titl
                         <AlertTitle>Pipeline is not running</AlertTitle>
                         <AlertDescription>
                           Live logs require a running pipeline.{' '}
-                          <button
-                            className="font-medium underline"
-                            onClick={() => setLiveViewEnabled(false)}
-                            type="button"
-                          >
+                          <button className="font-medium underline" onClick={() => setLiveView(false)} type="button">
                             Switch to Recent Logs
                           </button>{' '}
                           to view historical logs.
@@ -514,23 +527,43 @@ export function LogExplorer({ pipeline, serverless, enableLiveView = false, titl
                   </TableRow>
                 );
               }
-              return table.getRowModel().rows.map((row) => (
-                <TableRow
-                  className="cursor-pointer"
-                  key={row.id}
-                  onClick={() => setSelectedMessage(row.original)}
-                >
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell
-                      className="px-3 py-2"
-                      key={cell.id}
-                      style={{ minWidth: cell.column.columnDef.minSize, width: cell.column.getSize() !== TANSTACK_DEFAULT_COLUMN_SIZE ? cell.column.getSize() : undefined }}
-                    >
-                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                    </TableCell>
+              const rows = table.getRowModel().rows;
+              const placeholderColumns = table.getVisibleFlatColumns();
+              // Pad partial pages up to pageSize so the table keeps a constant
+              // height and doesn't jump as logs stream in.
+              const placeholderCount = Math.max(0, pageSize - rows.length);
+              return (
+                <>
+                  {rows.map((row) => (
+                    <TableRow className="cursor-pointer" key={row.id} onClick={() => setSelectedMessage(row.original)}>
+                      {row.getVisibleCells().map((cell) => (
+                        <TableCell
+                          className="px-3 py-2"
+                          key={cell.id}
+                          style={{ minWidth: cell.column.columnDef.minSize, width: cell.column.getSize() !== TANSTACK_DEFAULT_COLUMN_SIZE ? cell.column.getSize() : undefined }}
+                        >
+                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </TableCell>
+                      ))}
+                    </TableRow>
                   ))}
-                </TableRow>
-              ));
+                  {Array.from({ length: placeholderCount }, (_, i) => (
+                    <TableRow aria-hidden className="pointer-events-none" key={`placeholder-${i}`}>
+                      {placeholderColumns.map((column, columnIndex) => (
+                        <TableCell className="px-3 py-2" key={column.id}>
+                          {/* Mirror the Time cell's two-line height so placeholder rows match data rows. */}
+                          {columnIndex === 0 ? (
+                            <div className="flex flex-col leading-tight">
+                              <span className="text-[11px]">&nbsp;</span>
+                              <span className="text-sm">&nbsp;</span>
+                            </div>
+                          ) : null}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  ))}
+                </>
+              );
             })()}
           </TableBody>
         </Table>

--- a/frontend/src/components/ui/connect/log-explorer.tsx
+++ b/frontend/src/components/ui/connect/log-explorer.tsx
@@ -21,7 +21,6 @@ import {
 } from '@tanstack/react-table';
 import { Alert, AlertDescription, AlertTitle } from 'components/redpanda-ui/components/alert';
 import { Badge } from 'components/redpanda-ui/components/badge';
-import { Button } from 'components/redpanda-ui/components/button';
 import { Label } from 'components/redpanda-ui/components/label';
 import { SimpleCodeBlock } from 'components/redpanda-ui/components/code-block';
 import { DataTablePagination } from 'components/redpanda-ui/components/data-table';
@@ -42,7 +41,7 @@ import { type Pipeline, Pipeline_State } from '../../../protogen/redpanda/api/da
 import type { TopicMessage } from '../../../state/rest-interfaces';
 import { TimestampDisplay } from '../../../utils/tsx-utils';
 import { cullText, prettyBytes } from '../../../utils/utils';
-import { RefreshIcon } from 'components/icons';
+import { RefreshButton } from 'components/ui/refresh-button';
 import { ArrowDown, ArrowUp, InfoIcon } from 'lucide-react';
 
 const DEFAULT_PAGE_SIZE = 10;
@@ -305,7 +304,9 @@ export function LogExplorer({ pipeline, serverless, enableLiveView = false, titl
           return (
             <Tooltip>
               <TooltipTrigger asChild>
-                <span className="block truncate text-muted-foreground text-sm">{abbreviateComponentPath(path)}</span>
+                <Text as="span" className="block truncate text-muted-foreground" variant="bodySmall">
+                  {abbreviateComponentPath(path)}
+                </Text>
               </TooltipTrigger>
               <TooltipContent>{path}</TooltipContent>
             </Tooltip>
@@ -415,15 +416,7 @@ export function LogExplorer({ pipeline, serverless, enableLiveView = false, titl
             }}
           />
           </div>
-          <Button
-            data-testid="log-refresh-button"
-            disabled={isSearching}
-            onClick={refresh}
-            size="icon"
-            variant="ghost"
-          >
-            <RefreshIcon className={cn(isSearching && 'animate-spin')} />
-          </Button>
+          <RefreshButton loading={isSearching} onClick={refresh} testId="log-refresh-button" />
         </div>
       </div>
 

--- a/frontend/src/components/ui/connect/log-explorer.tsx
+++ b/frontend/src/components/ui/connect/log-explorer.tsx
@@ -415,7 +415,7 @@ export function LogExplorer({ pipeline, serverless, enableLiveView = false, titl
             <TooltipContent side="top" testId="log-live-tooltip-content">
               {liveViewEnabled
                 ? 'Showing new log messages as they arrive in real time.'
-                : 'Showing log messages from the last 5 hours. Toggle on to see live logs as they arrive.'}
+                : 'Showing the most recent log messages. Toggle on to see live logs as they arrive.'}
             </TooltipContent>
           </Tooltip>
           <Switch
@@ -514,7 +514,7 @@ export function LogExplorer({ pipeline, serverless, enableLiveView = false, titl
                 } else if (liveViewEnabled) {
                   emptyText = 'Listening for new log messages… Switch to Recent Logs to view historical logs.';
                 } else {
-                  emptyText = 'No logs found in the last 5 hours for this pipeline.';
+                  emptyText = 'No logs found for this pipeline.';
                 }
                 return (
                   <TableRow>
@@ -529,9 +529,9 @@ export function LogExplorer({ pipeline, serverless, enableLiveView = false, titl
               }
               const rows = table.getRowModel().rows;
               const placeholderColumns = table.getVisibleFlatColumns();
-              // Pad partial pages up to pageSize so the table keeps a constant
-              // height and doesn't jump as logs stream in.
-              const placeholderCount = Math.max(0, pageSize - rows.length);
+              // Pad partial pages so the table keeps a constant height and doesn't
+              // jump as logs stream in — capped at DEFAULT_PAGE_SIZE rows.
+              const placeholderCount = Math.max(0, Math.min(pageSize, DEFAULT_PAGE_SIZE) - rows.length);
               return (
                 <>
                   {rows.map((row) => (

--- a/frontend/src/components/ui/connect/log-explorer.tsx
+++ b/frontend/src/components/ui/connect/log-explorer.tsx
@@ -34,7 +34,7 @@ import { Heading, Text } from 'components/redpanda-ui/components/typography';
 import { Tooltip, TooltipContent, TooltipTrigger } from 'components/redpanda-ui/components/tooltip';
 import { createFilterFn } from 'components/redpanda-ui/lib/filter-utils';
 import { useDataTableFilter } from 'components/redpanda-ui/lib/use-data-table-filter';
-import { Progress } from 'components/redpanda-ui/components/progress';
+import { cn } from 'components/redpanda-ui/lib/utils';
 import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useLogSearch } from '../../../react-query/api/logs';
@@ -47,10 +47,7 @@ import { ArrowDown, ArrowUp, InfoIcon } from 'lucide-react';
 
 const DEFAULT_PAGE_SIZE = 10;
 
-/**
- * TanStack Table assigns a default size of 150 to columns without an explicit `size`.
- * We use this to detect "unsized" columns and avoid applying a fixed width.
- */
+// TanStack Table's default column size; used to detect "unsized" columns.
 const TANSTACK_DEFAULT_COLUMN_SIZE = 150;
 
 type LogPayload = {
@@ -70,6 +67,16 @@ function getLogPayload(msg: TopicMessage): LogPayload | null {
     return payload as LogPayload;
   }
   return null;
+}
+
+// Component paths (e.g. root.pipeline.processors.1.branch.catch) are long; keep
+// the head + tail so the column stays compact (full path shown on hover).
+function abbreviateComponentPath(path: string): string {
+  const parts = path.split('.');
+  if (parts.length <= 3) {
+    return path;
+  }
+  return `${parts[0]}…${parts.slice(-2).join('.')}`;
 }
 
 type LogLevelVariant = 'destructive-inverted' | 'warning-inverted' | 'info-inverted' | 'neutral-inverted';
@@ -254,7 +261,7 @@ export function LogExplorer({ pipeline, serverless, enableLiveView = false, titl
   const messageTableColumns = useMemo<ColumnDef<TopicMessage>[]>(
     () => [
       {
-        header: 'Timestamp',
+        header: 'Time',
         accessorKey: 'timestamp',
         enableSorting: !liveViewEnabled,
         cell: ({
@@ -263,15 +270,16 @@ export function LogExplorer({ pipeline, serverless, enableLiveView = false, titl
           },
         }) => {
           const d = new Date(timestamp);
+          // Time is the scannable field; date sits muted above, full date/time on hover.
           return (
-            <div className="flex flex-col leading-tight">
-              <span className="text-[11px] text-muted-foreground">{d.toLocaleDateString()}</span>
+            <div className="flex flex-col leading-tight" title={d.toLocaleString()}>
+              <span className="text-[11px] text-muted-foreground tabular-nums">{d.toLocaleDateString()}</span>
               <span className="font-medium text-sm tabular-nums">{d.toLocaleTimeString()}</span>
             </div>
           );
         },
-        minSize: 140,
-        size: 140,
+        minSize: 120,
+        size: 132,
       },
       {
         id: 'level',
@@ -291,12 +299,20 @@ export function LogExplorer({ pipeline, serverless, enableLiveView = false, titl
         enableSorting: !liveViewEnabled,
         cell: ({ row: { original } }) => {
           const path = getLogPayload(original)?.path;
-          return path ? (
-            <Text as="span" className="text-muted-foreground" variant="bodySmall">{path}</Text>
-          ) : null;
+          if (!path) {
+            return null;
+          }
+          return (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="block truncate text-muted-foreground text-sm">{abbreviateComponentPath(path)}</span>
+              </TooltipTrigger>
+              <TooltipContent>{path}</TooltipContent>
+            </Tooltip>
+          );
         },
-        minSize: 140,
-        size: 160,
+        minSize: 150,
+        size: 180,
       },
       {
         id: 'message',
@@ -406,17 +422,12 @@ export function LogExplorer({ pipeline, serverless, enableLiveView = false, titl
             size="icon"
             variant="ghost"
           >
-            <RefreshIcon className={isSearching ? 'animate-spin' : ''} />
+            <RefreshIcon className={cn(isSearching && 'animate-spin')} />
           </Button>
         </div>
       </div>
 
       <div className="relative min-h-0">
-        {isSearching && hasProgress && (
-          <div className="absolute inset-x-0 top-0 z-10">
-            <Progress className="h-1 w-full rounded-none" testId="log-progress-bar" value={null} />
-          </div>
-        )}
         <div className="overflow-auto">
         <Table className="table-fixed" variant="simple">
           <TableHeader>
@@ -424,7 +435,7 @@ export function LogExplorer({ pipeline, serverless, enableLiveView = false, titl
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
                   <TableHead
-                    className={header.column.getCanSort() ? 'cursor-pointer select-none' : ''}
+                    className={cn('px-3', header.column.getCanSort() && 'cursor-pointer select-none')}
                     key={header.id}
                     onClick={header.column.getToggleSortingHandler()}
                     style={{ minWidth: header.column.columnDef.minSize, width: header.getSize() !== TANSTACK_DEFAULT_COLUMN_SIZE ? header.getSize() : undefined }}
@@ -518,6 +529,7 @@ export function LogExplorer({ pipeline, serverless, enableLiveView = false, titl
                 >
                   {row.getVisibleCells().map((cell) => (
                     <TableCell
+                      className="px-3 py-2"
                       key={cell.id}
                       style={{ minWidth: cell.column.columnDef.minSize, width: cell.column.getSize() !== TANSTACK_DEFAULT_COLUMN_SIZE ? cell.column.getSize() : undefined }}
                     >

--- a/frontend/src/components/ui/connect/log-explorer.tsx
+++ b/frontend/src/components/ui/connect/log-explorer.tsx
@@ -217,16 +217,14 @@ export function LogExplorer({ pipeline, serverless, enableLiveView = false, titl
   const [sorting, setSorting] = useState<SortingState>([]);
   const [selectedMessage, setSelectedMessage] = useState<TopicMessage | null>(null);
 
-  // Switching live/history swaps the dataset (and its ordering), so reset to the
-  // first page and drop sorting — otherwise a stale page index hides new logs.
+  // Switching modes swaps the dataset, so reset page + sorting (a stale page index hides new logs).
   const setLiveView = (enabled: boolean) => {
     setLiveViewEnabled(enabled);
     setPageIndex(0);
     setSorting([]);
   };
 
-  // Sync live mode when the pipeline's enableLiveView prop changes (start/stop transitions).
-  // Skip mount — always start in history mode; only react to subsequent transitions.
+  // Sync live mode on enableLiveView changes (start/stop), but never on mount — start in history.
   const mountedRef = useRef(false);
   useEffect(() => {
     if (mountedRef.current) {
@@ -381,8 +379,7 @@ export function LogExplorer({ pipeline, serverless, enableLiveView = false, titl
   const hasProgress = progress.bytesConsumed > 0 || progress.messagesConsumed > 0;
   const pipelineNotRunning = pipeline.state !== Pipeline_State.RUNNING;
 
-  // Clamp back to the first page if filtering (or a smaller dataset) leaves the
-  // current page out of range — otherwise the user is stranded on a blank page.
+  // Clamp to the first page when filtering leaves the current page out of range.
   useEffect(() => {
     const pageCount = Math.ceil(filteredRowCount / pageSize);
     if (pageCount > 0 && pageIndex > pageCount - 1) {
@@ -529,8 +526,7 @@ export function LogExplorer({ pipeline, serverless, enableLiveView = false, titl
               }
               const rows = table.getRowModel().rows;
               const placeholderColumns = table.getVisibleFlatColumns();
-              // Pad partial pages so the table keeps a constant height and doesn't
-              // jump as logs stream in — capped at DEFAULT_PAGE_SIZE rows.
+              // Pad partial pages to a constant height (capped at DEFAULT_PAGE_SIZE) so it doesn't jump.
               const placeholderCount = Math.max(0, Math.min(pageSize, DEFAULT_PAGE_SIZE) - rows.length);
               return (
                 <>

--- a/frontend/src/components/ui/refresh-button.tsx
+++ b/frontend/src/components/ui/refresh-button.tsx
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { RefreshIcon } from 'components/icons';
+import { Button } from 'components/redpanda-ui/components/button';
+import { cn } from 'components/redpanda-ui/lib/utils';
+
+type RefreshButtonProps = {
+  onClick: () => void;
+  /** Spins the icon and (by default) disables the button while a refresh is in flight. */
+  loading?: boolean;
+  disabled?: boolean;
+  label?: string;
+  testId?: string;
+};
+
+// Ghost icon button with a refresh icon that spins while loading. Shared so the
+// throughput card, log explorer, etc. keep a consistent refresh affordance.
+export function RefreshButton({ onClick, loading = false, disabled, label = 'Refresh', testId }: RefreshButtonProps) {
+  return (
+    <Button
+      aria-label={label}
+      data-testid={testId}
+      disabled={disabled ?? loading}
+      onClick={onClick}
+      size="icon"
+      variant="ghost"
+    >
+      <RefreshIcon className={cn('size-4', loading && 'animate-spin')} />
+    </Button>
+  );
+}

--- a/frontend/src/components/ui/refresh-button.tsx
+++ b/frontend/src/components/ui/refresh-button.tsx
@@ -22,8 +22,7 @@ type RefreshButtonProps = {
   testId?: string;
 };
 
-// Ghost icon button with a refresh icon that spins while loading. Shared so the
-// throughput card, log explorer, etc. keep a consistent refresh affordance.
+/** Ghost icon button whose icon spins while `loading`; shared for a consistent refresh affordance. */
 export function RefreshButton({ onClick, loading = false, disabled, label = 'Refresh', testId }: RefreshButtonProps) {
   return (
     <Button

--- a/frontend/src/components/ui/yaml/whitespace.test.ts
+++ b/frontend/src/components/ui/yaml/whitespace.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { normalizePastedWhitespace } from './whitespace';
+
+const NBSP = String.fromCharCode(0xa0);
+const EM_SPACE = String.fromCharCode(0x2003);
+
+describe('normalizePastedWhitespace', () => {
+  it('replaces non-breaking-space indentation with regular spaces', () => {
+    const pasted = `input:\n${NBSP}${NBSP}redpanda:\n${NBSP}${NBSP}${NBSP}${NBSP}seed_brokers: []`;
+    expect(normalizePastedWhitespace(pasted)).toBe('input:\n  redpanda:\n    seed_brokers: []');
+  });
+
+  it('normalizes other unicode space separators', () => {
+    expect(normalizePastedWhitespace(`a${EM_SPACE}b`)).toBe('a b');
+  });
+
+  it('leaves regular spaces and content unchanged', () => {
+    const valid = 'input:\n  redpanda: {}\n';
+    expect(normalizePastedWhitespace(valid)).toBe(valid);
+  });
+});

--- a/frontend/src/components/ui/yaml/whitespace.ts
+++ b/frontend/src/components/ui/yaml/whitespace.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+// Invisible space separators (esp. U+00A0) sneak in when pasting config from
+// docs/chat. YAML only accepts U+0020 for indentation, so they silently break
+// parsing. Built from code points so the source stays ASCII.
+const INVISIBLE_SPACE_CODE_POINTS = [
+  0xa0, 0x1680, 0x2000, 0x2001, 0x2002, 0x2003, 0x2004, 0x2005, 0x2006, 0x2007, 0x2008, 0x2009, 0x200a, 0x202f, 0x205f,
+  0x3000,
+];
+const INVISIBLE_SPACES = new RegExp(
+  `[${INVISIBLE_SPACE_CODE_POINTS.map((code) => String.fromCharCode(code)).join('')}]`,
+  'g'
+);
+
+export function normalizePastedWhitespace(text: string): string {
+  return text.replace(INVISIBLE_SPACES, ' ');
+}

--- a/frontend/src/components/ui/yaml/yaml-editor.tsx
+++ b/frontend/src/components/ui/yaml/yaml-editor.tsx
@@ -16,6 +16,8 @@ import type { JSONSchema } from 'monaco-yaml';
 import { configureMonacoYaml, type MonacoYaml, type MonacoYamlOptions } from 'monaco-yaml';
 import { useEffect, useMemo, useRef } from 'react';
 
+import { normalizePastedWhitespace } from './whitespace';
+
 export type YamlEditorProps = EditorProps & {
   'data-testid'?: string;
   transparentBackground?: boolean;
@@ -145,7 +147,6 @@ export const YamlEditor = (props: YamlEditorProps) => {
     yamlRef.current?.update(monacoYamlOptions);
   }, [monacoYamlOptions]);
 
-  // Cleanup on unmount
   useEffect(() => {
     return () => {
       if (yamlRef.current) {
@@ -173,6 +174,20 @@ export const YamlEditor = (props: YamlEditorProps) => {
       defaultLanguage="yaml"
       loading={<LoadingPlaceholder />}
       onMount={(editorInstance) => {
+        // Invisible space separators (esp. U+00A0) pasted from docs/chat aren't
+        // valid YAML indentation and silently break parsing. Replace just the
+        // pasted range so config behaves as written.
+        editorInstance.onDidPaste((e) => {
+          const model = editorInstance.getModel();
+          if (!model) {
+            return;
+          }
+          const pasted = model.getValueInRange(e.range);
+          const normalized = normalizePastedWhitespace(pasted);
+          if (normalized !== pasted) {
+            editorInstance.executeEdits('normalize-pasted-whitespace', [{ range: e.range, text: normalized }]);
+          }
+        });
         onEditorMount?.(editorInstance);
       }}
       options={options}

--- a/frontend/src/react-query/api/logs.test.tsx
+++ b/frontend/src/react-query/api/logs.test.tsx
@@ -205,4 +205,27 @@ describe('useLogSearch history mode', () => {
       expect(result.current.progress.messagesConsumed).toBe(99);
     });
   });
+
+  test('returns history messages newest-first (matches live ordering)', async () => {
+    fakeMessages.push(makeMessage(1), makeMessage(2), makeMessage(3));
+
+    mockListMessages.mockImplementation(async function* () {
+      for (const _msg of fakeMessages) {
+        yield { controlMessage: { case: 'data' as const, value: {} } };
+      }
+      yield { controlMessage: { case: 'done' as const, value: {} } };
+    });
+
+    const { result } = renderHook(
+      () => useLogSearch({ pipelineId: 'pipeline-1', live: false, enabled: true, serverless: false }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.messages).toHaveLength(3);
+    });
+
+    expect(result.current.messages[0].offset).toBe(3);
+    expect(result.current.messages[2].offset).toBe(1);
+  });
 });

--- a/frontend/src/react-query/api/logs.tsx
+++ b/frontend/src/react-query/api/logs.tsx
@@ -11,7 +11,7 @@
 
 import { create } from '@bufbuild/protobuf';
 import { useQuery as useTanstackQuery } from '@tanstack/react-query';
-import { useEffect, useReducer, useRef, useState } from 'react';
+import { useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { ONE_MINUTE, ONE_SECOND } from 'react-query/react-query.utils';
 import { toast as sonnerToast } from 'sonner';
 
@@ -226,7 +226,8 @@ function useLogHistory(opts: { pipelineId: string; serverless: boolean; enabled:
   });
 
   // While streaming, show incremental messages. Once resolved, show query data.
-  const messages = query.data ?? streamingMessages;
+  // Reversed to newest-first so it matches the live tail's ordering.
+  const messages = useMemo(() => (query.data ?? streamingMessages).toReversed(), [query.data, streamingMessages]);
 
   return { messages, phase, progress, error: query.error?.message ?? null, refetch: query.refetch };
 }

--- a/frontend/src/react-query/api/logs.tsx
+++ b/frontend/src/react-query/api/logs.tsx
@@ -87,8 +87,7 @@ function buildRequest(pipelineId: string, live: boolean, serverless: boolean) {
     req.startTimestamp = 0n;
     req.maxResults = LIVE_MAX_RESULTS;
   } else {
-    // Most recent HISTORY_MAX_RESULTS messages (high water mark - maxResults), so
-    // newly produced logs stay visible instead of being capped to the oldest N.
+    // Most recent N (high water mark - maxResults), so new logs stay visible instead of the oldest N.
     req.startOffset = BigInt(PartitionOffsetOrigin.EndMinusResults);
     req.startTimestamp = 0n;
     req.maxResults = HISTORY_MAX_RESULTS;

--- a/frontend/src/react-query/api/logs.tsx
+++ b/frontend/src/react-query/api/logs.tsx
@@ -32,7 +32,6 @@ import { encodeBase64 } from '../../utils/utils';
 const LOGS_TOPIC = '__redpanda.connect.logs';
 const LIVE_MAX_RESULTS = 1000;
 const HISTORY_MAX_RESULTS = 1000;
-const HISTORY_HOURS = 5;
 const LIVE_TIMEOUT_MS = 30 * ONE_MINUTE;
 const HISTORY_TIMEOUT_MS = 30 * ONE_SECOND;
 const FLUSH_INTERVAL_MS = 200;
@@ -88,10 +87,10 @@ function buildRequest(pipelineId: string, live: boolean, serverless: boolean) {
     req.startTimestamp = 0n;
     req.maxResults = LIVE_MAX_RESULTS;
   } else {
-    const startTime = new Date();
-    startTime.setHours(startTime.getHours() - HISTORY_HOURS);
-    req.startOffset = BigInt(PartitionOffsetOrigin.Timestamp);
-    req.startTimestamp = BigInt(startTime.getTime());
+    // Most recent HISTORY_MAX_RESULTS messages (high water mark - maxResults), so
+    // newly produced logs stay visible instead of being capped to the oldest N.
+    req.startOffset = BigInt(PartitionOffsetOrigin.EndMinusResults);
+    req.startTimestamp = 0n;
     req.maxResults = HISTORY_MAX_RESULTS;
   }
 

--- a/frontend/src/state/onboarding-wizard-store.ts
+++ b/frontend/src/state/onboarding-wizard-store.ts
@@ -22,41 +22,56 @@ import type {
 
 export const CONNECT_WIZARD_CONNECTOR_KEY = 'connect-wizard-connections';
 
-const initialWizardData: Partial<OnboardingWizardFormData> = {};
-const initialTopicData: Partial<MinimalTopicData> = {};
-const initialUserData: Partial<MinimalUserData> = {};
+// One store for the Connect onboarding wizard (was four). The `use*` aliases
+// below keep existing consumers working.
+type OnboardingData = Partial<OnboardingWizardFormData> &
+  Partial<MinimalTopicData> &
+  Partial<MinimalUserData> & { yamlContent: string | undefined };
 
-export const useOnboardingWizardDataStore = create<
-  Partial<OnboardingWizardFormData> & {
-    setWizardData: (data: Partial<OnboardingWizardFormData>) => void;
-    reset: () => void;
-    hasHydrated: boolean;
-    setHasHydrated: (state: boolean) => void;
-  }
->()(
+type OnboardingStore = OnboardingData & {
+  hasHydrated: boolean;
+  setWizardData: (data: Partial<OnboardingWizardFormData>) => void;
+  setTopicData: (data: Partial<MinimalTopicData>) => void;
+  setUserData: (data: Partial<MinimalUserData>) => void;
+  setYamlContent: (data: { yamlContent: string | undefined }) => void;
+  setHasHydrated: (state: boolean) => void;
+  reset: () => void;
+};
+
+const initialData: OnboardingData = { yamlContent: undefined };
+
+export const useOnboardingStore = create<OnboardingStore>()(
   persist(
     (set, get) => ({
-      ...initialWizardData,
+      ...initialData,
       hasHydrated: false,
       setWizardData: (data) => set(data),
+      setTopicData: (data) => set(data),
+      setUserData: (data) => set(data),
+      setYamlContent: (data) => set(data),
+      setHasHydrated: (state) => set({ hasHydrated: state }),
       reset: () => {
         sessionStorage.removeItem(CONNECT_WIZARD_CONNECTOR_KEY);
+        // replace: true clears all data while preserving the action methods.
         return set(
           {
-            ...initialWizardData,
-            setWizardData: get().setWizardData,
-            reset: get().reset,
+            ...initialData,
             hasHydrated: false,
+            setWizardData: get().setWizardData,
+            setTopicData: get().setTopicData,
+            setUserData: get().setUserData,
+            setYamlContent: get().setYamlContent,
             setHasHydrated: get().setHasHydrated,
+            reset: get().reset,
           },
           true
         );
       },
-      setHasHydrated: (state) => set({ hasHydrated: state }),
     }),
     {
       name: CONNECT_WIZARD_CONNECTOR_KEY,
-      storage: createFlatStorage<Partial<OnboardingWizardFormData>>(),
+      storage: createFlatStorage<Pick<OnboardingWizardFormData, 'input' | 'output'>>(),
+      // Only input/output connections persist; topic/user/yaml are transient.
       partialize: (state) => ({
         input: state.input,
         output: state.output,
@@ -68,64 +83,34 @@ export const useOnboardingWizardDataStore = create<
   )
 );
 
-export const useOnboardingTopicDataStore = create<
-  Partial<MinimalTopicData> & {
-    setTopicData: (data: Partial<MinimalTopicData>) => void;
-    reset: () => void;
-  }
->()((set, get) => ({
-  ...initialTopicData,
-  setTopicData: (data) => set(data),
-  reset: () => set({ ...initialTopicData, setTopicData: get().setTopicData, reset: get().reset }, true),
-}));
+// Backward-compatible aliases — all resolve to the single store above.
+export const useOnboardingWizardDataStore = useOnboardingStore;
+export const useOnboardingTopicDataStore = useOnboardingStore;
+export const useOnboardingUserDataStore = useOnboardingStore;
+export const useOnboardingYamlContentStore = useOnboardingStore;
 
-export const useOnboardingUserDataStore = create<
-  Partial<MinimalUserData> & {
-    setUserData: (data: Partial<MinimalUserData>) => void;
-    reset: () => void;
-  }
->()((set, get) => ({
-  ...initialUserData,
-  setUserData: (data) => set(data),
-  reset: () => set({ ...initialUserData, setUserData: get().setUserData, reset: get().reset }, true),
-}));
+export const useResetOnboardingWizardStore = () => useCallback(() => useOnboardingStore.getState().reset(), []);
 
-type OnboardingYamlContent = {
-  yamlContent: undefined | string;
-};
+// Strip store metadata, leaving only the data fields.
+function onboardingData(state: OnboardingStore): OnboardingData {
+  const {
+    setWizardData: _setWizardData,
+    setTopicData: _setTopicData,
+    setUserData: _setUserData,
+    setYamlContent: _setYamlContent,
+    setHasHydrated: _setHasHydrated,
+    reset: _reset,
+    hasHydrated: _hasHydrated,
+    ...data
+  } = state;
+  return data;
+}
 
-const initialYamlContent: OnboardingYamlContent = {
-  yamlContent: undefined,
-};
-
-export const useOnboardingYamlContentStore = create<
-  OnboardingYamlContent & {
-    setYamlContent: (data: OnboardingYamlContent) => void;
-    reset: () => void;
-  }
->()((set, get) => ({
-  ...initialYamlContent,
-  setYamlContent: (data) => set(data),
-  reset: () => set({ ...initialYamlContent, setYamlContent: get().setYamlContent, reset: get().reset }, true),
-}));
-
-export const useResetOnboardingWizardStore = () =>
-  useCallback(() => {
-    useOnboardingWizardDataStore.getState().reset();
-    useOnboardingTopicDataStore.getState().reset();
-    useOnboardingUserDataStore.getState().reset();
-    useOnboardingYamlContentStore.getState().reset();
-  }, []);
-
-/**
- * Read wizard connection data from the Zustand store, falling back to session storage.
- * The persist middleware hydrates once at store creation — if CloudV2 writes to session
- * storage and then does a client-side navigation (no full reload), the store may have
- * hydrated before the data was set. This function handles that race condition.
- */
+// Read connection data, falling back to session storage to cover the race where
+// the store hydrated before CloudV2 wrote the data (client-side nav, no reload).
 export function getWizardConnectionData(): Pick<OnboardingWizardFormData, 'input' | 'output'> {
-  let input = useOnboardingWizardDataStore.getState().input;
-  let output = useOnboardingWizardDataStore.getState().output;
+  let input = useOnboardingStore.getState().input;
+  let output = useOnboardingStore.getState().output;
 
   if (!(input || output)) {
     try {
@@ -135,7 +120,7 @@ export function getWizardConnectionData(): Pick<OnboardingWizardFormData, 'input
         input = parsed.input;
         output = parsed.output;
         // Sync the store so other consumers see the data
-        useOnboardingWizardDataStore.getState().setWizardData({ input, output });
+        useOnboardingStore.getState().setWizardData({ input, output });
       }
     } catch {
       // Ignore malformed session storage
@@ -145,40 +130,16 @@ export function getWizardConnectionData(): Pick<OnboardingWizardFormData, 'input
   return { input, output };
 }
 
-// Imperative API for non-hook contexts (class components, utility functions)
+// Imperative API for non-hook contexts (class components, utility functions).
 export const onboardingWizardStore = {
-  getWizardData: () => {
-    const {
-      setWizardData: _,
-      reset: __,
-      hasHydrated: ___,
-      setHasHydrated: ____,
-      ...data
-    } = useOnboardingWizardDataStore.getState();
-    return data;
-  },
-  getTopicData: () => {
-    const { setTopicData: _, reset: __, ...data } = useOnboardingTopicDataStore.getState();
-    return data;
-  },
-  getUserData: () => {
-    const { setUserData: _, reset: __, ...data } = useOnboardingUserDataStore.getState();
-    return data;
-  },
-  getYamlContent: () => {
-    const { setYamlContent: _, reset: __, ...data } = useOnboardingYamlContentStore.getState();
-    return data;
-  },
-  hasHydrated: () => useOnboardingWizardDataStore.getState().hasHydrated,
-  setWizardData: (data: Partial<OnboardingWizardFormData>) =>
-    useOnboardingWizardDataStore.getState().setWizardData(data),
-  setTopicData: (data: Partial<MinimalTopicData>) => useOnboardingTopicDataStore.getState().setTopicData(data),
-  setUserData: (data: Partial<MinimalUserData>) => useOnboardingUserDataStore.getState().setUserData(data),
-  setYamlContent: (data: OnboardingYamlContent) => useOnboardingYamlContentStore.getState().setYamlContent(data),
-  reset: () => {
-    useOnboardingWizardDataStore.getState().reset();
-    useOnboardingTopicDataStore.getState().reset();
-    useOnboardingUserDataStore.getState().reset();
-    useOnboardingYamlContentStore.getState().reset();
-  },
+  getWizardData: () => onboardingData(useOnboardingStore.getState()),
+  getTopicData: () => onboardingData(useOnboardingStore.getState()),
+  getUserData: () => onboardingData(useOnboardingStore.getState()),
+  getYamlContent: () => onboardingData(useOnboardingStore.getState()),
+  hasHydrated: () => useOnboardingStore.getState().hasHydrated,
+  setWizardData: (data: Partial<OnboardingWizardFormData>) => useOnboardingStore.getState().setWizardData(data),
+  setTopicData: (data: Partial<MinimalTopicData>) => useOnboardingStore.getState().setTopicData(data),
+  setUserData: (data: Partial<MinimalUserData>) => useOnboardingStore.getState().setUserData(data),
+  setYamlContent: (data: { yamlContent: string | undefined }) => useOnboardingStore.getState().setYamlContent(data),
+  reset: () => useOnboardingStore.getState().reset(),
 };

--- a/frontend/src/state/rpcn-wizard-store.test.tsx
+++ b/frontend/src/state/rpcn-wizard-store.test.tsx
@@ -18,29 +18,27 @@ import { act, renderHook } from '@testing-library/react';
 
 import {
   CONNECT_WIZARD_CONNECTOR_KEY,
-  onboardingWizardStore,
-  useOnboardingTopicDataStore,
-  useOnboardingUserDataStore,
-  useOnboardingWizardDataStore,
-  useResetOnboardingWizardStore,
-} from './onboarding-wizard-store';
+  rpcnWizardStore,
+  useResetRpcnWizardStore,
+  useRpcnWizardStore,
+} from './rpcn-wizard-store';
 import type { OnboardingWizardFormData } from '../components/pages/rp-connect/types/wizard';
 
-describe('Onboarding Wizard Store', () => {
+describe('RPCN Wizard Store', () => {
   beforeEach(() => {
     sessionStorage.clear();
   });
 
-  describe('useOnboardingWizardDataStore', () => {
+  describe('connection data & persistence', () => {
     test('should initialize with empty state', () => {
-      const { result } = renderHook(() => useOnboardingWizardDataStore());
+      const { result } = renderHook(() => useRpcnWizardStore());
 
       expect(result.current.input).toBeUndefined();
       expect(result.current.output).toBeUndefined();
     });
 
     test('should set wizard data', () => {
-      const { result } = renderHook(() => useOnboardingWizardDataStore());
+      const { result } = renderHook(() => useRpcnWizardStore());
 
       const wizardData: Partial<OnboardingWizardFormData> = {
         input: {
@@ -57,7 +55,7 @@ describe('Onboarding Wizard Store', () => {
     });
 
     test('should merge wizard data on multiple sets', () => {
-      const { result } = renderHook(() => useOnboardingWizardDataStore());
+      const { result } = renderHook(() => useRpcnWizardStore());
 
       act(() => {
         result.current.setWizardData({
@@ -76,7 +74,7 @@ describe('Onboarding Wizard Store', () => {
     });
 
     test('should reset wizard data completely', () => {
-      const { result } = renderHook(() => useOnboardingWizardDataStore());
+      const { result } = renderHook(() => useRpcnWizardStore());
 
       act(() => {
         result.current.setWizardData({
@@ -97,7 +95,7 @@ describe('Onboarding Wizard Store', () => {
     });
 
     test('should preserve action methods after reset', () => {
-      const { result } = renderHook(() => useOnboardingWizardDataStore());
+      const { result } = renderHook(() => useRpcnWizardStore());
 
       act(() => {
         result.current.setWizardData({ input: { connectionName: 'test', connectionType: 'input' } });
@@ -118,7 +116,7 @@ describe('Onboarding Wizard Store', () => {
     });
 
     test('should persist wizard data to sessionStorage', () => {
-      const { result } = renderHook(() => useOnboardingWizardDataStore());
+      const { result } = renderHook(() => useRpcnWizardStore());
 
       const wizardData: Partial<OnboardingWizardFormData> = {
         input: { connectionName: 'redpanda', connectionType: 'input' },
@@ -136,7 +134,7 @@ describe('Onboarding Wizard Store', () => {
     });
 
     test('should clear sessionStorage on reset', () => {
-      const { result } = renderHook(() => useOnboardingWizardDataStore());
+      const { result } = renderHook(() => useRpcnWizardStore());
 
       act(() => {
         result.current.setWizardData({ input: { connectionName: 'test', connectionType: 'input' } });
@@ -156,13 +154,13 @@ describe('Onboarding Wizard Store', () => {
     });
 
     test('should initialize with hasHydrated as false', () => {
-      const { result } = renderHook(() => useOnboardingWizardDataStore());
+      const { result } = renderHook(() => useRpcnWizardStore());
 
       expect(result.current.hasHydrated).toBe(false);
     });
 
     test('should reset hasHydrated to false on reset', () => {
-      const { result } = renderHook(() => useOnboardingWizardDataStore());
+      const { result } = renderHook(() => useRpcnWizardStore());
 
       // Simulate hydration complete
       act(() => {
@@ -186,7 +184,7 @@ describe('Onboarding Wizard Store', () => {
     });
 
     test('should NOT persist hasHydrated to sessionStorage', () => {
-      const { result } = renderHook(() => useOnboardingWizardDataStore());
+      const { result } = renderHook(() => useRpcnWizardStore());
 
       act(() => {
         result.current.setWizardData({ input: { connectionName: 'test', connectionType: 'input' } });
@@ -204,7 +202,7 @@ describe('Onboarding Wizard Store', () => {
     });
 
     test('should allow setting hasHydrated', () => {
-      const { result } = renderHook(() => useOnboardingWizardDataStore());
+      const { result } = renderHook(() => useRpcnWizardStore());
 
       expect(result.current.hasHydrated).toBe(false);
 
@@ -216,15 +214,15 @@ describe('Onboarding Wizard Store', () => {
     });
   });
 
-  describe('useOnboardingTopicDataStore', () => {
+  describe('topic data', () => {
     test('should initialize with empty state', () => {
-      const { result } = renderHook(() => useOnboardingTopicDataStore());
+      const { result } = renderHook(() => useRpcnWizardStore());
 
       expect(result.current.topicName).toBeUndefined();
     });
 
     test('should set topic data', () => {
-      const { result } = renderHook(() => useOnboardingTopicDataStore());
+      const { result } = renderHook(() => useRpcnWizardStore());
 
       act(() => {
         result.current.setTopicData({ topicName: 'my-topic' });
@@ -234,7 +232,7 @@ describe('Onboarding Wizard Store', () => {
     });
 
     test('should reset topic data completely', () => {
-      const { result } = renderHook(() => useOnboardingTopicDataStore());
+      const { result } = renderHook(() => useRpcnWizardStore());
 
       act(() => {
         result.current.setTopicData({ topicName: 'my-topic' });
@@ -250,7 +248,7 @@ describe('Onboarding Wizard Store', () => {
     });
 
     test('should NOT persist to sessionStorage', () => {
-      const { result } = renderHook(() => useOnboardingTopicDataStore());
+      const { result } = renderHook(() => useRpcnWizardStore());
 
       act(() => {
         result.current.setTopicData({ topicName: 'my-topic' });
@@ -263,7 +261,7 @@ describe('Onboarding Wizard Store', () => {
     });
 
     test('should preserve action methods after reset', () => {
-      const { result } = renderHook(() => useOnboardingTopicDataStore());
+      const { result } = renderHook(() => useRpcnWizardStore());
 
       act(() => {
         result.current.setTopicData({ topicName: 'topic-1' });
@@ -284,16 +282,16 @@ describe('Onboarding Wizard Store', () => {
     });
   });
 
-  describe('useOnboardingUserDataStore', () => {
+  describe('user data', () => {
     test('should initialize with empty state', () => {
-      const { result } = renderHook(() => useOnboardingUserDataStore());
+      const { result } = renderHook(() => useRpcnWizardStore());
 
       expect(result.current.username).toBeUndefined();
       expect(result.current.saslMechanism).toBeUndefined();
     });
 
     test('should set user data', () => {
-      const { result } = renderHook(() => useOnboardingUserDataStore());
+      const { result } = renderHook(() => useRpcnWizardStore());
 
       act(() => {
         result.current.setUserData({
@@ -307,7 +305,7 @@ describe('Onboarding Wizard Store', () => {
     });
 
     test('should reset user data completely', () => {
-      const { result } = renderHook(() => useOnboardingUserDataStore());
+      const { result } = renderHook(() => useRpcnWizardStore());
 
       act(() => {
         result.current.setUserData({
@@ -327,7 +325,7 @@ describe('Onboarding Wizard Store', () => {
     });
 
     test('should NOT persist to sessionStorage', () => {
-      const { result } = renderHook(() => useOnboardingUserDataStore());
+      const { result } = renderHook(() => useRpcnWizardStore());
 
       act(() => {
         result.current.setUserData({ username: 'test-user' });
@@ -340,7 +338,7 @@ describe('Onboarding Wizard Store', () => {
     });
 
     test('should preserve action methods after reset', () => {
-      const { result } = renderHook(() => useOnboardingUserDataStore());
+      const { result } = renderHook(() => useRpcnWizardStore());
 
       act(() => {
         result.current.setUserData({ username: 'user-1' });
@@ -361,12 +359,12 @@ describe('Onboarding Wizard Store', () => {
     });
   });
 
-  describe('useResetOnboardingWizardStore', () => {
+  describe('useResetRpcnWizardStore', () => {
     test('should reset all three stores', () => {
-      const wizardResult = renderHook(() => useOnboardingWizardDataStore()).result;
-      const topicResult = renderHook(() => useOnboardingTopicDataStore()).result;
-      const userResult = renderHook(() => useOnboardingUserDataStore()).result;
-      const { result: resetResult } = renderHook(() => useResetOnboardingWizardStore());
+      const wizardResult = renderHook(() => useRpcnWizardStore()).result;
+      const topicResult = renderHook(() => useRpcnWizardStore()).result;
+      const userResult = renderHook(() => useRpcnWizardStore()).result;
+      const { result: resetResult } = renderHook(() => useResetRpcnWizardStore());
 
       // Set data in all stores
       act(() => {
@@ -390,7 +388,7 @@ describe('Onboarding Wizard Store', () => {
     });
 
     test('should return stable callback reference', () => {
-      const { result, rerender } = renderHook(() => useResetOnboardingWizardStore());
+      const { result, rerender } = renderHook(() => useResetRpcnWizardStore());
 
       const firstCallback = result.current;
       rerender();
@@ -400,13 +398,13 @@ describe('Onboarding Wizard Store', () => {
     });
   });
 
-  describe('onboardingWizardStore (Imperative API)', () => {
+  describe('rpcnWizardStore (Imperative API)', () => {
     test('getWizardData should return only data fields', () => {
       act(() => {
-        onboardingWizardStore.setWizardData({ input: { connectionName: 'test', connectionType: 'input' } });
+        rpcnWizardStore.setWizardData({ input: { connectionName: 'test', connectionType: 'input' } });
       });
 
-      const data = onboardingWizardStore.getWizardData();
+      const data = rpcnWizardStore.getWizardData();
 
       expect(data.input).toBeDefined();
 
@@ -420,10 +418,10 @@ describe('Onboarding Wizard Store', () => {
 
     test('getTopicData should return only data fields', () => {
       act(() => {
-        onboardingWizardStore.setTopicData({ topicName: 'my-topic' });
+        rpcnWizardStore.setTopicData({ topicName: 'my-topic' });
       });
 
-      const data = onboardingWizardStore.getTopicData();
+      const data = rpcnWizardStore.getTopicData();
 
       expect(data.topicName).toBe('my-topic');
 
@@ -437,10 +435,10 @@ describe('Onboarding Wizard Store', () => {
 
     test('getUserData should return only data fields', () => {
       act(() => {
-        onboardingWizardStore.setUserData({ username: 'test-user' });
+        rpcnWizardStore.setUserData({ username: 'test-user' });
       });
 
-      const data = onboardingWizardStore.getUserData();
+      const data = rpcnWizardStore.getUserData();
 
       expect(data.username).toBe('test-user');
 
@@ -454,43 +452,43 @@ describe('Onboarding Wizard Store', () => {
 
     test('reset should clear all stores', () => {
       act(() => {
-        onboardingWizardStore.setWizardData({ input: { connectionName: 'test', connectionType: 'input' } });
-        onboardingWizardStore.setTopicData({ topicName: 'my-topic' });
-        onboardingWizardStore.setUserData({ username: 'test-user' });
+        rpcnWizardStore.setWizardData({ input: { connectionName: 'test', connectionType: 'input' } });
+        rpcnWizardStore.setTopicData({ topicName: 'my-topic' });
+        rpcnWizardStore.setUserData({ username: 'test-user' });
       });
 
-      expect(onboardingWizardStore.getWizardData().input).toBeDefined();
-      expect(onboardingWizardStore.getTopicData().topicName).toBe('my-topic');
-      expect(onboardingWizardStore.getUserData().username).toBe('test-user');
+      expect(rpcnWizardStore.getWizardData().input).toBeDefined();
+      expect(rpcnWizardStore.getTopicData().topicName).toBe('my-topic');
+      expect(rpcnWizardStore.getUserData().username).toBe('test-user');
 
       act(() => {
-        onboardingWizardStore.reset();
+        rpcnWizardStore.reset();
       });
 
-      expect(onboardingWizardStore.getWizardData().input).toBeUndefined();
-      expect(onboardingWizardStore.getTopicData().topicName).toBeUndefined();
-      expect(onboardingWizardStore.getUserData().username).toBeUndefined();
+      expect(rpcnWizardStore.getWizardData().input).toBeUndefined();
+      expect(rpcnWizardStore.getTopicData().topicName).toBeUndefined();
+      expect(rpcnWizardStore.getUserData().username).toBeUndefined();
     });
 
     test('hasHydrated should return hydration status', () => {
       // Initially false
-      expect(onboardingWizardStore.hasHydrated()).toBe(false);
+      expect(rpcnWizardStore.hasHydrated()).toBe(false);
 
       // Set to true
       act(() => {
-        useOnboardingWizardDataStore.getState().setHasHydrated(true);
+        useRpcnWizardStore.getState().setHasHydrated(true);
       });
 
-      expect(onboardingWizardStore.hasHydrated()).toBe(true);
+      expect(rpcnWizardStore.hasHydrated()).toBe(true);
     });
 
     test('getWizardData should NOT include hasHydrated in returned data', () => {
       act(() => {
-        onboardingWizardStore.setWizardData({ input: { connectionName: 'test', connectionType: 'input' } });
-        useOnboardingWizardDataStore.getState().setHasHydrated(true);
+        rpcnWizardStore.setWizardData({ input: { connectionName: 'test', connectionType: 'input' } });
+        useRpcnWizardStore.getState().setHasHydrated(true);
       });
 
-      const data = onboardingWizardStore.getWizardData();
+      const data = rpcnWizardStore.getWizardData();
 
       expect(data.input).toBeDefined();
       expect(Object.hasOwn(data, 'hasHydrated')).toBe(false);

--- a/frontend/src/state/rpcn-wizard-store.ts
+++ b/frontend/src/state/rpcn-wizard-store.ts
@@ -126,10 +126,9 @@ export function getWizardConnectionData(): Pick<OnboardingWizardFormData, 'input
 
 // Imperative API for non-hook contexts (class components, utility functions).
 export const rpcnWizardStore = {
-  getWizardData: () => rpcnWizardData(useRpcnWizardStore.getState()),
-  getTopicData: () => rpcnWizardData(useRpcnWizardStore.getState()),
-  getUserData: () => rpcnWizardData(useRpcnWizardStore.getState()),
-  getYamlContent: () => rpcnWizardData(useRpcnWizardStore.getState()),
+  getWizardData: (): Partial<OnboardingWizardFormData> => rpcnWizardData(useRpcnWizardStore.getState()),
+  getTopicData: (): Partial<MinimalTopicData> => rpcnWizardData(useRpcnWizardStore.getState()),
+  getUserData: (): Partial<MinimalUserData> => rpcnWizardData(useRpcnWizardStore.getState()),
   hasHydrated: () => useRpcnWizardStore.getState().hasHydrated,
   setWizardData: (data: Partial<OnboardingWizardFormData>) => useRpcnWizardStore.getState().setWizardData(data),
   setTopicData: (data: Partial<MinimalTopicData>) => useRpcnWizardStore.getState().setTopicData(data),

--- a/frontend/src/state/rpcn-wizard-store.ts
+++ b/frontend/src/state/rpcn-wizard-store.ts
@@ -100,8 +100,10 @@ function rpcnWizardData(state: RpcnWizardStore): RpcnWizardData {
   return data;
 }
 
-// Read connection data, falling back to session storage to cover the race where
-// the store hydrated before CloudV2 wrote the data (client-side nav, no reload).
+/**
+ * Read connection data, falling back to session storage for the race where the
+ * store hydrated before CloudV2 wrote it (client-side nav, no full reload).
+ */
 export function getWizardConnectionData(): Pick<OnboardingWizardFormData, 'input' | 'output'> {
   let input = useRpcnWizardStore.getState().input;
   let output = useRpcnWizardStore.getState().output;
@@ -124,7 +126,7 @@ export function getWizardConnectionData(): Pick<OnboardingWizardFormData, 'input
   return { input, output };
 }
 
-// Imperative API for non-hook contexts (class components, utility functions).
+/** Imperative API for non-hook contexts (class components, utility functions). */
 export const rpcnWizardStore = {
   getWizardData: (): Partial<OnboardingWizardFormData> => rpcnWizardData(useRpcnWizardStore.getState()),
   getTopicData: (): Partial<MinimalTopicData> => rpcnWizardData(useRpcnWizardStore.getState()),

--- a/frontend/src/state/rpcn-wizard-store.ts
+++ b/frontend/src/state/rpcn-wizard-store.ts
@@ -22,13 +22,13 @@ import type {
 
 export const CONNECT_WIZARD_CONNECTOR_KEY = 'connect-wizard-connections';
 
-// One store for the Connect onboarding wizard (was four). The `use*` aliases
-// below keep existing consumers working.
-type OnboardingData = Partial<OnboardingWizardFormData> &
+// Single store for the RPCN (Redpanda Connect) creation wizard, grouping the
+// connection / topic / user / yaml slices that were once separate stores.
+type RpcnWizardData = Partial<OnboardingWizardFormData> &
   Partial<MinimalTopicData> &
   Partial<MinimalUserData> & { yamlContent: string | undefined };
 
-type OnboardingStore = OnboardingData & {
+type RpcnWizardStore = RpcnWizardData & {
   hasHydrated: boolean;
   setWizardData: (data: Partial<OnboardingWizardFormData>) => void;
   setTopicData: (data: Partial<MinimalTopicData>) => void;
@@ -38,9 +38,9 @@ type OnboardingStore = OnboardingData & {
   reset: () => void;
 };
 
-const initialData: OnboardingData = { yamlContent: undefined };
+const initialData: RpcnWizardData = { yamlContent: undefined };
 
-export const useOnboardingStore = create<OnboardingStore>()(
+export const useRpcnWizardStore = create<RpcnWizardStore>()(
   persist(
     (set, get) => ({
       ...initialData,
@@ -83,16 +83,10 @@ export const useOnboardingStore = create<OnboardingStore>()(
   )
 );
 
-// Backward-compatible aliases — all resolve to the single store above.
-export const useOnboardingWizardDataStore = useOnboardingStore;
-export const useOnboardingTopicDataStore = useOnboardingStore;
-export const useOnboardingUserDataStore = useOnboardingStore;
-export const useOnboardingYamlContentStore = useOnboardingStore;
-
-export const useResetOnboardingWizardStore = () => useCallback(() => useOnboardingStore.getState().reset(), []);
+export const useResetRpcnWizardStore = () => useCallback(() => useRpcnWizardStore.getState().reset(), []);
 
 // Strip store metadata, leaving only the data fields.
-function onboardingData(state: OnboardingStore): OnboardingData {
+function rpcnWizardData(state: RpcnWizardStore): RpcnWizardData {
   const {
     setWizardData: _setWizardData,
     setTopicData: _setTopicData,
@@ -109,8 +103,8 @@ function onboardingData(state: OnboardingStore): OnboardingData {
 // Read connection data, falling back to session storage to cover the race where
 // the store hydrated before CloudV2 wrote the data (client-side nav, no reload).
 export function getWizardConnectionData(): Pick<OnboardingWizardFormData, 'input' | 'output'> {
-  let input = useOnboardingStore.getState().input;
-  let output = useOnboardingStore.getState().output;
+  let input = useRpcnWizardStore.getState().input;
+  let output = useRpcnWizardStore.getState().output;
 
   if (!(input || output)) {
     try {
@@ -120,7 +114,7 @@ export function getWizardConnectionData(): Pick<OnboardingWizardFormData, 'input
         input = parsed.input;
         output = parsed.output;
         // Sync the store so other consumers see the data
-        useOnboardingStore.getState().setWizardData({ input, output });
+        useRpcnWizardStore.getState().setWizardData({ input, output });
       }
     } catch {
       // Ignore malformed session storage
@@ -131,15 +125,15 @@ export function getWizardConnectionData(): Pick<OnboardingWizardFormData, 'input
 }
 
 // Imperative API for non-hook contexts (class components, utility functions).
-export const onboardingWizardStore = {
-  getWizardData: () => onboardingData(useOnboardingStore.getState()),
-  getTopicData: () => onboardingData(useOnboardingStore.getState()),
-  getUserData: () => onboardingData(useOnboardingStore.getState()),
-  getYamlContent: () => onboardingData(useOnboardingStore.getState()),
-  hasHydrated: () => useOnboardingStore.getState().hasHydrated,
-  setWizardData: (data: Partial<OnboardingWizardFormData>) => useOnboardingStore.getState().setWizardData(data),
-  setTopicData: (data: Partial<MinimalTopicData>) => useOnboardingStore.getState().setTopicData(data),
-  setUserData: (data: Partial<MinimalUserData>) => useOnboardingStore.getState().setUserData(data),
-  setYamlContent: (data: { yamlContent: string | undefined }) => useOnboardingStore.getState().setYamlContent(data),
-  reset: () => useOnboardingStore.getState().reset(),
+export const rpcnWizardStore = {
+  getWizardData: () => rpcnWizardData(useRpcnWizardStore.getState()),
+  getTopicData: () => rpcnWizardData(useRpcnWizardStore.getState()),
+  getUserData: () => rpcnWizardData(useRpcnWizardStore.getState()),
+  getYamlContent: () => rpcnWizardData(useRpcnWizardStore.getState()),
+  hasHydrated: () => useRpcnWizardStore.getState().hasHydrated,
+  setWizardData: (data: Partial<OnboardingWizardFormData>) => useRpcnWizardStore.getState().setWizardData(data),
+  setTopicData: (data: Partial<MinimalTopicData>) => useRpcnWizardStore.getState().setTopicData(data),
+  setUserData: (data: Partial<MinimalUserData>) => useRpcnWizardStore.getState().setUserData(data),
+  setYamlContent: (data: { yamlContent: string | undefined }) => useRpcnWizardStore.getState().setYamlContent(data),
+  reset: () => useRpcnWizardStore.getState().reset(),
 };

--- a/frontend/src/utils/pipeline-throughput.utils.test.ts
+++ b/frontend/src/utils/pipeline-throughput.utils.test.ts
@@ -4,6 +4,7 @@ import {
   addSeriesToMap,
   formatChartTimestamp,
   formatTooltipLabel,
+  insertGapMarkers,
   type MergedPoint,
   mergeTimeSeries,
   type TimeSeriesResult,
@@ -94,6 +95,41 @@ describe('mergeTimeSeries', () => {
     const ingress: TimeSeriesResult[] = [{ values: [{ timestamp: { seconds: 100n }, value: 10 }] }];
     const result = mergeTimeSeries(ingress, []);
     expect(result).toEqual([{ timestamp: 100_000, ingress: 10, egress: 0 }]);
+  });
+});
+
+describe('insertGapMarkers', () => {
+  const pt = (timestamp: number, ingress: number): MergedPoint => ({ timestamp, ingress, egress: ingress });
+
+  test('leaves evenly spaced points untouched', () => {
+    const points = [pt(0, 1), pt(60, 2), pt(120, 3)];
+    expect(insertGapMarkers(points)).toEqual(points);
+  });
+
+  test('inserts a null marker inside a larger-than-step gap', () => {
+    // Regular 60s step, then a jump of 600s (service was down).
+    const points = [pt(0, 1), pt(60, 2), pt(660, 3)];
+    const result = insertGapMarkers(points);
+    expect(result).toEqual([pt(0, 1), pt(60, 2), { timestamp: 120, ingress: null, egress: null }, pt(660, 3)]);
+  });
+
+  test('returns fewer than two points unchanged', () => {
+    expect(insertGapMarkers([])).toEqual([]);
+    expect(insertGapMarkers([pt(0, 1)])).toEqual([pt(0, 1)]);
+  });
+
+  test('mergeTimeSeries breaks the line across a no-data gap', () => {
+    const ingress: TimeSeriesResult[] = [
+      {
+        values: [
+          { timestamp: { seconds: 0n }, value: 1 },
+          { timestamp: { seconds: 60n }, value: 2 },
+          { timestamp: { seconds: 660n }, value: 3 },
+        ],
+      },
+    ];
+    const result = mergeTimeSeries(ingress, []);
+    expect(result.some((p) => p.ingress === null)).toBe(true);
   });
 });
 

--- a/frontend/src/utils/pipeline-throughput.utils.ts
+++ b/frontend/src/utils/pipeline-throughput.utils.ts
@@ -32,8 +32,7 @@ export function addSeriesToMap(
   }
 }
 
-// Smallest regular spacing between consecutive points; for a fixed-step range
-// query this is the step itself, so larger gaps stand out against it.
+// Smallest spacing between points — the step for a fixed-step range query.
 function inferStepMs(points: MergedPoint[]): number | null {
   if (points.length < 2) {
     return null;
@@ -48,10 +47,10 @@ function inferStepMs(points: MergedPoint[]): number | null {
   return Number.isFinite(min) ? min : null;
 }
 
-// The backend omits timestamps with no data (e.g. while the pipeline was down),
-// so consecutive points straddle the gap and the chart draws a continuous line
-// across it. Insert a null marker in any larger-than-step gap so the line/area
-// breaks there instead (recharts splits series at nulls when connectNulls=false).
+/**
+ * Insert a null marker into any larger-than-step gap so the chart breaks the line
+ * there (recharts splits at nulls) instead of drawing across a no-data stretch.
+ */
 export function insertGapMarkers(points: MergedPoint[]): MergedPoint[] {
   const step = inferStepMs(points);
   if (step === null) {

--- a/frontend/src/utils/pipeline-throughput.utils.ts
+++ b/frontend/src/utils/pipeline-throughput.utils.ts
@@ -10,7 +10,9 @@
  */
 
 export type TimeSeriesResult = { values: { timestamp?: { seconds: bigint }; value?: number }[]; name?: string };
-export type MergedPoint = { timestamp: number; ingress: number; egress: number };
+// Values are nullable: a null marks a no-data gap so the chart breaks the line
+// there instead of drawing across it (see insertGapMarkers).
+export type MergedPoint = { timestamp: number; ingress: number | null; egress: number | null };
 
 export function addSeriesToMap(
   map: Map<number, MergedPoint>,
@@ -30,11 +32,49 @@ export function addSeriesToMap(
   }
 }
 
+// Smallest regular spacing between consecutive points; for a fixed-step range
+// query this is the step itself, so larger gaps stand out against it.
+function inferStepMs(points: MergedPoint[]): number | null {
+  if (points.length < 2) {
+    return null;
+  }
+  let min = Number.POSITIVE_INFINITY;
+  for (let i = 1; i < points.length; i++) {
+    const delta = points[i].timestamp - points[i - 1].timestamp;
+    if (delta > 0 && delta < min) {
+      min = delta;
+    }
+  }
+  return Number.isFinite(min) ? min : null;
+}
+
+// The backend omits timestamps with no data (e.g. while the pipeline was down),
+// so consecutive points straddle the gap and the chart draws a continuous line
+// across it. Insert a null marker in any larger-than-step gap so the line/area
+// breaks there instead (recharts splits series at nulls when connectNulls=false).
+export function insertGapMarkers(points: MergedPoint[]): MergedPoint[] {
+  const step = inferStepMs(points);
+  if (step === null) {
+    return points;
+  }
+  const maxGap = step * 1.5;
+  const result: MergedPoint[] = [];
+  for (let i = 0; i < points.length; i++) {
+    result.push(points[i]);
+    const next = points[i + 1];
+    if (next && next.timestamp - points[i].timestamp > maxGap) {
+      result.push({ timestamp: points[i].timestamp + step, ingress: null, egress: null });
+    }
+  }
+  return result;
+}
+
 export function mergeTimeSeries(ingressResults: TimeSeriesResult[], egressResults: TimeSeriesResult[]): MergedPoint[] {
   const map = new Map<number, MergedPoint>();
   addSeriesToMap(map, ingressResults, 'ingress');
   addSeriesToMap(map, egressResults, 'egress');
-  return [...map.values()].sort((a, b) => a.timestamp - b.timestamp);
+  const sorted = [...map.values()].sort((a, b) => a.timestamp - b.timestamp);
+  return insertGapMarkers(sorted);
 }
 
 export function formatChartTimestamp(value: number): string {

--- a/frontend/src/utils/time-range.test.ts
+++ b/frontend/src/utils/time-range.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { getEvenlySpacedTimeTicks } from './time-range';
+
+describe('getEvenlySpacedTimeTicks', () => {
+  it('spans the full window inclusive of both endpoints', () => {
+    const ticks = getEvenlySpacedTimeTicks(0, 60_000, 6);
+    expect(ticks).toHaveLength(6);
+    expect(ticks[0]).toBe(0);
+    expect(ticks.at(-1)).toBe(60_000);
+  });
+
+  it('produces evenly spaced ticks', () => {
+    const ticks = getEvenlySpacedTimeTicks(0, 100, 5);
+    expect(ticks).toEqual([0, 25, 50, 75, 100]);
+  });
+
+  it('falls back to a single tick for degenerate ranges', () => {
+    expect(getEvenlySpacedTimeTicks(500, 500)).toEqual([500]);
+    expect(getEvenlySpacedTimeTicks(800, 500)).toEqual([800]);
+    expect(getEvenlySpacedTimeTicks(0, 100, 1)).toEqual([0]);
+  });
+});

--- a/frontend/src/utils/time-range.ts
+++ b/frontend/src/utils/time-range.ts
@@ -51,8 +51,7 @@ export function calculateTimeRange(selectedTimeRange: TimeRange): TimeRangeDates
   };
 }
 
-// Evenly spaced timestamps (ms) across [startMs, endMs] inclusive, for explicit
-// chart axis ticks so the axis can span the full window even when data is sparse.
+/** Evenly spaced timestamps (ms) across [startMs, endMs] inclusive, for chart axis ticks. */
 export function getEvenlySpacedTimeTicks(startMs: number, endMs: number, count = 6): number[] {
   if (count < 2 || endMs <= startMs) {
     return [startMs];

--- a/frontend/src/utils/time-range.ts
+++ b/frontend/src/utils/time-range.ts
@@ -50,3 +50,13 @@ export function calculateTimeRange(selectedTimeRange: TimeRange): TimeRangeDates
     end: now,
   };
 }
+
+// Evenly spaced timestamps (ms) across [startMs, endMs] inclusive, for explicit
+// chart axis ticks so the axis can span the full window even when data is sparse.
+export function getEvenlySpacedTimeTicks(startMs: number, endMs: number, count = 6): number[] {
+  if (count < 2 || endMs <= startMs) {
+    return [startMs];
+  }
+  const step = (endMs - startMs) / (count - 1);
+  return Array.from({ length: count }, (_, i) => Math.round(startMs + step * i));
+}


### PR DESCRIPTION
## Summary

* UX-1266
  * Fixing logs getting stuck on deep pages when switching to live mode 
* UX-1322
  * Adding a way to view the connect config without going to the edit view
* UX-1320
  *  Detect and convert non-breaking-space point when we paste configs into the editor.  Often these get added when being shared through chat services like Slack. 
* UX-1326
  * Throughput graph showing the full selected range, better display 
  * Removing `24h` from logs as the backend only supports up to 12 hours, broken on the master version currently.
* UX-1307  
  * Improving the Log table display to not overflow the text into other lines
* UX-1333
  * Show logs most recent first, matches live mode ordering and more intuitive
  * Fetch logs most recent first, so we don't lose logs newer than 1,000
  * Adding placeholder rows for first 10 items, so there's less UI jumping initially
* Moving some data and actions into Zustand stores for consistency and reduced prop-drilling 
  * Preparing for future work 
* Using Separator component in one more place


### Screenshots   

<img width="45%" alt="Screenshot 2026-06-03 at 12 44 17 PM" src="https://github.com/user-attachments/assets/5ac7de5c-5d08-4f5d-a05e-3b58ee57386e" />


<img width="45%" alt="Screenshot 2026-06-03 at 12 23 49 PM" src="https://github.com/user-attachments/assets/d7c56cc8-d3cc-4621-9926-a60aa2f9d266" />

##### Before

<img width="45%" alt="Screenshot 2026-06-04 at 1 39 22 PM" src="https://github.com/user-attachments/assets/d3ddad56-d892-4a4c-bd38-0f935dab6161" />
<img width="45%" alt="Screenshot 2026-06-04 at 1 40 02 PM" src="https://github.com/user-attachments/assets/801eb3d3-8c5a-4e10-82fd-02025c750b5a" />


