### PR TITLE
fix(frontend): bound long-lived-tab renderer memory growth

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -51,7 +51,6 @@
         "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
         "dexie": "^4.2.1",
-        "dexie-react-hooks": "^4.2.0",
         "dotenv": "^17.2.3",
         "es-cookie": "^1.5.0",
         "framer-motion": "^7.10.3",
@@ -1933,8 +1932,6 @@
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "dexie": ["dexie@4.2.1", "", {}, "sha512-Ckej0NS6jxQ4Po3OrSQBFddayRhTCic2DoCAG5zacOfOVB9P2Q5Xc5uL/nVa7ZVs+HdMnvUPzLFCB/JwpB6Csg=="],
-
-    "dexie-react-hooks": ["dexie-react-hooks@4.2.0", "", { "peerDependencies": { "@types/react": ">=16", "dexie": ">=4.2.0-alpha.1 <5.0.0", "react": ">=16" } }, "sha512-u7KqTX9JpBQK8+tEyA9X0yMGXlSCsbm5AU64N6gjvGk/IutYDpLBInMYEAEC83s3qhIvryFS+W+sqLZUBEvePQ=="],
 
     "diff": ["diff@4.0.4", "", {}, "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ=="],
 

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -61,7 +61,6 @@
         "jwt-decode": "^4.0.0",
         "lottie-react": "^2.4.1",
         "lucide-react": "^1.17.0",
-        "moment": "^2.30.1",
         "monaco-editor": "^0.54.0",
         "monaco-editor-webpack-plugin": "^7.1.1",
         "monaco-yaml": "^5.5.0",
@@ -2678,8 +2677,6 @@
     "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
 
     "mlly": ["mlly@1.8.0", "", { "dependencies": { "acorn": "^8.15.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.1" } }, "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g=="],
