### PR TITLE
ci(frontend-ui-audit): blobless partial clone of ui-registry

### DIFF
--- a/.github/workflows/frontend-ui-audit.yml
+++ b/.github/workflows/frontend-ui-audit.yml
@@ -52,7 +52,13 @@ jobs:
         with:
           repository: redpanda-data/ui-registry
           ref: ${{ env.UI_REGISTRY_REF }}
+          # The audit resolves component versions via `git show v<tag>:<path>`,
+          # so it needs full history and all v* tags (fetch-depth: 0).
+          # filter: blob:none makes it a blobless partial clone — commit and tag
+          # metadata is fetched, but file blobs are pulled lazily only when
+          # `git show` touches them, keeping the checkout fast.
           fetch-depth: 0
+          filter: blob:none
           path: ui-registry
           token: ${{ env.ACTIONS_BOT_TOKEN }}
       - name: Setup Bun


### PR DESCRIPTION
## What

Add `filter: blob:none` to the **Checkout ui-registry** step in `frontend-ui-audit.yml`.

## Why

The audit resolves component versions via `git show v<tag>:<path>`, so it clones ui-registry with `fetch-depth: 0` to get all `v*` tags. A blobless partial clone (`filter: blob:none`) still fetches all commit and tag metadata — so versions resolve — but defers file-blob downloads until `git show` actually needs them, keeping the checkout fast.

Mirrors the same change in cloudv2's `registry-drift.yml` (redpanda-data/cloudv2#27428).

## Test plan

- On a PR touching `frontend/src`, confirm the drift comment still shows real component versions (not `?`).
