### PR TITLE
shadowlink: survive slow status aggregation on large clusters

### DIFF
--- a/backend/pkg/factory/redpanda/redpanda.go
+++ b/backend/pkg/factory/redpanda/redpanda.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"time"
 
 	"buf.build/gen/go/redpandadata/core/connectrpc/go/redpanda/core/admin/v2/adminv2connect"
 	"connectrpc.com/connect"
@@ -36,6 +37,12 @@ type ClientOption func(*ClientOptions) error
 // ClientOptions holds all configurable parameters for constructing an AdminAPIClient.
 type ClientOptions struct {
 	URLs []string
+	// Timeout overrides the HTTP client timeout of the admin API client
+	// (rpadmin defaults to 10s).
+	Timeout time.Duration
+	// MaxRetries overrides the number of attempts of the admin API client's
+	// retrying HTTP client (rpadmin defaults to 3).
+	MaxRetries int
 }
 
 // WithURLs lets the caller override the URLs that the client will use.
@@ -46,6 +53,35 @@ func WithURLs(urls ...string) ClientOption {
 			return errors.New("WithURLs: at least one URL must be provided")
 		}
 		o.URLs = urls
+		return nil
+	}
+}
+
+// WithClientTimeout lets the caller override the HTTP client timeout used for
+// admin API requests. Used by console-enterprise for requests that are known
+// to be slow, such as shadow link status aggregations on large clusters. It
+// requires a positive duration; otherwise it returns an error immediately.
+func WithClientTimeout(timeout time.Duration) ClientOption {
+	return func(o *ClientOptions) error {
+		if timeout <= 0 {
+			return errors.New("WithClientTimeout: timeout must be greater than zero")
+		}
+		o.Timeout = timeout
+		return nil
+	}
+}
+
+// WithMaxRetries lets the caller override how many attempts the admin API
+// client's retrying HTTP client makes for a request. Used by
+// console-enterprise for expensive requests where retrying multiplies load on
+// the cluster. It requires a positive value; otherwise it returns an error
+// immediately.
+func WithMaxRetries(retries int) ClientOption {
+	return func(o *ClientOptions) error {
+		if retries <= 0 {
+			return errors.New("WithMaxRetries: retries must be greater than zero")
+		}
+		o.MaxRetries = retries
 		return nil
 	}
 }

--- a/backend/pkg/factory/redpanda/single_client.go
+++ b/backend/pkg/factory/redpanda/single_client.go
@@ -82,7 +82,15 @@ func (p *SingleClientProvider) GetRedpandaAPIClient(ctx context.Context, opts ..
 		tlsCfg = nil
 	}
 
-	adminClient, err := rpadmin.NewAdminAPI(cfg.URLs, p.cfg.RPAdminAuth(), tlsCfg)
+	var rpadminOpts []rpadmin.Opt
+	if cfg.Timeout > 0 {
+		rpadminOpts = append(rpadminOpts, rpadmin.ClientTimeout(cfg.Timeout))
+	}
+	if cfg.MaxRetries > 0 {
+		rpadminOpts = append(rpadminOpts, rpadmin.MaxRetries(cfg.MaxRetries))
+	}
+
+	adminClient, err := rpadmin.NewClient(cfg.URLs, tlsCfg, p.cfg.RPAdminAuth(), false, rpadminOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create admin client: %w", err)
 	}

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -51,6 +51,7 @@ import { patchedRedpandaTheme as redpandaTheme } from 'utils/redpanda-theme';
 
 import { applyOverrides as applyDebugFeatureFlagOverrides } from './components/debug-helper/feature-flag-overrides';
 import { NotFoundPage } from './components/misc/not-found-page';
+import { RoutePendingFallback } from './components/misc/route-pending-fallback';
 import { addBearerTokenInterceptor, checkExpiredLicenseInterceptor, getGrpcBasePath, setup } from './config';
 import { routeTree } from './routeTree.gen';
 import { installUISettingsSideEffects } from './state/ui';
