### PR TITLE
fix(frontend): re-root federated Console router to avoid host __root collision (MF v2 dev)

### DIFF
--- a/frontend/src/federation/console-app.tsx
+++ b/frontend/src/federation/console-app.tsx
@@ -38,12 +38,42 @@ import { protobufRegistry } from 'protobuf-registry';
 import { LONG_LIVED_CACHE_STALE_TIME } from 'react-query/react-query.utils';
 
 import { FederatedProviders } from './federated-providers';
+import { federatedRootRoute } from './federated-routes';
 import { TokenManager } from './token-manager';
 import type { ConsoleAppProps } from './types';
 import { NotFoundPage } from '../components/misc/not-found-page';
 import { addBearerTokenInterceptor, checkExpiredLicenseInterceptor, config, getGrpcBasePath, setup } from '../config';
 import { routeTree } from '../routeTree.gen';
 import { installUISettingsSideEffects } from '../state/ui';
+
+/**
+ * Re-root the generated route tree onto Console's federated root.
+ *
+ * In the federated dev build, the generated tree's root route (from
+ * `src/routes/__root.tsx`) can be substituted by Cloud UI's own `__root` route
+ * — both apps compile a module with the identical id `./src/routes/__root.tsx`,
+ * and in the shared rsbuild/MF dev runtime the host's wins. The result is that
+ * the embedded Console renders Cloud UI's root chrome (its react NuqsAdapter,
+ * Builder.io `<Content>`, and `<CommandPalette>`/KBar) instead of Console's own
+ * federated layout — which breaks nuqs (NUQS-404), crashes on KBar
+ * (`getState is not a function`, no `KBarProvider` in this subtree), and leaves
+ * the embedded sidebar empty.
+ *
+ * `federatedRootRoute` lives at a Console-unique module path
+ * (`src/federation/federated-routes.tsx`) that cannot collide with Cloud UI, so
+ * reattaching the generated child routes to it guarantees the embedded app
+ * renders Console's own root. Standalone (`app.tsx`) and the legacy embedded
+ * entry keep using the generated `routeTree` unchanged.
+ */
+function createFederatedRouteTree() {
+  const childRoutes = routeTree.children ? Object.values(routeTree.children) : [];
+  for (const child of childRoutes) {
+    child.options.getParentRoute = () => federatedRootRoute;
+  }
+  return federatedRootRoute._addFileChildren(childRoutes);
+}
+
+const federatedRouteTree = createFederatedRouteTree();
 
 /**
  * Creates an interceptor that refreshes the token on 401 and retries the request.
@@ -255,7 +285,7 @@ function ConsoleAppInner({
     });
 
     const r = createRouter({
-      routeTree,
+      routeTree: federatedRouteTree,
       history: memoryHistory,
       context: {
         basePath: '',

--- a/frontend/src/federation/federated-routes.tsx
+++ b/frontend/src/federation/federated-routes.tsx
@@ -14,6 +14,7 @@ import type { QueryClient } from '@tanstack/react-query';
 import { createRootRouteWithContext, Outlet } from '@tanstack/react-router';
 import { NuqsAdapter } from 'nuqs/adapters/tanstack-router';
 
+import { DebugHelper } from '../components/debug-helper/debug-dialog';
 import AppFooter from '../components/layout/footer';
 import AppPageHeader from '../components/layout/header';
 import { LicenseNotification } from '../components/license/license-notification';
@@ -74,6 +75,8 @@ function FederatedRootLayout() {
             <FederatedAppContent />
           </RequireAuth>
         </ErrorBoundary>
+        {/* Cmd+Shift+D debug dialog — mirrors __root.tsx; dev-only. */}
+        {process.env.NODE_ENV === 'development' && <DebugHelper />}
       </NuqsAdapter>
     </>
   );

--- a/frontend/src/federation/federated-routes.tsx
+++ b/frontend/src/federation/federated-routes.tsx
@@ -21,6 +21,8 @@ import { ErrorBoundary } from '../components/misc/error-boundary';
 import { ErrorDisplay } from '../components/misc/error-display';
 import { ErrorModalsRenderer } from '../components/misc/error-modal';
 import { NullFallbackBoundary } from '../components/misc/null-fallback-boundary';
+import { RouterSync } from '../components/misc/router-sync';
+import RequireAuth from '../components/require-auth';
 import { ModalContainer } from '../utils/modal-container';
 
 /**
@@ -60,11 +62,20 @@ export const federatedRootRoute = createRootRouteWithContext<FederatedRouterCont
  */
 function FederatedRootLayout() {
   return (
-    <NuqsAdapter>
-      <ErrorBoundary>
-        <FederatedAppContent />
-      </ErrorBoundary>
-    </NuqsAdapter>
+    <>
+      <RouterSync />
+      <NuqsAdapter>
+        <ErrorBoundary>
+          {/* RequireAuth triggers the user-data fetch (api.refreshUserData) that
+              gates Console's endpoint-compatibility fetch and, in turn, the
+              embedded sidebar items. The standalone root (__root.tsx) wraps its
+              embedded layout the same way. */}
+          <RequireAuth>
+            <FederatedAppContent />
+          </RequireAuth>
+        </ErrorBoundary>
+      </NuqsAdapter>
+    </>
   );
 }
 
