### PR TITLE
[release-2.8] deps: bump Go to 1.26.4 to address Snyk findings

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/console/backend
 
-go 1.26.3
+go 1.26.4
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.35.2-20241127180247-a33202765966.1


### PR DESCRIPTION
## What
Backport of #2490 to **release-2.8**. Bumps `backend/go.mod` go directive to **1.26.4**.

## Why
Clears two stdlib HIGH Snyk findings still flagged on the release-2.8 branch (`console(release-2.8):backend/go.mod`):
- **CVE-2026-27145** / GO-2026-5037 — `crypto/x509` resource exhaustion
- **CVE-2026-42504** / GO-2026-5038 — `net/mime` resource exhaustion

Both fixed in go1.26.4. No `go.sum` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)