### PR TITLE
fix(git): bound protobuf git-sync memory (shallow clone) + allow disabling refresh

### DIFF
--- a/backend/pkg/config/git.go
+++ b/backend/pkg/config/git.go
@@ -29,7 +29,9 @@ type Git struct {
 	// Whether or not to use the filename or the full filepath as key in the map
 	IndexByFullFilepath bool `yaml:"-"`
 
-	// RefreshInterval specifies how often the repository shall be pulled to check for new changes.
+	// RefreshInterval specifies how often the repository shall be refreshed to check for new changes.
+	// A value of 0 disables periodic refresh: the repository is cloned once at startup and only
+	// refreshed again on restart.
 	RefreshInterval time.Duration `yaml:"refreshInterval"`
 
 	// Repository that contains markdown files that document a Kafka topic.
@@ -54,9 +56,8 @@ func (c *Git) Validate() error {
 	if !c.Enabled {
 		return nil
 	}
-	if c.RefreshInterval == 0 {
-		return errors.New("git config is enabled but refresh interval is set to 0 (disabled)")
-	}
+	// A refresh interval of 0 (or less) is allowed and disables periodic refresh; the repository
+	// is cloned once at startup. See SetDefaults for the default interval when none is configured.
 	if c.MaxFileSize <= 0 {
 		return errors.New("git config is enabled but file max size is <= 0")
 	}

--- a/backend/pkg/git/service.go
+++ b/backend/pkg/git/service.go
@@ -113,6 +113,13 @@ func (c *Service) CloneRepository(ctx context.Context) error {
 		URL:           c.Cfg.Repository.URL,
 		Auth:          c.auth,
 		ReferenceName: referenceName,
+		// Console only ever reads the current revision of the tracked files, so
+		// we fetch a shallow, single-branch snapshot without tags. This avoids
+		// materializing the repository's full history in the in-memory object
+		// store, which for large/active repositories can consume many GB of RAM.
+		SingleBranch: true,
+		Depth:        1,
+		Tags:         git.NoTags,
 	}
 
 	if c.Cfg.CloneSubmodules {
@@ -144,18 +151,16 @@ func (c *Service) CloneRepository(ctx context.Context) error {
 	return nil
 }
 
-// SyncRepo periodically pulls the repository contents to ensure it's always up to date. When changes appear
-// the file cache will be updated. This function will periodically pull the repository until the passed context
-// is done.
+// SyncRepo periodically refreshes the repository contents to ensure they are always up to date. When changes
+// appear the file cache will be updated. This function periodically refreshes the repository until a termination
+// signal is received.
+//
+// Because the repository is cloned shallowly into an in-memory store (see CloneRepository), refreshing is done
+// by re-cloning rather than pulling: a re-clone keeps the in-memory object store bounded to a single revision
+// (the previous store is released and garbage collected) and avoids go-git's unreliable shallow-pull behavior.
 func (c *Service) SyncRepo() {
 	if c.Cfg.RefreshInterval == 0 {
 		c.logger.Info("refresh interval for sync is set to 0 (disabled)")
-		return
-	}
-
-	tree, err := c.repo.Worktree()
-	if err != nil {
-		c.logger.Error("failed to get work tree from repository. stopping git sync", slog.Any("error", err))
 		return
 	}
 
@@ -170,32 +175,12 @@ func (c *Service) SyncRepo() {
 			c.logger.Info("stopped sync", slog.String("reason", "received signal"))
 			return
 		case <-ticker.C:
-			var referenceName plumbing.ReferenceName
-			if c.Cfg.Repository.Branch != "" {
-				referenceName = plumbing.NewBranchReferenceName(c.Cfg.Repository.Branch)
-			}
-			err := tree.Pull(&git.PullOptions{Auth: c.auth, ReferenceName: referenceName})
-			if err != nil {
-				if errors.Is(err, git.NoErrAlreadyUpToDate) {
-					continue
-				}
-				c.logger.Error("pulling the repo has failed", slog.Any("error", err))
+			// Re-clone the latest shallow snapshot. CloneRepository rebuilds the in-memory filesystem and
+			// object store, updates the file cache, and fires OnFilesUpdatedHook on success. On failure it
+			// leaves the previously cached file contents intact, so we keep serving the last good revision.
+			if err := c.CloneRepository(context.Background()); err != nil {
+				c.logger.Error("refreshing the repo has failed", slog.Any("error", err))
 				continue
-			}
-
-			// Update cache with new markdowns
-			empty := make(map[string]filesystem.File)
-			files, err := c.readFiles(c.memFs, empty, c.Cfg.Repository.BaseDirectory, c.Cfg.Repository.MaxDepth)
-			if err != nil {
-				c.logger.Error("failed to read files after pulling", slog.Any("error", err))
-				continue
-			}
-			c.setFileContents(files)
-			c.logger.Info("successfully pulled git repository",
-				slog.Int("read_files", len(files)))
-
-			if c.OnFilesUpdatedHook != nil {
-				c.OnFilesUpdatedHook()
 			}
 		}
 	}

--- a/backend/pkg/git/service.go
+++ b/backend/pkg/git/service.go
@@ -159,8 +159,8 @@ func (c *Service) CloneRepository(ctx context.Context) error {
 // by re-cloning rather than pulling: a re-clone keeps the in-memory object store bounded to a single revision
 // (the previous store is released and garbage collected) and avoids go-git's unreliable shallow-pull behavior.
 func (c *Service) SyncRepo() {
-	if c.Cfg.RefreshInterval == 0 {
-		c.logger.Info("refresh interval for sync is set to 0 (disabled)")
+	if c.Cfg.RefreshInterval <= 0 {
+		c.logger.Info("periodic git refresh disabled (refresh interval <= 0); repository was cloned once at startup")
 		return
 	}
 


### PR DESCRIPTION
## Problem

Console clones the configured Git repository into go-git's **in-memory** object store (`memory.NewStorage()`) to read protobuf schema files. The clone had **no depth limit**, so the entire repository history was materialized (decompressed and un-deltified) in RAM, and the periodic refresh used an incremental `tree.Pull()` that kept appending every newly fetched object to that same **never-pruned** store.

This scales with repository *history*, not with the files Console actually needs. Heap profiling (`/debug/pprof/heap`) of a Console pod pointed at a large monorepo:

```
6.68 GB total in-use
  6.20 GB (92.75%)  go-git MemoryObject.Write   <- under git.(*Service).CloneRepository
```

For that repository (example figures): ~600 MB packed on disk but **~8.5 GB inflated** across full history (dominated by many revisions of generated/lock files), growing **~0.5 GB/month** — enough to OOM the node over time. Proto compilation itself was <30 MB, i.e. not the cause. Console only ever reads the **current** revision of the tracked files.

## Background: how the current full-clone + pull model uses memory

This explains *why* the above isn't a tuning issue but a structural one in the current design.

**1. The store is fully in-memory and never pruned.** `CloneRepository` calls `git.CloneContext(ctx, memory.NewStorage(), fs, ...)`. `memory.Storage` holds every git object as a decompressed `[]byte` in a map that lives for the **entire process lifetime** — there is no eviction, GC of unreferenced objects, or spill-to-disk.

**2. A full clone fetches and expands *all history*, not just the current files.** With no `Depth`, go-git fetches the complete packfile (every commit, tree, and blob ever reachable) and must resolve it: the pprof stack shows `packfile.Parser.resolveDeltas → applyPatchBase → patchDeltaWriter → MemoryObject.Write`. To resolve a delta, go-git reconstructs the **full byte content of each object version** and stores it. So the resident cost is roughly the *sum of the inflated sizes of every object version in history*.

**3. Inflated ≫ packed.** On disk git is compact: objects are **delta-encoded** (a revision stored as a diff against another) and **zlib-compressed**. The in-memory store is the opposite — every object is **decompressed and fully reconstructed**. For repos that frequently rewrite large text files (lockfiles, generated code, manifests), a few hundred MB packed expands to multiple GB in memory. This is why the on-disk repo size is not a useful proxy for Console's footprint.

**4. The refresh makes it worse, not bounded.** Every `refreshInterval`, `SyncRepo` ran `tree.Pull(...)` against the *same* `memory.Storage`. Pull fetches the new objects since the last sync and **adds them to the store** — but never removes anything. On an active repo (thousands of commits/month) the store therefore grows monotonically for as long as the process runs, on top of the already-large initial full-history baseline. An incremental pull can never bound an in-memory store; only discarding the store can.

**Net:** memory scales with *total history × commit rate*, while Console only needs *one revision of a few files*. The fix removes both multipliers — shallow clone (one revision, no history) and re-clone-on-refresh (fresh store each time, old one released).

## Changes

### 1. Shallow clone (`backend/pkg/git/service.go`) — fixes memory
- `CloneRepository`: `SingleBranch: true`, `Depth: 1`, `Tags: git.NoTags` on `CloneOptions`. Fetches only the tip snapshot. `Depth: 1` limits history, not the worktree, so all tracked files are still checked out and read normally.
- `SyncRepo`: refresh now re-runs the (shallow) `CloneRepository` each tick instead of `tree.Pull(...)`. A fresh clone keeps the in-memory store bounded to a single revision (previous store released for GC) and avoids go-git's unreliable shallow-pull. On failure the last good cache is retained.

### 2. Allow `refreshInterval: 0` to disable periodic refresh — controls bandwidth
A shallow re-clone transfers a full latest snapshot each refresh (example: ~69 MiB compressed for the large monorepo above); at `refreshInterval: 5m` that is ~580 GiB/month per replica. Proto schemas typically change rarely, so frequent refresh is usually unnecessary. `Validate()` previously rejected `refreshInterval: 0` even though `SyncRepo` already treated `0` as disabled and the sample config documented it as the way to disable.
- `backend/pkg/config/git.go`: drop the `Validate()` rejection of `RefreshInterval == 0`; document on the field that `0` = clone once at startup.
- `backend/pkg/git/service.go`: guard `SyncRepo` with `<= 0` (also prevents a `time.NewTicker` panic on a negative duration); generic disabled-log message.
- Default stays `1m`; behavior unchanged unless `0` is set explicitly.

Operators can now set the protobuf git `refreshInterval` to e.g. `12h` (~4 GiB/month) or `0` (clone-once, refresh on redeploy).

## Testing

- `go build ./...` — OK
- `go vet ./pkg/git/ ./pkg/config/` — clean
- `go test -count=1 ./pkg/git/... ./pkg/config/...` — pass