### PR TITLE
fix(connect): handle null value sections in connector config validation

### DIFF
--- a/frontend/src/components/pages/connect/create-connector.test.ts
+++ b/frontend/src/components/pages/connect/create-connector.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type { ConnectorProperty, ConnectorValidationResult } from '../../../state/rest-interfaces';
+import { DataType, PropertyImportance, PropertyWidth } from '../../../state/rest-interfaces';
+import { getDataSource } from './create-connector';
+
+function makeProperty(name: string, errors: string[]): ConnectorProperty {
+  return {
+    definition: {
+      name,
+      type: DataType.String as ConnectorProperty['definition']['type'],
+      required: false,
+      default_value: null,
+      importance: PropertyImportance.High,
+      documentation: '',
+      width: PropertyWidth.Medium,
+      display_name: name,
+      dependents: [],
+      order: 0,
+    },
+    value: {
+      name,
+      value: null,
+      recommended_values: [],
+      errors,
+      visible: true,
+    },
+    metadata: {},
+  };
+}
+
+function makeNullValueProperty(name: string): ConnectorProperty {
+  return {
+    definition: {
+      name,
+      type: DataType.String as ConnectorProperty['definition']['type'],
+      required: false,
+      default_value: null,
+      importance: PropertyImportance.High,
+      documentation: '',
+      width: PropertyWidth.Medium,
+      display_name: name,
+      dependents: [],
+      order: 0,
+    },
+    value: null,
+    metadata: {},
+  };
+}
+
+function makeValidationResult(configs: ConnectorProperty[]): ConnectorValidationResult {
+  return {
+    name: 'test-connector',
+    configs,
+    steps: [],
+  };
+}
+
+describe('getDataSource', () => {
+  it('returns only configs that have errors', () => {
+    const result = makeValidationResult([
+      makeProperty('topic.prefix', ['required field']),
+      makeProperty('database.hostname', []),
+    ]);
+
+    const rows = getDataSource(result);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.name).toBe('topic.prefix');
+  });
+
+  it('does not throw when value is null (Debezium Oracle 3.5.x deprecated properties)', () => {
+    const result = makeValidationResult([
+      makeProperty('topic.prefix', ['required field']),
+      makeNullValueProperty('database.out.server.name'),
+    ]);
+
+    expect(() => getDataSource(result)).not.toThrow();
+  });
+
+  it('excludes null-value configs from results even when mixing with erroring configs', () => {
+    const result = makeValidationResult([
+      makeProperty('topic.prefix', ['required field']),
+      makeNullValueProperty('database.out.server.name'),
+      makeProperty('database.hostname', []),
+    ]);
+
+    const rows = getDataSource(result);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.name).toBe('topic.prefix');
+  });
+
+  it('returns empty array when all configs have no errors', () => {
+    const result = makeValidationResult([
+      makeProperty('topic.prefix', []),
+      makeProperty('database.hostname', []),
+    ]);
+
+    expect(getDataSource(result)).toHaveLength(0);
+  });
+
+  it('returns empty array when configs list is empty', () => {
+    expect(getDataSource(makeValidationResult([]))).toHaveLength(0);
+  });
+});

--- a/frontend/src/components/pages/connect/create-connector.tsx
+++ b/frontend/src/components/pages/connect/create-connector.tsx
@@ -439,7 +439,7 @@ const ConnectorWizard = ({ connectClusters, activeCluster }: ConnectorWizardProp
             propertiesObject ?? {}
           );
 
