### PR TITLE
ci: add frontend UI registry audit workflow

### DIFF
--- a/.github/workflows/frontend-ui-audit.yml
+++ b/.github/workflows/frontend-ui-audit.yml
@@ -19,6 +19,7 @@ env:
   CI: true
   UI_REGISTRY_REF: main
 permissions:
+  id-token: write
   contents: read
   pull-requests: write
 jobs:
@@ -32,6 +33,20 @@ jobs:
         with:
           fetch-depth: 0
           path: console
+      # ui-registry is private, and the job's GITHUB_TOKEN is scoped to console
+      # only. Fetch the org-wide actions bot token from AWS Secrets Manager to
+      # check it out — same pattern as fork-pr-dispatch.yml / cloudv2.
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ vars.RP_AWS_CRED_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.RP_AWS_CRED_ACCOUNT_ID }}:role/${{ vars.RP_AWS_CRED_BASE_ROLE_NAME }}${{ github.event.repository.name }}
+      - name: Get actions bot token
+        uses: aws-actions/aws-secretsmanager-get-secrets@v3
+        with:
+          secret-ids: |
+            ,sdlc/prod/github/actions_bot_token
+          parse-json-secrets: true
       - name: Checkout ui-registry
         uses: actions/checkout@v5
         with:
@@ -39,8 +54,7 @@ jobs:
           ref: ${{ env.UI_REGISTRY_REF }}
           fetch-depth: 0
           path: ui-registry
-          # If ui-registry is private, set UI_REGISTRY_TOKEN to a PAT with read access.
-          token: ${{ secrets.UI_REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ env.ACTIONS_BOT_TOKEN }}
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
       - name: Build registry manifest

--- a/.github/workflows/frontend-ui-audit.yml
+++ b/.github/workflows/frontend-ui-audit.yml
@@ -1,0 +1,85 @@
+---
+name: "Frontend UI Audit"
+# Audits PRs that touch frontend code against the redpanda-ui registry:
+# - outdated / locally-modified components vs the latest registry release
+# - off-token palette colours (red-500, indigo-300, …) instead of semantic tokens
+# - ad-hoc utility classes (text-[11px], bg-[#0f1626], …)
+#
+# Posts a sticky PR comment with the findings, fails the job if any are found.
+# Runs the script directly from redpanda-data/ui-registry; no copy in this repo.
+on:
+  pull_request:
+    paths:
+      - 'frontend/src/**'
+      - '.github/workflows/frontend-ui-audit.yml'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+env:
+  CI: true
+  UI_REGISTRY_REF: main
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  audit:
+    name: Audit registry usage
+    timeout-minutes: 5
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: Checkout console
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          path: console
+      - name: Checkout ui-registry
+        uses: actions/checkout@v5
+        with:
+          repository: redpanda-data/ui-registry
+          ref: ${{ env.UI_REGISTRY_REF }}
+          fetch-depth: 0
+          path: ui-registry
+          # If ui-registry is private, set UI_REGISTRY_TOKEN to a PAT with read access.
+          token: ${{ secrets.UI_REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+      - name: Build registry manifest
+        # audit-changes reads packages/registry/registry.json, a gitignored
+        # build artifact — generate it before running the audit.
+        working-directory: ui-registry
+        run: |
+          bun install --frozen-lockfile
+          bun run registry:build
+      - name: Run audit (markdown report + exit code)
+        id: audit
+        run: |
+          set +e
+          bun ui-registry/packages/lookout/scripts/audit-changes.ts \
+            --app console/frontend \
+            --diff origin/${{ github.event.pull_request.base.ref }} \
+            --format markdown \
+            --fail-on any \
+            > /tmp/audit-body.md
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+      - name: Post or update sticky PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          marker='<!-- ui-audit-frontend -->'
+          { echo "$marker"; cat /tmp/audit-body.md; } > /tmp/body.md
+          existing=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --paginate --jq "[.[] | select(.body | startswith(\"$marker\"))][0].id // empty")
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/$existing" \
+              --field body=@/tmp/body.md > /dev/null
+          else
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              --field body=@/tmp/body.md > /dev/null
+          fi
+      - name: Fail job if findings
+        if: steps.audit.outputs.exit_code != '0'
+        run: |
+          echo "::error::UI audit found drift or off-token usage — see PR comment above."
+          exit ${{ steps.audit.outputs.exit_code }}


### PR DESCRIPTION
## What

Adds a `Frontend UI Audit` GitHub Actions workflow that runs on PRs touching `frontend/src/**`. It audits frontend code against the `redpanda-data/ui-registry` for:

- outdated / locally-modified registry components vs the latest release
- off-token palette colours (e.g. `red-500`, `indigo-300`) instead of semantic tokens
- ad-hoc utility classes (e.g. `text-[11px]`, `bg-[#0f1626]`)

Findings are posted as a sticky PR comment, and the job **fails** if any are found (`--fail-on any`).

## Why this shape

Modeled on the proven cloudv2 `registry-drift.yml`. The key correctness point: `audit-changes.ts` reads `packages/registry/registry.json`, which is a **gitignored build artifact** — so the workflow runs `bun install` + `bun run registry:build` in the checked-out ui-registry before invoking the audit. Without this step the audit fails with `ENOENT`.

Differences from cloudv2 (intentional):
- `--fail-on any` (console blocks PRs) vs cloudv2's informational `--fail-on none`.
- Auth via `UI_REGISTRY_TOKEN`/`GITHUB_TOKEN` rather than cloudv2's AWS Secrets Manager bot token (different infra).
