### PR TITLE
fix(frontend): fetch all pages in aigw MCP server and LLM provider lists

### DIFF
--- a/frontend/src/components/pages/agents/list/ai-agent-list-page.test.tsx
+++ b/frontend/src/components/pages/agents/list/ai-agent-list-page.test.tsx
@@ -220,6 +220,64 @@ describe('AIAgentsListPage', () => {
     expect(screen.getByText('gpt-3.5-turbo')).toBeVisible();
   });
 
+  test('should resolve MCP tools for servers beyond the first page of the aigw list', async () => {
+    const agent = create(AIAgentSchema, {
+      id: 'agent-1',
+      displayName: 'Test Agent 1',
+      description: 'Description 1',
+      state: AIAgent_State.RUNNING,
+      provider: {
+        provider: {
+          case: 'openai',
+          value: {
+            apiKey: 'secret-1',
+          },
+        },
+      },
+      model: 'gpt-4',
+      systemPrompt: 'You are helpful',
+      // The referenced server is NOT on the first page of the MCP list —
+      // the regression was a single-page read that made it invisible.
+      mcpServers: {
+        servicenow: { id: 'servicenow-knowledge' },
+      },
+      tags: {},
+    });
+
+    const listAIAgentsMock = vi
+      .fn()
+      .mockReturnValue(create(ListAIAgentsResponseSchema, { aiAgents: [agent], nextPageToken: '' }));
+
+    const listMCPServersMock = vi.fn((req: { pageToken: string }) => {
+      if (req.pageToken === '') {
+        return create(ListMCPServersResponseSchema, {
+          mcpServers: [create(MCPServerSchema, { name: 'recently-created-server', tools: [] })],
+          nextPageToken: 'page-2',
+        });
+      }
+      return create(ListMCPServersResponseSchema, {
+        mcpServers: [
+          create(MCPServerSchema, {
+            name: 'servicenow-knowledge',
+            tools: [{ name: 'kb-search', description: '', inputSchema: '' }],
+          }),
+        ],
+        nextPageToken: '',
+      });
+    });
+
+    const transport = createAIAgentsTransport({ listAIAgentsMock, listMCPServersMock });
+
+    renderWithFileRoutes(<AIAgentsListPage />, { transport });
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Agent 1')).toBeVisible();
+      expect(screen.getByText('kb-search')).toBeVisible();
+    });
+
+    expect(listMCPServersMock).toHaveBeenCalledTimes(2);
+  });
+
   test('should delete an AI agent from the list', async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/react-query/api/aigw/llm-providers.test.tsx
+++ b/frontend/src/react-query/api/aigw/llm-providers.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+/**
+ * Pagination contract for useListLLMProvidersQuery — same contract as the
+ * aigw MCP server list: aigw pages results (default 50, created_at desc),
+ * so the hook walks next_page_token until exhausted instead of silently
+ * truncating to the newest page.
+ */
+
+import { create } from '@bufbuild/protobuf';
+import { Code, ConnectError, createRouterTransport } from '@connectrpc/connect';
+import { renderHook, waitFor } from '@testing-library/react';
+import {
+  type ListLLMProvidersRequest,
+  ListLLMProvidersResponseSchema,
+  LLMProviderSchema,
+} from 'protogen/redpanda/api/adp/v1alpha1/llm_provider_pb';
+import { listLLMProviders } from 'protogen/redpanda/api/adp/v1alpha1/llm_provider-LLMProviderService_connectquery';
+import { connectQueryWrapper } from 'test-utils';
+import { describe, expect, test, vi } from 'vitest';
+
+import { useListLLMProvidersQuery } from './llm-providers';
+
+// Route aigw queries through the wrapper's test transport.
+vi.mock('hooks/use-aigw-transport', async () => {
+  const { useTransport } = await import('@connectrpc/connect-query');
+  return {
+    useAigwTransport: () => useTransport(),
+  };
+});
+
+type RecordedRequest = {
+  pageToken: string;
+  pageSize: number;
+  nameContains: string | undefined;
+};
+
+const recordRequest = (req: ListLLMProvidersRequest): RecordedRequest => ({
+  pageToken: req.pageToken,
+  pageSize: req.pageSize,
+  nameContains: req.filter?.nameContains,
+});
+
+/**
+ * Serves `pages` in order, keyed by the page token the client must echo back
+ * (page N's response carries the token that unlocks page N+1). Records every
+ * request for assertions.
+ */
+const makePagedHarness = (pages: string[][]) => {
+  const requests: RecordedRequest[] = [];
+  const responseByToken = new Map(
+    pages.map((names, index) => [
+      index === 0 ? '' : `page-${index}`,
+      create(ListLLMProvidersResponseSchema, {
+        llmProviders: names.map((name) => create(LLMProviderSchema, { name })),
+        nextPageToken: index < pages.length - 1 ? `page-${index + 1}` : '',
+      }),
+    ])
+  );
+  const transport = createRouterTransport(({ rpc }) => {
+    rpc(listLLMProviders, (req) => {
+      requests.push(recordRequest(req));
+      const response = responseByToken.get(req.pageToken);
+      if (!response) {
+        throw new ConnectError(`unexpected page token: ${req.pageToken}`, Code.InvalidArgument);
+      }
+      return response;
+    });
+  });
+  const { wrapper } = connectQueryWrapper({ defaultOptions: { queries: { retry: false } } }, transport);
+  return { wrapper, requests };
+};
+
+describe('useListLLMProvidersQuery', () => {
+  test('walks next_page_token and flattens providers from every page in order', async () => {
+    const { wrapper, requests } = makePagedHarness([['openai', 'anthropic'], ['google'], ['bedrock']]);
+
+    const { result } = renderHook(() => useListLLMProvidersQuery(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.data.llmProviders).toHaveLength(4);
+    });
+
+    expect(result.current.data.llmProviders.map((p) => p.name)).toEqual(['openai', 'anthropic', 'google', 'bedrock']);
+    expect(requests.map((r) => r.pageToken)).toEqual(['', 'page-1', 'page-2']);
+  });
+
+  test('leaves page_size unset on every request — the server owns page-size policy', async () => {
+    const { wrapper, requests } = makePagedHarness([['a'], ['b']]);
+
+    const { result } = renderHook(() => useListLLMProvidersQuery(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(requests).toHaveLength(2);
+    expect(requests.every((r) => r.pageSize === 0)).toBe(true);
+  });
+
+  test('forwards the filter on every page request', async () => {
+    const { wrapper, requests } = makePagedHarness([['openai-eu'], ['openai-us']]);
+
+    const { result } = renderHook(() => useListLLMProvidersQuery({ filter: { nameContains: 'openai' } }), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data.llmProviders.map((p) => p.name)).toEqual(['openai-eu', 'openai-us']);
+    expect(requests).toHaveLength(2);
+    expect(requests.every((r) => r.nameContains === 'openai')).toBe(true);
+  });
+
+  test('issues a single request when the first page is the last', async () => {
+    const { wrapper, requests } = makePagedHarness([['only-provider']]);
+
+    const { result } = renderHook(() => useListLLMProvidersQuery(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(result.current.data.llmProviders.map((p) => p.name)).toEqual(['only-provider']);
+  });
+
+  test('returns an empty list for an empty tenant', async () => {
+    const { wrapper, requests } = makePagedHarness([[]]);
+
+    const { result } = renderHook(() => useListLLMProvidersQuery(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(result.current.data.llmProviders).toEqual([]);
+  });
+
+  test('does not fetch when disabled', async () => {
+    const { wrapper, requests } = makePagedHarness([['hidden']]);
+
+    const { result } = renderHook(() => useListLLMProvidersQuery(undefined, { enabled: false }), { wrapper });
+
+    // Give a disabled query a chance to misbehave before asserting silence.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(requests).toHaveLength(0);
+    expect(result.current.data.llmProviders).toEqual([]);
+  });
+
+  test('stops the walk and surfaces the error when a later page fails', async () => {
+    let calls = 0;
+    const transport = createRouterTransport(({ rpc }) => {
+      rpc(listLLMProviders, (req) => {
+        calls += 1;
+        if (req.pageToken === '') {
+          return create(ListLLMProvidersResponseSchema, {
+            llmProviders: [create(LLMProviderSchema, { name: 'first' })],
+            nextPageToken: 'page-1',
+          });
+        }
+        throw new ConnectError('backend exploded', Code.Internal);
+      });
+    });
+    const { wrapper } = connectQueryWrapper({ defaultOptions: { queries: { retry: false } } }, transport);
+
+    const { result } = renderHook(() => useListLLMProvidersQuery(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    // First page + one failed second page; the auto-fetch effect must not
+    // retry-loop a failing page.
+    expect(calls).toBe(2);
+  });
+});

--- a/frontend/src/react-query/api/aigw/llm-providers.tsx
+++ b/frontend/src/react-query/api/aigw/llm-providers.tsx
@@ -7,9 +7,6 @@
 
 import { create } from '@bufbuild/protobuf';
 import type { GenMessage } from '@bufbuild/protobuf/codegenv1';
-import type { ConnectError } from '@connectrpc/connect';
-import { useQuery } from '@connectrpc/connect-query';
-import type { UseQueryResult } from '@tanstack/react-query';
 import { useAigwTransport } from 'hooks/use-aigw-transport';
 import {
   type ListLLMProvidersRequest,
@@ -17,13 +14,18 @@ import {
   type ListLLMProvidersResponse,
 } from 'protogen/redpanda/api/adp/v1alpha1/llm_provider_pb';
 import { listLLMProviders } from 'protogen/redpanda/api/adp/v1alpha1/llm_provider-LLMProviderService_connectquery';
+import { useMemo } from 'react';
 import type { MessageInit, QueryOptions } from 'react-query/react-query.utils';
-
-const AIGW_DEFAULT_PAGE_SIZE = 50;
+import { useInfiniteQueryWithAllPages } from 'react-query/use-infinite-query-with-all-pages';
 
 /**
  * Hook to list LLM Providers using the AI Gateway v2 API.
  * Lists available LLM providers (OpenAI, Anthropic, Google, Bedrock, etc.)
+ *
+ * The server pages results (default 50, created_at desc), so this walks
+ * next_page_token until exhausted — a single-page read silently hides every
+ * provider older than the newest page. page_size stays unset: the server
+ * owns that policy.
  *
  * @note This hook uses the aigw v2 transport - requires /.aigw/api/ proxy configuration
  *
@@ -35,17 +37,30 @@ const AIGW_DEFAULT_PAGE_SIZE = 50;
 export const useListLLMProvidersQuery = (
   input?: MessageInit<ListLLMProvidersRequest>,
   options?: QueryOptions<GenMessage<ListLLMProvidersRequest>, ListLLMProvidersResponse>
-): UseQueryResult<ListLLMProvidersResponse, ConnectError> => {
+) => {
   const transport = useAigwTransport();
 
   const request = create(ListLLMProvidersRequestSchema, {
-    pageToken: input?.pageToken ?? '',
-    pageSize: input?.pageSize ?? AIGW_DEFAULT_PAGE_SIZE,
+    pageToken: '',
     ...(input?.filter && { filter: input.filter }),
-  });
+  }) as ListLLMProvidersRequest & Required<Pick<ListLLMProvidersRequest, 'pageToken'>>;
 
-  return useQuery(listLLMProviders, request, {
+  const result = useInfiniteQueryWithAllPages(listLLMProviders, request, {
     enabled: options?.enabled,
+    getNextPageParam: (lastPage) => lastPage?.nextPageToken || undefined,
+    pageParamKey: 'pageToken',
     transport,
   });
+
+  const llmProviders = useMemo(
+    () => result.data?.pages.flatMap((page) => page?.llmProviders ?? []) ?? [],
+    [result.data]
+  );
+
+  const data = useMemo(() => ({ llmProviders }), [llmProviders]);
+
+  return {
+    ...result,
+    data,
+  };
 };

--- a/frontend/src/react-query/api/aigw/mcp-servers.test.tsx
+++ b/frontend/src/react-query/api/aigw/mcp-servers.test.tsx
@@ -1,0 +1,257 @@
+/**
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+/**
+ * Pagination contract for useListAigwMCPServersQuery.
+ *
+ * aigw pages ListMCPServers (default 50, created_at desc), so the hook must
+ * walk next_page_token until exhausted. The original single-page read
+ * silently hid every server older than the newest page — on a tenant with
+ * 82 servers, two month-old servers never appeared in the agent pages
+ * unless a name filter shrank the result set under one page.
+ */
+
+import { create } from '@bufbuild/protobuf';
+import { Code, ConnectError, createRouterTransport } from '@connectrpc/connect';
+import { renderHook, waitFor } from '@testing-library/react';
+import {
+  type ListMCPServersRequest,
+  ListMCPServersResponseSchema,
+  MCPServerSchema,
+} from 'protogen/redpanda/api/adp/v1alpha1/mcp_server_pb';
+import { listMCPServers } from 'protogen/redpanda/api/adp/v1alpha1/mcp_server-MCPServerService_connectquery';
+import { connectQueryWrapper } from 'test-utils';
+import { describe, expect, test, vi } from 'vitest';
+
+import { useListAigwMCPServersQuery } from './mcp-servers';
+
+// Route aigw queries through the wrapper's test transport.
+vi.mock('hooks/use-aigw-transport', async () => {
+  const { useTransport } = await import('@connectrpc/connect-query');
+  return {
+    useAigwTransport: () => useTransport(),
+  };
+});
+
+type RecordedRequest = {
+  pageToken: string;
+  pageSize: number;
+  nameContains: string | undefined;
+};
+
+const recordRequest = (req: ListMCPServersRequest): RecordedRequest => ({
+  pageToken: req.pageToken,
+  pageSize: req.pageSize,
+  nameContains: req.filter?.nameContains,
+});
+
+/**
+ * Serves `pages` in order, keyed by the page token the client must echo back
+ * (page N's response carries the token that unlocks page N+1). Records every
+ * request for assertions.
+ */
+const makePagedHarness = (pages: string[][]) => {
+  const requests: RecordedRequest[] = [];
+  const responseByToken = new Map(
+    pages.map((names, index) => [
+      index === 0 ? '' : `page-${index}`,
+      create(ListMCPServersResponseSchema, {
+        mcpServers: names.map((name) => create(MCPServerSchema, { name })),
+        nextPageToken: index < pages.length - 1 ? `page-${index + 1}` : '',
+      }),
+    ])
+  );
+  const transport = createRouterTransport(({ rpc }) => {
+    rpc(listMCPServers, (req) => {
+      requests.push(recordRequest(req));
+      const response = responseByToken.get(req.pageToken);
+      if (!response) {
+        throw new ConnectError(`unexpected page token: ${req.pageToken}`, Code.InvalidArgument);
+      }
+      return response;
+    });
+  });
+  const { wrapper } = connectQueryWrapper({ defaultOptions: { queries: { retry: false } } }, transport);
+  return { wrapper, requests };
+};
+
+describe('useListAigwMCPServersQuery', () => {
+  test('walks next_page_token and flattens servers from every page in order', async () => {
+    const { wrapper, requests } = makePagedHarness([['newest-a', 'newest-b'], ['middle-c'], ['oldest-d']]);
+
+    const { result } = renderHook(() => useListAigwMCPServersQuery(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.data.mcpServers).toHaveLength(4);
+    });
+
+    expect(result.current.data.mcpServers.map((s) => s.name)).toEqual(['newest-a', 'newest-b', 'middle-c', 'oldest-d']);
+    expect(requests.map((r) => r.pageToken)).toEqual(['', 'page-1', 'page-2']);
+  });
+
+  test('leaves page_size unset on every request — the server owns page-size policy', async () => {
+    const { wrapper, requests } = makePagedHarness([['a'], ['b']]);
+
+    const { result } = renderHook(() => useListAigwMCPServersQuery(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(requests).toHaveLength(2);
+    expect(requests.every((r) => r.pageSize === 0)).toBe(true);
+  });
+
+  test('forwards the filter on every page request', async () => {
+    const { wrapper, requests } = makePagedHarness([['servicenow-catalog'], ['servicenow-knowledge']]);
+
+    const { result } = renderHook(() => useListAigwMCPServersQuery({ filter: { nameContains: 'servicenow' } }), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data.mcpServers.map((s) => s.name)).toEqual(['servicenow-catalog', 'servicenow-knowledge']);
+    expect(requests).toHaveLength(2);
+    expect(requests.every((r) => r.nameContains === 'servicenow')).toBe(true);
+  });
+
+  test('issues a single request when the first page is the last', async () => {
+    const { wrapper, requests } = makePagedHarness([['only-server']]);
+
+    const { result } = renderHook(() => useListAigwMCPServersQuery(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(result.current.data.mcpServers.map((s) => s.name)).toEqual(['only-server']);
+  });
+
+  test('returns an empty list for an empty tenant', async () => {
+    const { wrapper, requests } = makePagedHarness([[]]);
+
+    const { result } = renderHook(() => useListAigwMCPServersQuery(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(result.current.data.mcpServers).toEqual([]);
+  });
+
+  test('completes a deep walk without dropping or reordering pages', async () => {
+    const pages = Array.from({ length: 10 }, (_, index) => [`server-${index}`]);
+    const { wrapper, requests } = makePagedHarness(pages);
+
+    const { result } = renderHook(() => useListAigwMCPServersQuery(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.data.mcpServers).toHaveLength(10);
+    });
+
+    expect(requests).toHaveLength(10);
+    expect(result.current.data.mcpServers.map((s) => s.name)).toEqual(pages.flat());
+  });
+
+  test('does not fetch when disabled', async () => {
+    const { wrapper, requests } = makePagedHarness([['hidden']]);
+
+    const { result } = renderHook(() => useListAigwMCPServersQuery(undefined, { enabled: false }), { wrapper });
+
+    // Give a disabled query a chance to misbehave before asserting silence.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(requests).toHaveLength(0);
+    expect(result.current.data.mcpServers).toEqual([]);
+  });
+
+  test('stops the walk and surfaces the error when a later page fails', async () => {
+    let calls = 0;
+    const transport = createRouterTransport(({ rpc }) => {
+      rpc(listMCPServers, (req) => {
+        calls += 1;
+        if (req.pageToken === '') {
+          return create(ListMCPServersResponseSchema, {
+            mcpServers: [create(MCPServerSchema, { name: 'first' })],
+            nextPageToken: 'page-1',
+          });
+        }
+        throw new ConnectError('backend exploded', Code.Internal);
+      });
+    });
+    const { wrapper } = connectQueryWrapper({ defaultOptions: { queries: { retry: false } } }, transport);
+
+    const { result } = renderHook(() => useListAigwMCPServersQuery(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    // First page + one failed second page; the auto-fetch effect must not
+    // retry-loop a failing page.
+    expect(calls).toBe(2);
+  });
+
+  test('reports loading until the last page has landed, not just the first', async () => {
+    let releaseSecondPage: (() => void) | undefined;
+    const secondPageGate = new Promise<void>((resolve) => {
+      releaseSecondPage = resolve;
+    });
+    let calls = 0;
+    const transport = createRouterTransport(({ rpc }) => {
+      rpc(listMCPServers, async (req) => {
+        calls += 1;
+        if (req.pageToken === '') {
+          return create(ListMCPServersResponseSchema, {
+            mcpServers: [create(MCPServerSchema, { name: 'first' })],
+            nextPageToken: 'page-1',
+          });
+        }
+        await secondPageGate;
+        return create(ListMCPServersResponseSchema, {
+          mcpServers: [create(MCPServerSchema, { name: 'second' })],
+          nextPageToken: '',
+        });
+      });
+    });
+    const { wrapper } = connectQueryWrapper({ defaultOptions: { queries: { retry: false } } }, transport);
+
+    try {
+      const { result } = renderHook(() => useListAigwMCPServersQuery(), { wrapper });
+
+      // The second page is in flight (gated) — consumers must still see loading,
+      // otherwise they render a truncated list as if it were complete.
+      await waitFor(() => {
+        expect(calls).toBe(2);
+      });
+      expect(result.current.isLoading).toBe(true);
+
+      releaseSecondPage?.();
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+      expect(result.current.data.mcpServers.map((s) => s.name)).toEqual(['first', 'second']);
+    } finally {
+      // A failed assertion above must not leave the gate pending — an
+      // unresolved in-flight RPC keeps the worker's event loop alive and
+      // hangs the run at teardown.
+      releaseSecondPage?.();
+    }
+  });
+});

--- a/frontend/src/react-query/api/aigw/mcp-servers.tsx
+++ b/frontend/src/react-query/api/aigw/mcp-servers.tsx
@@ -7,9 +7,6 @@
 
 import { create } from '@bufbuild/protobuf';
 import type { GenMessage } from '@bufbuild/protobuf/codegenv1';
-import type { ConnectError } from '@connectrpc/connect';
-import { useQuery } from '@connectrpc/connect-query';
-import type { UseQueryResult } from '@tanstack/react-query';
 import { useAigwTransport } from 'hooks/use-aigw-transport';
 import {
   type ListMCPServersRequest,
@@ -17,13 +14,18 @@ import {
   type ListMCPServersResponse,
 } from 'protogen/redpanda/api/adp/v1alpha1/mcp_server_pb';
 import { listMCPServers } from 'protogen/redpanda/api/adp/v1alpha1/mcp_server-MCPServerService_connectquery';
+import { useMemo } from 'react';
 import type { MessageInit, QueryOptions } from 'react-query/react-query.utils';
-
-const AIGW_DEFAULT_PAGE_SIZE = 50;
+import { useInfiniteQueryWithAllPages } from 'react-query/use-infinite-query-with-all-pages';
 
 /**
  * Hook to list MCP Servers using the AI Gateway v2 API.
  * Lists managed and remote MCP servers registered in aigw's store.
+ *
+ * The server pages results (default 50, created_at desc), so this walks
+ * next_page_token until exhausted — a single-page read silently hides every
+ * server older than the newest page. page_size stays unset: the server owns
+ * that policy.
  *
  * @note This hook uses the aigw v2 transport - requires /.aigw/api/ proxy configuration
  *
@@ -34,17 +36,27 @@ const AIGW_DEFAULT_PAGE_SIZE = 50;
 export const useListAigwMCPServersQuery = (
   input?: MessageInit<ListMCPServersRequest>,
   options?: QueryOptions<GenMessage<ListMCPServersRequest>, ListMCPServersResponse>
-): UseQueryResult<ListMCPServersResponse, ConnectError> => {
+) => {
   const transport = useAigwTransport();
 
   const request = create(ListMCPServersRequestSchema, {
-    pageToken: input?.pageToken ?? '',
-    pageSize: input?.pageSize ?? AIGW_DEFAULT_PAGE_SIZE,
+    pageToken: '',
     ...(input?.filter && { filter: input.filter }),
-  });
+  }) as ListMCPServersRequest & Required<Pick<ListMCPServersRequest, 'pageToken'>>;
 
-  return useQuery(listMCPServers, request, {
+  const result = useInfiniteQueryWithAllPages(listMCPServers, request, {
     enabled: options?.enabled,
+    getNextPageParam: (lastPage) => lastPage?.nextPageToken || undefined,
+    pageParamKey: 'pageToken',
     transport,
   });
+
+  const mcpServers = useMemo(() => result.data?.pages.flatMap((page) => page?.mcpServers ?? []) ?? [], [result.data]);
+
+  const data = useMemo(() => ({ mcpServers }), [mcpServers]);
+
+  return {
+    ...result,
+    data,
+  };
 };


### PR DESCRIPTION
## What

Make the aigw v2 list hooks — `useListAigwMCPServersQuery` and `useListLLMProvidersQuery` — walk `next_page_token` until exhausted instead of reading a single page. Applies to every consumer: the AI agent list page, the create page, and the agent configuration tab.

## Why

aigw pages its list endpoints (default 50, ordered `created_at` desc) and returns a `next_page_token`. Both hooks did one call with `pageSize: 50` and threw the token away. Once a tenant crosses 50 MCP servers, everything older than the newest page silently disappears: the agent configuration tab renders the agent's stale server references as disabled remotes (the lookup against the truncated list fails), and the add-server picker can't offer the missing servers at all.

Surfaced on a tenant with 82 MCP servers: `servicenow-catalog` and `servicenow-knowledge` at positions 74/75 in newest-first order, permanently outside the first page.

Silently truncating a list is worse than failing. The server was saying there were more pages; the client didn't listen.

## Implementation details

**Reuse the existing helper.** Both hooks switch to `useInfiniteQueryWithAllPages` — the same auto-paginating wrapper the dataplane MCP list (`react-query/api/remote-mcp.tsx`) already uses — and flatten the pages. Consumers keep the same `data.mcpServers` / `data.llmProviders` shape.

**page_size stays unset.** The server owns page-size policy (default 50, oversized requests clamped); the token walk is the correctness mechanism. If the backend tunes its default, clients follow for free.

**Loading semantics.** `isLoading` holds until the last page lands, so consumers never render a truncated list as if it were complete. A failing page stops the walk and surfaces the error instead of retry-looping.

**Tests.** Hook-level suites pin the full contract for both endpoints: multi-page walk and flatten order, token echo sequence, page_size unset on every request, filter forwarded per page, single-page and empty-tenant cases, disabled query, mid-walk failure, and loading-until-final-page. Plus a page-level regression on the agent list: an agent whose MCP server lives beyond page one resolves its tools.

## References

Same bug fixed in cloudv2 adp-ui (agents v2): redpanda-data/cloudv2#27046