### PR TITLE
fix(sql): show bridge badge for Iceberg-tiered topics before sync

### DIFF
--- a/frontend/src/components/pages/sql/sql-workspace.tsx
+++ b/frontend/src/components/pages/sql/sql-workspace.tsx
@@ -33,6 +33,7 @@ import {
   useInvalidateSqlCatalog,
   useListCatalogsQuery,
   useListTablesQuery,
+  useTopicIcebergQuery,
 } from 'react-query/api/sql';
 import { useLegacyListTopicsQuery } from 'react-query/api/topic';
 import { toast } from 'sonner';
@@ -405,9 +406,17 @@ export function SqlWorkspace({ sqlRole: sqlRoleProp }: SqlWorkspaceProps) {
     }));
   }, [catalogsData]);
 
+  // Whether the queried topic is Iceberg-tiered — the authoritative bridge-query
+  // signal (`redpanda.iceberg.mode`), independent of any lag metric. A topic that
+  // is tiered but hasn't started translating yet emits no lag series, so the badge
+  // must key off the config, not metric presence (else a not-yet-synced bridge
+  // query — every row served from the topic — would look like a plain query).
+  const { isIceberg: bridgeTopicTiered } = useTopicIcebergQuery(bridgeTopic ?? '', {
+    enabled: Boolean(bridgeTopic),
+  });
   // Bridge-query lag for the queried topic, read from the ObservabilityService
-  // (per-topic named queries) — decoupled from ExecuteQuery. A non-Iceberg topic
-  // has no pending-lag series, so `bridge` resolves to undefined and nothing shows.
+  // (per-topic named queries) — decoupled from ExecuteQuery. Drives only the lag
+  // timeline; the badge itself comes from `bridgeTopicTiered` above.
   const bridgeTxLag = useExecuteInstantQuery(
     {
       queryName: 'iceberg_topic_translation_lag',
@@ -429,18 +438,18 @@ export function SqlWorkspace({ sqlRole: sqlRoleProp }: SqlWorkspaceProps) {
     { enabled: Boolean(bridgeTopic) }
   );
   const bridge = useMemo<BridgeInfo | undefined>(() => {
-    if (!bridgeTopic) {
+    // Bridge-ness is the topic being Iceberg-tiered — not whether lag has shown up.
+    // Lag defaults to 0 when its series is absent (e.g. translation hasn't started),
+    // which the timeline reads as "fully caught up" and hides; the badge still shows.
+    if (!(bridgeTopic && bridgeTopicTiered)) {
       return;
     }
     const tx = bridgeTxLag.data?.results?.[0]?.value?.value;
     const commit = bridgeCommitLag.data?.results?.[0]?.value?.value;
-    if (tx === undefined && commit === undefined) {
-      return;
-    }
     const translationLag = tx ?? 0;
     const commitLag = commit ?? 0;
     return { topic: bridgeTopic, translationLag, commitLag, totalLag: translationLag + commitLag };
-  }, [bridgeTopic, bridgeTxLag.data, bridgeCommitLag.data]);
+  }, [bridgeTopic, bridgeTopicTiered, bridgeTxLag.data, bridgeCommitLag.data]);
 
   // Redpanda-catalog tables, fetched up front so both the add-topic wizard and
   // editor autocomplete (and the bridge indicator below) can resolve table refs.


### PR DESCRIPTION
## What

The SQL editor's **Bridge query** badge now appears for any Iceberg-tiered topic, including ones that haven't synced to Iceberg yet.

## Why

The badge was gated on the **presence of an Iceberg lag metric**, not on whether the topic is actually Iceberg-tiered:

```js
// sql-workspace.tsx (before)
const tx = bridgeTxLag.data?.results?.[0]?.value?.value;
const commit = bridgeCommitLag.data?.results?.[0]?.value?.value;
if (tx === undefined && commit === undefined) {
  return; // → run.bridge undefined → badge hidden
}
```

A freshly-tiered topic that hasn't started translating yet emits no `iceberg_topic_translation_lag` / `iceberg_topic_commit_lag` series, so `bridge` resolved to `undefined` and the query — with **every row served from the topic tail** — was misclassified as a plain query and showed no badge. This is exactly the case where the bridge is doing the most work.

## Fix

Decouple **bridge classification** from **lag display**:

- Classify bridge-ness from the authoritative `redpanda.iceberg.mode` config via `useTopicIcebergQuery` (already used by the catalog tree), independent of lag-metric availability.
- Lag values default to `0` when their series is absent; the lag timeline stays hidden until real lag appears (unchanged `totalLag === 0` guard), but the badge now shows for any tiered topic.
- Bonus correctness: a non-tiered topic now correctly shows no badge because the config says so, not because a metric happened to be missing.

## Testing

- `tsgo --noEmit` clean
- SQL unit tests pass (`sql.test.tsx`)
- No new lint errors introduced