### PR TITLE
fix(security): allow assigning OIDC/mTLS principals to a role

### DIFF
--- a/frontend/src/components/pages/security/roles/role-detail-page-new.test.tsx
+++ b/frontend/src/components/pages/security/roles/role-detail-page-new.test.tsx
@@ -9,7 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -62,9 +62,10 @@ describe('RoleDetailPageNew principal assignment', () => {
     const user = userEvent.setup();
     renderPage();
 
-    // type() targets the input directly. keyboard() would rely on ambient focus,
-    // which the popover's focus guards can steal once it opens.
-    await user.type(screen.getByRole('combobox'), 'person@email.com');
+    // Set the value in one change event rather than per-keystroke: the first
+    // character opens the popover, whose focus guards then take focus, so the
+    // remaining characters are dropped. The handler reads e.target.value whole.
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'person@email.com' } });
     await user.click(await screen.findByText('Create "person@email.com"'));
 
     expect(updateMembershipMock).toHaveBeenCalledTimes(1);

--- a/frontend/src/components/pages/security/roles/role-detail-page-new.test.tsx
+++ b/frontend/src/components/pages/security/roles/role-detail-page-new.test.tsx
@@ -62,10 +62,9 @@ describe('RoleDetailPageNew principal assignment', () => {
     const user = userEvent.setup();
     renderPage();
 
-    await user.click(screen.getByRole('combobox'));
-    await user.keyboard('person@email.com');
-    // Click the create row rather than pressing Enter: the Enter branch only
-    // fires once the row has rendered, which lags under parallel test load.
+    // type() targets the input directly. keyboard() would rely on ambient focus,
+    // which the popover's focus guards can steal once it opens.
+    await user.type(screen.getByRole('combobox'), 'person@email.com');
     await user.click(await screen.findByText('Create "person@email.com"'));
 
     expect(updateMembershipMock).toHaveBeenCalledTimes(1);

--- a/frontend/src/components/pages/security/roles/role-detail-page-new.test.tsx
+++ b/frontend/src/components/pages/security/roles/role-detail-page-new.test.tsx
@@ -64,7 +64,9 @@ describe('RoleDetailPageNew principal assignment', () => {
 
     await user.click(screen.getByRole('combobox'));
     await user.keyboard('person@email.com');
-    await user.keyboard('{Enter}');
+    // Click the create row rather than pressing Enter: the Enter branch only
+    // fires once the row has rendered, which lags under parallel test load.
+    await user.click(await screen.findByText('Create "person@email.com"'));
 
     expect(updateMembershipMock).toHaveBeenCalledTimes(1);
     expect(updateMembershipMock.mock.calls[0][0]).toMatchObject({

--- a/frontend/src/components/pages/security/roles/role-detail-page-new.test.tsx
+++ b/frontend/src/components/pages/security/roles/role-detail-page-new.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { TooltipProvider } from '../../../redpanda-ui/components/tooltip';
+
+const { updateMembershipMock } = vi.hoisted(() => ({
+  updateMembershipMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  useParams: () => ({ roleName: 'test-role' }),
+}));
+
+vi.mock('../../../../state/ui-state', () => ({
+  setPageHeader: vi.fn(),
+}));
+
+vi.mock('../shared/acls-card', () => ({
+  AclsCard: () => null,
+}));
+
+vi.mock('../../../../react-query/api/acl', () => ({
+  useGetAclsByPrincipal: () => ({ data: [], isLoading: false }),
+}));
+
+vi.mock('../../../../react-query/api/security', () => ({
+  useListRoleMembersQuery: () => ({ data: { members: [] }, isLoading: false }),
+  useUpdateRoleMembershipMutation: () => ({ mutateAsync: updateMembershipMock, isPending: false }),
+}));
+
+vi.mock('../../../../react-query/api/user', () => ({
+  useListUsersQuery: () => ({ data: { users: [{ name: 'scram-user' }] } }),
+}));
+
+import { RoleDetailPageNew } from './role-detail-page-new';
+
+const renderPage = () =>
+  render(
+    <TooltipProvider>
+      <RoleDetailPageNew />
+    </TooltipProvider>
+  );
+
+describe('RoleDetailPageNew principal assignment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('assigns an OIDC email principal that is absent from the SCRAM user list', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole('combobox'));
+    await user.keyboard('person@email.com');
+    await user.keyboard('{Enter}');
+
+    expect(updateMembershipMock).toHaveBeenCalledTimes(1);
+    expect(updateMembershipMock.mock.calls[0][0]).toMatchObject({
+      roleName: 'test-role',
+      add: [{ principal: 'User:person@email.com' }],
+    });
+  });
+
+  test('still assigns an existing SCRAM user selected from the list', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(await screen.findByText('scram-user'));
+
+    expect(updateMembershipMock).toHaveBeenCalledTimes(1);
+    expect(updateMembershipMock.mock.calls[0][0]).toMatchObject({
+      add: [{ principal: 'User:scram-user' }],
+    });
+  });
+});

--- a/frontend/src/components/pages/security/roles/role-detail-page-new.tsx
+++ b/frontend/src/components/pages/security/roles/role-detail-page-new.tsx
@@ -119,10 +119,12 @@ export const RoleDetailPageNew = () => {
             <Combobox
               className="w-56"
               clearable={false}
+              creatable
+              createLabel="principal"
               disabled={isSubmitting}
               onChange={addMember}
               options={availablePrincipalOptions}
-              placeholder="Add a principal..."
+              placeholder="Select or type a principal..."
               testId="add-principal-combobox"
               value=""
             />


### PR DESCRIPTION
## Problem

Since v3.7.4, an OIDC/email principal cannot be assigned to a role from the role detail page. Reported by a user who is blocked from granting topic access on a production cluster and is currently working around it with `rpk security role assign`.

`enableNewSecurityPage` does not exist in v3.7.3 and lands in v3.7.4 defaulting to `true` (`constants.ts:19`), which is why the regression surfaced exactly at that version — every user switched to the new page at once.

## Cause

The new page renders a `Combobox` whose `options` come solely from `ListUsers` (`role-detail-page-new.tsx:72-74`) and does not pass `creatable`. Console cannot enumerate OIDC or mTLS identities — they live in an external IdP — so those principals never appear as options, and typing one has nowhere to land.

The previous page (`matching-users-card.tsx:209`) used `AutocompleteInput`, where `suggestions` were advisory and the committed value was free text:

```ts
add: [{ principal: `${principalTypeToAdd}:${newUserName.trim()}` }],
```

The new page's own copy still advertises the concept it can no longer accept — `roles-tab-new.tsx:285` reads "OIDC identity, or mTLS client".

## Fix

Pass `creatable` (+ `createLabel`) to the Combobox, matching the existing precedent at `add-acl-dialog.tsx:255-267`. `addMember` already builds `User:${userName}`, so an OIDC principal yields `User:person@email.com` — byte-identical to what v3.7.3 sent.

`onCreateOption` is intentionally **not** passed: `handleCreatableSubmit` (`combobox/index.tsx:190-192`) invokes both `onChange` and `onCreateOption`, so wiring both would submit the membership mutation twice.

## Tests

Adds `role-detail-page-new.test.tsx`. Verified it's a genuine regression test by reverting the fix: the OIDC case fails without `creatable` and passes with it, while the SCRAM-user case passes either way — so it pins the bug without over-fitting.

This flow had no coverage: every E2E spec pins `enableNewSecurityPage: false`, which is how a default-on flag shipped with this gap.

## Follow-ups (deliberately not in this PR)

- **Copy:** the create row reads `Create "person@email.com"`, which misleads — the identity already exists in the IdP; we're only granting it a role. The string is hardcoded at `combobox/index.tsx:452` with no prop controlling it, and the component is registry-owned (`frontend-ui-audit.yml` runs with `--fail-on any`), so changing it needs an upstream `ui-registry` prop rather than a local edit that would fail CI and be clobbered on the next sync.
- **Group principals:** the new page dropped the GBAC-gated User/Group selector (`matching-users-card.tsx:187-206`) and hardcodes `User:`, making group membership unreachable. Needs a design call.
- **E2E coverage** for the new security page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
