### PR TITLE
ci: upgrade GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/backend-lint-test.yml
+++ b/.github/workflows/backend-lint-test.yml
@@ -15,7 +15,7 @@ jobs:
           go-version-file: 'backend/go.mod'
           cache-dependency-path: 'backend/go.sum'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10
           working-directory: backend

--- a/.github/workflows/backend-lint-test.yml
+++ b/.github/workflows/backend-lint-test.yml
@@ -9,7 +9,7 @@ jobs:
     name: Lint Backend
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
           go-version-file: 'backend/go.mod'
@@ -25,7 +25,7 @@ jobs:
     name: Test Backend
     runs-on: blacksmith-8vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
           go-version-file: 'backend/go.mod'

--- a/.github/workflows/backend-lint-test.yml
+++ b/.github/workflows/backend-lint-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Docker Builder
         uses: useblacksmith/setup-docker-builder@v1
       - name: Install Task
-        uses: arduino/setup-task@v1
+        uses: arduino/setup-task@v2
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Cache Claude Code
         id: cache-claude
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: claude-code-${{ runner.os }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -33,7 +33,7 @@ jobs:
           git checkout -b "changelog/${{ steps.tag.outputs.name }}"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -98,7 +98,7 @@ jobs:
       # the PR mergeable — mirrors enterprise-ci-skip.yml.
       - name: Post Enterprise CI skip status
         if: ${{ steps.changelog_pr.outputs.created == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ github.token }}
           script: |

--- a/.github/workflows/enterprise-ci-skip.yml
+++ b/.github/workflows/enterprise-ci-skip.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
-      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v3
         with:
           secret-ids: |
             ,sdlc/prod/github/actions_bot_token

--- a/.github/workflows/enterprise-ci-skip.yml
+++ b/.github/workflows/enterprise-ci-skip.yml
@@ -23,7 +23,7 @@ jobs:
   skip-enterprise-ci:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}

--- a/.github/workflows/enterprise-ci-skip.yml
+++ b/.github/workflows/enterprise-ci-skip.yml
@@ -33,7 +33,7 @@ jobs:
             ,sdlc/prod/github/actions_bot_token
           parse-json-secrets: true
       - name: Set success enterprise CI status
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ env.ACTIONS_BOT_TOKEN }}
           script: |

--- a/.github/workflows/fork-pr-dispatch.yml
+++ b/.github/workflows/fork-pr-dispatch.yml
@@ -31,7 +31,7 @@ jobs:
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const payload = {
@@ -52,7 +52,7 @@ jobs:
       - name: Set pending enterprise CI status
         env:
           HEAD_SHA: ${{ steps.payload.outputs.sha }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ env.ACTIONS_BOT_TOKEN }}
           script: |

--- a/.github/workflows/fork-pr-dispatch.yml
+++ b/.github/workflows/fork-pr-dispatch.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
-      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v3
         with:
           secret-ids: |
             ,sdlc/prod/github/actions_bot_token

--- a/.github/workflows/fork-pr-dispatch.yml
+++ b/.github/workflows/fork-pr-dispatch.yml
@@ -43,7 +43,7 @@ jobs:
             core.setOutput('json', JSON.stringify(payload));
             core.setOutput('sha', process.env.HEAD_SHA);
       - name: Repository dispatch for fork PR
-        uses: peter-evans/repository-dispatch@caebe2a7c967e9f927ff8780fea8e16e50b5ce40
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ env.ACTIONS_BOT_TOKEN }}
           repository: redpanda-data/console-enterprise

--- a/.github/workflows/fork-pr-dispatch.yml
+++ b/.github/workflows/fork-pr-dispatch.yml
@@ -16,7 +16,7 @@ jobs:
       github.event.workflow_run.head_repository.fork == true
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}

--- a/.github/workflows/frontend-react-doctor.yml
+++ b/.github/workflows/frontend-react-doctor.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-cache-${{ env.BUN_CACHE_SALT }}-${{ hashFiles('frontend/bun.lock') }}

--- a/.github/workflows/frontend-react-doctor.yml
+++ b/.github/workflows/frontend-react-doctor.yml
@@ -21,7 +21,7 @@ jobs:
         working-directory: frontend
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
       - name: Cache dependencies

