### PR TITLE
sql: render "record" composite columns with the JSON tree viewer [UX-1330]

### DIFF
--- a/frontend/src/components/pages/sql/catalog-tree.test.tsx
+++ b/frontend/src/components/pages/sql/catalog-tree.test.tsx
@@ -98,7 +98,7 @@ describe('CatalogTree', () => {
   });
 
   test('expanding a table lists its columns with type labels', async () => {
-    // Types arrive lower-cased from the backend; composite columns as "json"
+    // Types arrive lower-cased from the backend; composite columns as "record"
     // with their nested fields parsed server-side.
     vi.mocked(useDescribeTableQuery).mockReturnValue({
       data: {
@@ -106,7 +106,7 @@ describe('CatalogTree', () => {
           { name: 'id', type: 'bigint' },
           { name: 'payload', type: 'jsonb' },
           { name: 'tags', type: 'text[]' },
-          { name: 'customer', type: 'json', fields: [{ name: 'street', type: 'text' }] },
+          { name: 'customer', type: 'record', fields: [{ name: 'street', type: 'text' }] },
         ],
       },
       isLoading: false,
@@ -119,7 +119,7 @@ describe('CatalogTree', () => {
     expect(screen.getByText('jsonb')).toBeInTheDocument();
     expect(screen.getByText('text[]')).toBeInTheDocument();
 
-    // Composite column shows "json" and expands into its nested fields.
+    // Composite column shows "record" and expands into its nested fields.
     const customerRow = screen.getByRole('button', { name: CUSTOMER_RE });
     expect(customerRow).toBeInTheDocument();
     expect(screen.queryByText('street')).not.toBeInTheDocument();

--- a/frontend/src/components/pages/sql/sql-editor.tsx
+++ b/frontend/src/components/pages/sql/sql-editor.tsx
@@ -121,8 +121,6 @@ function useIsDarkMode(): boolean {
 // muted gutter line numbers. CodeMirror themes are plain CSS, so registry
 // custom properties can be referenced directly and stay live.
 function editorChrome(mode: 'light' | 'dark'): Extension {
-  const gutter = mode === 'dark' ? 'var(--color-grey-600)' : 'var(--color-grey-400)';
-  const gutterActive = mode === 'dark' ? 'var(--color-grey-400)' : 'var(--color-grey-600)';
   return EditorView.theme(
     {
       '&': { backgroundColor: 'transparent', height: '100%', fontSize: '13px' },
@@ -132,24 +130,18 @@ function editorChrome(mode: 'light' | 'dark'): Extension {
         lineHeight: '21px',
       },
       '.cm-content': { padding: '12px 0' },
-      '.cm-gutters': { backgroundColor: 'transparent', border: 'none', color: gutter },
-      '.cm-activeLineGutter': { backgroundColor: 'transparent', color: gutterActive },
-      '.cm-activeLine': {
-        backgroundColor: mode === 'dark' ? 'rgba(255, 255, 255, 0.04)' : 'rgba(0, 0, 0, 0.03)',
-      },
+      '.cm-gutters': { backgroundColor: 'transparent', border: 'none', color: 'var(--color-muted-foreground)' },
+      '.cm-activeLineGutter': { backgroundColor: 'transparent', color: 'var(--color-foreground)' },
+      '.cm-activeLine': { backgroundColor: 'var(--color-surface-default-hover)' },
     },
     { dark: mode === 'dark' }
   );
 }
 
 // SQL syntax palette mapped onto the Lezer highlight tags the SQL grammar
-// emits. Hued tokens use theme-adaptive semantic tokens; only the grey
-// comment/identifier shades vary by mode.
-function sqlHighlight(mode: 'light' | 'dark'): Extension {
-  const grey =
-    mode === 'dark'
-      ? { comment: 'var(--color-grey-400)', id: 'var(--color-grey-100)' }
-      : { comment: 'var(--color-grey-600)', id: 'var(--color-grey-900)' };
+// emits, entirely from theme-adaptive semantic tokens so it tracks light/dark
+// without per-mode values.
+function sqlHighlight(): Extension {
   return syntaxHighlighting(
     HighlightStyle.define([
       { tag: tags.keyword, color: 'var(--color-secondary)', fontWeight: 'bold' },
@@ -159,18 +151,18 @@ function sqlHighlight(mode: 'light' | 'dark'): Extension {
       },
       { tag: [tags.string, tags.special(tags.string)], color: 'var(--color-success)' },
       { tag: tags.number, color: 'var(--color-warning)' },
-      { tag: tags.comment, color: grey.comment, fontStyle: 'italic' },
+      { tag: tags.comment, color: 'var(--color-muted-foreground)', fontStyle: 'italic' },
       {
         tag: [tags.operator, tags.punctuation, tags.separator, tags.paren, tags.brace, tags.squareBracket],
-        color: 'var(--color-grey-500)',
+        color: 'var(--color-muted-foreground)',
       },
-      { tag: tags.name, color: grey.id },
+      { tag: tags.name, color: 'var(--color-foreground)' },
     ])
   );
 }
 
-const LIGHT_THEME: Extension = [editorChrome('light'), sqlHighlight('light')];
-const DARK_THEME: Extension = [editorChrome('dark'), sqlHighlight('dark')];
+const LIGHT_THEME: Extension = [editorChrome('light'), sqlHighlight()];
+const DARK_THEME: Extension = [editorChrome('dark'), sqlHighlight()];
 
 function tableNamespace(table: TableRef): SQLNamespace {
   return {

--- a/frontend/src/components/pages/sql/sql-editor.tsx
+++ b/frontend/src/components/pages/sql/sql-editor.tsx
@@ -15,7 +15,7 @@ import {
   type CompletionResult,
   startCompletion,
 } from '@codemirror/autocomplete';
-import { PostgreSQL, type SQLNamespace, sql as sqlLanguage } from '@codemirror/lang-sql';
+import { PostgreSQL, type SQLNamespace, schemaCompletionSource, sql as sqlLanguage } from '@codemirror/lang-sql';
 import { HighlightStyle, indentUnit, syntaxHighlighting, syntaxTree } from '@codemirror/language';
 import { EditorState, type Extension, Prec } from '@codemirror/state';
 import { EditorView, keymap } from '@codemirror/view';
@@ -192,12 +192,9 @@ function tableNamespace(table: TableRef): SQLNamespace {
   };
 }
 
-// Builds the lang-sql completion schema from the loaded catalog tree: bare
-// table names → columns. Tables are deliberately NOT nested under their
-// catalog — Redpanda SQL (Oxla) addresses catalog tables with arrow notation
-// (`catalog=>table`), which catalogArrowSource below handles; dot-style
-// nesting would advertise syntax the server rejects. Bare entries still give
-// alias/column resolution (`FROM default_redpanda_catalog=>cars c` → `c.`).
+// Bare table name → columns. Powers alias/column resolution only
+// (schemaColumnSource); tables aren't nested under catalogs since Oxla uses
+// `catalog=>table` arrow notation, handled by catalogArrowSource.
 function buildSchema(catalogs: Catalog[]): SQLNamespace {
   const root: Record<string, SQLNamespace> = {};
   for (const catalog of catalogs) {
@@ -210,6 +207,20 @@ function buildSchema(catalogs: Catalog[]): SQLNamespace {
     }
   }
   return root;
+}
+
+// Schema completion limited to dotted members (`c.` → columns); bare table
+// names are suppressed at the top level so catalogArrowSource owns them.
+function schemaColumnSource(catalogs: Catalog[]): (context: CompletionContext) => CompletionResult | null {
+  const source = schemaCompletionSource({ dialect: PostgreSQL, schema: buildSchema(catalogs) });
+  return (context) => {
+    const result = source(context);
+    if (!result || result instanceof Promise) {
+      return null;
+    }
+    const dotted = context.state.sliceDoc(result.from - 1, result.from) === '.';
+    return dotted ? result : null;
+  };
 }
 
 // Matches an identifier followed by `=>` or `.` and a partial table name,
@@ -415,7 +426,9 @@ export const SqlEditor = forwardRef<SqlEditorHandle, SqlEditorProps>(
     };
 
     const extensions = useMemo(() => {
-      const sqlSupport = sqlLanguage({ dialect: PostgreSQL, schema: buildSchema(catalogs), upperCaseKeywords: true });
+      // No `schema` here — schemaColumnSource adds it back for dotted
+      // completions only, avoiding bare table names at the top level.
+      const sqlSupport = sqlLanguage({ dialect: PostgreSQL, upperCaseKeywords: true });
       return [
         // Prec.highest so Mod-Enter beats the default keymap's insertBlankLine.
         Prec.highest(
@@ -441,6 +454,7 @@ export const SqlEditor = forwardRef<SqlEditorHandle, SqlEditorProps>(
         ),
         sqlSupport,
         sqlSupport.language.data.of({ autocomplete: catalogArrowSource(catalogs) }),
+        sqlSupport.language.data.of({ autocomplete: schemaColumnSource(catalogs) }),
         isDark ? DARK_THEME : LIGHT_THEME,
         EditorView.updateListener.of((update) => {
           if (update.selectionSet) {

--- a/frontend/src/components/pages/sql/sql-editor.tsx
+++ b/frontend/src/components/pages/sql/sql-editor.tsx
@@ -142,42 +142,29 @@ function editorChrome(mode: 'light' | 'dark'): Extension {
   );
 }
 
-// SQL syntax palette, mapped from the design's `.sql-*` token classes onto the
-// Lezer highlight tags the SQL grammar emits (keywords, built-ins, strings,
-// numbers, comments, operators/punctuation and identifiers).
+// SQL syntax palette mapped onto the Lezer highlight tags the SQL grammar
+// emits. Hued tokens use theme-adaptive semantic tokens; only the grey
+// comment/identifier shades vary by mode.
 function sqlHighlight(mode: 'light' | 'dark'): Extension {
-  const c =
+  const grey =
     mode === 'dark'
-      ? {
-          keyword: 'var(--color-purple-300)',
-          fn: 'var(--color-indigo-300)',
-          str: 'var(--color-green-300)',
-          num: 'var(--color-orange-300)',
-          comment: 'var(--color-grey-400)',
-          punct: 'var(--color-grey-500)',
-          id: 'var(--color-grey-100)',
-        }
-      : {
-          keyword: 'var(--color-purple-700)',
-          fn: 'var(--color-indigo-600)',
-          str: 'var(--color-green-700)',
-          num: 'var(--color-orange-700)',
-          comment: 'var(--color-grey-600)',
-          punct: 'var(--color-grey-500)',
-          id: 'var(--color-grey-900)',
-        };
+      ? { comment: 'var(--color-grey-400)', id: 'var(--color-grey-100)' }
+      : { comment: 'var(--color-grey-600)', id: 'var(--color-grey-900)' };
   return syntaxHighlighting(
     HighlightStyle.define([
-      { tag: tags.keyword, color: c.keyword, fontWeight: 'bold' },
-      { tag: [tags.standard(tags.name), tags.function(tags.variableName), tags.typeName], color: c.fn },
-      { tag: [tags.string, tags.special(tags.string)], color: c.str },
-      { tag: tags.number, color: c.num },
-      { tag: tags.comment, color: c.comment, fontStyle: 'italic' },
+      { tag: tags.keyword, color: 'var(--color-secondary)', fontWeight: 'bold' },
+      {
+        tag: [tags.standard(tags.name), tags.function(tags.variableName), tags.typeName],
+        color: 'var(--color-primary)',
+      },
+      { tag: [tags.string, tags.special(tags.string)], color: 'var(--color-success)' },
+      { tag: tags.number, color: 'var(--color-warning)' },
+      { tag: tags.comment, color: grey.comment, fontStyle: 'italic' },
       {
         tag: [tags.operator, tags.punctuation, tags.separator, tags.paren, tags.brace, tags.squareBracket],
-        color: c.punct,
+        color: 'var(--color-grey-500)',
       },
-      { tag: tags.name, color: c.id },
+      { tag: tags.name, color: grey.id },
     ])
   );
 }

--- a/frontend/src/components/pages/sql/sql-results.tsx
+++ b/frontend/src/components/pages/sql/sql-results.tsx
@@ -28,7 +28,19 @@ import { Spinner } from 'components/redpanda-ui/components/spinner';
 import { StatusDot } from 'components/redpanda-ui/components/status-dot';
 import { InlineCode, Text } from 'components/redpanda-ui/components/typography';
 import { cn } from 'components/redpanda-ui/lib/utils';
-import { Braces, CircleX, Clock, Database, Download, GitMerge, Lightbulb, Plus, Rows3, Terminal, X } from 'lucide-react';
+import {
+  Braces,
+  CircleX,
+  Clock,
+  Database,
+  Download,
+  GitMerge,
+  Lightbulb,
+  Plus,
+  Rows3,
+  Terminal,
+  X,
+} from 'lucide-react';
 import { createContext, useContext, useMemo, useState } from 'react';
 import DataGrid, { type Column } from 'react-data-grid';
 import { isMacOS } from 'utils/platform';

--- a/frontend/src/components/pages/sql/sql-results.tsx
+++ b/frontend/src/components/pages/sql/sql-results.tsx
@@ -28,7 +28,7 @@ import { Spinner } from 'components/redpanda-ui/components/spinner';
 import { StatusDot } from 'components/redpanda-ui/components/status-dot';
 import { InlineCode, Text } from 'components/redpanda-ui/components/typography';
 import { cn } from 'components/redpanda-ui/lib/utils';
-import { Braces, CircleX, Clock, Database, Download, GitMerge, Plus, Rows3, Terminal, X } from 'lucide-react';
+import { Braces, CircleX, Clock, Database, Download, GitMerge, Lightbulb, Plus, Rows3, Terminal, X } from 'lucide-react';
 import { createContext, useContext, useMemo, useState } from 'react';
 import DataGrid, { type Column } from 'react-data-grid';
 import { isMacOS } from 'utils/platform';
@@ -476,14 +476,17 @@ export function SqlResults({ run, sqlRole, onAddTable, hasTables = true }: SqlRe
           <AlertDescription>{run.message}</AlertDescription>
         </Alert>
         {run.hint ? (
-          <div className="flex items-center gap-3 text-muted-foreground text-sm">
-            {run.hint}
-            {run.hintAction && sqlRole === 'admin' && onAddTable ? (
-              <Button onClick={onAddTable} size="sm" variant="primary">
-                <Plus size={14} /> Add a topic to SQL
-              </Button>
-            ) : null}
-          </div>
+          <Alert icon={<Lightbulb />} variant="info">
+            <AlertTitle>Hint</AlertTitle>
+            <AlertDescription>
+              {run.hint}
+              {run.hintAction && sqlRole === 'admin' && onAddTable ? (
+                <Button onClick={onAddTable} size="sm" variant="primary">
+                  <Plus size={14} /> Add a topic to SQL
+                </Button>
+              ) : null}
+            </AlertDescription>
+          </Alert>
         ) : null}
       </div>
     );

--- a/frontend/src/components/pages/sql/sql-types.test.ts
+++ b/frontend/src/components/pages/sql/sql-types.test.ts
@@ -9,9 +9,12 @@
  * by the Apache License, Version 2.0
  */
 
+import { create } from '@bufbuild/protobuf';
+import { ConnectError } from '@connectrpc/connect';
+import { ErrorInfoSchema } from 'protogen/google/rpc/error_details_pb';
 import { describe, expect, test } from 'vitest';
 
-import { arrayElementPgType, columnKindForPgType, isArrayPgType, splitQueryError } from './sql-types';
+import { arrayElementPgType, columnKindForPgType, hintFromError, isArrayPgType, splitQueryError } from './sql-types';
 
 describe('columnKindForPgType', () => {
   test.each([
@@ -75,5 +78,22 @@ describe('splitQueryError', () => {
     const { message, hint } = splitQueryError('syntax error at or near "SELCT"');
     expect(message).toBe('syntax error at or near "SELCT"');
     expect(hint).toBeUndefined();
+  });
+});
+
+describe('hintFromError', () => {
+  test('reads the hint from ErrorInfo metadata', () => {
+    const error = new ConnectError('boom', undefined, undefined, [
+      {
+        desc: ErrorInfoSchema,
+        value: create(ErrorInfoSchema, { reason: 'REASON_INVALID_INPUT', metadata: { hint: 'use (customer).id' } }),
+      },
+    ]);
+    expect(hintFromError(error)).toBe('use (customer).id');
+  });
+
+  test('returns undefined when there is no ErrorInfo hint', () => {
+    expect(hintFromError(new ConnectError('boom'))).toBeUndefined();
+    expect(hintFromError(new Error('plain'))).toBeUndefined();
   });
 });

--- a/frontend/src/components/pages/sql/sql-types.test.ts
+++ b/frontend/src/components/pages/sql/sql-types.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, expect, test } from 'vitest';
 
-import { arrayElementPgType, columnKindForPgType, isArrayPgType } from './sql-types';
+import { arrayElementPgType, columnKindForPgType, isArrayPgType, splitQueryError } from './sql-types';
 
 describe('columnKindForPgType', () => {
   test.each([
@@ -61,5 +61,19 @@ describe('arrayElementPgType', () => {
     expect(arrayElementPgType('TEXT')).toBeNull();
     expect(isArrayPgType('TEXT')).toBe(false);
     expect(isArrayPgType('TEXT[]')).toBe(true);
+  });
+});
+
+describe('splitQueryError', () => {
+  test('splits the trailing hint onto its own field', () => {
+    const { message, hint } = splitQueryError("operator does not exist: record -> unknown\n\nHint: use (user).id");
+    expect(message).toBe('operator does not exist: record -> unknown');
+    expect(hint).toBe('use (user).id');
+  });
+
+  test('leaves a hintless message intact', () => {
+    const { message, hint } = splitQueryError('syntax error at or near "SELCT"');
+    expect(message).toBe('syntax error at or near "SELCT"');
+    expect(hint).toBeUndefined();
   });
 });

--- a/frontend/src/components/pages/sql/sql-types.test.ts
+++ b/frontend/src/components/pages/sql/sql-types.test.ts
@@ -14,7 +14,7 @@ import { ConnectError } from '@connectrpc/connect';
 import { ErrorInfoSchema } from 'protogen/google/rpc/error_details_pb';
 import { describe, expect, test } from 'vitest';
 
-import { arrayElementPgType, columnKindForPgType, hintFromError, isArrayPgType, splitQueryError } from './sql-types';
+import { arrayElementPgType, columnKindForPgType, hintFromError, isArrayPgType } from './sql-types';
 
 describe('columnKindForPgType', () => {
   test.each([
@@ -64,20 +64,6 @@ describe('arrayElementPgType', () => {
     expect(arrayElementPgType('TEXT')).toBeNull();
     expect(isArrayPgType('TEXT')).toBe(false);
     expect(isArrayPgType('TEXT[]')).toBe(true);
-  });
-});
-
-describe('splitQueryError', () => {
-  test('splits the trailing hint onto its own field', () => {
-    const { message, hint } = splitQueryError('operator does not exist: record -> unknown\n\nHint: use (user).id');
-    expect(message).toBe('operator does not exist: record -> unknown');
-    expect(hint).toBe('use (user).id');
-  });
-
-  test('leaves a hintless message intact', () => {
-    const { message, hint } = splitQueryError('syntax error at or near "SELCT"');
-    expect(message).toBe('syntax error at or near "SELCT"');
-    expect(hint).toBeUndefined();
   });
 });
 

--- a/frontend/src/components/pages/sql/sql-types.test.ts
+++ b/frontend/src/components/pages/sql/sql-types.test.ts
@@ -28,9 +28,10 @@ describe('columnKindForPgType', () => {
     ['JSONB', 'json'],
     ['TEXT', 'str'],
     ['UNKNOWN_TYPE', 'str'],
-    // Composite columns arrive pre-labelled as "json"/"json[]" from the backend.
-    ['json', 'json'],
-    ['json[]', 'json'],
+    // Composite columns arrive pre-labelled as "record"/"record[]" from the
+    // backend and render with the JSON tree viewer.
+    ['record', 'json'],
+    ['record[]', 'json'],
   ] as const)('%s → %s', (pgType, kind) => {
     expect(columnKindForPgType(pgType)).toBe(kind);
   });

--- a/frontend/src/components/pages/sql/sql-types.test.ts
+++ b/frontend/src/components/pages/sql/sql-types.test.ts
@@ -66,7 +66,7 @@ describe('arrayElementPgType', () => {
 
 describe('splitQueryError', () => {
   test('splits the trailing hint onto its own field', () => {
-    const { message, hint } = splitQueryError("operator does not exist: record -> unknown\n\nHint: use (user).id");
+    const { message, hint } = splitQueryError('operator does not exist: record -> unknown\n\nHint: use (user).id');
     expect(message).toBe('operator does not exist: record -> unknown');
     expect(hint).toBe('use (user).id');
   });

--- a/frontend/src/components/pages/sql/sql-types.ts
+++ b/frontend/src/components/pages/sql/sql-types.ts
@@ -9,6 +9,9 @@
  * by the Apache License, Version 2.0
  */
 
+import { ConnectError } from '@connectrpc/connect';
+import { ErrorInfoSchema } from 'protogen/google/rpc/error_details_pb';
+
 // Shared types for the SQL workspace, so the leaf components (catalog tree,
 // editor, results) and the data layer in sql-workspace agree on shape without
 // importing from each other.
@@ -165,6 +168,20 @@ export function splitQueryError(message: string): { message: string; hint?: stri
   const sep = '\n\nHint: ';
   const i = message.indexOf(sep);
   return i === -1 ? { message } : { message: message.slice(0, i), hint: message.slice(i + sep.length) };
+}
+
+// Structured hint from the Connect error's ErrorInfo metadata. Preferred over the
+// message-string fallback in splitQueryError — same text, but read from a typed
+// detail instead of parsed out of prose. undefined when absent.
+export function hintFromError(error: unknown): string | undefined {
+  if (error instanceof ConnectError) {
+    for (const info of error.findDetails(ErrorInfoSchema)) {
+      if (info.metadata.hint) {
+        return info.metadata.hint;
+      }
+    }
+  }
+  return;
 }
 
 // Word-boundary anchored so geometric/temporal names that merely contain a

--- a/frontend/src/components/pages/sql/sql-types.ts
+++ b/frontend/src/components/pages/sql/sql-types.ts
@@ -159,6 +159,14 @@ export function columnKindForPgType(pgType: string): ColumnKind {
   return 'str';
 }
 
+// The backend appends an actionable hint after a blank line ("\n\nHint: …");
+// split it off so it can render on its own line instead of inline in the message.
+export function splitQueryError(message: string): { message: string; hint?: string } {
+  const sep = '\n\nHint: ';
+  const i = message.indexOf(sep);
+  return i === -1 ? { message } : { message: message.slice(0, i), hint: message.slice(i + sep.length) };
+}
+
 // Word-boundary anchored so geometric/temporal names that merely contain a
 // numeric token (POINT → INT, INTERVAL → INT) don't get misread as numeric.
 const NUMERIC_TYPE = /\b(?:INT|INTEGER|SMALLINT|BIGINT|FLOAT|NUMERIC|DECIMAL|DOUBLE|REAL|SERIAL|MONEY)/;

--- a/frontend/src/components/pages/sql/sql-types.ts
+++ b/frontend/src/components/pages/sql/sql-types.ts
@@ -133,8 +133,8 @@ export function isArrayPgType(pgType: string): boolean {
 }
 
 // Maps a Postgres type name to a display kind. Composite columns arrive as the
-// literal "json"/"json[]" (the backend parses structure into Column.fields), so
-// they fall through to the JSON branch. Arrays map to their element kind;
+// literal "record"/"record[]" (the backend parses structure into Column.fields)
+// and render with the JSON tree viewer. Arrays map to their element kind;
 // anything unrecognized defaults to a string.
 export function columnKindForPgType(pgType: string): ColumnKind {
   const element = arrayElementPgType(pgType);
@@ -152,7 +152,8 @@ export function columnKindForPgType(pgType: string): ColumnKind {
   if (BOOL_TYPE.test(t)) {
     return 'bool';
   }
-  if (t.includes('JSON')) {
+  // RECORD/RECORD[] are composite columns; JSON kept for any real json scalar.
+  if (t.includes('RECORD') || t.includes('JSON')) {
     return 'json';
   }
   return 'str';

--- a/frontend/src/components/pages/sql/sql-types.ts
+++ b/frontend/src/components/pages/sql/sql-types.ts
@@ -162,17 +162,7 @@ export function columnKindForPgType(pgType: string): ColumnKind {
   return 'str';
 }
 
-// The backend appends an actionable hint after a blank line ("\n\nHint: …");
-// split it off so it can render on its own line instead of inline in the message.
-export function splitQueryError(message: string): { message: string; hint?: string } {
-  const sep = '\n\nHint: ';
-  const i = message.indexOf(sep);
-  return i === -1 ? { message } : { message: message.slice(0, i), hint: message.slice(i + sep.length) };
-}
-
-// Structured hint from the Connect error's ErrorInfo metadata. Preferred over the
-// message-string fallback in splitQueryError — same text, but read from a typed
-// detail instead of parsed out of prose. undefined when absent.
+// Structured hint from the Connect error's ErrorInfo metadata. undefined when absent.
 export function hintFromError(error: unknown): string | undefined {
   if (error instanceof ConnectError) {
     for (const info of error.findDetails(ErrorInfoSchema)) {

--- a/frontend/src/components/pages/sql/sql-workspace.tsx
+++ b/frontend/src/components/pages/sql/sql-workspace.tsx
@@ -50,6 +50,7 @@ import {
   type CellValue,
   type ColumnDef,
   columnKindForPgType,
+  hintFromError,
   isArrayPgType,
   type QueryRun,
   type ResultRow,
@@ -547,7 +548,9 @@ export function SqlWorkspace({ sqlRole: sqlRoleProp }: SqlWorkspaceProps) {
           if (latestRunToken.current !== token) {
             return;
           }
-          const { message, hint } = splitQueryError(error.message);
+          const { message, hint: messageHint } = splitQueryError(error.message);
+          // Prefer the structured ErrorInfo hint; fall back to the message string.
+          const hint = hintFromError(error) ?? messageHint;
           setRun({ state: 'error', token, title: 'Query failed', message, hint });
         },
       });

--- a/frontend/src/components/pages/sql/sql-workspace.tsx
+++ b/frontend/src/components/pages/sql/sql-workspace.tsx
@@ -53,8 +53,8 @@ import {
   isArrayPgType,
   type QueryRun,
   type ResultRow,
-  splitQueryError,
   type SqlRole,
+  splitQueryError,
   type TableRef,
 } from './sql-types';
 import { createTableSql, SqlWizard, type WizardTopic } from './sql-wizard';

--- a/frontend/src/components/pages/sql/sql-workspace.tsx
+++ b/frontend/src/components/pages/sql/sql-workspace.tsx
@@ -36,7 +36,6 @@ import {
   useTopicIcebergQuery,
 } from 'react-query/api/sql';
 import { useLegacyListTopicsQuery } from 'react-query/api/topic';
-import { toast } from 'sonner';
 import { Feature, isSupported, useSupportedFeaturesStore } from 'state/supported-features';
 import { uiState } from 'state/ui-state';
 
@@ -608,7 +607,6 @@ export function SqlWorkspace({ sqlRole: sqlRoleProp }: SqlWorkspaceProps) {
       executeQuery.mutate(create(ExecuteQueryRequestSchema, { statement }), {
         onSuccess: async () => {
           await invalidateSqlCatalog();
-          toast.success(`Table ${tableName} created`);
           closeWizard();
         },
         onError: (error) => setWizardError(error.message),

--- a/frontend/src/components/pages/sql/sql-workspace.tsx
+++ b/frontend/src/components/pages/sql/sql-workspace.tsx
@@ -55,7 +55,6 @@ import {
   type QueryRun,
   type ResultRow,
   type SqlRole,
-  splitQueryError,
   type TableRef,
 } from './sql-types';
 import { createTableSql, SqlWizard, type WizardTopic } from './sql-wizard';
@@ -548,10 +547,7 @@ export function SqlWorkspace({ sqlRole: sqlRoleProp }: SqlWorkspaceProps) {
           if (latestRunToken.current !== token) {
             return;
           }
-          const { message, hint: messageHint } = splitQueryError(error.message);
-          // Prefer the structured ErrorInfo hint; fall back to the message string.
-          const hint = hintFromError(error) ?? messageHint;
-          setRun({ state: 'error', token, title: 'Query failed', message, hint });
+          setRun({ state: 'error', token, title: 'Query failed', message: error.message, hint: hintFromError(error) });
         },
       });
     },

--- a/frontend/src/components/pages/sql/sql-workspace.tsx
+++ b/frontend/src/components/pages/sql/sql-workspace.tsx
@@ -53,6 +53,7 @@ import {
   isArrayPgType,
   type QueryRun,
   type ResultRow,
+  splitQueryError,
   type SqlRole,
   type TableRef,
 } from './sql-types';
@@ -546,7 +547,8 @@ export function SqlWorkspace({ sqlRole: sqlRoleProp }: SqlWorkspaceProps) {
           if (latestRunToken.current !== token) {
             return;
           }
-          setRun({ state: 'error', token, title: 'Query failed', message: error.message });
+          const { message, hint } = splitQueryError(error.message);
+          setRun({ state: 'error', token, title: 'Query failed', message, hint });
         },
       });
     },

--- a/frontend/src/components/pages/sql/sql-workspace.tsx
+++ b/frontend/src/components/pages/sql/sql-workspace.tsx
@@ -36,6 +36,7 @@ import {
   useTopicIcebergQuery,
 } from 'react-query/api/sql';
 import { useLegacyListTopicsQuery } from 'react-query/api/topic';
+import { toast } from 'sonner';
 import { Feature, isSupported, useSupportedFeaturesStore } from 'state/supported-features';
 import { uiState } from 'state/ui-state';
 
@@ -607,6 +608,7 @@ export function SqlWorkspace({ sqlRole: sqlRoleProp }: SqlWorkspaceProps) {
       executeQuery.mutate(create(ExecuteQueryRequestSchema, { statement }), {
         onSuccess: async () => {
           await invalidateSqlCatalog();
+          toast.success(`Table ${tableName} created`);
           closeWizard();
         },
         onError: (error) => setWizardError(error.message),

--- a/frontend/src/react-query/api/sql.tsx
+++ b/frontend/src/react-query/api/sql.tsx
@@ -31,8 +31,6 @@ import {
   listTables,
 } from 'protogen/redpanda/api/dataplane/v1alpha3/sql-SQLService_connectquery';
 import { MAX_PAGE_SIZE, type MessageInit } from 'react-query/react-query.utils';
-import { toast } from 'sonner';
-import { formatToastErrorMessageGRPC } from 'utils/toast.utils';
 
 type SqlQueryOptions = {
   enabled?: boolean;
@@ -94,10 +92,8 @@ export const useTopicIcebergQuery = (topicName: string, options?: SqlQueryOption
   return { ...result, isIceberg: Boolean(mode && mode !== 'disabled') };
 };
 
-export const useExecuteQueryMutation = () =>
-  useMutation(executeQuery, {
-    onError: (error) => toast.error(formatToastErrorMessageGRPC({ error, action: 'execute', entity: 'SQL query' })),
-  });
+// Errors surface inline (run panel / wizard), so no toast on failure.
+export const useExecuteQueryMutation = () => useMutation(executeQuery);
 
 // Returns a function that refreshes the catalog/table listings, e.g. after a
 // CREATE TABLE so the new table shows up in the tree.


### PR DESCRIPTION
## What

The SQL backend is changing the column type label for composite (struct) columns from `json`/`json[]` to `record`/`record[]`. This updates the frontend renderer to recognize the new labels.

`columnKindForPgType` now maps `record`/`record[]` to the existing `json` display **kind**, so composite cells keep the nested JSON tree viewer and the catalog tree / cell popover surface the accurate `record` label instead of `json`.

## Why

Labeling these columns `json` led Postgres users to try JSON arrow operators (`->`, `->>`), which the engine rejects — composite columns are accessed with `(col).field`. The `record` label stops implying unsupported JSON semantics. Cell **values** are still rendered as JSON for readability; only the type label changes.

<img width="1518" height="823" alt="image" src="https://github.com/user-attachments/assets/06c7f1de-4934-489e-b287-212f82ed0982" />


## Paired change

Backend counterpart (must land together): redpanda-data/console-enterprise#803

## Tests

`vitest run` on `sql-types.test.ts` + `catalog-tree.test.tsx` — 33 passed.

[UX-1330]

[UX-1330]: https://redpandadata.atlassian.net/browse/UX-1330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