### PR TITLE
fix(frontend): add rel=noopener noreferrer to target=_blank links

### DIFF
--- a/frontend/src/components/pages/connect/overview.tsx
+++ b/frontend/src/components/pages/connect/overview.tsx
@@ -163,7 +163,7 @@ class KafkaConnectOverview extends PageComponent<{
               {this.props.isKafkaConnectEnabled
                 ? 'Redpanda Connect is an alternative to Kafka Connect. Choose from a growing ecosystem of readily available connectors.'
                 : 'Redpanda Connect is a data streaming service for building scalable, high-performance data pipelines that drive real-time analytics and actionable business insights. Integrate data across systems with hundreds of prebuilt connectors, change data capture (CDC) capabilities, and YAML-configurable pipelines.'}{' '}
-              <Link href="https://docs.redpanda.com/redpanda-connect/home/" target="_blank">
+              <Link href="https://docs.redpanda.com/redpanda-connect/home/" rel="noopener noreferrer" target="_blank">
                 Learn more
               </Link>
             </Text>
@@ -179,7 +179,11 @@ class KafkaConnectOverview extends PageComponent<{
             <Text>
               Kafka Connect is our set of managed connectors. These provide a way to integrate your Redpanda data with
               different data systems.{' '}
-              <Link href="https://docs.redpanda.com/redpanda-cloud/develop/managed-connectors/" target="_blank">
+              <Link
+                href="https://docs.redpanda.com/redpanda-cloud/develop/managed-connectors/"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
                 Learn more.
               </Link>
             </Text>

--- a/frontend/src/components/pages/quotas/quotas-list.tsx
+++ b/frontend/src/components/pages/quotas/quotas-list.tsx
@@ -107,7 +107,7 @@ const QuotasList = () => {
           <Section>
             <Result
               extra={
-                <Link href="https://docs.redpanda.com/docs/manage/console/" target="_blank">
+                <Link href="https://docs.redpanda.com/docs/manage/console/" rel="noopener noreferrer" target="_blank">
                   <Button variant="solid">Redpanda Console documentation for roles and permissions</Button>
                 </Link>
               }

--- a/frontend/src/components/pages/rp-connect/onboarding/add-user-step.tsx
+++ b/frontend/src/components/pages/rp-connect/onboarding/add-user-step.tsx
@@ -545,6 +545,7 @@ export const AddUserStep = forwardRef<UserStepRef, AddUserStepProps & MotionProp
                             <TanStackRouterLink
                               className="text-blue-800"
                               params={{ userName: existingUserSelected.name }}
+                              rel="noopener noreferrer"
                               target="_blank"
                               to="/security/users/$userName/details"
                             >
@@ -693,6 +694,7 @@ export const AddUserStep = forwardRef<UserStepRef, AddUserStepProps & MotionProp
                                     <Text variant="small">
                                       You will need to configure{' '}
                                       <TanStackRouterLink
+                                        rel="noopener noreferrer"
                                         target="_blank"
                                         to={
                                           isFeatureFlagEnabled('enableNewSecurityPage')

--- a/frontend/src/components/pages/rp-connect/onboarding/connect-tiles.tsx
+++ b/frontend/src/components/pages/rp-connect/onboarding/connect-tiles.tsx
@@ -346,7 +346,7 @@ export const ConnectTiles = memo(
                     that drive real-time analytics and actionable business insights. Integrate data across systems with
                     hundreds of prebuilt connectors, change data capture (CDC) capabilities, and YAML-configurable
                     pipelines.{' '}
-                    <Link href="https://docs.redpanda.com/redpanda-connect/home/" target="_blank">
+                    <Link href="https://docs.redpanda.com/redpanda-connect/home/" rel="noopener noreferrer" target="_blank">
                       Learn more
                     </Link>
                   </Text>

--- a/frontend/src/components/pages/rp-connect/onboarding/connect-tiles.tsx
+++ b/frontend/src/components/pages/rp-connect/onboarding/connect-tiles.tsx
@@ -346,7 +346,11 @@ export const ConnectTiles = memo(
                     that drive real-time analytics and actionable business insights. Integrate data across systems with
                     hundreds of prebuilt connectors, change data capture (CDC) capabilities, and YAML-configurable
                     pipelines.{' '}
-                    <Link href="https://docs.redpanda.com/redpanda-connect/home/" rel="noopener noreferrer" target="_blank">
+                    <Link
+                      href="https://docs.redpanda.com/redpanda-connect/home/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
                       Learn more
                     </Link>
                   </Text>

--- a/frontend/src/components/pages/rp-connect/pipeline/list.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/list.tsx
@@ -750,7 +750,11 @@ export const PipelineListPage = () => {
               <Text>
                 Kafka Connect is our set of managed connectors. These provide a way to integrate your Redpanda data with
                 different data systems.{' '}
-                <Link href="https://docs.redpanda.com/redpanda-cloud/develop/managed-connectors/" rel="noopener noreferrer" target="_blank">
+                <Link
+                  href="https://docs.redpanda.com/redpanda-cloud/develop/managed-connectors/"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
                   Learn more
                 </Link>
               </Text>

--- a/frontend/src/components/pages/rp-connect/pipeline/list.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/list.tsx
@@ -698,7 +698,7 @@ const RedpandaConnectContent = () => (
       Redpanda Connect is a data streaming service for building scalable, high-performance data pipelines that drive
       real-time analytics and actionable business insights. Integrate data across systems with hundreds of prebuilt
       connectors, change data capture (CDC) capabilities, and YAML-configurable pipelines.{' '}
-      <Link href="https://docs.redpanda.com/redpanda-connect/home/" target="_blank">
+      <Link href="https://docs.redpanda.com/redpanda-connect/home/" rel="noopener noreferrer" target="_blank">
         Learn more
       </Link>
     </Text>
@@ -750,7 +750,7 @@ export const PipelineListPage = () => {
               <Text>
                 Kafka Connect is our set of managed connectors. These provide a way to integrate your Redpanda data with
                 different data systems.{' '}
-                <Link href="https://docs.redpanda.com/redpanda-cloud/develop/managed-connectors/" target="_blank">
+                <Link href="https://docs.redpanda.com/redpanda-cloud/develop/managed-connectors/" rel="noopener noreferrer" target="_blank">
                   Learn more
                 </Link>
               </Text>

--- a/frontend/src/components/pages/rp-connect/pipelines-create.tsx
+++ b/frontend/src/components/pages/rp-connect/pipelines-create.tsx
@@ -131,15 +131,27 @@ const RpConnectPipelinesCreateContent = () => {
       <div className="my-2">
         <UIText>
           For help creating your pipeline, see our{' '}
-          <UILink href="https://docs.redpanda.com/redpanda-cloud/develop/connect/connect-quickstart/" rel="noopener noreferrer" target="_blank">
+          <UILink
+            href="https://docs.redpanda.com/redpanda-cloud/develop/connect/connect-quickstart/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
             quickstart
           </UILink>
           ,{' '}
-          <UILink href="https://docs.redpanda.com/redpanda-cloud/develop/connect/cookbooks/" rel="noopener noreferrer" target="_blank">
+          <UILink
+            href="https://docs.redpanda.com/redpanda-cloud/develop/connect/cookbooks/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
             library of examples
           </UILink>
           , and{' '}
-          <UILink href="https://docs.redpanda.com/redpanda-cloud/develop/connect/components/catalog/" rel="noopener noreferrer" target="_blank">
+          <UILink
+            href="https://docs.redpanda.com/redpanda-cloud/develop/connect/components/catalog/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
             connector catalog
           </UILink>
           .

--- a/frontend/src/components/pages/rp-connect/pipelines-create.tsx
+++ b/frontend/src/components/pages/rp-connect/pipelines-create.tsx
@@ -131,15 +131,15 @@ const RpConnectPipelinesCreateContent = () => {
       <div className="my-2">
         <UIText>
           For help creating your pipeline, see our{' '}
-          <UILink href="https://docs.redpanda.com/redpanda-cloud/develop/connect/connect-quickstart/" target="_blank">
+          <UILink href="https://docs.redpanda.com/redpanda-cloud/develop/connect/connect-quickstart/" rel="noopener noreferrer" target="_blank">
             quickstart
           </UILink>
           ,{' '}
-          <UILink href="https://docs.redpanda.com/redpanda-cloud/develop/connect/cookbooks/" target="_blank">
+          <UILink href="https://docs.redpanda.com/redpanda-cloud/develop/connect/cookbooks/" rel="noopener noreferrer" target="_blank">
             library of examples
           </UILink>
           , and{' '}
-          <UILink href="https://docs.redpanda.com/redpanda-cloud/develop/connect/components/catalog/" target="_blank">
+          <UILink href="https://docs.redpanda.com/redpanda-cloud/develop/connect/components/catalog/" rel="noopener noreferrer" target="_blank">
             connector catalog
           </UILink>
           .
@@ -453,6 +453,7 @@ export const PipelineEditor = (p: {
                       This looks like a Kafka Connect configuration. For help with Redpanda Connect configurations,{' '}
                       <UILink
                         href="https://docs.redpanda.com/redpanda-cloud/develop/connect/connect-quickstart/"
+                        rel="noopener noreferrer"
                         target="_blank"
                       >
                         see our quickstart documentation

--- a/frontend/src/components/pages/rp-connect/pipelines-edit.tsx
+++ b/frontend/src/components/pages/rp-connect/pipelines-edit.tsx
@@ -147,15 +147,27 @@ const RpConnectPipelinesEditContent = ({ pipeline, pipelineId }: { pipeline: Pip
       <div className="my-2">
         <UIText>
           For help editing your pipeline, see our{' '}
-          <UILink href="https://docs.redpanda.com/redpanda-cloud/develop/connect/connect-quickstart/" rel="noopener noreferrer" target="_blank">
+          <UILink
+            href="https://docs.redpanda.com/redpanda-cloud/develop/connect/connect-quickstart/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
             quickstart documentation
           </UILink>
           , our{' '}
-          <UILink href="https://docs.redpanda.com/redpanda-cloud/develop/connect/cookbooks/" rel="noopener noreferrer" target="_blank">
+          <UILink
+            href="https://docs.redpanda.com/redpanda-cloud/develop/connect/cookbooks/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
             library of examples
           </UILink>
           , or our{' '}
-          <UILink href="https://docs.redpanda.com/redpanda-cloud/develop/connect/components/catalog/" rel="noopener noreferrer" target="_blank">
+          <UILink
+            href="https://docs.redpanda.com/redpanda-cloud/develop/connect/components/catalog/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
             connector catalog
           </UILink>
           .

--- a/frontend/src/components/pages/rp-connect/pipelines-edit.tsx
+++ b/frontend/src/components/pages/rp-connect/pipelines-edit.tsx
@@ -147,15 +147,15 @@ const RpConnectPipelinesEditContent = ({ pipeline, pipelineId }: { pipeline: Pip
       <div className="my-2">
         <UIText>
           For help editing your pipeline, see our{' '}
-          <UILink href="https://docs.redpanda.com/redpanda-cloud/develop/connect/connect-quickstart/" target="_blank">
+          <UILink href="https://docs.redpanda.com/redpanda-cloud/develop/connect/connect-quickstart/" rel="noopener noreferrer" target="_blank">
             quickstart documentation
           </UILink>
           , our{' '}
-          <UILink href="https://docs.redpanda.com/redpanda-cloud/develop/connect/cookbooks/" target="_blank">
+          <UILink href="https://docs.redpanda.com/redpanda-cloud/develop/connect/cookbooks/" rel="noopener noreferrer" target="_blank">
             library of examples
           </UILink>
           , or our{' '}
-          <UILink href="https://docs.redpanda.com/redpanda-cloud/develop/connect/components/catalog/" target="_blank">
+          <UILink href="https://docs.redpanda.com/redpanda-cloud/develop/connect/components/catalog/" rel="noopener noreferrer" target="_blank">
             connector catalog
           </UILink>
           .

--- a/frontend/src/components/pages/transcripts/transcript-list-page.tsx
+++ b/frontend/src/components/pages/transcripts/transcript-list-page.tsx
@@ -768,7 +768,11 @@ export const TranscriptListPage: FC<TranscriptListPageProps> = ({ disableFacetin
         <Text variant="muted">
           Trace and debug AI requests across your agentic dataplane — view LLM calls, tool invocations, and spans from
           agents, gateways, and services.{' '}
-          <Link href="https://docs.redpanda.com/redpanda-cloud/ai-agents/observability" rel="noopener noreferrer" target="_blank">
+          <Link
+            href="https://docs.redpanda.com/redpanda-cloud/ai-agents/observability"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
             Learn more
           </Link>
         </Text>

--- a/frontend/src/components/pages/transcripts/transcript-list-page.tsx
+++ b/frontend/src/components/pages/transcripts/transcript-list-page.tsx
@@ -768,7 +768,7 @@ export const TranscriptListPage: FC<TranscriptListPageProps> = ({ disableFacetin
         <Text variant="muted">
           Trace and debug AI requests across your agentic dataplane — view LLM calls, tool invocations, and spans from
           agents, gateways, and services.{' '}
-          <Link href="https://docs.redpanda.com/redpanda-cloud/ai-agents/observability" target="_blank">
+          <Link href="https://docs.redpanda.com/redpanda-cloud/ai-agents/observability" rel="noopener noreferrer" target="_blank">
             Learn more
           </Link>
         </Text>


### PR DESCRIPTION
## What & why

Audit finding **SECURITY-03**. Links opened with `target="_blank"` but no `rel`
expose **reverse-tabnabbing** (the opened page can drive `window.opener` to a
phishing URL) and referrer leakage. Practical risk is low here (destinations are
the trusted `docs.redpanda.com` domain and modern browsers imply `noopener`), but
it's a latent footgun the moment a `target="_blank"` href becomes dynamic.

## Change

Added `rel="noopener noreferrer"` to the **16** external-link sites (custom
`Link` / `UILink` / router-link components) across 8 files that were missing it.

Native `<a target="_blank">` are already covered by biome's recommended
`noBlankTarget` rule — but that rule only inspects native anchors, so the registry
`Link`/`UILink` consumers needed explicit `rel`. The vendor registry component
(`redpanda-ui/.../auto-form/field-wrapper.tsx`) was left untouched (it already had
`rel` anyway).

## Verification
- `bun run type:check` ✅
- `bun run lint:check` ✅
- Independent sweep: **0** `target="_blank"` elements remain without a `rel` (excluding vendor/generated).

## Follow-up (not in this PR)
Biome's `noBlankTarget` can't enforce `rel` on custom components. A small custom lint
rule (or defaulting `rel` in the upstream registry `Link`) would prevent regressions —
tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
