### PR TITLE
fix(frontend): add accessible names to icon-only buttons

### DIFF
--- a/frontend/src/components/pages/rp-connect/pipeline/index.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/index.tsx
@@ -970,7 +970,7 @@ function PipelinePageContent() {
       ) : null}
       {mode === 'view' && !pipeline ? (
         <div className="flex items-center gap-2">
-          <Button className="-ml-3.5 shrink-0" onClick={handleCancel} size="icon" variant="ghost">
+          <Button aria-label="Go back" className="-ml-3.5 shrink-0" onClick={handleCancel} size="icon" variant="ghost">
             <ArrowLeftIcon className="h-5 w-5" />
           </Button>
           <Skeleton variant="text" width="md" />

--- a/frontend/src/components/pages/security/tabs/acls-tab.tsx
+++ b/frontend/src/components/pages/security/tabs/acls-tab.tsx
@@ -214,7 +214,13 @@ const AclsTabContent: FC = () => {
                   return (
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
-                        <Button className="deleteButton" onClick={() => {}} size="icon-sm" variant="destructive-ghost">
+                        <Button
+                          aria-label="Delete ACL"
+                          className="deleteButton"
+                          onClick={() => {}}
+                          size="icon-sm"
+                          variant="destructive-ghost"
+                        >
                           <TrashIcon className="h-4 w-4" />
                         </Button>
                       </DropdownMenuTrigger>

--- a/frontend/src/components/pages/security/tabs/acls-tab.tsx
+++ b/frontend/src/components/pages/security/tabs/acls-tab.tsx
@@ -215,7 +215,7 @@ const AclsTabContent: FC = () => {
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
                         <Button
-                          aria-label="Delete ACL"
+                          aria-label={`Delete ACL for ${record.principalName}`}
                           className="deleteButton"
                           onClick={() => {}}
                           size="icon-sm"

--- a/frontend/src/components/pages/security/tabs/users-tab.tsx
+++ b/frontend/src/components/pages/security/tabs/users-tab.tsx
@@ -251,7 +251,7 @@ const UserActions = ({ user }: { user: PrincipalEntry }) => {
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button asChild className="deleteButton" size="icon-sm" variant="ghost">
-            <button aria-label="Open user actions" type="button">
+            <button aria-label={`Open actions for ${user.name}`} type="button">
               <MoreHorizontalIcon className="h-4 w-4" />
             </button>
           </Button>

--- a/frontend/src/components/pages/security/tabs/users-tab.tsx
+++ b/frontend/src/components/pages/security/tabs/users-tab.tsx
@@ -251,7 +251,7 @@ const UserActions = ({ user }: { user: PrincipalEntry }) => {
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button asChild className="deleteButton" size="icon-sm" variant="ghost">
-            <button type="button">
+            <button aria-label="Open user actions" type="button">
               <MoreHorizontalIcon className="h-4 w-4" />
             </button>
           </Button>

--- a/frontend/src/components/pages/shadowlinks/details/shadow-topics-table.tsx
+++ b/frontend/src/components/pages/shadowlinks/details/shadow-topics-table.tsx
@@ -229,11 +229,17 @@ export const ShadowTopicsTable: React.FC<ShadowTopicsTableProps> = ({
                 />
               </div>
               {Boolean(topicNameFilter) && (
-                <Button onClick={() => onTopicNameFilterChange?.('')} size="sm" variant="ghost">
+                <Button
+                  aria-label="Clear filter"
+                  onClick={() => onTopicNameFilterChange?.('')}
+                  size="sm"
+                  variant="ghost"
+                >
                   <X className="h-4 w-4" />
                 </Button>
               )}
               <Button
+                aria-label="Refresh topics"
                 data-testid="refresh-topics-button"
                 disabled={isFetching}
                 onClick={onRefresh}

--- a/frontend/src/components/pages/shadowlinks/details/tasks-table.tsx
+++ b/frontend/src/components/pages/shadowlinks/details/tasks-table.tsx
@@ -75,7 +75,14 @@ export const TasksTable = ({ tasks, onRefresh, dataUnavailable }: TasksTableProp
         <CardTitle>Tasks</CardTitle>
         {Boolean(onRefresh) && (
           <CardAction>
-            <Button data-testid="refresh-tasks-button" onClick={onRefresh} size="icon" type="button" variant="ghost">
+            <Button
+              aria-label="Refresh tasks"
+              data-testid="refresh-tasks-button"
+              onClick={onRefresh}
+              size="icon"
+              type="button"
+              variant="ghost"
+            >
               <RefreshCw className="h-5 w-5" />
             </Button>
           </CardAction>

--- a/frontend/src/components/pages/transcripts/components/transcript-filter-bar.tsx
+++ b/frontend/src/components/pages/transcripts/components/transcript-filter-bar.tsx
@@ -427,7 +427,14 @@ export const TranscriptFilterBar: FC<TranscriptFilterBarProps> = ({
         </Select>
 
         {/* Refresh button */}
-        <Button className="h-8 w-8" disabled={isLoading} onClick={onRefresh} size="icon" variant="outline">
+        <Button
+          aria-label="Refresh"
+          className="h-8 w-8"
+          disabled={isLoading}
+          onClick={onRefresh}
+          size="icon"
+          variant="outline"
+        >
           <RefreshCw className={`h-3.5 w-3.5 ${isLoading ? 'animate-spin' : ''}`} />
         </Button>
       </div>


### PR DESCRIPTION
## What & why

Audit finding **A11Y-02**. Icon-only buttons were announced as a bare "button" to
screen readers (WCAG 4.1.2 Name, Role, Value). The codebase already has the correct
pattern elsewhere (`secrets-store-actions` uses `sr-only`, `schema-list` uses
`aria-label`), so these are inconsistent omissions, not a missing capability.

## Change

Added `aria-label` to the verified-cited icon-only buttons:

| Location | Button | Label |
|----------|--------|-------|
| `transcripts/components/transcript-filter-bar` | refresh | "Refresh" |
| `security/tabs/acls-tab` | ACL delete trigger | "Delete ACL" |
| `security/tabs/users-tab` | user actions menu | "Open user actions" |
| `shadowlinks/details/tasks-table` | refresh | "Refresh tasks" |
| `shadowlinks/details/shadow-topics-table` | clear filter / refresh | "Clear filter" / "Refresh topics" |
| `rp-connect/pipeline` | back | "Go back" |

## Verification
- `bun run type:check` ✅
- `bun run lint:check` ✅
- `rp-connect/pipeline` integration tests (23) ✅

## Follow-up (not in this PR)
A broader sweep found ~77 icon-only buttons across the app lacking an accessible
name. This PR fixes the audit-cited, highest-traffic controls; the remaining sweep
(plus a lint rule to enforce it) is a separate change so this stays reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
