### PR TITLE
fix(ui): use percentage sizes for resizable panels after react-resizable-panels v4 bump [UX-1330]

### DIFF
--- a/frontend/src/components/pages/rp-connect/pipeline/index.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/index.tsx
@@ -600,7 +600,7 @@ function EditorPanel({
 }) {
   return (
     <ResizablePanelGroup orientation="vertical">
-      <ResizablePanel defaultSize={70} minSize={30}>
+      <ResizablePanel defaultSize="70%" minSize="30%">
         <div className="relative h-full">
           {isServerlessInitializing ? (
             <EditorSkeleton />
@@ -636,7 +636,7 @@ function EditorPanel({
         </div>
       </ResizablePanel>
       <ResizableHandle withHandle />
-      <ResizablePanel collapsible defaultSize={30}>
+      <ResizablePanel collapsible defaultSize="30%">
         <div className="h-full overflow-auto p-4">
           <div className="mb-3 flex items-center gap-2">
             <Heading className="text-muted-foreground" level={5}>

--- a/frontend/src/components/pages/sql/sql-workspace.tsx
+++ b/frontend/src/components/pages/sql/sql-workspace.tsx
@@ -680,13 +680,13 @@ export function SqlWorkspace({ sqlRole: sqlRoleProp }: SqlWorkspaceProps) {
             <ResizablePanelGroup className="min-w-0 flex-1" orientation="vertical">
               <ResizablePanel
                 className="flex min-h-0 bg-background [&>*]:min-w-0 [&>*]:flex-1"
-                defaultSize={42}
-                minSize={15}
+                defaultSize="42%"
+                minSize="15%"
               >
                 <SqlEditor catalogs={completionCatalogs} initialQuery={INITIAL_QUERY} onRun={doRun} ref={editorRef} />
               </ResizablePanel>
               <ResizableHandle withHandle />
-              <ResizablePanel className="flex min-h-0 bg-background [&>*]:min-w-0 [&>*]:flex-1" minSize={20}>
+              <ResizablePanel className="flex min-h-0 bg-background [&>*]:min-w-0 [&>*]:flex-1" minSize="20%">
                 <SqlResults
                   hasTables={hasTables}
                   onAddTable={openWizard}


### PR DESCRIPTION
## What

The SQL Studio editor pane (and the rp-connect pipeline YAML editor) render with the resize divider collapsed near the top — the editor shrinks to a ~42px strip while the results/lint pane takes the rest. Once you drag the divider it's fine, but it resets on every fresh load / panel remount.

## Why

`react-resizable-panels` was bumped from v3 → v4 in #2528. In v4 the size parser treats a **bare number** as **pixels**, where v3 treated it as a **percentage**:

```js
case "number": return [e, "px"];   // v4: bare number = pixels
// only a "42%"-suffixed string is parsed as percent
```

The SQL workspace and pipeline editor were written for v3 semantics (`defaultSize={42}` meaning 42%), so after the bump they became 42px / 70px strips.

## Fix

Pass percentage **strings** so v4 reads them as percentages:
- `sql-workspace.tsx`: editor `defaultSize="42%"` / `minSize="15%"`, results `minSize="20%"`
- `rp-connect/pipeline/index.tsx`: editor `defaultSize="70%"` / `minSize="30%"`, lint `defaultSize="30%"`

These were the only two `ResizablePanel` usages with numeric size props.

Ref: UX-1330