### PR TITLE
ci(claude): pass github token to action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,6 +44,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ github.token }}
           allowed_bots: ""
           allowed_non_write_users: ""
           use_commit_signing: true

--- a/frontend/src/__tests__/claude-workflow.test.ts
+++ b/frontend/src/__tests__/claude-workflow.test.ts
@@ -1,0 +1,39 @@
+import { parse } from 'yaml';
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const workflowPath = fileURLToPath(new URL('../../../.github/workflows/claude.yml', import.meta.url));
+
+type WorkflowStep = {
+  uses?: string;
+  with?: Record<string, unknown>;
+  env?: Record<string, unknown>;
+};
+
+type Workflow = {
+  jobs: {
+    claude: {
+      steps: WorkflowStep[];
+    };
+  };
+};
+
+const readClaudeCodeActionStep = () => {
+  const workflow = parse(readFileSync(workflowPath, 'utf8')) as Workflow;
+  const actionStep = workflow.jobs.claude.steps.find((step) => step.uses?.startsWith('anthropics/claude-code-action@'));
+
+  if (!actionStep) {
+    throw new Error('Claude Code Action step missing');
+  }
+
+  return actionStep;
+};
+
+describe('Claude Code workflow', () => {
+  test('passes the workflow token as an action input', () => {
+    const actionStep = readClaudeCodeActionStep();
+
+    expect(actionStep.with?.github_token).toBe('${{ github.token }}');
+  });
+});


### PR DESCRIPTION
## Summary
- Fix @claude runs by passing `github_token` as an action input, not only as an environment variable.
- Adds a regression test that fails if the Claude workflow stops passing the workflow token.

## Root cause
- Recent Claude Code Action v1 runs failed before Claude started because the action tried to exchange OIDC for a Claude GitHub App token.
- Run logs show: `Claude Code is not installed on this repository`.
- The repo was setting `GITHUB_TOKEN` only in `env`; current action code uses the `github_token` input (`OVERRIDE_GITHUB_TOKEN`) to bypass app-token auth.

## Commits
- `a503385c1` ci(claude): pass github token to action

## Test plan
- [x] `cd frontend && fnm exec --using=v22.22.3 bun run test:file:unit src/__tests__/claude-workflow.test.ts`
- [x] `cd frontend && fnm exec --using=v22.22.3 bun run type:check`
- [x] `cd frontend && fnm exec --using=v22.22.3 bun run lint` (exits 0; reports pre-existing no-restricted-import debt unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)