### PR TITLE
fix(frontend): construct protobuf messages with create(Schema)

### DIFF
--- a/frontend/src/components/pages/security/shared/acl-model.tsx
+++ b/frontend/src/components/pages/security/shared/acl-model.tsx
@@ -1,3 +1,4 @@
+import { create } from '@bufbuild/protobuf';
 import type { ConnectError } from '@connectrpc/connect';
 import {
   ACL_Operation,
@@ -5,6 +6,7 @@ import {
   ACL_ResourcePatternType,
   ACL_ResourceType,
   type CreateACLRequest,
+  CreateACLRequestSchema,
   type ListACLsResponse,
 } from 'protogen/redpanda/api/dataplane/v1/acl_pb';
 import type { ReactNode } from 'react';
@@ -522,45 +524,48 @@ export function getIdFromCreateACLRequest(request: CreateACLRequest): string {
 // Convert rules to CreateACLRequest array for API calls
 export function convertRulesToCreateACLRequests(rules: Rule[], principal: string, host: string): CreateACLRequest[] {
   return rules.reduce((acc, r) => {
-    const baseRule: Pick<CreateACLRequest, 'resourcePatternType' | '$typeName' | 'resourceName'> = {
+    const baseRule = {
       resourcePatternType:
         r.selectorType === 'any' ? ACL_ResourcePatternType.LITERAL : getGRPCResourcePatternType(r.selectorType),
-      $typeName: 'redpanda.api.dataplane.v1.CreateACLRequest',
       resourceName: getResourceNameValue(r),
     };
     if (r.mode === ModeAllowAll) {
-      const a: CreateACLRequest = {
-        ...baseRule,
-        host,
-        principal,
-        resourceType: getGRPCResourceType(r.resourceType),
-        operation: ACL_Operation.ALL,
-        permissionType: ACL_PermissionType.ALLOW,
-      };
-      acc.push(a);
+      acc.push(
+        create(CreateACLRequestSchema, {
+          ...baseRule,
+          host,
+          principal,
+          resourceType: getGRPCResourceType(r.resourceType),
+          operation: ACL_Operation.ALL,
+          permissionType: ACL_PermissionType.ALLOW,
+        })
+      );
     }
     if (r.mode === ModeDenyAll) {
-      const a: CreateACLRequest = {
-        ...baseRule,
-        host,
-        principal,
-        resourceType: getGRPCResourceType(r.resourceType),
-        operation: ACL_Operation.ALL,
-        permissionType: ACL_PermissionType.DENY,
-      };
-      acc.push(a);
+      acc.push(
+        create(CreateACLRequestSchema, {
+          ...baseRule,
+          host,
+          principal,
+          resourceType: getGRPCResourceType(r.resourceType),
+          operation: ACL_Operation.ALL,
+          permissionType: ACL_PermissionType.DENY,
+        })
+      );
     }
     if (r.mode === ModeCustom) {
       const customResults = Object.entries(r.operations).reduce((operations, [op, opValue]) => {
         if (opValue !== OperationTypeNotSet) {
-          operations.push({
-            ...baseRule,
-            host,
-            principal,
-            resourceType: getGRPCResourceType(r.resourceType),
-            operation: getGRPCOperationType(op),
-            permissionType: getGRPCPermissionType(opValue),
-          });
+          operations.push(
+            create(CreateACLRequestSchema, {
+              ...baseRule,
+              host,
+              principal,
+              resourceType: getGRPCResourceType(r.resourceType),
+              operation: getGRPCOperationType(op),
+              permissionType: getGRPCPermissionType(opValue),
+            })
+          );
         }
         return operations;
       }, [] as CreateACLRequest[]);

--- a/frontend/src/components/pages/transcripts/transcript-list-page.tsx
+++ b/frontend/src/components/pages/transcripts/transcript-list-page.tsx
@@ -221,7 +221,6 @@ const buildApiFilter = ({
       create(AttributeFilterSchema, {
         key: 'gen_ai.operation.name',
         operator: AttributeOperator.IN,
-        value: '',
         values: ['chat', 'text_completion'],
       })
     );
@@ -234,7 +233,6 @@ const buildApiFilter = ({
         key: 'gen_ai.operation.name',
         operator: AttributeOperator.EQUALS,
         value: 'execute_tool',
-        values: [],
       })
     );
   }
@@ -246,7 +244,6 @@ const buildApiFilter = ({
         key: 'gen_ai.operation.name',
         operator: AttributeOperator.EQUALS,
         value: 'invoke_agent',
-        values: [],
       })
     );
   }
@@ -258,7 +255,6 @@ const buildApiFilter = ({
         key: f.key,
         operator: f.op === 'equals' ? AttributeOperator.EQUALS : AttributeOperator.NOT_EQUALS,
         value: f.value,
-        values: [],
       })
     );
   }

--- a/frontend/src/components/pages/transcripts/transcript-list-page.tsx
+++ b/frontend/src/components/pages/transcripts/transcript-list-page.tsx
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
+import { create } from '@bufbuild/protobuf';
 import { timestampFromMs } from '@bufbuild/protobuf/wkt';
 import type { ColumnFiltersState } from '@tanstack/react-table';
 import { Button } from 'components/redpanda-ui/components/button';
@@ -17,8 +18,10 @@ import { Heading, Link, Text } from 'components/redpanda-ui/components/typograph
 import { parseAsArrayOf, parseAsBoolean, parseAsString, useQueryStates } from 'nuqs';
 import {
   type AttributeFilter,
+  AttributeFilterSchema,
   AttributeOperator,
   type ListTracesRequest_Filter,
+  ListTracesRequest_FilterSchema,
   type TraceSummary,
 } from 'protogen/redpanda/api/dataplane/v1alpha3/tracing_pb';
 import type { FC } from 'react';
@@ -214,50 +217,53 @@ const buildApiFilter = ({
 
   // LLM filter → attribute filter with IN operator
   if (activePresets.includes('llm')) {
-    attributeFilters.push({
-      $typeName: 'redpanda.api.dataplane.v1alpha3.AttributeFilter',
-      key: 'gen_ai.operation.name',
-      operator: AttributeOperator.IN,
-      value: '',
-      values: ['chat', 'text_completion'],
-    });
+    attributeFilters.push(
+      create(AttributeFilterSchema, {
+        key: 'gen_ai.operation.name',
+        operator: AttributeOperator.IN,
+        value: '',
+        values: ['chat', 'text_completion'],
+      })
+    );
   }
 
   // Tool filter → attribute filter
   if (activePresets.includes('tool')) {
-    attributeFilters.push({
-      $typeName: 'redpanda.api.dataplane.v1alpha3.AttributeFilter',
-      key: 'gen_ai.operation.name',
-      operator: AttributeOperator.EQUALS,
-      value: 'execute_tool',
-      values: [],
-    });
+    attributeFilters.push(
+      create(AttributeFilterSchema, {
+        key: 'gen_ai.operation.name',
+        operator: AttributeOperator.EQUALS,
+        value: 'execute_tool',
+        values: [],
+      })
+    );
   }
 
   // Agent filter → attribute filter
   if (activePresets.includes('agent')) {
-    attributeFilters.push({
-      $typeName: 'redpanda.api.dataplane.v1alpha3.AttributeFilter',
-      key: 'gen_ai.operation.name',
-      operator: AttributeOperator.EQUALS,
-      value: 'invoke_agent',
-      values: [],
-    });
+    attributeFilters.push(
+      create(AttributeFilterSchema, {
+        key: 'gen_ai.operation.name',
+        operator: AttributeOperator.EQUALS,
+        value: 'invoke_agent',
+        values: [],
+      })
+    );
   }
 
   // Add user-defined attribute filters
   for (const f of urlAttrFilters) {
-    attributeFilters.push({
-      $typeName: 'redpanda.api.dataplane.v1alpha3.AttributeFilter',
-      key: f.key,
-      operator: f.op === 'equals' ? AttributeOperator.EQUALS : AttributeOperator.NOT_EQUALS,
-      value: f.value,
-      values: [],
-    });
+    attributeFilters.push(
+      create(AttributeFilterSchema, {
+        key: f.key,
+        operator: f.op === 'equals' ? AttributeOperator.EQUALS : AttributeOperator.NOT_EQUALS,
+        value: f.value,
+        values: [],
+      })
+    );
   }
 
-  return {
-    $typeName: 'redpanda.api.dataplane.v1alpha3.ListTracesRequest.Filter',
+  return create(ListTracesRequest_FilterSchema, {
     startTime: startTimestamp,
     endTime: endTimestamp,
     attributeFilters,
@@ -268,7 +274,7 @@ const buildApiFilter = ({
     serviceNames: serviceNames.length > 0 ? serviceNames : [],
     // Span ID filter - not exposed in UI yet, but required by proto
     spanIds: [],
-  };
+  });
 };
 
 type TranscriptListPageProps = {


### PR DESCRIPTION
## What & why

Audit finding **DATA-01**. Three call sites hand-built protobuf messages as object
literals carrying a hardcoded `$typeName` string instead of the protobuf-es **v2**
`create(Schema, …)` API:

- `transcript-list-page.tsx` — `AttributeFilter[]` (4 presets + user filters) and the returned `ListTracesRequest_Filter`
- `acl-model.tsx` — `convertRulesToCreateACLRequests` built `CreateACLRequest` objects from a `baseRule` Pick that hardcoded `$typeName`

A proto rename or package-version bump (`v1alpha3` → `v1`) would leave these literals structurally valid to `tsgo` while the runtime message no longer matched the registered schema — breaking `anyPack`/serialization/equality — and omitted fields skipped proto defaults.

## Change

Use `create(AttributeFilterSchema, …)`, `create(ListTracesRequest_FilterSchema, …)`, and `create(CreateACLRequestSchema, …)` (protobuf-es v2). `$typeName` is dropped from the literals and from the `baseRule` shape; messages now carry it from the schema.

## Verification
- `bun run type:check` ✅
- `bun run lint:check` ✅
- `acl-model` / `create-acl` / `acl-detail` tests (29) ✅ and `transcript-list-page` tests (6) ✅
- `grep '$typeName'` in both files → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
