### PR TITLE
deps: bump Go to 1.26.4 to address Snyk findings

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/console/backend
 
-go 1.26.3
+go 1.26.4
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260209202127-80ab13bee0bf.1


### PR DESCRIPTION
## What
Bumps the `go` directive in `backend/go.mod` to **1.26.4** (Taskfile `GO_VERSION` derives from go.mod automatically).

## Why
Clears two stdlib HIGH Snyk findings:
- **CVE-2026-27145** / GO-2026-5037 — `crypto/x509` resource exhaustion
- **CVE-2026-42504** / GO-2026-5038 — `net/mime` resource exhaustion

Both fixed in go1.26.4. No `go.sum` changes.

## References
- https://pkg.go.dev/vuln/GO-2026-5037
- https://pkg.go.dev/vuln/GO-2026-5038

🤖 Generated with [Claude Code](https://claude.com/claude-code)