-
-    "moment": ["moment@2.30.1", "", {}, "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="],
 
     "monaco-editor": ["monaco-editor@0.54.0", "", { "dependencies": { "dompurify": "3.1.7", "marked": "14.0.0" } }, "sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -105,7 +105,6 @@
     "jwt-decode": "^4.0.0",
     "lottie-react": "^2.4.1",
     "lucide-react": "^1.17.0",
-    "moment": "^2.30.1",
     "monaco-editor": "^0.54.0",
     "monaco-editor-webpack-plugin": "^7.1.1",
     "monaco-yaml": "^5.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -95,7 +95,6 @@
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
     "dexie": "^4.2.1",
-    "dexie-react-hooks": "^4.2.0",
     "dotenv": "^17.2.3",
     "es-cookie": "^1.5.0",
     "framer-motion": "^7.10.3",

--- a/frontend/src/components/pages/rp-connect/pipeline/index.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/index.tsx
@@ -482,16 +482,30 @@ function YamlViewPanel({
   // Top/bottom shadows from Monaco's scroll position (useScrollShadow needs a native
   // scroll container; Monaco virtualizes, so onDidScrollChange is the only signal).
   const [overflow, setOverflow] = useState({ top: false, bottom: false });
+  // Listener disposables from the editor mount, torn down on unmount (effect below). Without
+  // this the sync closures (which capture the editor) keep the editor + listener graph alive
+  // per mount of the view page.
+  const scrollSyncSubscriptions = useRef<ReturnType<editor.IStandaloneCodeEditor['onDidScrollChange']>[]>([]);
   const handleMount = useCallback((instance: editor.IStandaloneCodeEditor) => {
     const sync = () => {
       const scrollTop = instance.getScrollTop();
       const maxY = instance.getScrollHeight() - instance.getLayoutInfo().height;
       setOverflow({ top: scrollTop > 1, bottom: scrollTop < maxY - 1 });
     };
-    instance.onDidScrollChange(sync);
-    instance.onDidContentSizeChange(sync);
-    instance.onDidLayoutChange(sync);
+    scrollSyncSubscriptions.current = [
+      instance.onDidScrollChange(sync),
+      instance.onDidContentSizeChange(sync),
+      instance.onDidLayoutChange(sync),
+    ];
     sync();
+  }, []);
+  useEffect(function disposeScrollSyncListeners() {
+    return () => {
+      for (const subscription of scrollSyncSubscriptions.current) {
+        subscription.dispose();
+      }
+      scrollSyncSubscriptions.current = [];
+    };
   }, []);
 
   const edge =

--- a/frontend/src/react-query/api/logs.test.tsx
+++ b/frontend/src/react-query/api/logs.test.tsx
@@ -41,7 +41,7 @@ vi.mock('../../config', () => ({
   },
 }));
 
-import { useLogSearch } from './logs';
+import { LIVE_INITIAL_STATE, liveReducer, MAX_LIVE_LOG_MESSAGES, useLogSearch } from './logs';
 
 function makeMessage(id: number, keyJson = 'pipeline-1'): TopicMessage {
   return {
@@ -227,5 +227,19 @@ describe('useLogSearch history mode', () => {
 
     expect(result.current.messages[0].offset).toBe(3);
     expect(result.current.messages[2].offset).toBe(1);
+  });
+});
+
+describe('liveReducer flushMessages cap', () => {
+  test('caps the live buffer to MAX_LIVE_LOG_MESSAGES, keeping the newest entries', () => {
+    const batch = Array.from({ length: MAX_LIVE_LOG_MESSAGES + 10 }, (_, i) => makeMessage(i));
+
+    const next = liveReducer(LIVE_INITIAL_STATE, { type: 'flushMessages', msgs: batch });
+
+    expect(next.messages).toHaveLength(MAX_LIVE_LOG_MESSAGES);
+    // Newest-first: msgs are reversed on flush, so the highest offset is at the front.
+    expect(next.messages[0].offset).toBe(MAX_LIVE_LOG_MESSAGES + 9);
+    // Oldest entries are dropped by the sliding window.
+    expect(next.messages.some((m) => m.offset === 0)).toBe(false);
   });
 });

--- a/frontend/src/react-query/api/logs.tsx
+++ b/frontend/src/react-query/api/logs.tsx
@@ -33,6 +33,13 @@ const HISTORY_MAX_RESULTS = 1000;
 const LIVE_TIMEOUT_MS = 30 * ONE_MINUTE;
 const HISTORY_TIMEOUT_MS = 30 * ONE_SECOND;
 const FLUSH_INTERVAL_MS = 200;
+/**
+ * Sliding-window cap for the live-tail log buffer. A live stream runs for up to 30 minutes
+ * and `flushMessages` prepends every batch with no limit, so without a cap the reducer's
+ * `messages` array would grow unbounded for the whole window on a long-lived/backgrounded tab.
+ * Newest-first means the most recent entries are kept.
+ */
+export const MAX_LIVE_LOG_MESSAGES = 5000;
 
 type UseLogSearchOptions = {
   pipelineId: string;
@@ -237,20 +244,26 @@ type LiveAction =
   | { type: 'done' }
   | { type: 'noClient' };
 
-const LIVE_INITIAL_STATE: LiveState = { messages: [], phase: null, error: null, progress: ZERO_PROGRESS };
+export const LIVE_INITIAL_STATE: LiveState = { messages: [], phase: null, error: null, progress: ZERO_PROGRESS };
 
-function liveReducer(state: LiveState, action: LiveAction): LiveState {
+export function liveReducer(state: LiveState, action: LiveAction): LiveState {
   switch (action.type) {
     case 'reset':
       return LIVE_INITIAL_STATE;
     case 'start':
       return { messages: [], phase: 'Searching...', error: null, progress: ZERO_PROGRESS };
-    case 'flushMessages':
+    case 'flushMessages': {
       if (action.msgs.length === 0) {
         return state;
       }
-      // Newest message first.
-      return { ...state, messages: [...action.msgs.toReversed(), ...state.messages] };
+      // Newest message first; cap to a sliding window so a 30-minute live tail cannot grow
+      // the reducer buffer without bound on a long-lived tab.
+      const messages = [...action.msgs.toReversed(), ...state.messages];
+      return {
+        ...state,
+        messages: messages.length > MAX_LIVE_LOG_MESSAGES ? messages.slice(0, MAX_LIVE_LOG_MESSAGES) : messages,
+      };
+    }
     case 'setPhase':
       return { ...state, phase: action.phase };
     case 'setProgress':

--- a/frontend/src/state/backend-api.test.tsx
+++ b/frontend/src/state/backend-api.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('../utils/fetch-with-timeout', () => ({ default: vi.fn() }));
+
+import { useApiStore } from './backend-api';
+import type { TopicConsumer, TopicDescription } from './rest-interfaces';
+import fetchWithTimeout from '../utils/fetch-with-timeout';
+
+const topicsResponse = (topicNames: string[]) =>
+  new Response(JSON.stringify({ topics: topicNames.map((topicName) => ({ topicName })) }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+
+describe('refreshTopics topic-cache pruning (F2)', () => {
+  beforeEach(() => {
+    vi.mocked(fetchWithTimeout).mockReset();
+    // Reset the topic-keyed caches so state does not leak between tests (the api store is a
+    // long-lived singleton that the harness does not reset).
+    useApiStore.setState({
+      topics: null,
+      topicConfig: new Map(),
+      topicConsumers: new Map(),
+    });
+  });
+
+  test('drops topic-keyed cache entries for topics that no longer exist', async () => {
+    vi.mocked(fetchWithTimeout).mockResolvedValue(topicsResponse(['live-topic']));
+    useApiStore.setState({
+      topicConfig: new Map<string, TopicDescription | null>([
+        ['live-topic', null],
+        ['stale-topic', null],
+      ]),
+      topicConsumers: new Map<string, TopicConsumer[]>([
+        ['live-topic', []],
+        ['stale-topic', []],
+      ]),
+    });
+
+    await useApiStore.getState().refreshTopics(true);
+
+    const state = useApiStore.getState();
+    expect([...state.topicConfig.keys()]).toEqual(['live-topic']);
+    expect([...state.topicConsumers.keys()]).toEqual(['live-topic']);
+    expect(state.topics).toEqual([{ topicName: 'live-topic' }]);
+  });
+
+  test('keeps cache entries for topics that still exist', async () => {
+    vi.mocked(fetchWithTimeout).mockResolvedValue(topicsResponse(['a', 'b']));
+    useApiStore.setState({
+      topicConfig: new Map<string, TopicDescription | null>([
+        ['a', null],
+        ['b', null],
+      ]),
+    });
+
+    await useApiStore.getState().refreshTopics(true);
+
+    expect([...useApiStore.getState().topicConfig.keys()].sort()).toEqual(['a', 'b']);
+  });
+});

--- a/frontend/src/state/backend-api.ts
+++ b/frontend/src/state/backend-api.ts
@@ -177,6 +177,13 @@ import { decodeBase64, getOidcSubject, TimeSince } from '../utils/utils';
 const REST_TIMEOUT_SEC = 25;
 export const REST_CACHE_DURATION_SEC = 20;
 
+/**
+ * Bounded LRU cap for the module-level REST `cache` below. Without it the cache retained one
+ * CacheEntry (a full parsed REST body) per distinct URL for the life of the tab. 500 keeps a
+ * generous working set; least-recently-used URLs are evicted and simply re-fetched on next use.
+ */
+const REST_CACHE_MAX_ENTRIES = 500;
+
 const { toast } = createStandaloneToast({
   theme: redpandaTheme,
   defaultOptions: redpandaToastOptions.defaultOptions,
@@ -289,7 +296,7 @@ function processVersionInfo(headers: Headers) {
 
 const _activeRequests: CacheEntry[] = [];
 
-const cache = new LazyMap<string, CacheEntry>((u) => new CacheEntry(u));
+const cache = new LazyMap<string, CacheEntry>((u) => new CacheEntry(u), REST_CACHE_MAX_ENTRIES);
 class CacheEntry {
   url: string;
 

--- a/frontend/src/state/backend-api.ts
+++ b/frontend/src/state/backend-api.ts
@@ -165,10 +165,10 @@ import type {
   KnowledgeBaseCreate,
   KnowledgeBaseUpdate,
 } from '../protogen/redpanda/api/dataplane/v1alpha3/knowledge_base_pb';
+import { boundedAppend, pruneMapToKeys, trimToLast } from '../utils/bounded-array';
 import { getBuildDate } from '../utils/env';
 import fetchWithTimeout from '../utils/fetch-with-timeout';
 import { toJson } from '../utils/json-utils';
-import { boundedAppend, pruneMapToKeys, trimToLast } from '../utils/bounded-array';
 import { LazyMap } from '../utils/lazy-map';
 import { convertListMessageData } from '../utils/message-converters';
 import { ObjToKv } from '../utils/tsx-utils';
@@ -2792,8 +2792,7 @@ export function createMessageSearch() {
       // from 30s to 30 minutes before ending the request gracefully.
       // The same condition marks a live-tail/filtered stream, which appends for the whole window
       // and so needs the sliding-window cap below (normal pagination never enters this branch).
-      const isLiveTail =
-        searchRequest.startOffset === PartitionOffsetOrigin.End || req.filterInterpreterCode !== null;
+      const isLiveTail = searchRequest.startOffset === PartitionOffsetOrigin.End || req.filterInterpreterCode !== null;
       let timeoutMs = 30 * 1000;
       if (isLiveTail) {
         const minuteMs = 60 * 1000;

--- a/frontend/src/state/backend-api.ts
+++ b/frontend/src/state/backend-api.ts
@@ -2701,6 +2701,13 @@ export const transformsApi = new Proxy<ReturnType<typeof _transformsCreator>>(
  */
 const LIVE_TAIL_MAX_MESSAGES = 50_000;
 
+/**
+ * Slack above `LIVE_TAIL_MAX_MESSAGES` before a trim runs, so the O(n) `splice` happens once per
+ * ~slack messages instead of on every message past the cap (which would be hottest exactly on the
+ * high-volume streams this guards). The memory ceiling stays cap + slack.
+ */
+const LIVE_TAIL_TRIM_SLACK = 1024;
+
 export function createMessageSearch() {
   const notify = () => useApiStore.setState((s: any) => ({ _msgSearchVersion: (s._msgSearchVersion ?? 0) + 1 }));
   const messageSearch = {
@@ -2842,8 +2849,10 @@ export function createMessageSearch() {
                 const m = convertListMessageData(res.controlMessage.value);
                 this.messages.push(m);
                 // Bound the live-tail/filtered buffer to a sliding window so a 30-minute stream
-                // on a high-volume topic cannot grow the heap without limit.
-                if (isLiveTail) {
+                // on a high-volume topic cannot grow the heap without limit. Only trim once the
+                // buffer drifts a slack margin past the cap, so the O(n) splice is amortized to
+                // roughly once per LIVE_TAIL_TRIM_SLACK messages instead of running on every one.
+                if (isLiveTail && this.messages.length > LIVE_TAIL_MAX_MESSAGES + LIVE_TAIL_TRIM_SLACK) {
                   trimToLast(this.messages, LIVE_TAIL_MAX_MESSAGES);
                 }
                 break;

--- a/frontend/src/state/backend-api.ts
+++ b/frontend/src/state/backend-api.ts
@@ -168,7 +168,7 @@ import type {
 import { getBuildDate } from '../utils/env';
 import fetchWithTimeout from '../utils/fetch-with-timeout';
 import { toJson } from '../utils/json-utils';
-import { boundedAppend, trimToLast } from '../utils/bounded-array';
+import { boundedAppend, pruneMapToKeys, trimToLast } from '../utils/bounded-array';
 import { LazyMap } from '../utils/lazy-map';
 import { convertListMessageData } from '../utils/message-converters';
 import { ObjToKv } from '../utils/tsx-utils';
@@ -665,7 +665,26 @@ const _apiCreator = (set: any, get: any) => ({
                         */
         }
       }
-      set({ topics: v?.topics });
+      const topics = v?.topics;
+      if (topics) {
+        // Prune topic-keyed caches to the current topic set so entries for deleted topics (or a
+        // previous cluster after a remount) don't accumulate for the life of the tab. Pruning to
+        // the live set never drops a topic that still exists, so nothing needs re-fetching.
+        const validTopicNames = new Set(topics.map((t) => t.topicName));
+        set((s: ReturnType<typeof _apiCreator>) => ({
+          topics,
+          topicConfig: pruneMapToKeys(s.topicConfig, validTopicNames),
+          topicDocumentation: pruneMapToKeys(s.topicDocumentation, validTopicNames),
+          topicPermissions: pruneMapToKeys(s.topicPermissions, validTopicNames),
+          topicPartitions: pruneMapToKeys(s.topicPartitions, validTopicNames),
+          topicPartitionErrors: pruneMapToKeys(s.topicPartitionErrors, validTopicNames),
+          topicWatermarksErrors: pruneMapToKeys(s.topicWatermarksErrors, validTopicNames),
+          topicConsumers: pruneMapToKeys(s.topicConsumers, validTopicNames),
+          topicAcls: pruneMapToKeys(s.topicAcls, validTopicNames),
+        }));
+      } else {
+        set({ topics });
+      }
     }, addError);
   },
 

--- a/frontend/src/state/backend-api.ts
+++ b/frontend/src/state/backend-api.ts
@@ -168,6 +168,7 @@ import type {
 import { getBuildDate } from '../utils/env';
 import fetchWithTimeout from '../utils/fetch-with-timeout';
 import { toJson } from '../utils/json-utils';
+import { boundedAppend, trimToLast } from '../utils/bounded-array';
 import { LazyMap } from '../utils/lazy-map';
 import { convertListMessageData } from '../utils/message-converters';
 import { ObjToKv } from '../utils/tsx-utils';
@@ -2667,6 +2668,13 @@ export const transformsApi = new Proxy<ReturnType<typeof _transformsCreator>>(
   }
 );
 
+/**
+ * Sliding-window cap for the live-tail / filtered message buffer (`messageSearch.messages`).
+ * Those streams append for up to 30 minutes; on a high-volume topic the array would otherwise
+ * grow unbounded for the whole window — the dominant long-lived-tab retention vector.
+ */
+const LIVE_TAIL_MAX_MESSAGES = 50_000;
+
 export function createMessageSearch() {
   const notify = () => useApiStore.setState((s: any) => ({ _msgSearchVersion: (s._msgSearchVersion ?? 0) + 1 }));
   const messageSearch = {
@@ -2756,8 +2764,12 @@ export function createMessageSearch() {
 
       // For StartOffset = Newest and any set push-down filter we need to bump the default timeout
       // from 30s to 30 minutes before ending the request gracefully.
+      // The same condition marks a live-tail/filtered stream, which appends for the whole window
+      // and so needs the sliding-window cap below (normal pagination never enters this branch).
+      const isLiveTail =
+        searchRequest.startOffset === PartitionOffsetOrigin.End || req.filterInterpreterCode !== null;
       let timeoutMs = 30 * 1000;
-      if (searchRequest.startOffset === PartitionOffsetOrigin.End || req.filterInterpreterCode !== null) {
+      if (isLiveTail) {
         const minuteMs = 60 * 1000;
         timeoutMs = 30 * minuteMs;
       }
@@ -2804,6 +2816,11 @@ export function createMessageSearch() {
               case 'data': {
                 const m = convertListMessageData(res.controlMessage.value);
                 this.messages.push(m);
+                // Bound the live-tail/filtered buffer to a sliding window so a 30-minute stream
+                // on a high-volume topic cannot grow the heap without limit.
+                if (isLiveTail) {
+                  trimToLast(this.messages, LIVE_TAIL_MAX_MESSAGES);
+                }
                 break;
               }
               default:
@@ -3049,8 +3066,18 @@ async function parseOrUnwrap<T>(response: Response, text: string | null): Promis
   return obj as T;
 }
 
+/**
+ * Cap on retained API errors. `addError` is called from ~20 legacy refresh paths; on a
+ * long-lived tab with auto-refresh enabled and a persistently failing endpoint the array
+ * would otherwise grow without bound (each entry retains a stack + the Response body).
+ * The error UI only ever surfaces the most recent entries, so a ring buffer loses nothing.
+ */
+const MAX_TRACKED_ERRORS = 50;
+
 function addError(err: Error) {
-  useApiStore.setState((s: any) => ({ errors: [...s.errors, err] }));
+  useApiStore.setState((s: ReturnType<typeof _apiCreator>) => ({
+    errors: boundedAppend(s.errors, err, MAX_TRACKED_ERRORS),
+  }));
 }
 
 /** React hook to subscribe to API store state. Use this in components instead of useStore(useApiStore, ...). */

--- a/frontend/src/state/backend-api.ts
+++ b/frontend/src/state/backend-api.ts
@@ -165,7 +165,7 @@ import type {
   KnowledgeBaseCreate,
   KnowledgeBaseUpdate,
 } from '../protogen/redpanda/api/dataplane/v1alpha3/knowledge_base_pb';
-import { boundedAppend, pruneMapToKeys, trimToLast } from '../utils/bounded-array';
+import { appendWithSlackCap, boundedAppend, pruneMapToKeys } from '../utils/bounded-array';
 import { getBuildDate } from '../utils/env';
 import fetchWithTimeout from '../utils/fetch-with-timeout';
 import { toJson } from '../utils/json-utils';
@@ -2847,13 +2847,13 @@ export function createMessageSearch() {
                 break;
               case 'data': {
                 const m = convertListMessageData(res.controlMessage.value);
-                this.messages.push(m);
-                // Bound the live-tail/filtered buffer to a sliding window so a 30-minute stream
-                // on a high-volume topic cannot grow the heap without limit. Only trim once the
-                // buffer drifts a slack margin past the cap, so the O(n) splice is amortized to
-                // roughly once per LIVE_TAIL_TRIM_SLACK messages instead of running on every one.
-                if (isLiveTail && this.messages.length > LIVE_TAIL_MAX_MESSAGES + LIVE_TAIL_TRIM_SLACK) {
-                  trimToLast(this.messages, LIVE_TAIL_MAX_MESSAGES);
+                // Bound the live-tail/filtered buffer to a sliding window so a 30-minute stream on
+                // a high-volume topic cannot grow the heap without limit. appendWithSlackCap
+                // amortizes the O(n) trim to ~once per LIVE_TAIL_TRIM_SLACK messages.
+                if (isLiveTail) {
+                  appendWithSlackCap(this.messages, m, LIVE_TAIL_MAX_MESSAGES, LIVE_TAIL_TRIM_SLACK);
+                } else {
+                  this.messages.push(m);
                 }
                 break;
               }

--- a/frontend/src/state/ui-state.ts
+++ b/frontend/src/state/ui-state.ts
@@ -12,8 +12,16 @@
 import type React from 'react';
 import { create } from 'zustand';
 
+import { boundedAppend } from '../utils/bounded-array';
 import { api } from './backend-api';
 import { createTopicDetailsSettings, type TopicDetailsSettings as TopicSettings, useUISettingsStore } from './ui';
+
+/**
+ * Cap on retained per-topic settings. The array grows by one entry per distinct topic ever
+ * visited and is persisted (as a full blob) by the settings store, so a session that browses
+ * many topics would grow heap and storage without bound. Oldest-visited entries drop first.
+ */
+const MAX_PER_TOPIC_SETTINGS = 200;
 
 export type BreadcrumbOptions = {
   canBeTruncated?: boolean;
@@ -175,7 +183,7 @@ export const useUIStateStore = create<UIStateStore>((set, get) => ({
       if (!uiSettings.perTopicSettings.find((s) => s.topicName === topicName)) {
         const topicSettings = createTopicDetailsSettings(topicName);
         useUISettingsStore.getState().updateSettings({
-          perTopicSettings: [...uiSettings.perTopicSettings, topicSettings],
+          perTopicSettings: boundedAppend(uiSettings.perTopicSettings, topicSettings, MAX_PER_TOPIC_SETTINGS),
         });
       }
     }

--- a/frontend/src/state/ui-state.ts
+++ b/frontend/src/state/ui-state.ts
@@ -12,9 +12,9 @@
 import type React from 'react';
 import { create } from 'zustand';
 
-import { boundedAppend } from '../utils/bounded-array';
 import { api } from './backend-api';
 import { createTopicDetailsSettings, type TopicDetailsSettings as TopicSettings, useUISettingsStore } from './ui';
+import { boundedAppend } from '../utils/bounded-array';
 
 /**
  * Cap on retained per-topic settings. The array grows by one entry per distinct topic ever

--- a/frontend/src/state/ui-state.ts
+++ b/frontend/src/state/ui-state.ts
@@ -19,7 +19,9 @@ import { boundedAppend } from '../utils/bounded-array';
 /**
  * Cap on retained per-topic settings. The array grows by one entry per distinct topic ever
  * visited and is persisted (as a full blob) by the settings store, so a session that browses
- * many topics would grow heap and storage without bound. Oldest-visited entries drop first.
+ * many topics would grow heap and storage without bound. Oldest-added entries drop first (FIFO;
+ * re-visits don't refresh position). The persisted zustand store has its own cap in
+ * stores/topic-settings-store.ts.
  */
 const MAX_PER_TOPIC_SETTINGS = 200;
 

--- a/frontend/src/stores/topic-settings-store.test.tsx
+++ b/frontend/src/stores/topic-settings-store.test.tsx
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { MAX_PER_TOPIC_SETTINGS, useTopicSettingsStore } from './topic-settings-store';
+
+describe('useTopicSettingsStore perTopicSettings cap', () => {
+  beforeEach(() => {
+    useTopicSettingsStore.setState({ perTopicSettings: [] });
+  });
+
+  test('bounds perTopicSettings to MAX_PER_TOPIC_SETTINGS, dropping the oldest-added entries', () => {
+    const total = MAX_PER_TOPIC_SETTINGS + 5;
+    for (let i = 0; i < total; i++) {
+      useTopicSettingsStore.getState().setSorting(`topic-${i}`, []);
+    }
+
+    const settings = useTopicSettingsStore.getState().perTopicSettings;
+    expect(settings).toHaveLength(MAX_PER_TOPIC_SETTINGS);
+    // oldest-added dropped, newest kept
+    expect(settings.some((t) => t.topicName === 'topic-0')).toBe(false);
+    expect(settings.some((t) => t.topicName === `topic-${total - 1}`)).toBe(true);
+  });
+});

--- a/frontend/src/stores/topic-settings-store.ts
+++ b/frontend/src/stores/topic-settings-store.ts
@@ -158,6 +158,15 @@ const createDefaultTopicSettings = (topicName: string, overrides: Partial<TopicS
 });
 
 /**
+ * Cap on retained per-topic settings. This persisted store appends one entry per distinct topic
+ * that gets any setting changed (sort, preview, …) and the persist middleware serializes the whole
+ * array, so a long session touching many topics would grow heap + storage without bound. Oldest-added
+ * entries are dropped first (FIFO; a dropped topic re-creates defaults on next access). Mirrors the
+ * cap on the `setCurrentTopicName` path in `state/ui-state.ts`.
+ */
+export const MAX_PER_TOPIC_SETTINGS = 200;
+
+/**
  * Subscribe to Zustand store changes and sync them to the legacy MobX uiSettings store.
  * This ensures that changes made via Zustand are persisted by MobX's autorun mechanism.
  */
@@ -449,3 +458,14 @@ export const useTopicSettingsStore = create<TopicSettingsStore>()(
 // This ensures that changes made via Zustand are also reflected in the legacy MobX store
 // and persisted by MobX's autorun mechanism
 useTopicSettingsStore.subscribe(syncPerTopicSettingsToMobX);
+
+// Enforce the perTopicSettings cap on every change. Registered after the MobX sync so that the
+// sync re-run (triggered by this trim's setState) ends up mirroring the trimmed array. The length
+// guard makes the re-entrant setState terminate immediately (the trimmed array is within the cap).
+useTopicSettingsStore.subscribe((state) => {
+  if (state.perTopicSettings.length > MAX_PER_TOPIC_SETTINGS) {
+    useTopicSettingsStore.setState({
+      perTopicSettings: state.perTopicSettings.slice(-MAX_PER_TOPIC_SETTINGS),
+    });
+  }
+});

--- a/frontend/src/utils/bounded-array.test.ts
+++ b/frontend/src/utils/bounded-array.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'vitest';
+
+import { boundedAppend, trimToLast } from './bounded-array';
+
+describe('boundedAppend', () => {
+  test('appends an item when under the cap', () => {
+    expect(boundedAppend([1, 2], 3, 5)).toEqual([1, 2, 3]);
+  });
+
+  test('drops the oldest entries when the cap is exceeded', () => {
+    expect(boundedAppend([1, 2, 3], 4, 3)).toEqual([2, 3, 4]);
+  });
+
+  test('returns a new array and does not mutate the input', () => {
+    const input = [1, 2];
+    const result = boundedAppend(input, 3, 5);
+    expect(input).toEqual([1, 2]);
+    expect(result).not.toBe(input);
+  });
+});
+
+describe('trimToLast', () => {
+  test('trims a buffer in place to the last max entries', () => {
+    const buffer = [1, 2, 3, 4, 5];
+    trimToLast(buffer, 2);
+    expect(buffer).toEqual([4, 5]);
+  });
+
+  test('leaves the buffer unchanged when within the cap', () => {
+    const buffer = [1, 2];
+    trimToLast(buffer, 5);
+    expect(buffer).toEqual([1, 2]);
+  });
+});

--- a/frontend/src/utils/bounded-array.test.ts
+++ b/frontend/src/utils/bounded-array.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, expect, test } from 'vitest';
 
-import { boundedAppend, pruneMapToKeys, trimToLast } from './bounded-array';
+import { appendWithSlackCap, boundedAppend, pruneMapToKeys, trimToLast } from './bounded-array';
 
 describe('boundedAppend', () => {
   test('appends an item when under the cap', () => {
@@ -69,5 +69,23 @@ describe('pruneMapToKeys', () => {
     ]);
     pruneMapToKeys(map, new Set(['a']));
     expect(map.size).toBe(2);
+  });
+});
+
+describe('appendWithSlackCap', () => {
+  test('appends without trimming until length exceeds max + slack', () => {
+    const buffer: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      appendWithSlackCap(buffer, i, 3, 2); // max 3 + slack 2 = 5, not yet exceeded
+    }
+    expect(buffer).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  test('trims to max keeping the newest once past max + slack', () => {
+    const buffer: number[] = [];
+    for (let i = 0; i < 6; i++) {
+      appendWithSlackCap(buffer, i, 3, 2); // the 6th push exceeds 5 and trims to the last 3
+    }
+    expect(buffer).toEqual([3, 4, 5]);
   });
 });

--- a/frontend/src/utils/bounded-array.test.ts
+++ b/frontend/src/utils/bounded-array.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import { boundedAppend, trimToLast } from './bounded-array';
+import { boundedAppend, pruneMapToKeys, trimToLast } from './bounded-array';
 
 describe('boundedAppend', () => {
   test('appends an item when under the cap', () => {
@@ -30,5 +30,33 @@ describe('trimToLast', () => {
     const buffer = [1, 2];
     trimToLast(buffer, 5);
     expect(buffer).toEqual([1, 2]);
+  });
+});
+
+describe('pruneMapToKeys', () => {
+  test('keeps only entries whose key is in validKeys', () => {
+    const map = new Map([
+      ['a', 1],
+      ['b', 2],
+      ['c', 3],
+    ]);
+    const result = pruneMapToKeys(map, new Set(['a', 'c']));
+    expect([...result.entries()]).toEqual([
+      ['a', 1],
+      ['c', 3],
+    ]);
+  });
+
+  test('returns an empty map when no keys are valid', () => {
+    expect(pruneMapToKeys(new Map([['a', 1]]), new Set<string>()).size).toBe(0);
+  });
+
+  test('does not mutate the input map', () => {
+    const map = new Map([
+      ['a', 1],
+      ['b', 2],
+    ]);
+    pruneMapToKeys(map, new Set(['a']));
+    expect(map.size).toBe(2);
   });
 });

--- a/frontend/src/utils/bounded-array.test.ts
+++ b/frontend/src/utils/bounded-array.test.ts
@@ -1,3 +1,14 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
 import { describe, expect, test } from 'vitest';
 
 import { boundedAppend, pruneMapToKeys, trimToLast } from './bounded-array';

--- a/frontend/src/utils/bounded-array.ts
+++ b/frontend/src/utils/bounded-array.ts
@@ -31,3 +31,20 @@ export function trimToLast<T>(buffer: T[], max: number): void {
     buffer.splice(0, buffer.length - max);
   }
 }
+
+/**
+ * Return a NEW map containing only the entries whose key is in `validKeys`.
+ *
+ * For entity caches keyed by a name (topics, schema subjects, …) that would otherwise retain
+ * entries for entities that no longer exist (deleted, or a different cluster after a remount).
+ * Pruning to the current set never drops a live entity, so callers re-fetch nothing.
+ */
+export function pruneMapToKeys<V>(map: ReadonlyMap<string, V>, validKeys: ReadonlySet<string>): Map<string, V> {
+  const next = new Map<string, V>();
+  for (const [key, value] of map) {
+    if (validKeys.has(key)) {
+      next.set(key, value);
+    }
+  }
+  return next;
+}

--- a/frontend/src/utils/bounded-array.ts
+++ b/frontend/src/utils/bounded-array.ts
@@ -33,6 +33,19 @@ export function trimToLast<T>(buffer: T[], max: number): void {
 }
 
 /**
+ * Push `item` onto `buffer`, trimming to the last `max` entries only once the buffer drifts more
+ * than `slack` past `max`. The sliding-window ceiling stays `max + slack`, but the O(n) splice is
+ * amortized to roughly once per `slack` items instead of running on every push past the cap —
+ * important on hot append paths (e.g. a high-volume live-tail stream).
+ */
+export function appendWithSlackCap<T>(buffer: T[], item: T, max: number, slack: number): void {
+  buffer.push(item);
+  if (buffer.length > max + slack) {
+    trimToLast(buffer, max);
+  }
+}
+
+/**
  * Return a NEW map containing only the entries whose key is in `validKeys`.
  *
  * For entity caches keyed by a name (topics, schema subjects, …) that would otherwise retain

--- a/frontend/src/utils/bounded-array.ts
+++ b/frontend/src/utils/bounded-array.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+/**
+ * Append `item` to `arr`, returning a NEW array capped to the last `max` entries.
+ *
+ * For immutable state (zustand `setState`, reducers) where an unbounded append would
+ * otherwise retain every entry for the lifetime of a long-lived tab.
+ */
+export function boundedAppend<T>(arr: readonly T[], item: T, max: number): T[] {
+  const next = [...arr, item];
+  return next.length > max ? next.slice(next.length - max) : next;
+}
+
+/**
+ * Trim a mutable buffer IN PLACE to its last `max` entries (sliding window).
+ *
+ * For long-lived push-buffers (e.g. the live-tail message array) where bounding memory
+ * matters more than keeping the full history.
+ */
+export function trimToLast<T>(buffer: T[], max: number): void {
+  if (buffer.length > max) {
+    buffer.splice(0, buffer.length - max);
+  }
+}

--- a/frontend/src/utils/lazy-map.test.ts
+++ b/frontend/src/utils/lazy-map.test.ts
@@ -1,3 +1,14 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
 import { describe, expect, test } from 'vitest';
 
 import { LazyMap } from './lazy-map';

--- a/frontend/src/utils/lazy-map.test.ts
+++ b/frontend/src/utils/lazy-map.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'vitest';
+
+import { LazyMap } from './lazy-map';
+
+describe('LazyMap', () => {
+  test('auto-creates missing values via defaultCreate', () => {
+    const map = new LazyMap<string, string>((k) => `v:${k}`);
+    expect(map.get('a')).toBe('v:a');
+    expect(map.size).toBe(1);
+  });
+
+  test('without a max size it never evicts', () => {
+    const map = new LazyMap<string, number>(() => 0);
+    for (let i = 0; i < 100; i++) {
+      map.get(`k${i}`);
+    }
+    expect(map.size).toBe(100);
+  });
+
+  describe('with a max size', () => {
+    test('evicts the oldest entry when the cap is exceeded', () => {
+      const map = new LazyMap<string, number>(() => 0, 2);
+      map.get('a');
+      map.get('b');
+      map.get('c'); // exceeds cap -> 'a' (oldest) evicted
+
+      expect(map.size).toBe(2);
+      expect(map.has('a')).toBe(false);
+      expect(map.has('b')).toBe(true);
+      expect(map.has('c')).toBe(true);
+    });
+
+    test('keeps recently accessed entries (LRU)', () => {
+      const map = new LazyMap<string, number>(() => 0, 2);
+      map.get('a');
+      map.get('b');
+      map.get('a'); // access 'a' -> most recently used
+      map.get('c'); // evicts the least recently used ('b'), not 'a'
+
+      expect(map.has('a')).toBe(true);
+      expect(map.has('b')).toBe(false);
+      expect(map.has('c')).toBe(true);
+    });
+  });
+});

--- a/frontend/src/utils/lazy-map.ts
+++ b/frontend/src/utils/lazy-map.ts
@@ -17,7 +17,7 @@ export class LazyMap<K, V> extends Map<K, V> {
    * @param defaultCreate factory for missing values.
    * @param maxSize when set, the map behaves as a bounded LRU cache: accessing a key marks it
    *   most-recently-used and inserting beyond `maxSize` evicts the least-recently-used entry.
-   *   Unbounded when omitted (original behaviour).
+   *   Recency is refreshed by `get()` only — `has()` does not bump it. Unbounded when omitted.
    */
   constructor(defaultCreate: (key: K) => V, maxSize?: number) {
     super();

--- a/frontend/src/utils/lazy-map.ts
+++ b/frontend/src/utils/lazy-map.ts
@@ -11,10 +11,18 @@
 
 export class LazyMap<K, V> extends Map<K, V> {
   private readonly defaultCreate: (key: K) => V;
+  private readonly maxSize?: number;
 
-  constructor(defaultCreate: (key: K) => V) {
+  /**
+   * @param defaultCreate factory for missing values.
+   * @param maxSize when set, the map behaves as a bounded LRU cache: accessing a key marks it
+   *   most-recently-used and inserting beyond `maxSize` evicts the least-recently-used entry.
+   *   Unbounded when omitted (original behaviour).
+   */
+  constructor(defaultCreate: (key: K) => V, maxSize?: number) {
     super();
     this.defaultCreate = defaultCreate;
+    this.maxSize = maxSize;
   }
 
   /**
@@ -23,14 +31,33 @@ export class LazyMap<K, V> extends Map<K, V> {
    * @param create An optional `create` method to use instead of `defaultCreate` to create missing values
    */
   get(key: K, createFn?: (k: K) => V): V {
-    let v = super.get(key);
-    if (v !== undefined) {
-      return v;
+    const existing = super.get(key);
+    if (existing !== undefined) {
+      if (this.maxSize !== undefined) {
+        // Mark as most-recently-used so it survives eviction.
+        super.delete(key);
+        super.set(key, existing);
+      }
+      return existing;
     }
 
-    v = this.handleMiss(key, createFn);
-    this.set(key, v);
-    return v;
+    const created = this.handleMiss(key, createFn);
+    this.set(key, created);
+    this.evictOldest();
+    return created;
+  }
+
+  private evictOldest(): void {
+    if (this.maxSize === undefined) {
+      return;
+    }
+    while (this.size > this.maxSize) {
+      const oldestKey = this.keys().next().value;
+      if (oldestKey === undefined) {
+        return;
+      }
+      this.delete(oldestKey);
+    }
   }
 
   private handleMiss(key: K, createFn?: (k: K) => V): V {


### PR DESCRIPTION
Bounds renderer-memory growth on long-lived Console tabs (the BYOC Chrome-OOM class). Code-only; investigation notes are kept out of the PR.

Landed:
- **api.errors ring buffer** — was an unbounded append from ~20 legacy refresh paths; on a long-lived tab with auto-refresh + a failing endpoint it retained an Error (stack + Response body) per failure forever. Now capped (50).
- **live-tail / filtered message buffer sliding window** — the `End`-origin / push-down-filter stream (30-min window) appended to `messages[]` with no cap; now a 50k sliding window, gated to the live path so pagination is untouched.
- New unit-tested `bounded-array` util (`boundedAppend`, `trimToLast`).

More memory fixes (log-view buffers, module caches, Monaco disposal, store/persist bounds, dependency dedupe/drop) land in follow-up commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)