### PR TITLE
UX-1264 - Fixing RPCN yaml area screen stretching

### DIFF
--- a/frontend/src/components/pages/rp-connect/pipeline/index.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/index.tsx
@@ -500,20 +500,24 @@ function YamlViewPanel({
     'pointer-events-none absolute inset-x-0 h-4 from-black/10 to-transparent transition-opacity duration-150 dark:from-black/40';
   return (
     <div className="relative h-full overflow-hidden [&_.cursors-layer]:opacity-0">
-      <YamlEditor
-        onEditorMount={handleMount}
-        options={{
-          readOnly: true,
-          domReadOnly: true,
-          renderLineHighlight: 'none',
-          mouseStyle: 'default',
-          padding: { top: 0 },
-          scrollbar: { alwaysConsumeMouseWheel: false, useShadows: false },
-        }}
-        schema={schema}
-        transparentBackground
-        value={configYaml}
-      />
+      {/* Absolutely positioned so Monaco fills the panel without feeding its width
+          back up the layout (which would stretch the page and never shrink back). */}
+      <div className="absolute inset-0">
+        <YamlEditor
+          onEditorMount={handleMount}
+          options={{
+            readOnly: true,
+            domReadOnly: true,
+            renderLineHighlight: 'none',
+            mouseStyle: 'default',
+            padding: { top: 0 },
+            scrollbar: { alwaysConsumeMouseWheel: false, useShadows: false },
+          }}
+          schema={schema}
+          transparentBackground
+          value={configYaml}
+        />
+      </div>
       <div aria-hidden className={cn(edge, 'top-0 bg-gradient-to-b', overflow.top ? 'opacity-100' : 'opacity-0')} />
       <div
         aria-hidden
@@ -605,14 +609,19 @@ function EditorPanel({
                   </Banner>
                 </div>
               ) : null}
-              <YamlEditor
-                onChange={(val) => onYamlChange(val || '')}
-                onEditorMount={onEditorMount}
-                options={slashTipVisible ? { padding: { top: 32 } } : undefined}
-                schema={yamlEditorSchema}
-                transparentBackground
-                value={yamlContent}
-              />
+              {/* Absolutely positioned so Monaco fills the panel but never feeds its
+                  width back up the layout — otherwise automaticLayout grows it and it
+                  never shrinks, stretching the page horizontally. */}
+              <div className="absolute inset-0">
+                <YamlEditor
+                  onChange={(val) => onYamlChange(val || '')}
+                  onEditorMount={onEditorMount}
+                  options={slashTipVisible ? { padding: { top: 32 } } : undefined}
+                  schema={yamlEditorSchema}
+                  transparentBackground
+                  value={yamlContent}
+                />
+              </div>
             </>
           )}
         </div>
@@ -953,7 +962,9 @@ function PipelinePageContent() {
   }, [mode, clearWizardStore, navigate, pipelineId, router]);
 
   return (
-    <div className="flex min-h-[calc(100dvh-10rem)] max-w-[calc(100dvw-(--sidebar-width))] flex-col gap-4">
+    // min-w-0 lets the column shrink; overflow-x-clip guards the page from any stray
+    // horizontal overflow (clip avoids hidden's overflow-y:auto side-effect).
+    <div className="flex min-h-[calc(100dvh-10rem)] min-w-0 flex-col gap-4 overflow-x-clip">
       {/* Page top divider. Negative margin cancels the layout's pt-8. */}
       <div className="-mt-8 border-divider-default border-b" />
       {mode === 'view' && pipeline ? (
@@ -995,8 +1006,9 @@ function PipelinePageContent() {
           </TabsList>
         </Tabs>
       ) : null}
-      {/* Keeps a usable minimum height so the editor/flow panels aren't squished by a tall summary card. */}
-      <div className="flex min-h-[640px] flex-1 rounded-lg border border-border!">
+      {/* min-w-0 + overflow-hidden bound the editor region: it clips its own
+          overflow and never propagates a min-width up to the latch-prone shell. */}
+      <div className="flex min-h-[640px] min-w-0 flex-1 overflow-hidden rounded-lg border border-border!">
         <SidebarPanel
           isPipelineDiagramsEnabled={isPipelineDiagramsEnabled}
           mode={mode}

--- a/frontend/src/components/pages/rp-connect/pipeline/index.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/index.tsx
@@ -624,8 +624,8 @@ function EditorPanel({
       <ResizableHandle withHandle />
       <ResizablePanel collapsible defaultSize={30}>
         <div className="h-full overflow-auto p-4">
-          <div className="flex items-center gap-2">
-            <Heading className="mb-2 text-muted-foreground" level={5}>
+          <div className="mb-3 flex items-center gap-2">
+            <Heading className="text-muted-foreground" level={5}>
               Lint issues
             </Heading>
             {Object.keys(lintHints).length > 0 ? (

--- a/frontend/src/components/pages/rp-connect/pipeline/index.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/index.tsx
@@ -479,10 +479,8 @@ function YamlViewPanel({
   configYaml: string;
   schema: ReturnType<typeof parseYamlEditorSchema>;
 }) {
-  // Track vertical overflow off the editor's scroll position to drive top/bottom
-  // shadows. The registry's useScrollShadow can't help: it observes sentinels in a
-  // native scroll container, but Monaco virtualizes and scrolls internally, so
-  // onDidScrollChange is the only reliable signal.
+  // Top/bottom shadows from Monaco's scroll position (useScrollShadow needs a native
+  // scroll container; Monaco virtualizes, so onDidScrollChange is the only signal).
   const [overflow, setOverflow] = useState({ top: false, bottom: false });
   const handleMount = useCallback((instance: editor.IStandaloneCodeEditor) => {
     const sync = () => {
@@ -500,8 +498,7 @@ function YamlViewPanel({
     'pointer-events-none absolute inset-x-0 h-4 from-black/10 to-transparent transition-opacity duration-150 dark:from-black/40';
   return (
     <div className="relative h-full overflow-hidden [&_.cursors-layer]:opacity-0">
-      {/* Absolutely positioned so Monaco fills the panel without feeding its width
-          back up the layout (which would stretch the page and never shrink back). */}
+      {/* Out of flow so Monaco can't feed its width up the layout and latch the page wide. */}
       <div className="absolute inset-0">
         <YamlEditor
           onEditorMount={handleMount}
@@ -609,9 +606,7 @@ function EditorPanel({
                   </Banner>
                 </div>
               ) : null}
-              {/* Absolutely positioned so Monaco fills the panel but never feeds its
-                  width back up the layout — otherwise automaticLayout grows it and it
-                  never shrinks, stretching the page horizontally. */}
+              {/* Out of flow so Monaco can't feed its width up the layout and latch the page wide. */}
               <div className="absolute inset-0">
                 <YamlEditor
                   onChange={(val) => onYamlChange(val || '')}
@@ -962,8 +957,7 @@ function PipelinePageContent() {
   }, [mode, clearWizardStore, navigate, pipelineId, router]);
 
   return (
-    // min-w-0 lets the column shrink; overflow-x-clip guards the page from any stray
-    // horizontal overflow (clip avoids hidden's overflow-y:auto side-effect).
+    // overflow-x-clip guards against stray horizontal overflow (clip, not hidden, to keep overflow-y visible).
     <div className="flex min-h-[calc(100dvh-10rem)] min-w-0 flex-col gap-4 overflow-x-clip">
       {/* Page top divider. Negative margin cancels the layout's pt-8. */}
       <div className="-mt-8 border-divider-default border-b" />
@@ -1006,8 +1000,7 @@ function PipelinePageContent() {
           </TabsList>
         </Tabs>
       ) : null}
-      {/* min-w-0 + overflow-hidden bound the editor region: it clips its own
-          overflow and never propagates a min-width up to the latch-prone shell. */}
+      {/* min-w-0 + overflow-hidden keep the editor region from propagating width upward. */}
       <div className="flex min-h-[640px] min-w-0 flex-1 overflow-hidden rounded-lg border border-border!">
         <SidebarPanel
           isPipelineDiagramsEnabled={isPipelineDiagramsEnabled}

--- a/frontend/src/components/pages/rp-connect/pipeline/pipeline-header.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/pipeline-header.tsx
@@ -237,8 +237,7 @@ export function PipelineViewHeader({
           >
             Edit pipeline
           </Button>
-          {/* self-center! overrides the registry's self-stretch so the fixed-height separator isn't top-aligned. */}
-          <Separator className="self-center! mx-1 h-6" orientation="vertical" />
+          <Separator className="mx-1 h-6" orientation="vertical" />
           <PipelineStatusToggle pipelineId={pipeline.id} pipelineState={pipeline.state} />
         </div>
       </div>

--- a/frontend/src/components/redpanda-ui/components/separator.tsx
+++ b/frontend/src/components/redpanda-ui/components/separator.tsx
@@ -4,33 +4,31 @@ import React from 'react';
 
 import { cn, type SharedProps } from '../lib/utils';
 
-const separatorVariants = cva(
-  'shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px data-[orientation=vertical]:self-stretch',
-  {
-    variants: {
-      variant: {
-        default: 'bg-divider-default',
-        subtle: 'bg-divider-subtle',
-        strong: 'bg-divider-strong',
-      },
+const separatorVariants = cva('shrink-0', {
+  variants: {
+    variant: {
+      default: 'bg-divider-default',
+      subtle: 'bg-divider-subtle',
+      strong: 'bg-divider-strong',
     },
-    defaultVariants: {
-      variant: 'default',
-    },
-  }
-);
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
+
+// Plain classes (not data-[orientation] variants) so a consumer's explicit size wins.
+const orientationClasses = {
+  horizontal: 'h-px w-full',
+  vertical: 'h-full w-px',
+} as const;
 
 export type SeparatorVariant = VariantProps<typeof separatorVariants>['variant'];
 
 type SeparatorProps = React.ComponentProps<typeof SeparatorPrimitive> &
   SharedProps & {
     variant?: SeparatorVariant;
-    /**
-     * When `true` (the Radix default), the separator is purely decorative and
-     * will not be announced to assistive tech (`role="none"` + `aria-hidden`).
-     * When `false`, the native Base UI `role="separator"` with an orientation
-     * is used. Honored faithfully — this is not a compat no-op.
-     */
+    /** `true` (default): decorative (`role="none"` + `aria-hidden`). `false`: native `role="separator"`. */
     decorative?: boolean;
   };
 
@@ -45,7 +43,7 @@ function Separator({
   const a11yProps = decorative ? { 'aria-hidden': true, role: 'none' as const } : {};
   return (
     <SeparatorPrimitive
-      className={cn(separatorVariants({ variant }), className)}
+      className={cn(separatorVariants({ variant }), orientationClasses[orientation], className)}
       data-orientation={orientation}
       data-slot="separator"
       data-testid={testId}

--- a/frontend/src/components/ui/lint-hint/lint-hint-list.tsx
+++ b/frontend/src/components/ui/lint-hint/lint-hint-list.tsx
@@ -39,14 +39,15 @@ export const LintHintList: React.FC<LintHintListProps> = memo(({ className, lint
       {isPending && !hasHints && <Spinner className="size-4 text-foreground" />}
       {hasHints && (
         <div className="overflow-hidden rounded-lg border border-surface-strong">
-          <div className="flex flex-col gap-4 p-3">
+          <div className="flex min-w-0 flex-col gap-4 p-3">
             {Object.entries(lintHints).map(([toolName, hint]) => (
-              <div className="flex-col flex gap-1.5" key={toolName}>
-                {hint.line > 0 ? (
-                    <SimpleCodeBlock code={`Line ${hint.line}, Col ${hint.column}: ${hint.hint}`} width="full" className="my-0"/>
-                ) : (
-                  <SimpleCodeBlock code={hint.hint} width="full" className="my-0"/>
-                )}
+              <div className="flex min-w-0 flex-col gap-1.5" key={toolName}>
+                {/* min-w-0 + wrapping the inner <pre> keep long lint messages from stretching the page. */}
+                <SimpleCodeBlock
+                  className="my-0 text-xs [&_pre]:whitespace-pre-wrap [&_pre]:break-words"
+                  code={hint.line > 0 ? `Line ${hint.line}, Col ${hint.column}: ${hint.hint}` : hint.hint}
+                  width="full"
+                />
                 {hint.lintType && (
                   <Text className="font-medium text-muted-foreground text-xs uppercase tracking-wide">{hint.lintType}</Text>
                 )}

--- a/frontend/src/components/ui/lint-hint/lint-hint-list.tsx
+++ b/frontend/src/components/ui/lint-hint/lint-hint-list.tsx
@@ -37,25 +37,24 @@ export const LintHintList: React.FC<LintHintListProps> = memo(({ className, lint
   return (
     <div className={cn('space-y-3', className)}>
       {isPending && !hasHints && <Spinner className="size-4 text-foreground" />}
-      {hasHints && (
-        <div className="overflow-hidden rounded-lg border border-surface-strong">
-          <div className="flex min-w-0 flex-col gap-4 p-3">
-            {Object.entries(lintHints).map(([toolName, hint]) => (
-              <div className="flex min-w-0 flex-col gap-1.5" key={toolName}>
-                {/* min-w-0 + wrapping the inner <pre> keep long lint messages from stretching the page. */}
-                <SimpleCodeBlock
-                  className="my-0 text-xs [&_pre]:whitespace-pre-wrap [&_pre]:break-words"
-                  code={hint.line > 0 ? `Line ${hint.line}, Col ${hint.column}: ${hint.hint}` : hint.hint}
-                  width="full"
-                />
-                {hint.lintType && (
-                  <Text className="font-medium text-muted-foreground text-xs uppercase tracking-wide">{hint.lintType}</Text>
-                )}
-              </div>
-            ))}
+      {/* One code block per hint, stacked — no outer wrapper, to avoid a box-in-box look. */}
+      {hasHints &&
+        Object.entries(lintHints).map(([toolName, hint]) => (
+          <div className="flex min-w-0 flex-col gap-1" key={toolName}>
+            {/* Type label heads its message so each hint reads as one group. */}
+            {hint.lintType && (
+              <Text className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+                {hint.lintType}
+              </Text>
+            )}
+            {/* min-w-0 + wrapping the inner <pre> keep long lint messages from stretching the page. */}
+            <SimpleCodeBlock
+              className="my-0 text-xs [&_pre]:whitespace-pre-wrap [&_pre]:break-words"
+              code={hint.line > 0 ? `Line ${hint.line}, Col ${hint.column}: ${hint.hint}` : hint.hint}
+              width="full"
+            />
           </div>
-        </div>
-      )}
+        ))}
     </div>
   );
 });


### PR DESCRIPTION
* UX-1264
* Fixing an issue where the Monaco editor expands, but doesn't collapse, so the page ends up stretching
  * When the sidebar collapses then expands
  * When there are long lint errors.
* Fixing by removing the Monaco editor from the direct DOM flow.  
* Updating `Separator` to the latest registry version
* Improvements to the linting area.


### Screenshots

Lint areas before/after

<img width="45%" alt="Screenshot 2026-06-08 at 12 50 40 PM" src="https://github.com/user-attachments/assets/d1ac5fb1-a2db-4ef6-80e5-66eb7bb9d9ec" />

<img width="45%"  alt="Screenshot 2026-06-08 at 12 50 21 PM" src="https://github.com/user-attachments/assets/9883180b-41b0-4271-bfdb-3a0a68310009" />

