### PR TITLE
ci: upgrade buf.yml actions to Node 24 and pin buf CLI to 1.65.0

### DIFF
--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -47,6 +47,8 @@ jobs:
       - name: Buf – lint, format & breaking
         uses: bufbuild/buf-action@v1
         with:
+          # buf CLI version - keep in sync with BUF_VERSION in taskfiles/proto.yaml
+          version: 1.65.0
           lint: true
           format: true
           breaking: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'Buf Skip Breaking') }}
@@ -79,6 +81,8 @@ jobs:
       - name: Buf – push to registry
         uses: bufbuild/buf-action@v1
         with:
+          # buf CLI version - keep in sync with BUF_VERSION in taskfiles/proto.yaml
+          version: 1.65.0
           # No validation - already done in validate job
           lint: false
           format: false
@@ -112,6 +116,8 @@ jobs:
       - name: Buf – archive label (ignore if not found)
         uses: bufbuild/buf-action@v1
         with:
+          # buf CLI version - keep in sync with BUF_VERSION in taskfiles/proto.yaml
+          version: 1.65.0
           # Only archive - no other operations
           push: true
           token: ${{ env.BUF_TOKEN }}

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -43,7 +43,7 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'pull_request'
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Buf – lint, format & breaking
         uses: bufbuild/buf-action@v1
         with:
@@ -63,18 +63,18 @@ jobs:
     needs: validate  # Only run after validation passes
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
 
-      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v3
         with:
           secret-ids: |
             ,sdlc/prod/github/buf_token
           parse-json-secrets: true
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Buf – push to registry
         uses: bufbuild/buf-action@v1
@@ -96,18 +96,18 @@ jobs:
       github.repository == 'redpanda-data/console'
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.RP_AWS_CRED_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
 
-      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v3
         with:
           secret-ids: |
             ,sdlc/prod/github/buf_token
           parse-json-secrets: true
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Buf – archive label (ignore if not found)
         uses: bufbuild/buf-action@v1


### PR DESCRIPTION
## Summary

Two `buf.yml`-only changes, split out so [#2511](https://github.com/redpanda-data/console/pull/2511) (the rest of the Node 24 action upgrades) can stay green without re-triggering Buf CI:

1. **Node 24 action bumps** in `.github/workflows/buf.yml` — `actions/checkout` v5→v6 (×3), `aws-actions/configure-aws-credentials` v4→v6 (×2), `aws-actions/aws-secretsmanager-get-secrets` v2→v3 (×2). (Moved here from #2511.)
2. **Pin the buf CLI to `1.65.0`** for `bufbuild/buf-action@v1` (all three jobs).

## Why pin buf

`buf-action@v1` installs the **latest** buf by default. buf **1.71.0** changed the formatter (it collapses short nested message literals onto one line), so `buf format --diff` in the `validate` job started failing on protos that are formatted for the repo's pinned buf **1.65.0** (`BUF_VERSION` in `taskfiles/proto.yaml`, used by `task proto:generate`).

CI's format/lint check and code generation were running **different** buf versions. Pinning `buf-action` to 1.65.0 puts them on a single source of truth, so a new buf release can't silently break `Buf CI` again. No proto reformatting is needed — the committed protos are already 1.65.0-clean (verified locally: `buf 1.65.0 format --diff --exit-code` is clean).

> An earlier revision of this PR reformatted all protos to buf 1.71.0. That was dropped: `task proto:generate` (pinned to buf 1.65.0) re-expands 1.71.0's formatting, so the reformat and the codegen pin were mutually inconsistent. Pinning the CI buf to 1.65.0 is the lower-churn fix and keeps a single buf version across the repo.

## Test plan

- [x] `buf 1.65.0 format --diff --exit-code` clean on the committed protos (build + lint also pass)
- [ ] `Buf CI` (`validate`) green on this PR
- [ ] `Proto generate` green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