--- a/.github/workflows/frontend-verify.yml
+++ b/.github/workflows/frontend-verify.yml
@@ -82,7 +82,7 @@ jobs:
           REACT_APP_DEV_HINT=true
           bun run build
       - name: Upload frontend build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: frontend-build
           path: frontend/build
@@ -103,7 +103,7 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Run unit tests
         run: bun run test:unit
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: unit-test-results
@@ -129,7 +129,7 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Run integration tests
         run: bun run test:integration -- --shard=${{ matrix.shard }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: integration-test-results-${{ matrix.shard }}

--- a/.github/workflows/frontend-verify.yml
+++ b/.github/workflows/frontend-verify.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Restore Rspack build cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: frontend/node_modules/.cache
           key: ${{ runner.os }}-rspack-${{ env.BUN_CACHE_SALT }}-${{ hashFiles('frontend/bun.lock', 'frontend/package.json', 'frontend/src/**', 'frontend/rsbuild.config.ts') }}

--- a/.github/workflows/frontend-verify.yml
+++ b/.github/workflows/frontend-verify.yml
@@ -14,7 +14,7 @@ jobs:
         working-directory: frontend
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
       - name: Install dependencies
@@ -46,7 +46,7 @@ jobs:
         working-directory: frontend
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
       - name: Install dependencies
@@ -62,7 +62,7 @@ jobs:
         working-directory: frontend
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
       - name: Install dependencies
@@ -96,7 +96,7 @@ jobs:
         working-directory: frontend
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
       - name: Install dependencies
@@ -122,7 +122,7 @@ jobs:
         working-directory: frontend
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
       - name: Install dependencies

--- a/.github/workflows/proto-generate.yml
+++ b/.github/workflows/proto-generate.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       CI: "true"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/proto-generate.yml
+++ b/.github/workflows/proto-generate.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}

--- a/.github/workflows/proto-generate.yml
+++ b/.github/workflows/proto-generate.yml
@@ -29,7 +29,7 @@ jobs:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
 
-      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v3
         with:
           secret-ids: |
             ,sdlc/prod/github/buf_token

--- a/.github/workflows/proto-generate.yml
+++ b/.github/workflows/proto-generate.yml
@@ -41,7 +41,7 @@ jobs:
           cache-dependency-path: 'backend/go.sum'
 
       - name: Install Task
-        uses: arduino/setup-task@v1
+        uses: arduino/setup-task@v2
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/proto-generate.yml
+++ b/.github/workflows/proto-generate.yml
@@ -47,7 +47,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache proto tools
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: build
           key: proto-tools-${{ runner.os }}-go${{ hashFiles('backend/go.mod') }}-${{ hashFiles('taskfiles/proto.yaml') }}

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -48,7 +48,7 @@ jobs:
             ,sdlc/prod/github/actions_bot_token
           parse-json-secrets: true
       - name: Repository Dispatch on Release
-        uses: peter-evans/repository-dispatch@caebe2a7c967e9f927ff8780fea8e16e50b5ce40
+        uses: peter-evans/repository-dispatch@v4
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         with:
           token: ${{ env.ACTIONS_BOT_TOKEN }}
@@ -56,7 +56,7 @@ jobs:
           event-type: release
           client-payload: '{"branch": "master", "commit_sha": "${{ github.sha }}", "tag_name": "${{ github.event.release.tag_name }}"}'
       - name: Repository Dispatch on push
-        uses: peter-evans/repository-dispatch@caebe2a7c967e9f927ff8780fea8e16e50b5ce40
+        uses: peter-evans/repository-dispatch@v4
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         with:
           token: ${{ env.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -38,7 +38,7 @@ jobs:
     if: "!failure() && !cancelled()"
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
-      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v3
         with:
           secret-ids: |
             ,sdlc/prod/github/actions_bot_token

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -65,7 +65,7 @@ jobs:
           client-payload: '{"branch": "${{ github.ref_name }}", "commit_sha": "${{ github.sha }}"}'
       - name: Set pending enterprise CI status
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ env.ACTIONS_BOT_TOKEN }}
           script: |


### PR DESCRIPTION
## Summary

GitHub is [deprecating Node 20](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) on Actions runners (Node 16 is already removed). Workflows pinned to actions running on those runtimes will eventually break. This PR upgrades the external actions in `.github/workflows/` to a Node 24-supporting version — **one commit per action**, so each upgrade can be reviewed and reverted independently. Each commit body links to the upstream release notes and calls out any breaking change relevant to our usage.