@@ -75,6 +76,7 @@ const router = createRouter({
   basepath: getBasePath(),
   trailingSlash: 'never',
   defaultNotFoundComponent: NotFoundPage,
+  defaultPendingComponent: RoutePendingFallback,
 });
 
 declare global {

--- a/frontend/src/components/misc/route-pending-fallback.tsx
+++ b/frontend/src/components/misc/route-pending-fallback.tsx
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { Spinner } from 'components/redpanda-ui/components/spinner';
+import { Text } from 'components/redpanda-ui/components/typography';
+
+/**
+ * Rendered by the router while a route loader is pending. Without it, slow
+ * loaders (e.g. shadow link status aggregation on large clusters) leave the
+ * user staring at a blank page.
+ */
+export const RoutePendingFallback = () => (
+  <div className="flex h-64 items-center justify-center" data-testid="route-pending-fallback">
+    <div className="flex items-center gap-2">
+      <Spinner className="h-6 w-6" />
+      <Text>Loading...</Text>
+    </div>
+  </div>
+);

--- a/frontend/src/components/pages/shadowlinks/edit/shadowlink-edit-page.tsx
+++ b/frontend/src/components/pages/shadowlinks/edit/shadowlink-edit-page.tsx
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
+import { Code } from '@connectrpc/connect';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useNavigate, useParams } from '@tanstack/react-router';
 import { Button } from 'components/redpanda-ui/components/button';
@@ -25,6 +26,7 @@ import { SourceTab } from './source-tab';
 import { TopicConfigTab } from './topic-config-tab';
 import { useEditShadowLink } from '../../../../react-query/api/shadowlink';
 import { FormSchema, type FormValues } from '../create/model';
+import { ShadowLinkLoadErrorState } from '../list/shadowlink-empty-state';
 
 /**
  * Map form field to its corresponding tab
@@ -76,7 +78,7 @@ export const ShadowLinkEditPage = () => {
   }
 
   // Use the unified edit hook that handles embedded/dataplane logic
-  const { formValues, isLoading, isUpdating, hasData, updateShadowLink, dataplaneUpdate, controlplaneUpdate } =
+  const { formValues, isLoading, error, isUpdating, hasData, updateShadowLink, dataplaneUpdate, controlplaneUpdate } =
     useEditShadowLink(name);
 
   // Set up mutation callbacks
@@ -158,6 +160,12 @@ export const ShadowLinkEditPage = () => {
       { title: 'Edit', linkTo: `/shadowlinks/${name}/edit` },
     ];
   }, [name]);
+
+  // Load errors (e.g. a timeout while Redpanda aggregates shadow link status
+  // on a large cluster) are not the same as a missing shadow link.
+  if (!(isLoading || hasData) && error && error.code !== Code.NotFound) {
+    return <ShadowLinkLoadErrorState errorMessage={error.message} />;
+  }
 
   if (!(isLoading || hasData)) {
     return (

--- a/frontend/src/components/pages/shadowlinks/list/shadowlink-route-loader.test.tsx
+++ b/frontend/src/components/pages/shadowlinks/list/shadowlink-route-loader.test.tsx
@@ -46,7 +46,26 @@ describe('shadowlinks route loader', () => {
     await expect(runLoader(Code.Unavailable, 'admin api unavailable')).resolves.toBeUndefined();
   });
 
-  test('still rethrows unexpected errors (so the router error boundary is shown)', async () => {
-    await expect(runLoader(Code.Internal, 'boom')).rejects.toThrow('boom');
+  // Bug UX-1392: on large clusters Redpanda aggregates shadow link status from
+  // every broker, so ListShadowLinks can time out (deadline_exceeded). The
+  // loader rethrew it, failing the whole route with a raw error boundary
+  // instead of letting the page render its error state.
+  test('swallows DeadlineExceeded (status aggregation timeout on large clusters)', async () => {
+    await expect(
+      runLoader(Code.DeadlineExceeded, 'context deadline exceeded while awaiting headers')
+    ).resolves.toBeUndefined();
+  });
+
+  test('swallows any other ConnectError so the page can render its error state with retry', async () => {
+    await expect(runLoader(Code.Internal, 'boom')).resolves.toBeUndefined();
+  });
+  test('still rethrows non-Connect errors (so the router error boundary is shown)', async () => {
+    const queryClient = { ensureQueryData: () => Promise.reject(new TypeError('unexpected programming error')) };
+    // biome-ignore lint/suspicious/noExplicitAny: the loader only reads queryClient + dataplaneTransport off context.
+    await expect(
+      (Route.options.loader as any)({
+        context: { queryClient, dataplaneTransport: failingTransport(Code.Internal, 'unused') },
+      })
+    ).rejects.toThrow('unexpected programming error');
   });
 });

--- a/frontend/src/embedded-app.tsx
+++ b/frontend/src/embedded-app.tsx
@@ -44,6 +44,7 @@ import queryClient from 'query-client';
 import { patchedRedpandaTheme as redpandaTheme } from 'utils/redpanda-theme';
 
 import { NotFoundPage } from './components/misc/not-found-page';
+import { RoutePendingFallback } from './components/misc/route-pending-fallback';
 import {
   addBearerTokenInterceptor,
   checkExpiredLicenseInterceptor,
@@ -144,6 +145,7 @@ function EmbeddedApp({ basePath = '', ...p }: EmbeddedProps) {
         },
         basepath: basePath,
         defaultNotFoundComponent: NotFoundPage,
+        defaultPendingComponent: RoutePendingFallback,
       }),
     [basePath, dataplaneTransport]
   );

--- a/frontend/src/routes/shadowlinks/$name/edit.tsx
+++ b/frontend/src/routes/shadowlinks/$name/edit.tsx
@@ -46,6 +46,10 @@ export const Route = createFileRoute('/shadowlinks/$name/edit')({
       if (error instanceof ConnectError && error.code === Code.NotFound) {
         throw notFound();
       }
+      if (error instanceof ConnectError) {
+        // The edit page renders its own error state for API errors.
+        return;
+      }
       throw error;
     }
   },

--- a/frontend/src/routes/shadowlinks/$name/index.tsx
+++ b/frontend/src/routes/shadowlinks/$name/index.tsx
@@ -46,6 +46,10 @@ export const Route = createFileRoute('/shadowlinks/$name/')({
       if (error instanceof ConnectError && error.code === Code.NotFound) {
         throw notFound();
       }
+      if (error instanceof ConnectError) {
+        // The page renders its own error state for API errors.
+        return;
+      }
       throw error;
     }
   },

--- a/frontend/src/routes/shadowlinks/index.tsx
+++ b/frontend/src/routes/shadowlinks/index.tsx
@@ -10,7 +10,7 @@
  */
 
 import { create } from '@bufbuild/protobuf';
