### PR TITLE
chore(frontend): sync redpanda-ui components from registry

### DIFF
--- a/frontend/src/components/redpanda-ui/components/auto-form/fields/boolean.tsx
+++ b/frontend/src/components/redpanda-ui/components/auto-form/fields/boolean.tsx
@@ -14,6 +14,13 @@ import type { FieldTypeDefinition } from '../registry';
 // BooleanFieldComponent — tri-state select (true / false / unset)
 // ---------------------------------------------------------------------------
 
+function renderBooleanSelectedValue(value: unknown) {
+  if (value === UNSET_SELECT_VALUE || value === undefined || value === null || value === '') {
+    return 'Not set';
+  }
+  return value === 'true' ? 'True' : 'False';
+}
+
 function BooleanFieldComponent({ error, field, id, inputProps, label }: AutoFormFieldProps) {
   const testIds = useFieldTestIds(id);
   const fieldLabel = getControlLabel(label, field);
@@ -37,7 +44,7 @@ function BooleanFieldComponent({ error, field, id, inputProps, label }: AutoForm
         id={id}
         testId={testIds.control}
       >
-        <SelectValue placeholder="Choose a value" />
+        <SelectValue placeholder="Choose a value">{renderBooleanSelectedValue}</SelectValue>
       </SelectTrigger>
       <SelectContent>
         <SelectItem testId={testIds.option('not-set')} value={UNSET_SELECT_VALUE}>

--- a/frontend/src/components/redpanda-ui/components/auto-form/fields/multiselect.tsx
+++ b/frontend/src/components/redpanda-ui/components/auto-form/fields/multiselect.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { getGroupedOptions, readDataProviderId, renderOptionLabel, useFieldTestIds } from './shared';
+import { useFieldContext } from '../../field';
 import { SimpleMultiSelect } from '../../multi-select';
 import { useAutoForm } from '../context';
 import type { AutoFormFieldProps } from '../core-types';
@@ -8,8 +9,9 @@ import { resolveDataProvider } from '../data-providers';
 import { getFieldUiConfig, NUMERIC_OPTION_PATTERN } from '../helpers';
 import type { FieldTypeDefinition } from '../registry';
 
-function MultiSelectFieldComponent({ field, id, inputProps }: AutoFormFieldProps) {
+function MultiSelectFieldComponent({ error, field, id, inputProps }: AutoFormFieldProps) {
   const testIds = useFieldTestIds(id);
+  const { errorId } = useFieldContext();
   const itemField = field.schema?.[0];
   const numericOptions = Boolean(itemField?.options?.every(([value]) => NUMERIC_OPTION_PATTERN.test(value)));
   const optionGroups = itemField ? getGroupedOptions(itemField) : undefined;
@@ -33,6 +35,8 @@ function MultiSelectFieldComponent({ field, id, inputProps }: AutoFormFieldProps
 
   return (
     <SimpleMultiSelect
+      aria-describedby={error ? errorId : undefined}
+      aria-invalid={Boolean(error)}
       disabled={inputProps.disabled}
       id={id}
       onValueChange={(values) =>
@@ -69,8 +73,9 @@ export const multiselectFieldDefinition: FieldTypeDefinition = {
 // button — one row per method. A multi-select collapses that to a single
 // control that holds every picked method as a chip.
 
-function DataProviderMultiSelectComponent({ field, id, inputProps }: AutoFormFieldProps) {
+function DataProviderMultiSelectComponent({ error, field, id, inputProps }: AutoFormFieldProps) {
   const testIds = useFieldTestIds(id);
+  const { errorId } = useFieldContext();
   const itemField = field.schema?.[0];
   const providerId = readDataProviderId(itemField);
   const { dataProviders } = useAutoForm();
@@ -103,6 +108,8 @@ function DataProviderMultiSelectComponent({ field, id, inputProps }: AutoFormFie
 
   return (
     <SimpleMultiSelect
+      aria-describedby={error ? errorId : undefined}
+      aria-invalid={Boolean(error)}
       disabled={inputProps.disabled || isLoading}
       id={id}
       onValueChange={(values) => inputProps.onValueChange(values)}

--- a/frontend/src/components/redpanda-ui/components/auto-form/fields/select.tsx
+++ b/frontend/src/components/redpanda-ui/components/auto-form/fields/select.tsx
@@ -9,6 +9,7 @@ import {
   renderOptionLabel,
   useFieldTestIds,
 } from './shared';
+import { useFieldContext } from '../../field';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue } from '../../select';
 import { useAutoForm } from '../context';
 import type { AutoFormFieldProps } from '../core-types';
@@ -16,8 +17,31 @@ import { type DataProviderOption, resolveDataProvider } from '../data-providers'
 import { UNSET_SELECT_VALUE } from '../helpers';
 import type { FieldTypeDefinition } from '../registry';
 
+function renderUnsetValue(required: boolean) {
+  return required ? null : 'Not set';
+}
+
+function renderStaticSelectedValue(value: unknown, options: ReturnType<typeof getFlatOptions>, required: boolean) {
+  if (value === UNSET_SELECT_VALUE || value === undefined || value === null || value === '') {
+    return renderUnsetValue(required);
+  }
+
+  const option = options.find((candidate) => candidate.value === String(value));
+  return option ? renderOptionLabel(option) : renderUnsetValue(required);
+}
+
+function renderProviderSelectedValue(value: unknown, options: DataProviderOption[], required: boolean) {
+  if (value === UNSET_SELECT_VALUE || value === undefined || value === null || value === '') {
+    return renderUnsetValue(required);
+  }
+
+  const option = options.find((candidate) => candidate.value === String(value));
+  return option ? <ProviderOptionLabel option={option} /> : String(value);
+}
+
 function SelectFieldComponent({ error, field, id, inputProps, label }: AutoFormFieldProps) {
   const testIds = useFieldTestIds(id);
+  const { errorId } = useFieldContext();
   const { dataProviders } = useAutoForm();
   const providerId = readDataProviderId(field);
   const provider = resolveDataProvider(dataProviders, providerId);
@@ -65,13 +89,17 @@ function SelectFieldComponent({ error, field, id, inputProps, label }: AutoFormF
       value={currentValue}
     >
       <SelectTrigger
+        aria-describedby={error ? errorId : undefined}
+        aria-invalid={Boolean(error)}
         aria-label={fieldLabel}
         className={error ? 'border-destructive' : ''}
         disabled={inputProps.disabled}
         id={id}
         testId={testIds.control}
       >
-        <SelectValue placeholder="Select an option" />
+        <SelectValue placeholder="Select an option">
+          {(value) => renderStaticSelectedValue(value, flatOptions, field.required)}
+        </SelectValue>
       </SelectTrigger>
       <SelectContent>
         {field.required ? null : (
@@ -122,6 +150,7 @@ function SelectFieldFromProvider({
   provider: () => { options: DataProviderOption[]; isLoading?: boolean; error?: unknown };
   testIds: ReturnType<typeof useFieldTestIds>;
 }) {
+  const { errorId } = useFieldContext();
   const { options, isLoading, error: providerError } = provider();
 
   if (providerError) {
@@ -157,13 +186,17 @@ function SelectFieldFromProvider({
       value={currentValue}
     >
       <SelectTrigger
+        aria-describedby={error ? errorId : undefined}
+        aria-invalid={Boolean(error)}
         aria-label={fieldLabel}
         className={error ? 'border-destructive' : ''}
         disabled={inputProps.disabled || isLoading}
         id={id}
         testId={testIds.control}
       >
-        <SelectValue placeholder={isLoading ? 'Loading…' : 'Select an option'} />
+        <SelectValue placeholder={isLoading ? 'Loading…' : 'Select an option'}>
+          {(value) => renderProviderSelectedValue(value, options, field.required)}
+        </SelectValue>
       </SelectTrigger>
       <SelectContent>
         {field.required ? null : (

--- a/frontend/src/components/redpanda-ui/components/auto-form/fields/toggle-group.tsx
+++ b/frontend/src/components/redpanda-ui/components/auto-form/fields/toggle-group.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { getControlLabel, getFlatOptions, hasNumericOptions, renderOptionLabel, useFieldTestIds } from './shared';
+import { useFieldContext } from '../../field';
 import { ToggleGroup, ToggleGroupItem } from '../../toggle-group';
 import type { AutoFormFieldProps } from '../core-types';
 import { getFieldUiConfig } from '../helpers';
@@ -8,12 +9,14 @@ import type { FieldTypeDefinition } from '../registry';
 
 function ToggleGroupFieldComponent({ error, field, id, inputProps, label }: AutoFormFieldProps) {
   const testIds = useFieldTestIds(id);
+  const { errorId } = useFieldContext();
   const numericOptions = hasNumericOptions(field);
   const value = inputProps.value === undefined || inputProps.value === null ? '' : String(inputProps.value);
   const options = getFlatOptions(field);
 
   return (
     <ToggleGroup
+      aria-describedby={error ? errorId : undefined}
       aria-invalid={Boolean(error)}
       aria-label={getControlLabel(label, field)}
       onValueChange={(nextValue) => inputProps.onValueChange(numericOptions ? Number(nextValue) : nextValue)}

--- a/frontend/src/components/redpanda-ui/components/auto-form/renderers/oneof.tsx
+++ b/frontend/src/components/redpanda-ui/components/auto-form/renderers/oneof.tsx
@@ -14,6 +14,15 @@ import { createEmptyFieldValue, getFieldErrorMessage, getFieldUiConfig, UNSET_SE
 import { FormDepthProvider, useFormDepth } from '../layout-context';
 import { getAutoFormFieldTestId } from '../test-ids';
 
+function renderOneofSelectedValue(value: unknown, fields: ParsedField[], required: boolean) {
+  if (value === UNSET_SELECT_VALUE || value === undefined || value === null || value === '') {
+    return required ? null : 'Not set';
+  }
+
+  const selectedField = fields.find((candidate) => candidate.key === String(value));
+  return selectedField ? getLabel(selectedField) : null;
+}
+
 export function OneofFieldRenderer({
   field,
   path,
@@ -96,7 +105,9 @@ export function OneofFieldRenderer({
           value={oneofValue.case ?? UNSET_SELECT_VALUE}
         >
           <SelectTrigger aria-label={String(label)} disabled={isDisabled} id={fullPath} testId={controlTestId}>
-            <SelectValue placeholder="Choose a field" />
+            <SelectValue placeholder="Choose a field">
+              {(value) => renderOneofSelectedValue(value, availableFields, field.required)}
+            </SelectValue>
           </SelectTrigger>
           <SelectContent>
             {field.required ? null : (

--- a/frontend/src/components/redpanda-ui/components/card.tsx
+++ b/frontend/src/components/redpanda-ui/components/card.tsx
@@ -6,7 +6,7 @@ import { Heading, Text } from './typography';
 import { cn, type SharedProps } from '../lib/utils';
 
 const cardVariants = cva(
-  'flex min-w-0 flex-col rounded-lg border border-base-200 border-solid bg-white dark:border-base-800 dark:bg-base-900',
+  'flex min-w-0 flex-col rounded-lg border border-border border-solid bg-card',
   {
     variants: {
       size: {

--- a/frontend/src/components/redpanda-ui/components/data-table/data-table.tsx
+++ b/frontend/src/components/redpanda-ui/components/data-table/data-table.tsx
@@ -56,12 +56,14 @@ type PaginationConfig =
       onPaginationChange?: OnChangeFn<PaginationState>;
       defaultPageSize?: number;
       pageCount?: number;
+      pageSizeOptions?: number[];
     }
   | {
       pagination: false;
       onPaginationChange?: never;
       defaultPageSize?: never;
       pageCount?: never;
+      pageSizeOptions?: never;
     };
 
 type SortingConfig =
@@ -170,6 +172,7 @@ export function DataTable<TData>({
   onPaginationChange: onPaginationChangeProp,
   defaultPageSize: defaultPageSizeProp,
   pageCount: pageCountProp,
+  pageSizeOptions: pageSizeOptionsProp,
   sorting: sortingProp,
   onSortingChange: onSortingChangeProp,
 }: DataTableProps<TData>) {
@@ -392,7 +395,7 @@ export function DataTable<TData>({
           <TableFooter className={classNames?.footer}>
             <TableRow>
               <TableCell className="p-0" colSpan={totalColumns}>
-                <DataTablePagination table={table} />
+                <DataTablePagination pageSizeOptions={pageSizeOptionsProp} table={table} />
               </TableCell>
             </TableRow>
           </TableFooter>

--- a/frontend/src/components/redpanda-ui/components/data-table/index.tsx
+++ b/frontend/src/components/redpanda-ui/components/data-table/index.tsx
@@ -208,9 +208,16 @@ export function DataTableFacetedFilter<TData, TValue>({
 
 interface DataTablePaginationProps<TData> extends SharedProps {
   table: Table<TData>;
+  pageSizeOptions?: number[];
 }
 
-export function DataTablePagination<TData>({ table, testId }: DataTablePaginationProps<TData>) {
+const DEFAULT_PAGE_SIZE_OPTIONS = [10, 20, 25, 30, 40, 50];
+
+export function DataTablePagination<TData>({
+  table,
+  testId,
+  pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS,
+}: DataTablePaginationProps<TData>) {
   return (
     <div className="flex items-center justify-between px-2" data-testid={testId}>
       <div className="flex-1 text-muted-foreground text-sm">
@@ -229,7 +236,7 @@ export function DataTablePagination<TData>({ table, testId }: DataTablePaginatio
               <SelectValue placeholder={table.getState().pagination.pageSize} />
             </SelectTrigger>
             <SelectContent side="top">
-              {[10, 20, 25, 30, 40, 50].map((pageSize) => (
+              {pageSizeOptions.map((pageSize) => (
                 <SelectItem key={pageSize} value={`${pageSize}`}>
                   {pageSize}
                 </SelectItem>

--- a/frontend/src/components/redpanda-ui/components/separator.tsx
+++ b/frontend/src/components/redpanda-ui/components/separator.tsx
@@ -4,33 +4,31 @@ import React from 'react';
 
 import { cn, type SharedProps } from '../lib/utils';
 
-const separatorVariants = cva(
-  'shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px data-[orientation=vertical]:self-stretch',
-  {
-    variants: {
-      variant: {
-        default: 'bg-divider-default',
-        subtle: 'bg-divider-subtle',
-        strong: 'bg-divider-strong',
-      },
+const separatorVariants = cva('shrink-0', {
+  variants: {
+    variant: {
+      default: 'bg-divider-default',
+      subtle: 'bg-divider-subtle',
+      strong: 'bg-divider-strong',
     },
-    defaultVariants: {
-      variant: 'default',
-    },
-  }
-);
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
+
+// Plain classes (not data-[orientation] variants) so a consumer's explicit size wins.
+const orientationClasses = {
+  horizontal: 'h-px w-full',
+  vertical: 'h-full w-px',
+} as const;
 
 export type SeparatorVariant = VariantProps<typeof separatorVariants>['variant'];
 
 type SeparatorProps = React.ComponentProps<typeof SeparatorPrimitive> &
   SharedProps & {
     variant?: SeparatorVariant;
-    /**
-     * When `true` (the Radix default), the separator is purely decorative and
-     * will not be announced to assistive tech (`role="none"` + `aria-hidden`).
-     * When `false`, the native Base UI `role="separator"` with an orientation
-     * is used. Honored faithfully — this is not a compat no-op.
-     */
+    /** `true` (default): decorative (`role="none"` + `aria-hidden`). `false`: native `role="separator"`. */
     decorative?: boolean;
   };
 
@@ -45,7 +43,7 @@ function Separator({
   const a11yProps = decorative ? { 'aria-hidden': true, role: 'none' as const } : {};
   return (
     <SeparatorPrimitive
-      className={cn(separatorVariants({ variant }), className)}
+      className={cn(separatorVariants({ variant }), orientationClasses[orientation], className)}
       data-orientation={orientation}
       data-slot="separator"
       data-testid={testId}

--- a/frontend/src/components/redpanda-ui/components/sidebar.tsx
+++ b/frontend/src/components/redpanda-ui/components/sidebar.tsx
@@ -264,7 +264,7 @@ function Sidebar({
           // Adjust the padding for floating and inset variants.
           variant === 'floating' || variant === 'inset'
             ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]'
-            : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l',
+            : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon)',
           className
         )}
         data-slot="sidebar-container"

--- a/frontend/src/components/redpanda-ui/components/stepper.tsx
+++ b/frontend/src/components/redpanda-ui/components/stepper.tsx
@@ -11,7 +11,7 @@ import {
 import { cva, type VariantProps } from 'class-variance-authority';
 import React from 'react';
 
-import { Button } from './button';
+import { Button, type ButtonVariants } from './button';
 import { Heading, Text } from './typography';
 import { Slot } from '../lib/base-ui-compat';
 import { cn, type SharedProps } from '../lib/utils';
@@ -456,6 +456,8 @@ namespace Stepper {
           of: Get.Id<Steps>;
           icon?: React.ReactNode;
           testId?: string;
+          /** Render the trigger Button in a non-default variant. */
+          variant?: ButtonVariants['variant'];
         }
       ) => React.ReactElement;
       Title: (props: AsChildProps<'h4'>) => React.ReactElement;

--- a/frontend/src/components/redpanda-ui/components/table.tsx
+++ b/frontend/src/components/redpanda-ui/components/table.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { cn, type SharedProps } from '../lib/utils';
 
 const tableVariants = cva(
-  'relative w-full min-w-0 overflow-x-auto rounded-lg border border-base-200 border-solid bg-white p-0 shadow-shadow-elevated dark:border-base-800 dark:bg-base-900',
+  'relative w-full min-w-0 overflow-x-auto rounded-lg border border-border border-solid bg-card p-0 shadow-shadow-elevated',
   {
     variants: {
       variant: {

--- a/frontend/src/components/redpanda-ui/components/tabs.tsx
+++ b/frontend/src/components/redpanda-ui/components/tabs.tsx
@@ -29,8 +29,10 @@ type TabsRenderFn = any;
 
 type TabsRenderProp = React.ReactElement | TabsRenderFn | undefined;
 
-// Build the data-state attribute from Base UI's state so Radix-era CSS selectors
-// (`data-[state=active]:...`) keep working.
+/**
+ * Build the data-state attribute from Base UI's render-prop state so Radix-era
+ * CSS selectors (`data-[state=active]:...`) keep working.
+ */
 function dataStateFromBaseUi(state: { active?: boolean; hidden?: boolean }): Record<string, unknown> {
   const attrs: Record<string, unknown> = {};
   if (typeof state?.active === 'boolean') {
@@ -41,8 +43,12 @@ function dataStateFromBaseUi(state: { active?: boolean; hidden?: boolean }): Rec
   return attrs;
 }
 
-// Render prop factory: inject `data-state` onto the default element, or compose
-// it onto a user-supplied render so router links/anchors keep working as triggers.
+/**
+ * Render prop factory. When no user-supplied render is provided, render the
+ * given element tag with injected `data-state`. When the user supplies a
+ * render (JSX element or function), compose it with `data-state` so router
+ * links / anchors keep working as Tabs triggers.
+ */
 function renderTabWithActiveState(Element: 'button' | 'div', userRender?: TabsRenderProp): TabsRenderFn {
   return ((props: Record<string, unknown>, state: { active?: boolean; hidden?: boolean }) => {
     const mergedProps = { ...props, ...dataStateFromBaseUi(state) };
@@ -239,8 +245,9 @@ const TabsList = React.forwardRef<HTMLDivElement, TabsListProps>(
 
     const prefersReducedMotion = useReducedMotion();
     const isHorizontal = orientation !== 'vertical';
-    // Lock the perpendicular axis so the highlight snaps (not animates) when the
-    // active tab moves to a different row/column.
+    // Lock the perpendicular axis: when the active tab moves to a different
+    // row (horizontal) or column (vertical), the highlight should snap on that
+    // axis instead of animating in 2D, which looks amateur.
     const axisLockedTransition: Transition = React.useMemo(() => {
       if (prefersReducedMotion) {
         return { duration: 0 };
@@ -311,14 +318,20 @@ const tabsTriggerVariants = cva(
 type TabsTriggerProps = Omit<React.ComponentProps<typeof TabsPrimitive.Tab>, 'render'> &
   SharedProps & {
     variant?: VariantProps<typeof tabsTriggerVariants>['variant'];
-    // Base UI render prop: swap the rendered element (e.g. a router `<Link />`)
-    // while keeping Tab behavior. Defaults to a native `<button>`.
+    /**
+     * Base UI render prop. Pass a JSX element (e.g. a router `<Link />`) or a
+     * function to swap the rendered element while keeping Tab keyboard and
+     * active-state behavior. Defaults to a native `<button>`.
+     */
     render?: TabsRenderProp;
   };
 
 function TabsTrigger({ className, value, variant, testId, disabled, render, ...props }: TabsTriggerProps) {
-  // Non-button intrinsic renders (e.g. `<a href>`) need Base UI's button-semantics
-  // polyfill; function/component renders are assumed to render a <button>.
+  // If the consumer's render is a non-button intrinsic (e.g. `<a href>` for
+  // link-style tabs), tell Base UI to polyfill button semantics instead of
+  // asserting a native button. Function-form renders and component children
+  // are assumed to render a <button>; consumers can pass nativeButton={false}
+  // explicitly otherwise.
   const nativeButton =
     React.isValidElement(render) && typeof render.type === 'string' && render.type !== 'button' ? false : undefined;
 

--- a/frontend/src/components/redpanda-ui/style/theme.css
+++ b/frontend/src/components/redpanda-ui/style/theme.css
@@ -1,3 +1,13 @@
+/* =============================================================================
+   TAILWIND CSS V4 THEME CONFIGURATION
+   
+   Structure:
+   1. @theme {} - All design tokens (colors with light mode defaults)
+   2. @custom-variant - Dark mode selector configuration
+   3. .dark {} - Dark mode overrides only
+   4. @layer base {} - Global styles and defaults
+   ============================================================================= */
+
 @theme {
   /* ===================================================================
      TYPOGRAPHY TOKENS
@@ -707,17 +717,17 @@
 
 .dark {
   /* Core Semantic */
-  --color-background: var(--color-grey-900);
+  --color-background: var(--color-grey-black);
   --color-foreground: var(--color-grey-200);
-  --color-card: var(--color-grey-800);
+  --color-card: var(--color-grey-900);
   --color-card-foreground: var(--color-grey-200);
-  --color-popover: var(--color-grey-800);
+  --color-popover: var(--color-grey-900);
   --color-popover-foreground: var(--color-grey-200);
 
   /* Background - Basic (Dark Mode) */
-  --color-background-strong: var(--color-grey-700);
-  --color-background-base: var(--color-grey-800);
-  --color-background-subtle: var(--color-grey-900);
+  --color-background-strong: var(--color-grey-800);
+  --color-background-base: var(--color-grey-black);
+  --color-background-subtle: var(--color-grey-black);
 
   /* Background - Inverse (Dark Mode) */
   --color-background-inverse-subtle: var(--color-grey-400);
@@ -758,10 +768,10 @@
   --color-inverse-disabled: var(--color-grey-600);
 
   /* Background Variants */
-  --color-page: var(--color-grey-900);
-  --color-surface: var(--color-grey-800);
-  --color-surface-subtle: var(--color-grey-800);
-  --color-surface-strong: var(--color-grey-700);
+  --color-page: var(--color-grey-black);
+  --color-surface: var(--color-grey-900);
+  --color-surface-subtle: var(--color-grey-900);
+  --color-surface-strong: var(--color-grey-800);
 
   /* Primary */
   --color-primary: var(--color-indigo-500);
@@ -774,7 +784,7 @@
   --color-secondary-subtle: var(--color-dark-blue-alpha-200);
 
   /* Muted */
-  --color-muted: var(--color-grey-800);
+  --color-muted: var(--color-grey-900);
   --color-muted-foreground: var(--color-grey-400);
 
   /* Accent (translucent indigo surface - light foreground for dark mode) */
@@ -811,9 +821,9 @@
   --color-informative-foreground: var(--color-blue-900);
 
   /* Border, Input, Ring */
-  --color-border-subtle: var(--color-grey-600);
+  --color-border-subtle: var(--color-grey-800);
   --color-border: var(--color-grey-700);
-  --color-border-strong: var(--color-grey-800);
+  --color-border-strong: var(--color-grey-600);
   --color-input: var(--color-grey-600);
   --color-ring: var(--color-grey-white);
 


### PR DESCRIPTION
## What

Re-syncs the vendored `redpanda-ui` registry components from the `@redpanda` shadcn registry (`redpanda-ui-registry.netlify.app`) up to their current versions. **Component changes only — no dependency or application-code changes.**

## Changed (14 files)

- **Components:** `card`, `separator`, `sidebar`, `stepper`, `table`, `tabs`, `data-table` (+ `index`), the five `auto-form` field/renderer files, and `style/theme.css`.
  - `card`/`table` now use semantic `border-border` + `bg-card` instead of hardcoded `border-base-200 dark:border-base-800` / `bg-white dark:bg-base-900`.
  - `data-table` / `stepper` gain additive optional props (`pageSizeOptions`, trigger `variant`).
  - `theme.css` updates dark-mode color tokens to the registry's current values.

## No dependency changes

The registry items declare newer minor versions of `@bufbuild/protobuf`, `date-fns`, `react-hook-form`, and `zod`. An earlier revision of this PR included those bumps and they **regressed the enterprise e2e suite**: the `zod 4.3.6 -> 4.4.3` bump broke `validateSearch` on routes with zod-validated search params (quotas, acls/users-deeplink, consumers/unconsumed-partitions), so those routes threw before rendering and the tests timed out.

These components don't use any new APIs from those versions, so the bumps were dropped and the deps stay on master's versions.

## Verification

- `bun run type:check` passes.
- `bun run build` passes.
- Enterprise e2e re-run against this revision (deps reverted) to confirm the regression is resolved.
- Lint N/A — `redpanda-ui` is excluded from biome by design (vendored registry code).