-          const errorCount = validationResult.configs.sum((x) => x.value.errors.length);
+          const errorCount = validationResult.configs.sum((x) => (x.value?.errors ?? []).length);
 
           if (errorCount > 0) {
             setInvalidValidationResult(validationResult);
@@ -693,9 +693,9 @@ function Review({
   );
 }
 
-function getDataSource(validationResult: ConnectorValidationResult) {
+export function getDataSource(validationResult: ConnectorValidationResult) {
   return validationResult.configs
-    .filter((connectorProperty) => connectorProperty.value.errors.length > 0)
+    .filter((connectorProperty) => (connectorProperty.value?.errors ?? []).length > 0)
     .map((cp) => cp.value);
 }
 

--- a/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
@@ -51,7 +51,7 @@ export const PropertyComponent = (props: { property: Property }) => {
   switch (def.type) {
     case 'STRING':
     case 'CLASS': {
-      const recValues = p.entry.value.recommended_values;
+      const recValues = p.entry.value.recommended_values ?? [];
       if (metadata?.component_type === 'RADIO_GROUP') {
         const options =
           metadata.recommended_values && metadata.recommended_values?.length > 0

--- a/frontend/src/state/connect/state.test.ts
+++ b/frontend/src/state/connect/state.test.ts
@@ -31,6 +31,7 @@ function createMockProperty(overrides: {
   custom_default_value?: string;
   value?: string | null;
   required?: boolean;
+  errors?: string[];
 }): ConnectorProperty {
   return {
     definition: {
@@ -50,9 +51,31 @@ function createMockProperty(overrides: {
       name: overrides.name,
       value: overrides.value ?? null,
       recommended_values: [],
-      errors: [],
+      errors: overrides.errors ?? [],
       visible: true,
     },
+    metadata: {},
+  };
+}
+
+// Creates a ConnectorProperty whose entire value section is null.
+// Kafka Connect returns this for deprecated/inapplicable properties,
+// e.g. database.out.server.name in Debezium Oracle 3.5.x (LogMiner mode).
+function createNullValueProperty(name: string): ConnectorProperty {
+  return {
+    definition: {
+      name,
+      type: DataType.String as ConnectorProperty['definition']['type'],
+      required: false,
+      default_value: null,
+      importance: PropertyImportance.High,
+      documentation: '',
+      width: PropertyWidth.Medium,
+      display_name: name,
+      dependents: [],
+      order: 0,
+    },
+    value: null,
     metadata: {},
   };
 }
@@ -216,6 +239,88 @@ describe('ConnectorPropertiesStore', () => {
       // Assert: custom_default_value strings should be applied
       expect(store.propsByName.get('bool.custom.true')?.value).toBe('true');
       expect(store.propsByName.get('bool.custom.false')?.value).toBe('false');
+    });
+  });
+
+  describe('null value section handling', () => {
+    // Regression tests for Debezium Oracle 3.5.x returning "value": null for
+    // deprecated XStream properties (e.g. database.out.server.name).
+
+    it('excludes properties with a null value section from initConfig', async () => {
+      const properties = [
+        createMockProperty({ name: 'topic.prefix', value: 'cdc_oracle' }),
+        createNullValueProperty('database.out.server.name'),
+      ];
+
+      mockValidateConnectorConfig.mockResolvedValue(createMockValidationResult(properties));
+
+      const store = new ConnectorPropertiesStore('test-cluster', 'io.example.Connector', 'source', undefined);
+      await vi.waitFor(() => expect(store.initPending).toBe(false));
+
+      // The null-value property must be absent; the valid one must be present.
+      expect(store.propsByName.has('database.out.server.name')).toBe(false);
+      expect(store.propsByName.has('topic.prefix')).toBe(true);
+    });
+
+    it('does not throw when validate() response contains a null value section', async () => {
+      // initConfig: only valid properties
+      mockValidateConnectorConfig.mockResolvedValue(
+        createMockValidationResult([createMockProperty({ name: 'topic.prefix', value: 'cdc_oracle' })])
+      );
+
+      const store = new ConnectorPropertiesStore('test-cluster', 'io.example.Connector', 'source', undefined);
+      await vi.waitFor(() => expect(store.initPending).toBe(false));
+
+      // validate(): mix of valid and null-value property
+      mockValidateConnectorConfig.mockResolvedValue(
+        createMockValidationResult([
+          createMockProperty({ name: 'topic.prefix', value: 'cdc_oracle', errors: ['required field'] }),
+          createNullValueProperty('database.out.server.name'),
+        ])
+      );
+
+      await expect(store.validate({ 'topic.prefix': 'cdc_oracle' })).resolves.not.toThrow();
+
+      expect(store.propsByName.has('database.out.server.name')).toBe(false);
+      // Errors reported by the validate response should be reflected on the property.
+      expect(store.propsByName.get('topic.prefix')?.showErrors).toBe(true);
+    });
+
+    it('does not throw when validate() response contains null recommended_values or errors', async () => {
+      mockValidateConnectorConfig.mockResolvedValue(
+        createMockValidationResult([createMockProperty({ name: 'topic.prefix', value: 'cdc_oracle' })])
+      );
+
+      const store = new ConnectorPropertiesStore('test-cluster', 'io.example.Connector', 'source', undefined);
+      await vi.waitFor(() => expect(store.initPending).toBe(false));
+
+      // validate(): property with null recommended_values and null errors inside value
+      const propertyWithNullFields: ConnectorProperty = {
+        definition: {
+          name: 'topic.prefix',
+          type: DataType.String as ConnectorProperty['definition']['type'],
+          required: false,
+          default_value: null,
+          importance: PropertyImportance.High,
+          documentation: '',
+          width: PropertyWidth.Medium,
+          display_name: 'topic.prefix',
+          dependents: [],
+          order: 0,
+        },
+        value: {
+          name: 'topic.prefix',
+          value: 'cdc_oracle',
+          recommended_values: null,
+          errors: null,
+          visible: true,
+        },
+        metadata: {},
+      };
+
+      mockValidateConnectorConfig.mockResolvedValue(createMockValidationResult([propertyWithNullFields]));
+
+      await expect(store.validate({ 'topic.prefix': 'cdc_oracle' })).resolves.not.toThrow();
     });
   });
 

--- a/frontend/src/state/connect/state.ts
+++ b/frontend/src/state/connect/state.ts
@@ -18,6 +18,7 @@ import {
   type ConnectorGroup,
   type ConnectorPossibleStatesLiteral,
   type ConnectorProperty,
+  type ConnectorPropertyWithValue,
   type ConnectorStep,
   DataType,
   PropertyImportance,
@@ -762,9 +763,9 @@ export class ConnectorPropertiesStore {
         }
 
         // Update: recommended values
-        const suggestedSrc = source.entry.value.recommended_values;
+        const suggestedSrc = source.entry.value.recommended_values ?? [];
         const suggestedTar = target.entry.value.recommended_values;
-        if (!suggestedSrc.isEqual(suggestedTar)) {
+        if (suggestedTar != null && !suggestedSrc.isEqual(suggestedTar)) {
           suggestedTar.updateWith(suggestedSrc);
         }
 
@@ -772,28 +773,31 @@ export class ConnectorPropertiesStore {
         target.entry.value.visible = source.entry.value.visible;
 
         // Update: errors
-        if (!target.errors.isEqual(source.errors)) {
-          if (source.errors.length > 0) {
-            target.lastErrors = [...source.errors]; // create copy
+        const targetErrors = target.errors ?? [];
+        const sourceErrors = source.errors ?? [];
+        if (!targetErrors.isEqual(sourceErrors)) {
+          if (sourceErrors.length > 0) {
+            target.lastErrors = [...sourceErrors]; // create copy
           }
 
           // Update
-          target.errors.updateWith(source.errors);
+          targetErrors.updateWith(sourceErrors);
+          target.errors = targetErrors;
 
-          target.showErrors = target.errors.length > 0;
+          target.showErrors = targetErrors.length > 0;
 
           // Show first error
           target.currentErrorIndex = 0;
-          if (target.errors.length > 1) {
+          if (targetErrors.length > 1) {
             // Skip over simple / unhelpful messages
-            const betterStartValue = target.errors.findIndex((x) => !x.includes('which has no default value'));
+            const betterStartValue = targetErrors.findIndex((x) => !x.includes('which has no default value'));
             if (betterStartValue > -1) {
               target.currentErrorIndex = betterStartValue;
             }
           }
 
           // Add or remove from parent group
-          const hasErrors = target.errors.length > 0;
+          const hasErrors = targetErrors.length > 0;
           if (hasErrors) {
             target.propertyGroup.propertiesWithErrors.pushDistinct(target);
           } else {
@@ -849,6 +853,7 @@ export class ConnectorPropertiesStore {
 
     // Create our own properties
     const allProps = properties
+      .filter((p): p is ConnectorPropertyWithValue => p.value != null) // skip properties the API returned with a null value section
       .map((p) => {
         const name = p.definition.name;
         const definitionType = p.definition.type;
@@ -865,7 +870,7 @@ export class ConnectorPropertiesStore {
           isHidden: hiddenProperties.includes(name),
           errors: p.value.errors ?? [],
           lastErrors: [],
-          showErrors: p.value.errors.length > 0,
+          showErrors: (p.value.errors ?? []).length > 0,
           currentErrorIndex: 0,
           lastErrorValue: undefined as unknown,
           propertyGroup: undefined as unknown as PropertyGroup,
@@ -938,7 +943,7 @@ export type PropertyGroup = {
 
 export type Property = {
   name: string;
-  entry: ConnectorProperty;
+  entry: ConnectorPropertyWithValue;
   value: null | string | number | boolean | string[];
   isHidden: boolean; // currently only used for "connector.class"
   errors: string[]; // current errors

--- a/frontend/src/state/rest-interfaces.ts
+++ b/frontend/src/state/rest-interfaces.ts
@@ -1161,17 +1161,29 @@ export type ConnectorProperty = {
     // added by backend
     custom_default_value?: string;
   };
+  // Kafka Connect may return null for deprecated/inapplicable properties (e.g.
+  // database.out.server.name in Debezium Oracle 3.5.x when using LogMiner).
   value: {
     name: string;
     value: null | string;
-    recommended_values: string[];
-    errors: string[];
+    // Kafka Connect may return null for these fields under some conditions
+    recommended_values: string[] | null;
+    errors: string[] | null;
     visible: boolean;
-  };
+  } | null;
   metadata: {
     component_type?: 'RADIO_GROUP';
     recommended_values?: ConnectorRecommendedValueEntry[];
   };
+};
+
+/**
+ * A ConnectorProperty whose value section is guaranteed non-null.
+ * All Property objects produced by createCustomProperties() satisfy this
+ * because null-value entries are filtered out before the map.
+ */
+export type ConnectorPropertyWithValue = ConnectorProperty & {
+  value: NonNullable<ConnectorProperty['value']>;
 };
 
 export const PropertyImportance = {


### PR DESCRIPTION
  Summary
  
  Debezium Oracle 3.5.x returns "value": null for deprecated XStream properties (e.g. database.out.server.name) in the Kafka Connect /connector-plugins/.../config/validate response. The Console UI crashed in three places when encountering these null value sections.

  Crash 1 — createCustomProperties in state.ts:
  TypeError: Cannot read properties of null (reading 'length')
    at p.value.errors.length > 0
  Fix: filter null-value entries with a type predicate before mapping; add errors ?? [] guard.

  Crash 2 — validate() in state.ts:
  TypeError: Cannot read properties of null (reading 'isEqual')
    at suggestedSrc.isEqual(suggestedTar)
    at target.errors.isEqual(source.errors)
  Fix: ?? [] guards before .isEqual() calls.
  
  Crash 3 — transitionConditionMet / getDataSource in create-connector.tsx:
  TypeError: Cannot read properties of null (reading 'length')
    at transitionConditionMet
  Fix: value?.errors ?? [] guard on errorCount sum and getDataSource filter.

  Type changes
  
  - ConnectorProperty.value widened to {...} | null
  - Added ConnectorPropertyWithValue type predicate
  - recommended_values and errors inside value widened to string[] | null

  Test plan 

  - [x] Unit tests added in state.test.ts covering all three null-value crash scenarios
  - [x] Unit tests added in create-connector.test.ts covering getDataSource with null value sections
  - [x] Manually verified end-to-end: Oracle connector creation wizard navigates through all steps without crashing against a Debezium Oracle 3.5.1 connector