### PR TITLE
Improved overview & shadowlink pages for users w/o permissions

### DIFF
--- a/frontend/src/components/pages/overview/overview.tsx
+++ b/frontend/src/components/pages/overview/overview.tsx
@@ -36,6 +36,9 @@ import {
 import { Link } from '@tanstack/react-router';
 import type { Row } from '@tanstack/react-table';
 import { AlertIcon, CheckIcon, CrownIcon, ErrorIcon } from 'components/icons';
+import { Alert, AlertDescription, AlertTitle } from 'components/redpanda-ui/components/alert';
+import { Button as UiButton } from 'components/redpanda-ui/components/button';
+import { RefreshCwIcon, TriangleAlertIcon } from 'lucide-react';
 import React, { type FC, type ReactNode } from 'react';
 
 import ClusterHealthOverview from './cluster-health-overview';
@@ -51,6 +54,10 @@ import {
 import { OverviewLicenseNotification } from '../../license/overview-license-notification';
 import { NullFallbackBoundary } from '../../misc/null-fallback-boundary';
 import { Statistic } from '../../misc/statistic';
+
+// Shared placeholder for any metric that isn't available (cluster unreachable,
+// brokers not loaded, or backend simply didn't report a value).
+const NOT_AVAILABLE = 'N/A';
 
 class Overview extends PageComponent {
   initPage(p: PageInitHelper): void {
@@ -97,7 +104,11 @@ class Overview extends PageComponent {
       return { displayText: 'Unhealthy', className: 'status-red' };
     })();
 
-    const brokerSize = brokers.length > 0 ? prettyBytes(brokers.sum((x) => x.totalLogDirSizeBytes ?? 0)) : '...';
+    // On an unreachable cluster the brokers request fails and `api.brokers` stays
+    // null forever, so there is no storage to report — fall back to the same N/A
+    // placeholder as every other stat rather than a "..." that never resolves.
+    const brokerSize =
+      api.brokers && brokers.length > 0 ? prettyBytes(brokers.sum((x) => x.totalLogDirSizeBytes ?? 0)) : NOT_AVAILABLE;
 
     const renderIdColumn = (text: string, record: BrokerWithConfigAndStorage) => {
       if (!record.isController) {
@@ -115,7 +126,22 @@ class Overview extends PageComponent {
       );
     };
 
-    const version = overview.redpanda?.version ?? overview.kafka?.version;
+    const version = overview.redpanda?.version ?? overview.kafka?.version ?? NOT_AVAILABLE;
+
+    const brokersOnline = overview.kafka?.brokersOnline;
+    const brokersExpected = overview.kafka?.brokersExpected;
+    const brokersOnlineText =
+      brokersOnline === undefined || brokersExpected === undefined
+        ? NOT_AVAILABLE
+        : `${brokersOnline} of ${brokersExpected}`;
+
+    // "Unhealthy" is the catch-all status whenever Console can't get a healthy
+    // reading from the cluster. The frontend can't tell *why* on its own — an
+    // unreachable/down cluster and an authorization failure both surface here — so
+    // we avoid asserting a cause and instead show the backend's status reason,
+    // which is the only signal that carries the actual explanation.
+    const isClusterUnhealthy = clusterStatus.className === 'status-red';
+    const clusterStatusReason = overview.kafka?.status?.statusReason;
 
     return (
       <Box>
@@ -124,6 +150,22 @@ class Overview extends PageComponent {
         </NullFallbackBoundary>
 
         <PageContent className="overviewGrid">
+          {isClusterUnhealthy && (
+            <Alert className="mb-4" icon={<TriangleAlertIcon />} variant="destructive">
+              <AlertTitle>Cluster metrics unavailable</AlertTitle>
+              <AlertDescription>
+                <p>
+                  Console couldn't get a healthy reading from this cluster. This can mean the cluster is unreachable, or
+                  that your account lacks permission to view it.
+                </p>
+                {clusterStatusReason ? <p className="font-medium">Reported reason: {clusterStatusReason}</p> : null}
+                <UiButton className="mt-1" onClick={() => this.refreshData(true)} size="sm" variant="secondary">
+                  <RefreshCwIcon /> Retry
+                </UiButton>
+              </AlertDescription>
+            </Alert>
+          )}
+
           <Section my={4} py={5}>
             <Flex>
               <Statistic
@@ -133,12 +175,9 @@ class Overview extends PageComponent {
               />
               <Statistic title="Cluster Storage Size" value={brokerSize} />
               <Statistic title="Cluster Version" value={version} />
-              <Statistic
-                title="Brokers Online"
-                value={`${overview.kafka?.brokersOnline} of ${overview.kafka?.brokersExpected}`}
-              />
-              <Statistic title="Topics" value={overview.kafka?.topicsCount} />
-              <Statistic title="Replicas" value={overview.kafka?.replicasCount} />
+              <Statistic title="Brokers Online" value={brokersOnlineText} />
+              <Statistic title="Topics" value={overview.kafka?.topicsCount ?? NOT_AVAILABLE} />
+              <Statistic title="Replicas" value={overview.kafka?.replicasCount ?? NOT_AVAILABLE} />
             </Flex>
           </Section>
 
@@ -303,13 +342,20 @@ function ClusterDetails() {
   const brokers = api.brokers;
   const licenses = api.licenses;
 
-  if (!(overview && brokers)) {
+  // Only the cluster overview gates the skeleton. `brokers` can stay null on an
+  // unreachable cluster (the request fails and never resolves), so waiting for it
+  // would spin this panel forever — render what we have and mark the rest N/A.
+  if (!overview) {
     return <Skeleton height={4} mt={5} noOfLines={13} speed={0} />;
   }
 
-  const totalStorageBytes = brokers.sum((x) => x.totalLogDirSizeBytes ?? 0);
-  const totalPrimaryStorageBytes = brokers.sum((x) => x.totalPrimaryLogDirSizeBytes ?? 0);
+  const hasBrokers = brokers != null;
+  const brokerList = brokers ?? [];
+  const totalStorageBytes = brokerList.sum((x) => x.totalLogDirSizeBytes ?? 0);
+  const totalPrimaryStorageBytes = brokerList.sum((x) => x.totalPrimaryLogDirSizeBytes ?? 0);
   const totalReplicatedStorageBytes = totalStorageBytes - totalPrimaryStorageBytes;
+  // Without broker data, a "0 B" total would be wrong — report N/A instead.
+  const storageOrNA = (bytes: number) => (hasBrokers ? prettyBytesOrNA(bytes) : NOT_AVAILABLE);
 
   const serviceAccounts = overview.redpanda?.userCount ?? 'Admin API not configured';
 
@@ -364,11 +410,11 @@ function ClusterDetails() {
       </DetailsBlock>
 
       <DetailsBlock title="Storage">
-        <Details content={[[prettyBytesOrNA(totalStorageBytes)]]} title="Total Bytes" />
+        <Details content={[[storageOrNA(totalStorageBytes)]]} title="Total Bytes" />
 
-        <Details content={[[prettyBytesOrNA(totalPrimaryStorageBytes)]]} title="Primary" />
+        <Details content={[[storageOrNA(totalPrimaryStorageBytes)]]} title="Primary" />
 
-        <Details content={[[prettyBytesOrNA(totalReplicatedStorageBytes)]]} title="Replicated" />
+        <Details content={[[storageOrNA(totalReplicatedStorageBytes)]]} title="Replicated" />
       </DetailsBlock>
 
       <DetailsBlock title="Security">

--- a/frontend/src/components/pages/overview/overview.tsx
+++ b/frontend/src/components/pages/overview/overview.tsx
@@ -36,9 +36,6 @@ import {
 import { Link } from '@tanstack/react-router';
 import type { Row } from '@tanstack/react-table';
 import { AlertIcon, CheckIcon, CrownIcon, ErrorIcon } from 'components/icons';
-import { Alert, AlertDescription, AlertTitle } from 'components/redpanda-ui/components/alert';
-import { Button as UiButton } from 'components/redpanda-ui/components/button';
-import { RefreshCwIcon, TriangleAlertIcon } from 'lucide-react';
 import React, { type FC, type ReactNode } from 'react';
 
 import ClusterHealthOverview from './cluster-health-overview';
@@ -135,14 +132,6 @@ class Overview extends PageComponent {
         ? NOT_AVAILABLE
         : `${brokersOnline} of ${brokersExpected}`;
 
-    // "Unhealthy" is the catch-all status whenever Console can't get a healthy
-    // reading from the cluster. The frontend can't tell *why* on its own — an
-    // unreachable/down cluster and an authorization failure both surface here — so
-    // we avoid asserting a cause and instead show the backend's status reason,
-    // which is the only signal that carries the actual explanation.
-    const isClusterUnhealthy = clusterStatus.className === 'status-red';
-    const clusterStatusReason = overview.kafka?.status?.statusReason;
-
     return (
       <Box>
         <NullFallbackBoundary>
@@ -150,22 +139,6 @@ class Overview extends PageComponent {
         </NullFallbackBoundary>
 
         <PageContent className="overviewGrid">
-          {isClusterUnhealthy && (
-            <Alert className="mb-4" icon={<TriangleAlertIcon />} variant="destructive">
-              <AlertTitle>Cluster metrics unavailable</AlertTitle>
-              <AlertDescription>
-                <p>
-                  Console couldn't get a healthy reading from this cluster. This can mean the cluster is unreachable, or
-                  that your account lacks permission to view it.
-                </p>
-                {clusterStatusReason ? <p className="font-medium">Reported reason: {clusterStatusReason}</p> : null}
-                <UiButton className="mt-1" onClick={() => this.refreshData(true)} size="sm" variant="secondary">
-                  <RefreshCwIcon /> Retry
-                </UiButton>
-              </AlertDescription>
-            </Alert>
-          )}
-
           <Section my={4} py={5}>
             <Flex>
               <Statistic

--- a/frontend/src/components/pages/shadowlinks/list/shadowlink-empty-state.tsx
+++ b/frontend/src/components/pages/shadowlinks/list/shadowlink-empty-state.tsx
@@ -14,7 +14,7 @@ import { Button } from 'components/redpanda-ui/components/button';
 import { Card, CardContent, CardHeader, CardTitle } from 'components/redpanda-ui/components/card';
 import { CodeBlock, Pre } from 'components/redpanda-ui/components/code-block';
 import { Text } from 'components/redpanda-ui/components/typography';
-import { AlertCircle, Info, SearchX } from 'lucide-react';
+import { AlertCircle, Info, Lock, SearchX } from 'lucide-react';
 
 const ShadowingDescription = () => (
   <>
@@ -68,6 +68,22 @@ export const ShadowLinkEmptyStateCloud = ({ onCreateClick }: ShadowLinkEmptyStat
           Create shadow link in Redpanda Cloud
         </Button>
       </div>
+    </CardContent>
+  </Card>
+);
+
+export const ShadowLinkNoPermissionState = () => (
+  <Card data-testid="shadowlink-no-permission-card" size="full">
+    <CardHeader>
+      <CardTitle>Shadowing</CardTitle>
+    </CardHeader>
+    <CardContent className="flex flex-col gap-3">
+      <ShadowingDescription />
+      <Alert icon={<Lock />} variant="warning">
+        <AlertDescription>
+          You don't have permission to view shadow links on this cluster. Contact an administrator if you need access.
+        </AlertDescription>
+      </Alert>
     </CardContent>
   </Card>
 );

--- a/frontend/src/components/pages/shadowlinks/list/shadowlink-list-page.test.tsx
+++ b/frontend/src/components/pages/shadowlinks/list/shadowlink-list-page.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { Code, ConnectError } from '@connectrpc/connect';
+import { screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { ShadowLinkListPage } from './shadowlink-list-page';
+
+// Mock the data hook so we can drive query state (error / loading / data) directly.
+vi.mock('react-query/api/shadowlink', () => ({
+  useListShadowLinksQuery: vi.fn(),
+}));
+
+// Mock ui-state (mutated in a useEffect for breadcrumbs/title).
+vi.mock('state/ui-state', () => ({
+  uiState: {
+    pageTitle: '',
+    pageBreadcrumbs: [],
+  },
+}));
+
+// Mock toast notifications so we can assert on them.
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { useListShadowLinksQuery } from 'react-query/api/shadowlink';
+import { toast } from 'sonner';
+import { renderWithFileRoutes } from 'test-utils';
+
+const mockedUseListShadowLinksQuery = vi.mocked(useListShadowLinksQuery);
+
+const mockQueryResult = (overrides: Partial<ReturnType<typeof useListShadowLinksQuery>>) =>
+  ({
+    data: undefined,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+    ...overrides,
+  }) as unknown as ReturnType<typeof useListShadowLinksQuery>;
+
+describe('ShadowLinkListPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('renders the no-permission state (not a raw error) when the API returns PermissionDenied', async () => {
+    const error = new ConnectError('you are not authorized to call this endpoint', Code.PermissionDenied);
+    mockedUseListShadowLinksQuery.mockReturnValue(mockQueryResult({ error }));
+
+    renderWithFileRoutes(<ShadowLinkListPage />);
+
+    // Dedicated "no permission" card is shown...
+    expect(await screen.findByTestId('shadowlink-no-permission-card')).toBeInTheDocument();
+    expect(screen.getByText(/don't have permission to view shadow links/i)).toBeInTheDocument();
+
+    // ...and we do NOT show the generic error card.
+    expect(screen.queryByTestId('shadowlink-error-card')).not.toBeInTheDocument();
+  });
+
+  test('does not raise an error toast for PermissionDenied (it is expected, not a failure)', async () => {
+    const error = new ConnectError('you are not authorized to call this endpoint', Code.PermissionDenied);
+    mockedUseListShadowLinksQuery.mockReturnValue(mockQueryResult({ error }));
+
+    renderWithFileRoutes(<ShadowLinkListPage />);
+
+    await screen.findByTestId('shadowlink-no-permission-card');
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  test('still renders the generic error state (and toasts) for unexpected errors', async () => {
+    const error = new ConnectError('boom', Code.Internal);
+    mockedUseListShadowLinksQuery.mockReturnValue(mockQueryResult({ error }));
+
+    renderWithFileRoutes(<ShadowLinkListPage />);
+
+    expect(await screen.findByTestId('shadowlink-error-card')).toBeInTheDocument();
+    expect(screen.queryByTestId('shadowlink-no-permission-card')).not.toBeInTheDocument();
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Failed to load shadowlinks', expect.anything()));
+  });
+});

--- a/frontend/src/components/pages/shadowlinks/list/shadowlink-list-page.tsx
+++ b/frontend/src/components/pages/shadowlinks/list/shadowlink-list-page.tsx
@@ -30,6 +30,7 @@ import {
   ShadowLinkEmptyStateCloud,
   ShadowLinkErrorState,
   ShadowLinkFeatureDisabledState,
+  ShadowLinkNoPermissionState,
   ShadowLinkUnavailableState,
 } from './shadowlink-empty-state';
 import { isEmbedded } from '../../../../config';
@@ -122,7 +123,12 @@ export const ShadowLinkListPage = () => {
 
   // Show toast on error (except for feature-disabled or unavailable admin API errors)
   useEffect(() => {
-    if (error && error.code !== Code.FailedPrecondition && error.code !== Code.Unavailable) {
+    if (
+      error &&
+      error.code !== Code.FailedPrecondition &&
+      error.code !== Code.Unavailable &&
+      error.code !== Code.PermissionDenied
+    ) {
       toast.error('Failed to load shadowlinks', {
         description: error.message,
       });
@@ -146,6 +152,15 @@ export const ShadowLinkListPage = () => {
     return (
       <div className="my-2 flex justify-center gap-2">
         <ShadowLinkUnavailableState />
+      </div>
+    );
+  }
+
+  // No permission state
+  if (error?.code === Code.PermissionDenied) {
+    return (
+      <div className="my-2 flex justify-center gap-2">
+        <ShadowLinkNoPermissionState />
       </div>
     );
   }

--- a/frontend/src/components/pages/shadowlinks/list/shadowlink-route-loader.test.tsx
+++ b/frontend/src/components/pages/shadowlinks/list/shadowlink-route-loader.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { Code, ConnectError, createRouterTransport } from '@connectrpc/connect';
+import { QueryClient } from '@tanstack/react-query';
+import { listShadowLinks } from 'protogen/redpanda/api/console/v1alpha1/shadowlink-ShadowLinkService_connectquery';
+import { Route } from 'routes/shadowlinks/index';
+import { describe, expect, test } from 'vitest';
+
+// A transport whose listShadowLinks RPC always fails with the given code, so we
+// can drive the route loader's error handling.
+const failingTransport = (code: Code, message: string) =>
+  createRouterTransport(({ rpc }) => {
+    rpc(listShadowLinks, () => {
+      throw new ConnectError(message, code);
+    });
+  });
+
+const runLoader = (code: Code, message: string) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  // biome-ignore lint/suspicious/noExplicitAny: the loader only reads queryClient + dataplaneTransport off context.
+  return (Route.options.loader as any)({
+    context: { queryClient, dataplaneTransport: failingTransport(code, message) },
+  });
+};
+
+describe('shadowlinks route loader', () => {
+  // The bug: the loader rethrew everything except FailedPrecondition/Unavailable,
+  // so a permission_denied failed the whole route and the page never rendered.
+  test('swallows PermissionDenied so the page can render its no-permission state', async () => {
+    await expect(
+      runLoader(Code.PermissionDenied, 'you are not authorized to call this endpoint')
+    ).resolves.toBeUndefined();
+  });
+
+  test('swallows FailedPrecondition (feature disabled) and Unavailable (admin API down)', async () => {
+    await expect(runLoader(Code.FailedPrecondition, 'Cluster link feature is disabled')).resolves.toBeUndefined();
+    await expect(runLoader(Code.Unavailable, 'admin api unavailable')).resolves.toBeUndefined();
+  });
+
+  test('still rethrows unexpected errors (so the router error boundary is shown)', async () => {
+    await expect(runLoader(Code.Internal, 'boom')).rejects.toThrow('boom');
+  });
+});

--- a/frontend/src/routes/shadowlinks/index.tsx
+++ b/frontend/src/routes/shadowlinks/index.tsx
@@ -31,8 +31,13 @@ export const Route = createFileRoute('/shadowlinks/')({
     } catch (error) {
       if (
         error instanceof ConnectError &&
-        (error.code === Code.FailedPrecondition || error.code === Code.Unavailable)
+        (error.code === Code.FailedPrecondition ||
+          error.code === Code.Unavailable ||
+          error.code === Code.PermissionDenied)
       ) {
+        // The component renders dedicated states for these (feature disabled,
+        // admin API unavailable, no permission). Rethrowing here would fail the
+        // route and surface a raw error boundary instead of letting the page load.
         return;
       }
       throw error;


### PR DESCRIPTION
Before:
<img width="1489" height="692" alt="Screenshot 2026-06-27 at 17 03 50" src="https://github.com/user-attachments/assets/3b812716-0912-40be-9d81-b2894cb176cf" />
<img width="1408" height="970" alt="Screenshot 2026-06-27 at 17 25 44" src="https://github.com/user-attachments/assets/d5fae422-d3c3-421d-9b35-d9e43afb7c67" />

After:
<img width="1479" height="1239" alt="Screenshot 2026-06-29 at 11 43 49" src="https://github.com/user-attachments/assets/baedb7db-a01e-4916-b4ad-71cab4925f0f" />

<img width="1485" height="941" alt="Screenshot 2026-06-27 at 17 54 42" src="https://github.com/user-attachments/assets/7c640aa6-d206-4251-b153-9ff771b6b1b9" />
