### PR TITLE
ci: pin buf-action to 1.71.0 to match proto codegen

### DIFF
--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -48,7 +48,7 @@ jobs:
         uses: bufbuild/buf-action@v1
         with:
           # buf CLI version - keep in sync with BUF_VERSION in taskfiles/proto.yaml
-          version: 1.65.0
+          version: 1.71.0
           lint: true
           format: true
           breaking: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'Buf Skip Breaking') }}
@@ -82,7 +82,7 @@ jobs:
         uses: bufbuild/buf-action@v1
         with:
           # buf CLI version - keep in sync with BUF_VERSION in taskfiles/proto.yaml
-          version: 1.65.0
+          version: 1.71.0
           # No validation - already done in validate job
           lint: false
           format: false
@@ -117,7 +117,7 @@ jobs:
         uses: bufbuild/buf-action@v1
         with:
           # buf CLI version - keep in sync with BUF_VERSION in taskfiles/proto.yaml
-          version: 1.65.0
+          version: 1.71.0
           # Only archive - no other operations
           push: true
           token: ${{ env.BUF_TOKEN }}


### PR DESCRIPTION
## Summary

The post-merge `Buf CI` → `validate` job is failing on `master` after #2512: the `format` check reports diffs on ~30 protos (lint, breaking, and build all pass).

## Root cause

A semantic collision between two independently-green PRs:

- **#2518** ("adopt buf 1.71.0 formatter") set `BUF_VERSION: 1.71.0` in `taskfiles/proto.yaml` and reformatted every proto into 1.71.0's style (short nested message literals collapsed onto one line).
- **#2512** pinned the CI `buf-action` to `1.65.0`, based on the (by then stale) assumption that codegen was still on 1.65.0.

So `master` now formats protos with **1.71.0** but the CI `validate` job checks them with **1.65.0**, which re-expands the collapsed literals → `Format diff` on every affected proto. The `buf.yml` comments already say *"keep in sync with BUF_VERSION in taskfiles/proto.yaml"* — that's the invariant #2512 broke.

## Fix

Bump all three `buf-action` version pins in `.github/workflows/buf.yml` from `1.65.0` → `1.71.0`, matching `BUF_VERSION` in `taskfiles/proto.yaml`. No proto reformatting is needed — the committed protos are already 1.71.0-clean. This is the correct direction since #2518 deliberately moved the repo to the 1.71.0 formatter.

## Verification

Run against the current `master` protos:

| buf version | `buf format --diff --exit-code` |
| --- | --- |
| 1.65.0 (old CI pin) | exit 100, 3504-line diff — reproduces the CI failure |
| 1.71.0 (this PR) | clean (exit 0) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