-import { Code, ConnectError } from '@connectrpc/connect';
+import { ConnectError } from '@connectrpc/connect';
 import { createQueryOptions } from '@connectrpc/connect-query';
 import { createFileRoute } from '@tanstack/react-router';
 import { ShieldIcon } from 'components/icons';
@@ -29,15 +29,9 @@ export const Route = createFileRoute('/shadowlinks/')({
         createQueryOptions(listShadowLinks, create(ListShadowLinksRequestSchema, {}), { transport: dataplaneTransport })
       );
     } catch (error) {
-      if (
-        error instanceof ConnectError &&
-        (error.code === Code.FailedPrecondition ||
-          error.code === Code.Unavailable ||
-          error.code === Code.PermissionDenied)
-      ) {
-        // The component renders dedicated states for these (feature disabled,
-        // admin API unavailable, no permission). Rethrowing here would fail the
-        // route and surface a raw error boundary instead of letting the page load.
+      if (error instanceof ConnectError) {
+        // The page renders its own error states for API errors; rethrowing
+        // would fail the route into the raw error boundary.
         return;
       }
       throw error;


### PR DESCRIPTION
Redpanda builds shadow link status by fanning out
to every broker, so on large clusters any shadow
link request can exceed rpadmin's default 10s
client timeout. The pester client then retried
the expensive aggregation two more times, and the
route loaders awaited the result with no pending
UI and rethrew the failure, so users saw a blank
page followed by the raw error boundary.

The client factory now accepts per-request
timeout and max-attempt options that map onto
rpadmin options; console-enterprise consumes them
for shadow link calls, which is why they have no
in-repo caller. The router renders a pending
fallback while loaders run, and the shadowlink
loaders swallow Connect errors so the pages can
render their own error states with retry instead
of failing the route.

Example of the loading state:

<img width="1039" height="542" alt="image" src="https://github.com/user-attachments/assets/9458e97a-7272-4ac7-8d49-77f559814c0b" />