@@ -73,6 +84,9 @@ function FederatedRootLayout() {
  * Similar to EmbeddedLayout from __root.tsx but optimized for MF v2.0.
  */
 function FederatedAppContent() {
+  // Mirrors __root.tsx's EmbeddedLayout so the embedded experience matches
+  // production: AppPageHeader renders the page title (it already suppresses
+  // the breadcrumb/sidebar-trigger in embedded mode — the host supplies those).
   return (
     <div id="mainLayout">
       <NullFallbackBoundary>

--- a/frontend/src/federation/federated-routes.tsx
+++ b/frontend/src/federation/federated-routes.tsx
@@ -23,6 +23,7 @@ import { ErrorDisplay } from '../components/misc/error-display';
 import { ErrorModalsRenderer } from '../components/misc/error-modal';
 import { NullFallbackBoundary } from '../components/misc/null-fallback-boundary';
 import { RouterSync } from '../components/misc/router-sync';
+import { Toaster } from '../components/redpanda-ui/components/sonner';
 import RequireAuth from '../components/require-auth';
 import { ModalContainer } from '../utils/modal-container';
 
@@ -99,12 +100,18 @@ function FederatedAppContent() {
       <AppPageHeader />
 
       <ErrorDisplay>
-        <Outlet />
+        <div className="pt-8">
+          <Outlet />
+        </div>
       </ErrorDisplay>
 
       <AppFooter />
 
       <ErrorModalsRenderer />
+
+      {/* sonner isn't an MF-shared singleton, so the host's <Toaster> can't
+          surface Console's toasts; mirror __root.tsx's AppContent. */}
+      <Toaster position="top-right" richColors />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

When Console is embedded in Cloud UI via **Module Federation v2** (`enable-console-mf-v2`), the embedded app is broken in dev: **empty sidebar**, a **KBar crash** (`getState is not a function`), and a **nuqs `NUQS-404` ("nuqs requires an adapter")** on pages like Topics/Security. All three are one root cause.

## Root cause

Console's federated entry (`console-app.tsx`) builds its router from the generated `routeTree`, whose root comes from `src/routes/__root.tsx`. **Cloud UI (the host) also has a `src/routes/__root.tsx`** since its TanStack Router migration — an *identical rspack module id* (`./src/routes/__root.tsx`) in both apps. In the shared rsbuild/MF **dev** runtime, the host's already-registered module wins that collision, so Console's route tree ends up with **Cloud UI's root route** (its `RootComponent`) but **Console's child routes**.

Cloud UI's `RootComponent` renders `<CommandPalette/>` (KBar) and a `nuqs/adapters/react` `<NuqsAdapter>`. Inside Console's subtree there's no `KBarProvider` → `useKBar` throws → Console's render aborts → **sidebar never populates**. And the only nuqs provider present is Cloud UI's react adapter on Cloud UI's nuqs context, while Console's `useQueryState` consumers read Console's *own* nuqs instance → no matching provider → **NUQS-404**.

## Why this is surfacing now

It needed a conjunction of recent/rare conditions that only just lined up:

1. **Cloud UI migrated react-router-dom → TanStack Router (2026-01-26)** — that's when it first got a `src/routes/__root.tsx` with the same module id as Console's. Before that, nothing to collide with.
2. **MF v2 embedding is off by default** (`enable-console-mf-v2 = false`). Only the v2 path has Console build its *own* router from `routeTree.gen` (which imports `__root`). The default v1 legacy injector mounts differently and doesn't hit this.
3. **It only manifests in dev.** Production builds host and remote as fully isolated runtimes with no shared dev module-id registry, so Console always renders its own `__root` in prod. (It also only became observable in localdev once Console hot-reload actually started loading the dev bundle — previously localdev was serving the deployed prod Console image.)

So this is a latent **dev-only** MF hazard, newly exposed — not a regression in normal usage, and not present in production.

## Fix

Two files, embedded MF-v2 path only:

- **`console-app.tsx`** — `createFederatedRouteTree()` re-parents the generated child routes onto Console's own `federatedRootRoute` (from `federated-routes.tsx`, a Console-unique module path that can't collide with the host), and `createRouter` uses that tree. This guarantees the embedded app renders Console's own root regardless of the dev module-graph crossover.
- **`federated-routes.tsx`** — `FederatedRootLayout` gains `RouterSync` + `RequireAuth`. `RequireAuth` is what triggers `api.refreshUserData()` → the endpoint-compatibility fetch → the embedded sidebar items (without it the sidebar stays empty). Mirrors `__root.tsx`'s `EmbeddedLayout`.

Standalone (`app.tsx` / `__root.tsx`) and the legacy embedded entry keep using the generated `routeTree` unchanged.

## Verification (localdev, embedded in Cloud UI, dev build)

- Topics & Security pages: sidebar fully populated (Topics, Schema Registry, Consumer Groups, Security, Quotas, Connect, Transforms, Shadow Links, SQL, AI Agents, …), tables render, **no NUQS-404, no KBar crash, no error boundary**. Verified across two clusters.
- Standalone Console (direct) unaffected.

## For the reviewer

- The fix mutates the generated child routes' `getParentRoute` to point at `federatedRootRoute`. Safe because the federated `./App` and the standalone/legacy entries don't run in the same runtime simultaneously (MF v2 loads only `./App`). If you'd prefer to avoid any shared-object mutation, the alternative is generating the embedded tree from a Console-unique generated file — heavier; happy to switch.
- A separate, cosmetic dev-only issue (embedded Console inherits Cloud UI's 14px root font-size, shrinking rem-based Tailwind spacing vs prod) is **not** in this PR — still under investigation.