### PR TITLE
config(sql): add maxConnections config for Console's global SQL connection cap [UX-1332]

### DIFF
--- a/backend/pkg/config/sql.go
+++ b/backend/pkg/config/sql.go
@@ -24,6 +24,11 @@ type SQL struct {
 
 	Authentication HTTPAuthentication `yaml:"authentication"`
 	TLS            TLS                `yaml:"tls"`
+
+	// MaxConnections is the global cap on physical connections Console holds
+	// against Redpanda SQL across all connection pools, guarding the engine's
+	// shared max_connections budget. Default: 100.
+	MaxConnections int `yaml:"maxConnections"`
 }
 
 // RegisterFlags registers flags for sensitive SQL authentication inputs.
@@ -35,6 +40,9 @@ func (c *SQL) RegisterFlags(f *flag.FlagSet) {
 func (c *SQL) SetDefaults() {
 	c.Enabled = false
 	c.TLS.SetDefaults()
+	if c.MaxConnections == 0 {
+		c.MaxConnections = 100
+	}
 }
 
 // Validate the SQL configuration.
@@ -56,6 +64,10 @@ func (c *SQL) Validate() error {
 	isAuthSet := c.Authentication.BearerToken != "" || c.Authentication.BasicAuth.Username != "" || c.Authentication.BasicAuth.Password != ""
 	if c.Authentication.ImpersonateUser && isAuthSet {
 		return errors.New("sql authentication cannot set impersonateUser together with static basic/bearer credentials")
+	}
+
+	if c.MaxConnections <= 0 {
+		return fmt.Errorf("sql.maxConnections must be positive, got %d", c.MaxConnections)
 	}
 
 	return nil

--- a/backend/pkg/config/sql_test.go
+++ b/backend/pkg/config/sql_test.go
@@ -26,6 +26,7 @@ func TestSQL_SetDefaults(t *testing.T) {
 	if c.TLS.RefreshInterval == 0 {
 		t.Error("expected TLS defaults to be applied")
 	}
+	require.Equal(t, 100, c.MaxConnections)
 }
 
 func TestSQL_Validate(t *testing.T) {
@@ -45,7 +46,21 @@ func TestSQL_Validate(t *testing.T) {
 		},
 		{
 			name: "enabled with url is valid",
-			cfg:  SQL{Enabled: true, URL: "rpsql:5432"},
+			cfg:  SQL{Enabled: true, URL: "rpsql:5432", MaxConnections: 100},
+		},
+		{
+			name:    "zero maxConnections is invalid",
+			cfg:     SQL{Enabled: true, URL: "rpsql:5432"},
+			wantErr: true,
+		},
+		{
+			name:    "negative maxConnections is invalid",
+			cfg:     SQL{Enabled: true, URL: "rpsql:5432", MaxConnections: -1},
+			wantErr: true,
+		},
+		{
+			name: "custom maxConnections is valid",
+			cfg:  SQL{Enabled: true, URL: "rpsql:5432", MaxConnections: 250},
 		},
 		{
 			name: "impersonateUser with static bearer is invalid",
@@ -70,6 +85,7 @@ func TestSQL_Validate(t *testing.T) {
 			cfg: SQL{
 				Enabled:        true,
 				URL:            "rpsql:5432",
+				MaxConnections: 100,
 				Authentication: HTTPAuthentication{ImpersonateUser: true},
 			},
 		},


### PR DESCRIPTION
## What

Adds `sql.maxConnections` to the SQL config: the global cap on physical connections Console holds against Redpanda SQL across all of its connection pools. Defaults to **100** in `SetDefaults`, validated positive in `Validate`.

## Why

Console enterprise (redpanda-data/console-enterprise#792) opens per-user connection pools when impersonating callers against Oxla (per-user RBAC). Without a global ceiling, a burst of distinct principals could exhaust the engine's shared `max_connections` budget. The enterprise client enforces this cap with a semaphore across all per-user pools; this PR adds the OSS config knob it reads.

```yaml
sql:
  enabled: true
  url: rpsql:5432
  maxConnections: 100   # optional; default 100
```

## Notes

- Companion enterprise PR: redpanda-data/console-enterprise#792 (its CI builds against this branch via the matching-branch OSS clone).
- Merge this before the enterprise PR so the master fallback keeps compiling.