## Upgrades

| Action | From | To |
|---|---|---|
| `actions/cache` | v4 | [v5](https://github.com/actions/cache/releases/tag/v5.0.0) |
| `actions/checkout` | v5 | [v6](https://github.com/actions/checkout/releases/tag/v6.0.0) |
| `actions/github-script` | v7 | [v9](https://github.com/actions/github-script/releases/tag/v9.0.0) |
| `actions/setup-node` | v4 | [v6](https://github.com/actions/setup-node/releases/tag/v6.0.0) |
| `actions/upload-artifact` | v4 | [v7](https://github.com/actions/upload-artifact/releases/tag/v7.0.0) |
| `arduino/setup-task` | v1 | [v2](https://github.com/arduino/setup-task/releases/tag/v2.0.0) |
| `aws-actions/aws-secretsmanager-get-secrets` | v2 | [v3](https://github.com/aws-actions/aws-secretsmanager-get-secrets/releases/tag/v3.0.0) |
| `aws-actions/configure-aws-credentials` | v4 | [v6](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v6.0.0) |
| `golangci/golangci-lint-action` | v8 | [v9](https://github.com/golangci/golangci-lint-action/releases/tag/v9.0.0) |
| `peter-evans/repository-dispatch` | `@caebe2a7` (untagged ~v2.x) | [v4](https://github.com/peter-evans/repository-dispatch/releases/tag/v4.0.0) |

## Notes

- **`actions/checkout` v5 → v6** — v5 already runs on Node 24, so this is a currency bump to the approved major, not a runtime change. v6 persists the auth token to a separate file instead of `.git/config`; our checkout/build steps don't read `.git/config`.
- **`actions/github-script` v7 → v9** — v9 makes the bundled packages ESM-only (`require('@actions/github')` stops working; `getOctokit` becomes an injected parameter). All five of our `script:` bodies use only the pre-injected `github`/`context`/`core`, so none are affected.
- **`golangci/golangci-lint-action` v8 → v9** — stays within the golangci-lint **v2.x** era; the v1→v2 binary fork happened at v7. We pin `version: v2.10` and `--config=.golangci.yaml`, so neither the binary version nor the linter set changes.
- **`peter-evans/repository-dispatch`** — was pinned to an untagged **Node 16** commit (`caebe2a7`). Moved to the floating `v4` tag (currently v4.0.1, Node 24); pinned to `v4` rather than `v4.0.0`, whose `action.yml` declared the wrong Node version (fixed in v4.0.1). Our `token` / `repository` / `event-type` / `client-payload` inputs are unchanged.
  - **Supply-chain trade-off (deliberate):** this swaps an immutable commit-SHA pin for a floating tag on the repo's one privileged cross-repo dispatch step (`ACTIONS_BOT_TOKEN` → `console-enterprise`). We accept the standard publisher-trust posture here for consistency with the rest of `.github/workflows/` (every other action uses a floating major tag) and with `verify_actions.py`'s approved `v4` pin — and the prior SHA was itself stale (Node 16), not a current audited pin. If we want to harden later, the right move is to SHA-pin **all** third-party actions and add Dependabot/Renovate to surface upgrades, rather than singling out this one.

## Out of scope / follow-up

- **`arduino/setup-task`** — bumped **v1 → v2** to get off the already-removed Node 16 runtime, but **v2 runs on Node 20, not Node 24** — there is no Node 24 release yet. A further bump should follow once upstream ships one. (This is also why `verify_actions.py` still lists `arduino/setup-task@v2` as `unknown` — the action isn't in the tool's `allowed_actions` map.)

## Verification

- `verify_actions.py .github/workflows/` → all 41 version-mismatch violations resolved; the only remaining lines are the two `arduino/setup-task@v2` `unknown` refs (explained above).
- The diff is exclusively `uses:` version-string changes — no logic touched, and no new `yamllint` findings (repo has no yaml-lint CI).

## Test plan

- [ ] CI on this PR exercises the PR-/push-triggered workflows that use the upgraded actions (`buf`, `proto-generate`, `backend-lint-test`, `frontend-verify`, `frontend-react-doctor`).
- [ ] Post-merge, confirm the event-gated workflows still work: `changelog` (tag push), `repository-dispatch` / `enterprise-ci-skip` (push), `fork-pr-dispatch` (fork PR `workflow_run`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
