### PR TITLE
fe/shadowlink: make schema registry section editable

### DIFF
--- a/frontend/src/components/pages/shadowlinks/create/configuration/schema-registry-step.test.tsx
+++ b/frontend/src/components/pages/shadowlinks/create/configuration/schema-registry-step.test.tsx
@@ -13,28 +13,12 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import userEvent from '@testing-library/user-event';
 import { Form } from 'components/redpanda-ui/components/form';
 import { useForm } from 'react-hook-form';
-import { Feature, useSupportedFeaturesStore } from 'state/supported-features';
+import { useSupportedFeaturesStore } from 'state/supported-features';
 import { render, screen, waitFor } from 'test-utils';
 
 import { LegacySchemaRegistrySection, SchemaRegistryStep } from './schema-registry-step';
+import { setSchemaRegistrySyncGateSupported as setSrSyncSupported } from '../../shadowlink-test-helpers';
 import { FormSchema, type FormValues, initialValues, SCHEMA_REGISTRY_MODE } from '../model';
-
-// Drive the real supported-features store the way the app does at boot, so the
-// gate exercises the actual endpoint-compatibility fail-closed logic instead of
-// a mock: a supported endpoint yields the redesigned section, anything else
-// (unsupported, absent, or a never-loaded null store) yields the legacy switch.
-const setSrSyncSupported = (isSupported: boolean) => {
-  useSupportedFeaturesStore.getState().setEndpointCompatibility({
-    kafkaVersion: 'v26.2.0',
-    endpoints: [
-      {
-        endpoint: Feature.ShadowLinkSchemaRegistrySync.endpoint,
-        method: Feature.ShadowLinkSchemaRegistrySync.method,
-        isSupported,
-      },
-    ],
-  });
-};
 
 const TestWrapper = ({
   defaultValues = initialValues,

--- a/frontend/src/components/pages/shadowlinks/create/configuration/schema-registry/shadow-schema-registry-section.tsx
+++ b/frontend/src/components/pages/shadowlinks/create/configuration/schema-registry/shadow-schema-registry-section.tsx
@@ -29,16 +29,32 @@ const MODE_DESCRIPTIONS: Record<SchemaRegistryMode, string> = {
     'Schema Registry shadowing is off. The shadow cluster keeps its own independent Schema Registry.',
 };
 
-export const ShadowSchemaRegistrySection = () => {
+type ShadowSchemaRegistrySectionProps = {
+  /**
+   * Modes the user cannot switch to (edit page: direct topic<->api switches
+   * are not supported).
+   */
+  disabledModes?: SchemaRegistryMode[];
+  /** Rendered under the mode tabs (edit page: transition warnings). */
+  modeNotice?: React.ReactNode;
+};
+
+export const ShadowSchemaRegistrySection = ({ disabledModes = [], modeNotice }: ShadowSchemaRegistrySectionProps) => {
   const { control, getValues, setValue } = useFormContext<FormValues>();
   const mode = useWatch({ control, name: 'schemaRegistry.mode' });
 
-  // Migrate a legacy-switch choice into this UI: the boolean may already be on
-  // (toggled while the gate was closed), and leaving mode at 'none' would make
-  // the tabs disagree with what gets submitted.
+  // Migrate a legacy-switch choice into this UI (the switch may have been
+  // toggled either way while the gate was closed): the boolean is the legacy
+  // source of truth, so reconcile the mode with it in both directions —
+  // otherwise the tabs would disagree with what gets submitted.
   useEffect(() => {
-    if (getValues('enableSchemaRegistrySync') && getValues('schemaRegistry.mode') === SCHEMA_REGISTRY_MODE.NONE) {
+    const enabled = getValues('enableSchemaRegistrySync');
+    const currentMode = getValues('schemaRegistry.mode');
+    if (enabled && currentMode === SCHEMA_REGISTRY_MODE.NONE) {
       setValue('schemaRegistry.mode', SCHEMA_REGISTRY_MODE.TOPIC);
+    }
+    if (!enabled && currentMode === SCHEMA_REGISTRY_MODE.TOPIC) {
+      setValue('schemaRegistry.mode', SCHEMA_REGISTRY_MODE.NONE);
     }
   }, [getValues, setValue]);
 
@@ -64,13 +80,25 @@ export const ShadowSchemaRegistrySection = () => {
           <div className="flex flex-col gap-2">
             <Tabs onValueChange={handleModeChange} value={mode}>
               <TabsList>
-                <TabsTrigger testId="sr-mode-topic-tab" value={SCHEMA_REGISTRY_MODE.TOPIC}>
-                  _schemas topic
+                <TabsTrigger
+                  disabled={disabledModes.includes(SCHEMA_REGISTRY_MODE.TOPIC)}
+                  testId="sr-mode-topic-tab"
+                  value={SCHEMA_REGISTRY_MODE.TOPIC}
+                >
+                  Redpanda
                 </TabsTrigger>
-                <TabsTrigger testId="sr-mode-api-tab" value={SCHEMA_REGISTRY_MODE.API}>
-                  Sync over API
+                <TabsTrigger
+                  disabled={disabledModes.includes(SCHEMA_REGISTRY_MODE.API)}
+                  testId="sr-mode-api-tab"
+                  value={SCHEMA_REGISTRY_MODE.API}
+                >
+                  Other
                 </TabsTrigger>
-                <TabsTrigger testId="sr-mode-none-tab" value={SCHEMA_REGISTRY_MODE.NONE}>
+                <TabsTrigger
+                  disabled={disabledModes.includes(SCHEMA_REGISTRY_MODE.NONE)}
+                  testId="sr-mode-none-tab"
+                  value={SCHEMA_REGISTRY_MODE.NONE}
+                >
                   None
                 </TabsTrigger>
               </TabsList>
@@ -78,6 +106,12 @@ export const ShadowSchemaRegistrySection = () => {
             <div className="text-body-sm text-muted-foreground" data-testid="sr-mode-description">
               {MODE_DESCRIPTIONS[mode]}
             </div>
+            {disabledModes.length > 0 && (
+              <div className="text-body-sm text-muted-foreground" data-testid="sr-mode-locked-hint">
+                Switching between Redpanda and Other isn't supported.
+              </div>
+            )}
+            {modeNotice}
           </div>
 
           {mode === SCHEMA_REGISTRY_MODE.API && (

--- a/frontend/src/components/pages/shadowlinks/create/configuration/schema-registry/source-connection-section.test.tsx
+++ b/frontend/src/components/pages/shadowlinks/create/configuration/schema-registry/source-connection-section.test.tsx
@@ -12,11 +12,24 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import userEvent from '@testing-library/user-event';
 import { Form } from 'components/redpanda-ui/components/form';
+import { isEmbedded } from 'config';
 import { useForm } from 'react-hook-form';
 import { render, screen, waitFor } from 'test-utils';
+import { vi } from 'vitest';
 
 import { SourceConnectionSection } from './source-connection-section';
 import { FormSchema, type FormValues, initialValues, SCHEMA_REGISTRY_MODE, SR_AUTH_METHOD } from '../../model';
+
+vi.mock('config', () => ({
+  isEmbedded: vi.fn(() => false),
+  isFeatureFlagEnabled: vi.fn(() => false),
+}));
+
+let mockSecretsData: { secrets: { id: string }[] } | undefined;
+vi.mock('react-query/api/secret', () => ({
+  useCreateSecretMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useListSecretsQuery: () => ({ data: mockSecretsData }),
+}));
 
 const apiModeValues: FormValues = {
   ...initialValues,
@@ -93,6 +106,61 @@ describe('SourceConnectionSection', () => {
       expect(formValues?.schemaRegistry?.authMethod).toBe(SR_AUTH_METHOD.BASIC);
       expect(formValues?.schemaRegistry?.basicCredentials?.username).toBe('sr-replicator');
       expect(formValues?.schemaRegistry?.basicCredentials?.password).toBe('p@ssw0rd!');
+    });
+  });
+
+  describe('HTTP Basic password in embedded mode (Cloud)', () => {
+    beforeEach(() => {
+      vi.mocked(isEmbedded).mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      vi.mocked(isEmbedded).mockReturnValue(false);
+      mockSecretsData = undefined;
+    });
+
+    test('should render a secret selector instead of a raw password input and store a secret reference', async () => {
+      mockSecretsData = { secrets: [{ id: 'SR_PASSWORD' }, { id: 'OTHER_SECRET' }] };
+      const user = userEvent.setup();
+      let formValues: FormValues | undefined;
+
+      render(
+        <TestWrapper
+          onFormChange={(values) => {
+            formValues = values;
+          }}
+        />
+      );
+
+      await user.click(screen.getByTestId('sr-auth-basic-tab'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('sr-basic-auth-fields')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('sr-basic-password-input')).not.toBeInTheDocument();
+
+      // Queried by accessible name: form wiring must reach the trigger.
+      await user.click(screen.getByRole('combobox', { name: /password/i }));
+      await user.click(await screen.findByRole('option', { name: 'SR_PASSWORD' }));
+
+      await waitFor(() => {
+        expect(formValues?.schemaRegistry?.basicCredentials?.password).toBe('${secrets.SR_PASSWORD}');
+      });
+    });
+
+    test('should show the create-secret empty state when no secrets exist', async () => {
+      mockSecretsData = { secrets: [] };
+      const user = userEvent.setup();
+
+      render(<TestWrapper />);
+
+      await user.click(screen.getByTestId('sr-auth-basic-tab'));
+
+      await waitFor(() => {
+        expect(screen.getByText('No secrets available')).toBeInTheDocument();
+      });
+      expect(screen.getByText('Create a secret to securely store your Schema Registry password')).toBeInTheDocument();
+      expect(screen.queryByTestId('sr-basic-password-input')).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/pages/shadowlinks/create/configuration/schema-registry/source-connection-section.tsx
+++ b/frontend/src/components/pages/shadowlinks/create/configuration/schema-registry/source-connection-section.tsx
@@ -20,11 +20,26 @@ import {
 import { Input } from 'components/redpanda-ui/components/input';
 import { Tabs, TabsList, TabsTrigger } from 'components/redpanda-ui/components/tabs';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from 'components/redpanda-ui/components/tooltip';
+import { SecretSelector, type SecretSelectorCustomText } from 'components/ui/secret/secret-selector';
+import { isEmbedded } from 'config';
 import { InfoIcon } from 'lucide-react';
+import { Scope } from 'protogen/redpanda/api/dataplane/v1/secret_pb';
+import { useMemo } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
+import { useListSecretsQuery } from 'react-query/api/secret';
 
 import { SrTlsConfiguration } from './sr-tls-configuration';
+import { extractSecretId, toSecretReference } from '../../connection/secret-reference';
 import { type FormValues, SR_AUTH_METHOD } from '../../model';
+
+const SR_PASSWORD_SECRET_TEXT: SecretSelectorCustomText = {
+  dialogDescription:
+    'Create a new secret for your Schema Registry HTTP Basic password. The secret will be stored securely.',
+  secretNamePlaceholder: 'e.g., SCHEMA_REGISTRY_PASSWORD',
+  secretValuePlaceholder: 'Enter password...',
+  secretValueDescription: 'Your Schema Registry HTTP Basic password',
+  emptyStateDescription: 'Create a secret to securely store your Schema Registry password',
+};
 
 const InfoTooltip = ({ content }: { content: string }) => (
   <TooltipProvider>
@@ -40,6 +55,17 @@ const InfoTooltip = ({ content }: { content: string }) => (
 export const SourceConnectionSection = () => {
   const { control, setValue } = useFormContext<FormValues>();
   const authMethod = useWatch({ control, name: 'schemaRegistry.authMethod' });
+
+  // Fetch secrets for SecretSelector (embedded mode only)
+  const { data: secretsData } = useListSecretsQuery({}, { enabled: isEmbedded() });
+  const availableSecrets = useMemo(() => {
+    if (!secretsData?.secrets) {
+      return [];
+    }
+    return secretsData.secrets
+      .filter((secret): secret is NonNullable<typeof secret> & { id: string } => Boolean(secret?.id))
+      .map((secret) => ({ id: secret.id, name: secret.id }));
+  }, [secretsData]);
 
   const handleAuthMethodChange = (next: string) => {
     if (next !== SR_AUTH_METHOD.NONE && next !== SR_AUTH_METHOD.BASIC) {
@@ -115,7 +141,21 @@ export const SourceConnectionSection = () => {
                   <InfoTooltip content="For Confluent Cloud, this is the API secret." />
                 </FormLabel>
                 <FormControl>
-                  <Input {...field} testId="sr-basic-password-input" type="password" />
+                  {isEmbedded() ? (
+                    <SecretSelector
+                      availableSecrets={availableSecrets}
+                      customText={SR_PASSWORD_SECRET_TEXT}
+                      minValueLength={1}
+                      onChange={(secretId) => {
+                        field.onChange(secretId ? toSecretReference(secretId) : '');
+                      }}
+                      placeholder="Select or create password secret"
+                      scopes={[Scope.REDPANDA_CLUSTER]}
+                      value={extractSecretId(field.value)}
+                    />
+                  ) : (
+                    <Input {...field} testId="sr-basic-password-input" type="password" />
+                  )}
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/frontend/src/components/pages/shadowlinks/create/configuration/schema-registry/sr-tls-configuration.test.tsx
+++ b/frontend/src/components/pages/shadowlinks/create/configuration/schema-registry/sr-tls-configuration.test.tsx
@@ -1,0 +1,254 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import userEvent from '@testing-library/user-event';
+import { Form } from 'components/redpanda-ui/components/form';
+import { isEmbedded } from 'config';
+import { useForm } from 'react-hook-form';
+import { render, screen, waitFor } from 'test-utils';
+import { vi } from 'vitest';
+
+import { SrTlsConfiguration } from './sr-tls-configuration';
+import { FormSchema, type FormValues, initialValues, SCHEMA_REGISTRY_MODE } from '../../model';
+
+vi.mock('config', () => ({
+  isEmbedded: vi.fn(() => false),
+  isFeatureFlagEnabled: vi.fn(() => false),
+}));
+
+let mockSecretsData: { secrets: { id: string }[] } | undefined;
+vi.mock('react-query/api/secret', () => ({
+  useCreateSecretMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useListSecretsQuery: () => ({ data: mockSecretsData }),
+}));
+
+const apiModeValues = (schemaRegistry: Partial<FormValues['schemaRegistry']> = {}): FormValues => ({
+  ...structuredClone(initialValues),
+  schemaRegistry: {
+    ...structuredClone(initialValues.schemaRegistry),
+    mode: SCHEMA_REGISTRY_MODE.API,
+    sourceUrl: 'https://sr.example.com',
+    ...schemaRegistry,
+  },
+});
+
+const TestWrapper = ({
+  defaultValues,
+  onFormChange,
+}: {
+  defaultValues: FormValues;
+  onFormChange?: (values: FormValues) => void;
+}) => {
+  const form = useForm<FormValues>({
+    resolver: zodResolver(FormSchema),
+    defaultValues,
+  });
+
+  if (onFormChange) {
+    form.watch((values) => {
+      onFormChange(values as FormValues);
+    });
+  }
+
+  return (
+    <Form {...form}>
+      <form>
+        <SrTlsConfiguration />
+      </form>
+    </Form>
+  );
+};
+
+describe('SrTlsConfiguration', () => {
+  test('shows a generic label for a hydrated certificate without a file name', () => {
+    render(
+      <TestWrapper
+        defaultValues={apiModeValues({
+          mtls: {
+            ...initialValues.schemaRegistry.mtls,
+            ca: { pemContent: 'CA_PEM', fileName: '' },
+          },
+        })}
+      />
+    );
+
+    expect(screen.getByTestId('sr-ca-status')).toBeInTheDocument();
+    expect(screen.getByText('Configured certificate')).toBeInTheDocument();
+  });
+
+  test('shows the kept server-side key with its fingerprint and removes it', async () => {
+    const user = userEvent.setup();
+    let formValues: FormValues | undefined;
+
+    render(
+      <TestWrapper
+        defaultValues={apiModeValues({
+          mtls: {
+            ...initialValues.schemaRegistry.mtls,
+            clientCert: { pemContent: 'CERT_PEM', fileName: '' },
+            existingKeyConfigured: true,
+            existingKeyFingerprint: 'abc123=',
+          },
+        })}
+        onFormChange={(values) => {
+          formValues = values;
+        }}
+      />
+    );
+
+    // Hydrated pair opens the mTLS disclosure and shows the configured badge.
+    expect(screen.getByTestId('sr-clientKey-existing-status')).toBeInTheDocument();
+    expect(screen.getByTestId('sr-existing-key-fingerprint')).toHaveTextContent('SHA-256: abc123=');
+
+    await user.click(screen.getByTestId('remove-sr-existing-key-button'));
+
+    await waitFor(() => {
+      expect(formValues?.schemaRegistry.mtls.existingKeyConfigured).toBe(false);
+    });
+    // The dropzone replaces the configured row so a new key can be uploaded.
+    expect(screen.queryByTestId('sr-clientKey-existing-status')).not.toBeInTheDocument();
+    expect(screen.getByTestId('add-sr-clientKey-button')).toBeInTheDocument();
+    // With the cert still present, the pair rule now demands a new key.
+    await waitFor(() => {
+      expect(screen.getByTestId('sr-mtls-client-key-error')).toHaveTextContent(
+        'Client private key is required when client certificate is provided'
+      );
+    });
+  });
+
+  test('an uploaded key takes precedence over the kept-key row', async () => {
+    const user = userEvent.setup();
+    let formValues: FormValues | undefined;
+
+    render(
+      <TestWrapper
+        defaultValues={apiModeValues({
+          mtls: {
+            ...initialValues.schemaRegistry.mtls,
+            clientCert: { pemContent: 'CERT_PEM', fileName: '' },
+            clientKey: { pemContent: 'NEW_KEY_PEM', fileName: 'client.key' },
+            existingKeyConfigured: true,
+            existingKeyFingerprint: 'abc123=',
+          },
+        })}
+        onFormChange={(values) => {
+          formValues = values;
+        }}
+      />
+    );
+
+    expect(screen.queryByTestId('sr-clientKey-existing-status')).not.toBeInTheDocument();
+    expect(screen.getByTestId('sr-clientKey-status')).toBeInTheDocument();
+    expect(screen.getByText('client.key')).toBeInTheDocument();
+
+    // Removing the upload falls back to the kept server-side key.
+    await user.click(screen.getByTestId('remove-sr-clientKey-button'));
+
+    await waitFor(() => {
+      expect(formValues?.schemaRegistry.mtls.clientKey).toBeUndefined();
+    });
+    expect(screen.getByTestId('sr-clientKey-existing-status')).toBeInTheDocument();
+  });
+
+  describe('client key in embedded mode (Cloud)', () => {
+    beforeEach(() => {
+      vi.mocked(isEmbedded).mockReturnValue(true);
+      mockSecretsData = { secrets: [{ id: 'SR_MTLS_CLIENT_KEY' }] };
+    });
+
+    afterEach(() => {
+      vi.mocked(isEmbedded).mockReturnValue(false);
+      mockSecretsData = undefined;
+    });
+
+    test('replaces the key dropzone with a secret selector and stores a secret reference', async () => {
+      const user = userEvent.setup();
+      let formValues: FormValues | undefined;
+
+      render(
+        <TestWrapper
+          defaultValues={apiModeValues()}
+          onFormChange={(values) => {
+            formValues = values;
+          }}
+        />
+      );
+
+      await user.click(screen.getByTestId('sr-tls-mtls-disclosure-trigger'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Client private key secret')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('add-sr-clientKey-button')).not.toBeInTheDocument();
+      // The client certificate stays a PEM upload; only the key is a secret.
+      expect(screen.getByTestId('add-sr-clientCert-button')).toBeInTheDocument();
+
+      // Queried by accessible name: form wiring must reach the trigger.
+      await user.click(screen.getByRole('combobox', { name: /client private key secret/i }));
+      await user.click(await screen.findByRole('option', { name: 'SR_MTLS_CLIENT_KEY' }));
+
+      await waitFor(() => {
+        expect(formValues?.schemaRegistry.mtls.clientKey).toEqual({
+          pemContent: '${secrets.SR_MTLS_CLIENT_KEY}',
+          fileName: '',
+        });
+      });
+    });
+
+    test('kept server-side key still wins; removing it reveals the secret selector', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <TestWrapper
+          defaultValues={apiModeValues({
+            mtls: {
+              ...initialValues.schemaRegistry.mtls,
+              clientCert: { pemContent: 'CERT_PEM', fileName: '' },
+              existingKeyConfigured: true,
+              existingKeyFingerprint: 'abc123=',
+            },
+          })}
+        />
+      );
+
+      expect(screen.getByTestId('sr-clientKey-existing-status')).toBeInTheDocument();
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+
+      await user.click(screen.getByTestId('remove-sr-existing-key-button'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('combobox')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('add-sr-clientKey-button')).not.toBeInTheDocument();
+    });
+  });
+
+  test('renders file-path TLS settings read-only and hides the upload disclosures', () => {
+    render(
+      <TestWrapper
+        defaultValues={apiModeValues({
+          mtls: {
+            ...initialValues.schemaRegistry.mtls,
+            filePaths: { caPath: '/etc/tls/ca.pem', keyPath: '/etc/tls/client.key', certPath: '/etc/tls/client.pem' },
+          },
+        })}
+      />
+    );
+
+    expect(screen.getByTestId('sr-tls-file-settings-readonly')).toBeInTheDocument();
+    expect(screen.getByTestId('sr-tls-file-ca-path')).toHaveTextContent('/etc/tls/ca.pem');
+    expect(screen.getByTestId('sr-tls-file-key-path')).toHaveTextContent('/etc/tls/client.key');
+    expect(screen.getByTestId('sr-tls-file-cert-path')).toHaveTextContent('/etc/tls/client.pem');
+    expect(screen.queryByTestId('sr-mtls-certificates-form')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('sr-tls-ca-disclosure')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/pages/shadowlinks/create/configuration/schema-registry/sr-tls-configuration.tsx
+++ b/frontend/src/components/pages/shadowlinks/create/configuration/schema-registry/sr-tls-configuration.tsx
@@ -10,21 +10,36 @@
  */
 
 import { Badge } from 'components/redpanda-ui/components/badge';
+import { Button } from 'components/redpanda-ui/components/button';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from 'components/redpanda-ui/components/collapsible';
 import { Dropzone, DropzoneContent, DropzoneEmptyState } from 'components/redpanda-ui/components/dropzone';
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from 'components/redpanda-ui/components/form';
 import { Switch } from 'components/redpanda-ui/components/switch';
 import { cn } from 'components/redpanda-ui/lib/utils';
+import { SecretSelector, type SecretSelectorCustomText } from 'components/ui/secret/secret-selector';
+import { isEmbedded } from 'config';
 import { Check, ChevronRight, Trash2, UploadCloud } from 'lucide-react';
+import { Scope } from 'protogen/redpanda/api/dataplane/v1/secret_pb';
 import { useCallback, useMemo, useState } from 'react';
 import { useFormContext, useFormState, useWatch } from 'react-hook-form';
+import { useListSecretsQuery } from 'react-query/api/secret';
 import { docsLinks } from 'utils/docs-links';
 
-import { type FormValues, hasSrCertificate } from '../../model';
+import { extractSecretId, toSecretReference } from '../../connection/secret-reference';
+import { type FormValues, hasSrCertificate, hasSrClientKeyMaterial, type SchemaRegistryFormValues } from '../../model';
 
 const TLS_DOCS_URL = docsLinks.selfManaged.shadowingNetworkSetup;
 
 type SrCertificateType = 'ca' | 'clientCert' | 'clientKey';
+
+const SR_CLIENT_KEY_SECRET_TEXT: SecretSelectorCustomText = {
+  dialogDescription:
+    'Create a new secret for your Schema Registry mTLS client private key. The secret will be stored securely.',
+  secretNamePlaceholder: 'e.g., SR_MTLS_CLIENT_KEY',
+  secretValuePlaceholder: 'Paste PEM-encoded private key...',
+  secretValueDescription: 'Your Schema Registry mTLS client private key (PEM format)',
+  emptyStateDescription: 'Create a secret to securely store your Schema Registry mTLS client private key',
+};
 
 const CERTIFICATE_ACCEPT = {
   'application/x-pem-file': ['.pem'],
@@ -47,6 +62,28 @@ const CERTIFICATE_PAIR_SIBLING: Partial<Record<SrCertificateType, SrCertificateT
 };
 
 /**
+ * Trash affordance overlaid on the top-right corner of a dropzone or
+ * configured-material row. Stops propagation so the click never reaches the
+ * dropzone's file picker underneath.
+ */
+const RemoveMaterialButton = ({ label, onRemove, testId }: { label: string; onRemove: () => void; testId: string }) => (
+  <Button
+    aria-label={label}
+    className="absolute top-1/2 right-2 z-10 -translate-y-1/2"
+    onClick={(e) => {
+      e.stopPropagation();
+      onRemove();
+    }}
+    size="icon-xs"
+    testId={testId}
+    type="button"
+    variant="ghost"
+  >
+    <Trash2 />
+  </Button>
+);
+
+/**
  * Duplicated from connection/mtls-configuration.tsx rather than parameterized:
  * that component hardwires the connection step's 'mtls.*' field paths, its
  * file-path input mode, and the embedded secret-selector flow, none of which
@@ -58,7 +95,8 @@ function SrCertificateDropzone({ certType, optional }: { certType: SrCertificate
   const [uploadError, setUploadError] = useState<string | null>(null);
   const label = CERTIFICATE_LABELS[certType];
   const hasCert = hasSrCertificate(cert);
-  const fileName = hasCert ? cert?.fileName : undefined;
+  // PEMs hydrated from the API carry no file name; show a generic label.
+  const fileName = hasCert ? cert?.fileName || 'Configured certificate' : undefined;
 
   // Placeholder File so DropzoneContent renders — the real PEM bytes live in
   // form state.
@@ -137,18 +175,11 @@ function SrCertificateDropzone({ certType, optional }: { certType: SrCertificate
           </DropzoneContent>
         </Dropzone>
         {hasCert && (
-          <button
-            aria-label={`Remove ${label}`}
-            className="absolute top-1/2 right-2 z-10 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
-            data-testid={`remove-sr-${certType}-button`}
-            onClick={(e) => {
-              e.stopPropagation();
-              handleRemove();
-            }}
-            type="button"
-          >
-            <Trash2 className="h-3.5 w-3.5" />
-          </button>
+          <RemoveMaterialButton
+            label={`Remove ${label}`}
+            onRemove={handleRemove}
+            testId={`remove-sr-${certType}-button`}
+          />
         )}
       </div>
       {uploadError && (
@@ -174,12 +205,151 @@ const SrCaConfiguredBadge = () => {
 
 const SrMtlsConfiguredBadge = () => {
   const { control } = useFormContext<FormValues>();
-  const [clientCert, clientKey] = useWatch({
+  const [clientCert, clientKey, existingKeyConfigured] = useWatch({
     control,
-    name: ['schemaRegistry.mtls.clientCert', 'schemaRegistry.mtls.clientKey'],
+    name: [
+      'schemaRegistry.mtls.clientCert',
+      'schemaRegistry.mtls.clientKey',
+      'schemaRegistry.mtls.existingKeyConfigured',
+    ],
   });
-  return hasSrCertificate(clientCert) && hasSrCertificate(clientKey) ? <ConfiguredBadge /> : null;
+  const hasKeyMaterial = hasSrCertificate(clientKey) || existingKeyConfigured;
+  return hasSrCertificate(clientCert) && hasKeyMaterial ? <ConfiguredBadge /> : null;
 };
+
+/**
+ * Shown in place of the key dropzone when the stored key exists only
+ * server-side (the API never returns it). Removing it reveals the dropzone;
+ * an empty key in the update request keeps the stored one.
+ */
+const ExistingKeyRow = () => {
+  const { control, setValue, trigger } = useFormContext<FormValues>();
+  const fingerprint = useWatch({ control, name: 'schemaRegistry.mtls.existingKeyFingerprint' });
+
+  const handleRemove = () => {
+    setValue('schemaRegistry.mtls.existingKeyConfigured', false, { shouldDirty: true });
+    setValue('schemaRegistry.mtls.existingKeyFingerprint', '', { shouldDirty: true });
+    // The pair error for a now-keyless cert lands on the clientKey field.
+    trigger(['schemaRegistry.mtls.clientKey', 'schemaRegistry.mtls.clientCert']);
+  };
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="font-medium text-sm">{CERTIFICATE_LABELS.clientKey}</span>
+      <div className="relative">
+        <div
+          className="flex items-center gap-2.5 rounded-lg border bg-primary/5 p-2 text-sm"
+          data-testid="sr-clientKey-existing-status"
+        >
+          <Check className="h-4 w-4 shrink-0 text-success" />
+          <span className="flex-1 truncate text-left font-medium text-foreground">Configured</span>
+        </div>
+        <RemoveMaterialButton
+          label="Remove client private key"
+          onRemove={handleRemove}
+          testId="remove-sr-existing-key-button"
+        />
+      </div>
+      {fingerprint && (
+        <div className="truncate font-mono text-muted-foreground text-xs" data-testid="sr-existing-key-fingerprint">
+          SHA-256: {fingerprint}
+        </div>
+      )}
+    </div>
+  );
+};
+
+/**
+ * Embedded-mode client-key picker (lives in Cloud Secrets, not as a file).
+ * Mirrors ClientKeySecretField in connection/mtls-configuration.tsx: the
+ * secret reference is stored in the pemContent slot and sent verbatim.
+ */
+const SrClientKeySecretField = () => {
+  const { control, trigger } = useFormContext<FormValues>();
+
+  const { data: secretsData } = useListSecretsQuery({}, { enabled: isEmbedded() });
+  const availableSecrets = useMemo(() => {
+    if (!secretsData?.secrets) {
+      return [];
+    }
+    return secretsData.secrets
+      .filter((secret): secret is NonNullable<typeof secret> & { id: string } => Boolean(secret?.id))
+      .map((secret) => ({ id: secret.id, name: secret.id }));
+  }, [secretsData]);
+
+  return (
+    <FormField
+      control={control}
+      name="schemaRegistry.mtls.clientKey"
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>Client private key secret</FormLabel>
+          <FormControl>
+            <SecretSelector
+              availableSecrets={availableSecrets}
+              customText={SR_CLIENT_KEY_SECRET_TEXT}
+              onChange={(secretId) => {
+                field.onChange(secretId ? { pemContent: toSecretReference(secretId), fileName: '' } : undefined);
+                // The cert/key pair error lives on the sibling field too.
+                trigger(['schemaRegistry.mtls.clientKey', 'schemaRegistry.mtls.clientCert']);
+              }}
+              placeholder="Select or create client key secret"
+              scopes={[Scope.REDPANDA_CLUSTER]}
+              value={extractSecretId(field.value?.pemContent)}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+};
+
+const SrClientKeyField = () => {
+  const { control } = useFormContext<FormValues>();
+  const [clientKey, existingKeyConfigured] = useWatch({
+    control,
+    name: ['schemaRegistry.mtls.clientKey', 'schemaRegistry.mtls.existingKeyConfigured'],
+  });
+  const showExistingKey = !hasSrCertificate(clientKey) && existingKeyConfigured;
+
+  if (showExistingKey) {
+    return <ExistingKeyRow />;
+  }
+  return isEmbedded() ? <SrClientKeySecretField /> : <SrCertificateDropzone certType="clientKey" />;
+};
+
+/**
+ * Read-only view for TLS configured as certificate file paths (e.g. via rpk):
+ * Console can't edit those, only round-trip them.
+ */
+const SrTlsFilePathsNotice = ({
+  filePaths,
+}: {
+  filePaths: NonNullable<SchemaRegistryFormValues['mtls']['filePaths']>;
+}) => (
+  <div className="rounded-md border bg-muted/30 p-4" data-testid="sr-tls-file-settings-readonly">
+    <div className="font-medium text-sm">TLS certificate file paths</div>
+    <p className="mt-1 text-body-sm text-muted-foreground">
+      TLS for this link is configured with certificate file paths (for example via rpk). Console preserves these
+      settings as-is; use rpk or the Admin API to change them.
+    </p>
+    <div className="mt-3 grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm">
+      <span className="text-muted-foreground">CA</span>
+      <span className="truncate font-mono" data-testid="sr-tls-file-ca-path">
+        {filePaths.caPath || '—'}
+      </span>
+      <span className="text-muted-foreground">Private key</span>
+      <span className="truncate font-mono" data-testid="sr-tls-file-key-path">
+        {filePaths.keyPath || '—'}
+      </span>
+      <span className="text-muted-foreground">Certificate</span>
+      <span className="truncate font-mono" data-testid="sr-tls-file-cert-path">
+        {filePaths.certPath || '—'}
+      </span>
+    </div>
+  </div>
+);
 
 type DisclosureRowProps = {
   open: boolean;
@@ -232,6 +402,7 @@ function DisclosureRow({
 export const SrTlsConfiguration = () => {
   const { control, getValues, trigger } = useFormContext<FormValues>();
   const useTls = useWatch({ control, name: 'schemaRegistry.useTls' });
+  const filePaths = useWatch({ control, name: 'schemaRegistry.mtls.filePaths' });
   const { errors } = useFormState({
     control,
     name: ['schemaRegistry.mtls.clientCert', 'schemaRegistry.mtls.clientKey'],
@@ -243,8 +414,8 @@ export const SrTlsConfiguration = () => {
   // open/close.
   const [caOpen, setCaOpen] = useState(() => hasSrCertificate(getValues('schemaRegistry.mtls.ca')));
   const [mtlsOpen, setMtlsOpen] = useState(() => {
-    const { clientCert, clientKey } = getValues('schemaRegistry.mtls');
-    return hasSrCertificate(clientCert) || hasSrCertificate(clientKey);
+    const mtls = getValues('schemaRegistry.mtls');
+    return hasSrCertificate(mtls.clientCert) || hasSrClientKeyMaterial(mtls);
   });
 
   return (
@@ -281,58 +452,62 @@ export const SrTlsConfiguration = () => {
             </a>
           </div>
 
-          <div className="flex flex-col gap-3" data-testid="sr-mtls-certificates-form">
-            <DisclosureRow
-              badge={<SrCaConfiguredBadge />}
-              description="For self-signed certificates or a private CA on the source Schema Registry."
-              label="Use a custom CA certificate"
-              onOpenChange={setCaOpen}
-              open={caOpen}
-              testId="sr-tls-ca-disclosure"
-              triggerTestId="sr-tls-ca-disclosure-trigger"
-            >
-              <SrCertificateDropzone certType="ca" optional />
-            </DisclosureRow>
+          {filePaths ? (
+            <SrTlsFilePathsNotice filePaths={filePaths} />
+          ) : (
+            <div className="flex flex-col gap-3" data-testid="sr-mtls-certificates-form">
+              <DisclosureRow
+                badge={<SrCaConfiguredBadge />}
+                description="For self-signed certificates or a private CA on the source Schema Registry."
+                label="Use a custom CA certificate"
+                onOpenChange={setCaOpen}
+                open={caOpen}
+                testId="sr-tls-ca-disclosure"
+                triggerTestId="sr-tls-ca-disclosure-trigger"
+              >
+                <SrCertificateDropzone certType="ca" optional />
+              </DisclosureRow>
 
-            <DisclosureRow
-              badge={<SrMtlsConfiguredBadge />}
-              description="Authenticate the shadow cluster to the source Schema Registry with a client certificate."
-              label="Use mutual TLS (mTLS)"
-              onOpenChange={setMtlsOpen}
-              // Forced open while a pair-consistency error exists: the error
-              // messages render inside this panel, and a collapsed panel would
-              // otherwise block the wizard with no visible feedback.
-              open={mtlsOpen || hasMtlsError}
-              testId="sr-tls-mtls-disclosure"
-              triggerTestId="sr-tls-mtls-disclosure-trigger"
-            >
-              <div className="flex flex-col gap-4">
-                <FormField
-                  control={control}
-                  name="schemaRegistry.mtls.clientKey"
-                  render={() => (
-                    <FormItem>
-                      <SrCertificateDropzone certType="clientKey" />
-                      <FormMessage data-testid="sr-mtls-client-key-error" />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={control}
-                  name="schemaRegistry.mtls.clientCert"
-                  render={() => (
-                    <FormItem>
-                      <SrCertificateDropzone certType="clientCert" />
-                      <FormMessage data-testid="sr-mtls-client-cert-error" />
-                    </FormItem>
-                  )}
-                />
-                <div className="text-body-sm text-muted-foreground" data-testid="sr-mtls-pair-hint">
-                  Client certificate and private key must be provided together.
+              <DisclosureRow
+                badge={<SrMtlsConfiguredBadge />}
+                description="Authenticate the shadow cluster to the source Schema Registry with a client certificate."
+                label="Use mutual TLS (mTLS)"
+                onOpenChange={setMtlsOpen}
+                // Forced open while a pair-consistency error exists: the error
+                // messages render inside this panel, and a collapsed panel would
+                // otherwise block the wizard with no visible feedback.
+                open={mtlsOpen || hasMtlsError}
+                testId="sr-tls-mtls-disclosure"
+                triggerTestId="sr-tls-mtls-disclosure-trigger"
+              >
+                <div className="flex flex-col gap-4">
+                  <FormField
+                    control={control}
+                    name="schemaRegistry.mtls.clientKey"
+                    render={() => (
+                      <FormItem>
+                        <SrClientKeyField />
+                        <FormMessage data-testid="sr-mtls-client-key-error" />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={control}
+                    name="schemaRegistry.mtls.clientCert"
+                    render={() => (
+                      <FormItem>
+                        <SrCertificateDropzone certType="clientCert" />
+                        <FormMessage data-testid="sr-mtls-client-cert-error" />
+                      </FormItem>
+                    )}
+                  />
+                  <div className="text-body-sm text-muted-foreground" data-testid="sr-mtls-pair-hint">
+                    Client certificate and private key must be provided together.
+                  </div>
                 </div>
-              </div>
-            </DisclosureRow>
-          </div>
+              </DisclosureRow>
+            </div>
+          )}
         </>
       )}
     </div>

--- a/frontend/src/components/pages/shadowlinks/create/configuration/schema-registry/sync-behavior-section.test.tsx
+++ b/frontend/src/components/pages/shadowlinks/create/configuration/schema-registry/sync-behavior-section.test.tsx
@@ -99,4 +99,33 @@ describe('SyncBehaviorSection', () => {
       expect(screen.getByText('Use a number with a unit, e.g. 10s or 5m')).toBeInTheDocument();
     });
   });
+
+  test('should show a customized badge while collapsed when values are set', async () => {
+    const user = userEvent.setup();
+    render(
+      <TestWrapper
+        defaultValues={{
+          ...apiModeValues,
+          schemaRegistry: {
+            ...apiModeValues.schemaRegistry,
+            syncBehavior: { ...apiModeValues.schemaRegistry.syncBehavior, tailInterval: '10s' },
+          },
+        }}
+      />
+    );
+
+    // Collapsed with hydrated non-default values → badge signals customization.
+    expect(screen.getByTestId('sr-sync-behavior-customized-badge')).toBeInTheDocument();
+
+    // Expanded → the fields themselves are visible, badge disappears.
+    await user.click(screen.getByTestId('sr-sync-behavior-trigger'));
+    await waitFor(() => {
+      expect(screen.queryByTestId('sr-sync-behavior-customized-badge')).not.toBeInTheDocument();
+    });
+  });
+
+  test('should not show the customized badge for cluster defaults', () => {
+    render(<TestWrapper />);
+    expect(screen.queryByTestId('sr-sync-behavior-customized-badge')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/pages/shadowlinks/create/configuration/schema-registry/sync-behavior-section.tsx
+++ b/frontend/src/components/pages/shadowlinks/create/configuration/schema-registry/sync-behavior-section.tsx
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
+import { Badge } from 'components/redpanda-ui/components/badge';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from 'components/redpanda-ui/components/collapsible';
 import {
   FormControl,
@@ -29,7 +30,7 @@ import {
 import { cn } from 'components/redpanda-ui/lib/utils';
 import { ChevronRight } from 'lucide-react';
 import { useState } from 'react';
-import { useFormContext, useFormState } from 'react-hook-form';
+import { useFormContext, useFormState, useWatch } from 'react-hook-form';
 
 import type { FormValues } from '../../model';
 
@@ -54,6 +55,20 @@ export const SyncBehaviorSection = () => {
   // collapsed panel would block submit with no visible feedback.
   const open = isOpen || Boolean(errors.schemaRegistry?.syncBehavior);
 
+  const [tailInterval, fullSyncInterval, maxSourceRequestRate, unsupportedSchemaFeatures] = useWatch({
+    control,
+    name: [
+      'schemaRegistry.syncBehavior.tailInterval',
+      'schemaRegistry.syncBehavior.fullSyncInterval',
+      'schemaRegistry.syncBehavior.maxSourceRequestRate',
+      'schemaRegistry.syncBehavior.unsupportedSchemaFeatures',
+    ],
+  });
+  // Signal non-default values while collapsed (e.g. a hydrated link being
+  // edited) so customization isn't mistaken for cluster defaults.
+  const isCustomized =
+    Boolean(tailInterval || fullSyncInterval || maxSourceRequestRate) || unsupportedSchemaFeatures === 'remove';
+
   return (
     <Collapsible onOpenChange={setIsOpen} open={open} testId="sr-sync-behavior">
       <CollapsibleTrigger
@@ -67,7 +82,14 @@ export const SyncBehaviorSection = () => {
               className={cn('mt-1 h-4 w-4 shrink-0 text-muted-foreground transition-transform', open && 'rotate-90')}
             />
             <div className="flex-1">
-              <span className="font-medium text-sm">Sync behavior</span>
+              <div className="flex items-center gap-2">
+                <span className="font-medium text-sm">Sync behavior</span>
+                {!open && isCustomized && (
+                  <Badge size="sm" testId="sr-sync-behavior-customized-badge" variant="success-inverted">
+                    Customized
+                  </Badge>
+                )}
+              </div>
               <div className="mt-0.5 text-body-sm text-muted-foreground">
                 Polling intervals, rate limits, and how to handle unsupported schema features. Cluster defaults apply if
                 unset.

--- a/frontend/src/components/pages/shadowlinks/create/model.test.ts
+++ b/frontend/src/components/pages/shadowlinks/create/model.test.ts
@@ -383,8 +383,7 @@ describe('Shadow Link Form Validation', () => {
       const keyOnly = FormSchema.safeParse(
         createApiModeValues({
           mtls: {
-            ca: undefined,
-            clientCert: undefined,
+            ...initialValues.schemaRegistry.mtls,
             clientKey: { pemContent: '-----BEGIN PRIVATE KEY-----\nKEY...', fileName: 'client.key' },
           },
         })
@@ -394,13 +393,82 @@ describe('Shadow Link Form Validation', () => {
       const certOnly = FormSchema.safeParse(
         createApiModeValues({
           mtls: {
-            ca: undefined,
+            ...initialValues.schemaRegistry.mtls,
             clientCert: { pemContent: '-----BEGIN CERTIFICATE-----\nCERT...', fileName: 'client.crt' },
-            clientKey: undefined,
           },
         })
       );
       expect(issueMessages(certOnly)).toContain('Client private key is required when client certificate is provided');
+    });
+
+    test('accepts a hydrated certificate paired with a key kept server-side', () => {
+      const result = FormSchema.safeParse(
+        createApiModeValues({
+          mtls: {
+            ...initialValues.schemaRegistry.mtls,
+            clientCert: { pemContent: '-----BEGIN CERTIFICATE-----\nCERT...', fileName: '' },
+            existingKeyConfigured: true,
+            existingKeyFingerprint: 'abc123=',
+          },
+        })
+      );
+      expect(result.success).toBe(true);
+    });
+
+    test('requires a new key when replacing the certificate over a kept key', () => {
+      // A freshly uploaded cert (fileName set) cannot pair with the key
+      // stored server-side.
+      const result = FormSchema.safeParse(
+        createApiModeValues({
+          mtls: {
+            ...initialValues.schemaRegistry.mtls,
+            clientCert: { pemContent: '-----BEGIN CERTIFICATE-----\nNEW...', fileName: 'client.crt' },
+            existingKeyConfigured: true,
+            existingKeyFingerprint: 'abc123=',
+          },
+        })
+      );
+      expect(issueMessages(result)).toContain('Upload the matching private key when replacing the client certificate');
+    });
+
+    test('accepts a replaced certificate together with a new key', () => {
+      const result = FormSchema.safeParse(
+        createApiModeValues({
+          mtls: {
+            ...initialValues.schemaRegistry.mtls,
+            clientCert: { pemContent: '-----BEGIN CERTIFICATE-----\nNEW...', fileName: 'client.crt' },
+            clientKey: { pemContent: '-----BEGIN PRIVATE KEY-----\nNEW...', fileName: 'client.key' },
+            existingKeyConfigured: true,
+            existingKeyFingerprint: 'abc123=',
+          },
+        })
+      );
+      expect(result.success).toBe(true);
+    });
+
+    test('requires a certificate when only the server-side key remains', () => {
+      const result = FormSchema.safeParse(
+        createApiModeValues({
+          mtls: {
+            ...initialValues.schemaRegistry.mtls,
+            existingKeyConfigured: true,
+          },
+        })
+      );
+      expect(issueMessages(result)).toContain('Client certificate is required when client private key is provided');
+    });
+
+    test('skips the mtls pair rule for file-path TLS settings', () => {
+      const result = FormSchema.safeParse(
+        createApiModeValues({
+          mtls: {
+            ...initialValues.schemaRegistry.mtls,
+            clientCert: { pemContent: '-----BEGIN CERTIFICATE-----\nCERT...', fileName: 'client.crt' },
+            filePaths: { caPath: '/etc/tls/ca.pem', keyPath: '/etc/tls/client.key', certPath: '/etc/tls/client.pem' },
+          },
+        })
+      );
+      expect(result.success).toBe(true);
     });
 
     test('ignores leftover mtls uploads while TLS is off', () => {
@@ -410,8 +478,7 @@ describe('Shadow Link Form Validation', () => {
           sourceUrl: 'http://schema-registry.example.com:8081',
           useTls: false,
           mtls: {
-            ca: undefined,
-            clientCert: undefined,
+            ...initialValues.schemaRegistry.mtls,
             clientKey: { pemContent: '-----BEGIN PRIVATE KEY-----\nKEY...', fileName: 'client.key' },
           },
         })

--- a/frontend/src/components/pages/shadowlinks/create/model.ts
+++ b/frontend/src/components/pages/shadowlinks/create/model.ts
@@ -78,6 +78,24 @@ const schemaRegistrySchema = z.object({
     ca: srCertificateSchema.optional(),
     clientCert: srCertificateSchema.optional(),
     clientKey: srCertificateSchema.optional(),
+    // The API never returns the stored client key, only its fingerprint. On
+    // edit these mark a key that exists server-side; sending an empty key in
+    // the update keeps it.
+    existingKeyConfigured: z.boolean(),
+    existingKeyFingerprint: z.string(),
+    // TLS configured as certificate file paths (e.g. via rpk). Console can't
+    // edit these; they are round-tripped verbatim.
+    filePaths: z
+      .object({
+        caPath: z.string(),
+        keyPath: z.string(),
+        certPath: z.string(),
+      })
+      .optional(),
+    // TLSSettings.do_not_set_sni_hostname, round-tripped so rebuilding the
+    // message doesn't silently reset it. No UI; only rpk/API-created links
+    // set it.
+    doNotSetSniHostname: z.boolean(),
   }),
   scopeMode: z.enum(['all', 'specify']),
   contexts: z.array(z.string()),
@@ -97,138 +115,158 @@ const schemaRegistrySchema = z.object({
     maxSourceRequestRate: z.string(),
     unsupportedSchemaFeatures: z.enum(['fail', 'remove']),
   }),
+  // No UI: hydrated on edit and round-tripped so a message rebuild doesn't
+  // silently unpause a paused sync. Create always sends false.
+  paused: z.boolean(),
 });
 
 export type SchemaRegistryFormValues = z.infer<typeof schemaRegistrySchema>;
 
+// The key side of the mTLS pair is satisfied by a fresh upload or by a key
+// already stored server-side (edit flow).
+export const hasSrClientKeyMaterial = (mtls: SchemaRegistryFormValues['mtls']): boolean =>
+  hasSrCertificate(mtls.clientKey) || mtls.existingKeyConfigured;
+
 // Form schema with validation
-export const FormSchema = z
-  .object({
-    // Basic info
-    name: z.string().min(1, 'Shadow link name is required'),
+const formSchemaShape = z.object({
+  // Basic info
+  name: z.string().min(1, 'Shadow link name is required'),
 
-    // Source cluster connection
-    bootstrapServers: z
-      .array(
-        z.object({
-          value: z
-            .string()
-            .trim()
-            .min(1, 'at least one server url is required')
-            .regex(/^[a-zA-Z0-9.-]+:\d+$/, 'Must be in format host:port (e.g., localhost:9092)'),
-        })
-      )
-      .min(1, 'At least one bootstrap server is required'),
-
-    // SASL authentication
-    authMethod: z.enum([AUTH_METHOD.NONE, AUTH_METHOD.SCRAM, AUTH_METHOD.PLAIN]),
-    scramCredentials: z
-      .object({
-        username: z.string(),
-        password: z.string(),
-        mechanism: z.enum(ScramMechanism),
-      })
-      .optional(),
-    plainCredentials: z
-      .object({
-        username: z.string(),
-        password: z.string(),
-      })
-      .optional(),
-    advanceClientOptions: z.object({
-      metadataMaxAgeMs: z.number(),
-      connectionTimeoutMs: z.number(),
-      retryBackoffMs: z.number(),
-      fetchWaitMaxMs: z.number(),
-      fetchMinBytes: z.number(),
-      fetchMaxBytes: z.number(),
-      fetchPartitionMaxBytes: z.number(),
-    }),
-    // TLS configuration
-    useTls: z.boolean(),
-
-    // mTLS configuration (optional - determined by presence of certificates)
-    mtlsMode: z.enum([TLS_MODE.FILE_PATH, TLS_MODE.PEM]),
-    mtls: z.object({
-      ca: z
-        .object({
-          filePath: z.string().optional(),
-          pemContent: z.string().optional(),
-          fileName: z.string().optional(),
-        })
-        .optional(),
-      clientCert: z
-        .object({
-          filePath: z.string().optional(),
-          pemContent: z.string().optional(),
-          fileName: z.string().optional(),
-        })
-        .optional(),
-      clientKey: z
-        .object({
-          filePath: z.string().optional(),
-          pemContent: z.string().optional(),
-          fileName: z.string().optional(),
-        })
-        .optional(),
-    }),
-
-    // Topic selection
-    topicsMode: z.enum(['all', 'specify']),
-    topics: z.array(
+  // Source cluster connection
+  bootstrapServers: z
+    .array(
       z.object({
-        patternType: z.enum(PatternType),
-        filterType: z.enum(FilterType),
-        name: z.string().trim().min(1, 'name is required'),
+        value: z
+          .string()
+          .trim()
+          .min(1, 'at least one server url is required')
+          .regex(/^[a-zA-Z0-9.-]+:\d+$/, 'Must be in format host:port (e.g., localhost:9092)'),
       })
-    ),
-    // Topic properties
-    topicProperties: z.array(z.string()).optional(),
-    excludeDefault: z.boolean(),
+    )
+    .min(1, 'At least one bootstrap server is required'),
 
-    // Consumer offset sync
-    enableConsumerOffsetSync: z.boolean(),
-    consumersMode: z.enum(['all', 'specify']),
-    consumers: z.array(
-      z.object({
-        patternType: z.enum(PatternType),
-        filterType: z.enum(FilterType),
-        name: z.string().trim().min(1, 'name is required'),
+  // SASL authentication
+  authMethod: z.enum([AUTH_METHOD.NONE, AUTH_METHOD.SCRAM, AUTH_METHOD.PLAIN]),
+  scramCredentials: z
+    .object({
+      username: z.string(),
+      password: z.string(),
+      mechanism: z.enum(ScramMechanism),
+    })
+    .optional(),
+  plainCredentials: z
+    .object({
+      username: z.string(),
+      password: z.string(),
+    })
+    .optional(),
+  advanceClientOptions: z.object({
+    metadataMaxAgeMs: z.number(),
+    connectionTimeoutMs: z.number(),
+    retryBackoffMs: z.number(),
+    fetchWaitMaxMs: z.number(),
+    fetchMinBytes: z.number(),
+    fetchMaxBytes: z.number(),
+    fetchPartitionMaxBytes: z.number(),
+  }),
+  // TLS configuration
+  useTls: z.boolean(),
+
+  // mTLS configuration (optional - determined by presence of certificates)
+  mtlsMode: z.enum([TLS_MODE.FILE_PATH, TLS_MODE.PEM]),
+  mtls: z.object({
+    ca: z
+      .object({
+        filePath: z.string().optional(),
+        pemContent: z.string().optional(),
+        fileName: z.string().optional(),
       })
-    ),
-
-    // ACL filters
-    aclsMode: z.enum(['all', 'specify']),
-    aclFilters: z
-      .array(
-        z.object({
-          // Resource filter
-          resourceType: z.enum(ACLResource).optional(),
-          resourcePattern: z.enum(ACLPattern).optional(),
-          resourceName: z.string().optional(),
-
-          // Access filter
-          principal: z.string().optional(),
-          operation: z.enum(ACLOperation).optional(),
-          permissionType: z.enum(ACLPermissionType).optional(),
-          host: z.string().optional(),
-        })
-      )
       .optional(),
+    clientCert: z
+      .object({
+        filePath: z.string().optional(),
+        pemContent: z.string().optional(),
+        fileName: z.string().optional(),
+      })
+      .optional(),
+    clientKey: z
+      .object({
+        filePath: z.string().optional(),
+        pemContent: z.string().optional(),
+        fileName: z.string().optional(),
+      })
+      .optional(),
+  }),
 
-    // Schema Registry sync (legacy switch; mirrored to schemaRegistry.mode by
-    // the redesigned section so the topic-mode request path stays unchanged)
-    enableSchemaRegistrySync: z.boolean(),
+  // Topic selection
+  topicsMode: z.enum(['all', 'specify']),
+  topics: z.array(
+    z.object({
+      patternType: z.enum(PatternType),
+      filterType: z.enum(FilterType),
+      name: z.string().trim().min(1, 'name is required'),
+    })
+  ),
+  // Topic properties
+  topicProperties: z.array(z.string()).optional(),
+  excludeDefault: z.boolean(),
 
-    // Redesigned Schema Registry section (version-gated on the connected
-    // cluster's shadowLinkSchemaRegistrySync feature)
-    schemaRegistry: schemaRegistrySchema,
-  })
-  .superRefine((data, ctx) => {
-    refineAuthCredentials(data, ctx);
-    refineMtlsConsistency(data, ctx);
-    refineShadowSchemaRegistry(data.schemaRegistry, ctx);
-  });
+  // Consumer offset sync
+  enableConsumerOffsetSync: z.boolean(),
+  consumersMode: z.enum(['all', 'specify']),
+  consumers: z.array(
+    z.object({
+      patternType: z.enum(PatternType),
+      filterType: z.enum(FilterType),
+      name: z.string().trim().min(1, 'name is required'),
+    })
+  ),
+
+  // ACL filters
+  aclsMode: z.enum(['all', 'specify']),
+  aclFilters: z
+    .array(
+      z.object({
+        // Resource filter
+        resourceType: z.enum(ACLResource).optional(),
+        resourcePattern: z.enum(ACLPattern).optional(),
+        resourceName: z.string().optional(),
+
+        // Access filter
+        principal: z.string().optional(),
+        operation: z.enum(ACLOperation).optional(),
+        permissionType: z.enum(ACLPermissionType).optional(),
+        host: z.string().optional(),
+      })
+    )
+    .optional(),
+
+  // Schema Registry sync (legacy switch; mirrored to schemaRegistry.mode by
+  // the redesigned section so the topic-mode request path stays unchanged)
+  enableSchemaRegistrySync: z.boolean(),
+
+  // Redesigned Schema Registry section (version-gated on the connected
+  // cluster's shadowLinkSchemaRegistrySync feature)
+  schemaRegistry: schemaRegistrySchema,
+});
+
+export const FormSchema = formSchemaShape.superRefine((data, ctx) => {
+  refineAuthCredentials(data, ctx);
+  refineMtlsConsistency(data, ctx);
+  refineShadowSchemaRegistry(data.schemaRegistry, ctx);
+});
+
+/**
+ * Edit-page variant used while the Schema Registry feature gate is closed:
+ * the redesigned SR section isn't rendered there, so an api-mode link's
+ * hydrated slice (e.g. its never-returned basic-auth password) must not block
+ * saving the rest of the form. The SR slice itself stays untouched in that
+ * state, so the update builder emits no SR mask for it.
+ */
+export const FormSchemaWithoutSchemaRegistryRules = formSchemaShape.superRefine((data, ctx) => {
+  refineAuthCredentials(data, ctx);
+  refineMtlsConsistency(data, ctx);
+});
 
 const refineAuthCredentials = (
   data: {
@@ -310,8 +348,15 @@ const refineMtlsConsistency = (
   }
 };
 
-const SR_DURATION_REGEX = /^(\d+)(ms|s|m|h)$/;
-const SR_DURATION_UNIT_SECONDS: Record<string, number> = { ms: 0.001, s: 1, m: 60, h: 3600 };
+const SR_DURATION_REGEX = /^(\d+)(ns|us|ms|s|m|h)$/;
+const SR_DURATION_UNIT_SECONDS: Record<string, number> = {
+  ns: 0.000_000_001,
+  us: 0.000_001,
+  ms: 0.001,
+  s: 1,
+  m: 60,
+  h: 3600,
+};
 const SR_POSITIVE_INT_REGEX = /^[1-9]\d*$/;
 // google.protobuf.Duration and int32 upper bounds: past these the request
 // fails at serialization.
@@ -419,13 +464,14 @@ const addSrBasicAuthIssues = (sr: SchemaRegistryFormValues, ctx: z.RefinementCtx
 // Client key and cert are individually optional, but if one is provided both
 // must be. Skipped when TLS is off: the mTLS UI is hidden and the request
 // builder omits TLS settings, so leftover uploads must not block the wizard
-// invisibly.
+// invisibly. Also skipped for file-path TLS (rpk-created links): those
+// settings are read-only and round-tripped verbatim.
 const addSrMtlsPairIssues = (sr: SchemaRegistryFormValues, ctx: z.RefinementCtx) => {
-  if (!sr.useTls) {
+  if (!sr.useTls || sr.mtls.filePaths) {
     return;
   }
 
-  const hasClientKey = hasSrCertificate(sr.mtls.clientKey);
+  const hasClientKey = hasSrClientKeyMaterial(sr.mtls);
   const hasClientCert = hasSrCertificate(sr.mtls.clientCert);
 
   if (hasClientKey && !hasClientCert) {
@@ -440,6 +486,17 @@ const addSrMtlsPairIssues = (sr: SchemaRegistryFormValues, ctx: z.RefinementCtx)
     ctx.addIssue({
       code: 'custom',
       message: 'Client private key is required when client certificate is provided',
+      path: ['schemaRegistry', 'mtls', 'clientKey'],
+    });
+  }
+
+  // A cert uploaded this session (hydrated certs carry no fileName) cannot
+  // pair with the key stored server-side. Require the matching key upload.
+  const certReplaced = hasClientCert && Boolean(sr.mtls.clientCert?.fileName);
+  if (certReplaced && sr.mtls.existingKeyConfigured && !hasSrCertificate(sr.mtls.clientKey)) {
+    ctx.addIssue({
+      code: 'custom',
+      message: 'Upload the matching private key when replacing the client certificate',
       path: ['schemaRegistry', 'mtls', 'clientKey'],
     });
   }
@@ -646,6 +703,10 @@ export const initialValues: FormValues = {
       ca: undefined,
       clientCert: undefined,
       clientKey: undefined,
+      existingKeyConfigured: false,
+      existingKeyFingerprint: '',
+      filePaths: undefined,
+      doNotSetSniHostname: false,
     },
     scopeMode: 'all',
     contexts: [],
@@ -658,5 +719,6 @@ export const initialValues: FormValues = {
       maxSourceRequestRate: '',
       unsupportedSchemaFeatures: 'fail',
     },
+    paused: false,
   },
 };

--- a/frontend/src/components/pages/shadowlinks/create/schema-registry-request.test.ts
+++ b/frontend/src/components/pages/shadowlinks/create/schema-registry-request.test.ts
@@ -34,6 +34,16 @@ describe('durationFromString', () => {
     expect(durationFromString('1500ms')).toMatchObject({ seconds: 1n, nanos: 500_000_000 });
   });
 
+  test('parses sub-millisecond units exactly', () => {
+    expect(durationFromString('500000ns')).toMatchObject({ seconds: 0n, nanos: 500_000 });
+    expect(durationFromString('500us')).toMatchObject({ seconds: 0n, nanos: 500_000 });
+    expect(durationFromString('1500000001ns')).toMatchObject({ seconds: 1n, nanos: 500_000_001 });
+  });
+
+  test('keeps integer precision for large second-based values', () => {
+    expect(durationFromString('3000h')).toMatchObject({ seconds: 10_800_000n, nanos: 0 });
+  });
+
   test('returns undefined for empty or invalid input', () => {
     expect(durationFromString('')).toBeUndefined();
     expect(durationFromString('  ')).toBeUndefined();
@@ -74,10 +84,45 @@ describe('buildShadowSchemaRegistryApiOptions', () => {
     }
   });
 
+  test('passes an embedded-mode secret-reference password through verbatim', () => {
+    const options = buildShadowSchemaRegistryApiOptions(
+      createApiFormValues({
+        authMethod: SR_AUTH_METHOD.BASIC,
+        basicCredentials: { username: 'sr-replicator', password: '${secrets.SR_PASSWORD}' },
+      })
+    );
+
+    expect(options.authOptions?.authOptions?.case).toBe('basic');
+    if (options.authOptions?.authOptions?.case === 'basic') {
+      // The SecretSelector already stores the reference; the builder must not
+      // re-wrap or unwrap it.
+      expect(options.authOptions.authOptions.value.password).toBe('${secrets.SR_PASSWORD}');
+    }
+  });
+
+  test('passes an embedded-mode client-key secret reference through verbatim', () => {
+    const options = buildShadowSchemaRegistryApiOptions(
+      createApiFormValues({
+        mtls: {
+          ...initialValues.schemaRegistry.mtls,
+          clientCert: { pemContent: 'CERT_PEM', fileName: 'client.pem' },
+          clientKey: { pemContent: '${secrets.SR_MTLS_CLIENT_KEY}', fileName: '' },
+        },
+      })
+    );
+
+    expect(options.tlsSettings?.tlsSettings?.case).toBe('tlsPemSettings');
+    if (options.tlsSettings?.tlsSettings?.case === 'tlsPemSettings') {
+      expect(options.tlsSettings.tlsSettings.value.key).toBe('${secrets.SR_MTLS_CLIENT_KEY}');
+      expect(options.tlsSettings.tlsSettings.value.cert).toBe('CERT_PEM');
+    }
+  });
+
   test('sends raw PEM contents for TLS certificates and key', () => {
     const options = buildShadowSchemaRegistryApiOptions(
       createApiFormValues({
         mtls: {
+          ...initialValues.schemaRegistry.mtls,
           ca: { pemContent: '-----BEGIN CERTIFICATE-----\nCA', fileName: 'ca.pem' },
           clientCert: { pemContent: '-----BEGIN CERTIFICATE-----\nCERT', fileName: 'client.pem' },
           clientKey: { pemContent: '-----BEGIN PRIVATE KEY-----\nKEY\n', fileName: 'client.key' },
@@ -93,19 +138,63 @@ describe('buildShadowSchemaRegistryApiOptions', () => {
     }
   });
 
-  test('omits TLS settings when TLS is disabled', () => {
+  test('omits TLS settings when TLS is disabled and material is a fresh upload', () => {
     const options = buildShadowSchemaRegistryApiOptions(
       createApiFormValues({
         useTls: false,
         mtls: {
+          ...initialValues.schemaRegistry.mtls,
           ca: { pemContent: '-----BEGIN CERTIFICATE-----\nCA', fileName: 'ca.pem' },
-          clientCert: undefined,
-          clientKey: undefined,
         },
       })
     );
 
     expect(options.tlsSettings).toBeUndefined();
+  });
+
+  test('round-trips hydrated file-path settings stored with TLS disabled', () => {
+    const options = buildShadowSchemaRegistryApiOptions(
+      createApiFormValues({
+        useTls: false,
+        mtls: {
+          ...initialValues.schemaRegistry.mtls,
+          doNotSetSniHostname: true,
+          filePaths: { caPath: '/etc/tls/ca.pem', keyPath: '/etc/tls/client.key', certPath: '/etc/tls/client.pem' },
+        },
+      })
+    );
+
+    expect(options.tlsSettings?.enabled).toBe(false);
+    expect(options.tlsSettings?.doNotSetSniHostname).toBe(true);
+    expect(options.tlsSettings?.tlsSettings?.case).toBe('tlsFileSettings');
+    if (options.tlsSettings?.tlsSettings?.case === 'tlsFileSettings') {
+      expect(options.tlsSettings.tlsSettings.value).toMatchObject({ caPath: '/etc/tls/ca.pem' });
+    }
+  });
+
+  test('round-trips hydrated PEMs stored with TLS disabled', () => {
+    const options = buildShadowSchemaRegistryApiOptions(
+      createApiFormValues({
+        useTls: false,
+        mtls: {
+          ...initialValues.schemaRegistry.mtls,
+          // Hydrated material carries no fileName.
+          ca: { pemContent: 'CA_PEM', fileName: '' },
+          clientCert: { pemContent: 'CERT_PEM', fileName: '' },
+          existingKeyConfigured: true,
+          existingKeyFingerprint: 'fp=',
+        },
+      })
+    );
+
+    expect(options.tlsSettings?.enabled).toBe(false);
+    expect(options.tlsSettings?.tlsSettings?.case).toBe('tlsPemSettings');
+    if (options.tlsSettings?.tlsSettings?.case === 'tlsPemSettings') {
+      expect(options.tlsSettings.tlsSettings.value.ca).toBe('CA_PEM');
+      expect(options.tlsSettings.tlsSettings.value.cert).toBe('CERT_PEM');
+      // Empty key = keep the stored key, same as the enabled path.
+      expect(options.tlsSettings.tlsSettings.value.key).toBe('');
+    }
   });
 
   test('builds source filter and exact destination mappings', () => {
@@ -150,6 +239,82 @@ describe('buildShadowSchemaRegistryApiOptions', () => {
       createApiFormValues({ destinationContextsMode: 'map', contextMappings: [] })
     );
     expect(emptyMap.destination).toBeUndefined();
+  });
+
+  test('round-trips doNotSetSniHostname on every TLS shape', () => {
+    const bare = buildShadowSchemaRegistryApiOptions(
+      createApiFormValues({ mtls: { ...initialValues.schemaRegistry.mtls, doNotSetSniHostname: true } })
+    );
+    expect(bare.tlsSettings?.doNotSetSniHostname).toBe(true);
+
+    const withPem = buildShadowSchemaRegistryApiOptions(
+      createApiFormValues({
+        mtls: {
+          ...initialValues.schemaRegistry.mtls,
+          ca: { pemContent: 'CA_PEM', fileName: 'ca.pem' },
+          doNotSetSniHostname: true,
+        },
+      })
+    );
+    expect(withPem.tlsSettings?.doNotSetSniHostname).toBe(true);
+
+    const withFilePaths = buildShadowSchemaRegistryApiOptions(
+      createApiFormValues({
+        mtls: {
+          ...initialValues.schemaRegistry.mtls,
+          doNotSetSniHostname: true,
+          filePaths: { caPath: '/ca.pem', keyPath: '/client.key', certPath: '/client.pem' },
+        },
+      })
+    );
+    expect(withFilePaths.tlsSettings?.doNotSetSniHostname).toBe(true);
+  });
+
+  test('round-trips paused from the form slice', () => {
+    expect(buildShadowSchemaRegistryApiOptions(createApiFormValues()).paused).toBe(false);
+    expect(buildShadowSchemaRegistryApiOptions(createApiFormValues({ paused: true })).paused).toBe(true);
+  });
+
+  test('round-trips file-path TLS settings verbatim', () => {
+    const options = buildShadowSchemaRegistryApiOptions(
+      createApiFormValues({
+        mtls: {
+          ...initialValues.schemaRegistry.mtls,
+          filePaths: { caPath: '/etc/tls/ca.pem', keyPath: '/etc/tls/client.key', certPath: '/etc/tls/client.pem' },
+        },
+      })
+    );
+
+    expect(options.tlsSettings?.tlsSettings?.case).toBe('tlsFileSettings');
+    if (options.tlsSettings?.tlsSettings?.case === 'tlsFileSettings') {
+      expect(options.tlsSettings.tlsSettings.value).toMatchObject({
+        caPath: '/etc/tls/ca.pem',
+        keyPath: '/etc/tls/client.key',
+        certPath: '/etc/tls/client.pem',
+      });
+    }
+  });
+
+  test('sends an empty key alongside a kept server-side pair', () => {
+    const options = buildShadowSchemaRegistryApiOptions(
+      createApiFormValues({
+        mtls: {
+          ...initialValues.schemaRegistry.mtls,
+          clientCert: { pemContent: 'CERT_PEM', fileName: '' },
+          existingKeyConfigured: true,
+          existingKeyFingerprint: 'fp=',
+        },
+      })
+    );
+
+    expect(options.tlsSettings?.tlsSettings?.case).toBe('tlsPemSettings');
+    if (options.tlsSettings?.tlsSettings?.case === 'tlsPemSettings') {
+      expect(options.tlsSettings.tlsSettings.value.cert).toBe('CERT_PEM');
+      // Empty key = keep the stored key (verified server behavior); the
+      // fingerprint marker never reaches the wire.
+      expect(options.tlsSettings.tlsSettings.value.key).toBe('');
+      expect(options.tlsSettings.tlsSettings.value.keyFingerprint).toBe('');
+    }
   });
 });
 

--- a/frontend/src/components/pages/shadowlinks/create/schema-registry-request.ts
+++ b/frontend/src/components/pages/shadowlinks/create/schema-registry-request.ts
@@ -25,18 +25,33 @@ import {
   SchemaRegistrySyncOptionsSchema,
   UnsupportedSchemaFeaturePolicy,
 } from 'protogen/redpanda/core/admin/v2/shadow_link_pb';
-import { TLSPEMSettingsSchema, type TLSSettings, TLSSettingsSchema } from 'protogen/redpanda/core/common/v1/tls_pb';
+import {
+  TLSFileSettingsSchema,
+  TLSPEMSettingsSchema,
+  type TLSSettings,
+  TLSSettingsSchema,
+} from 'protogen/redpanda/core/common/v1/tls_pb';
 
 import {
   type FormValues,
   SCHEMA_REGISTRY_MODE,
   type SchemaRegistryFormValues,
   SR_AUTH_METHOD,
+  type SrCertificate,
   srCertificatePem,
 } from './model';
 
-const DURATION_UNIT_MS: Record<string, number> = { ms: 1, s: 1000, m: 60_000, h: 3_600_000 };
-const DURATION_INPUT_REGEX = /^(\d+)(ms|s|m|h)$/;
+// Sub-second units carry (units per second, nanos per unit) so seconds/nanos
+// are computed with exact integer math — a single total-nanos float would lose
+// precision past 2^53 ns (~104 days). Sub-millisecond units exist because rpk
+// accepts any Go duration and those values must round-trip unchanged.
+const DURATION_SUBSECOND_UNITS: Record<string, { perSecond: number; nsPerUnit: number }> = {
+  ns: { perSecond: 1_000_000_000, nsPerUnit: 1 },
+  us: { perSecond: 1_000_000, nsPerUnit: 1000 },
+  ms: { perSecond: 1000, nsPerUnit: 1_000_000 },
+};
+const DURATION_SECOND_UNITS: Record<string, number> = { s: 1, m: 60, h: 3600 };
+const DURATION_INPUT_REGEX = /^(\d+)(ns|us|ms|s|m|h)$/;
 
 /**
  * Parse a user-entered duration string ("10s", "5m", "100ms", "1h") into a
@@ -49,28 +64,94 @@ export const durationFromString = (value: string): Duration | undefined => {
     return;
   }
 
-  const totalMs = Number(match[1]) * DURATION_UNIT_MS[match[2]];
-  return create(DurationSchema, {
-    seconds: BigInt(Math.floor(totalMs / 1000)),
-    nanos: (totalMs % 1000) * 1_000_000,
+  const count = Number(match[1]);
+  const subSecond = DURATION_SUBSECOND_UNITS[match[2]];
+  if (subSecond) {
+    return create(DurationSchema, {
+      seconds: BigInt(Math.floor(count / subSecond.perSecond)),
+      nanos: (count % subSecond.perSecond) * subSecond.nsPerUnit,
+    });
+  }
+  return create(DurationSchema, { seconds: BigInt(count) * BigInt(DURATION_SECOND_UNITS[match[2]]), nanos: 0 });
+};
+
+// Hydrated PEMs carry no file name (the dropzone sets one on upload), so this
+// distinguishes server-stored material from fresh uploads.
+const hydratedSrPem = (cert: SrCertificate | undefined): string =>
+  cert?.fileName === '' ? srCertificatePem(cert) : '';
+
+/**
+ * TLS off normally omits the message entirely (the create contract). But an
+ * edit can hydrate TLS material the server stored with `enabled: false`
+ * (rpk/Admin API links); the field mask replaces the whole parent message, so
+ * that material must be round-tripped or any Schema Registry edit would
+ * silently delete it. Only hydrated material is preserved — file paths and
+ * PEMs without a file name; fresh uploads keep today's drop-on-disable
+ * behavior.
+ */
+const buildDisabledSrTlsSettings = (sr: SchemaRegistryFormValues): TLSSettings | undefined => {
+  if (sr.mtls.filePaths) {
+    return create(TLSSettingsSchema, {
+      doNotSetSniHostname: sr.mtls.doNotSetSniHostname,
+      enabled: false,
+      tlsSettings: {
+        case: 'tlsFileSettings',
+        value: create(TLSFileSettingsSchema, sr.mtls.filePaths),
+      },
+    });
+  }
+
+  const ca = hydratedSrPem(sr.mtls.ca);
+  const cert = hydratedSrPem(sr.mtls.clientCert);
+  const key = hydratedSrPem(sr.mtls.clientKey);
+
+  if (!(ca || cert || key)) {
+    return;
+  }
+
+  return create(TLSSettingsSchema, {
+    doNotSetSniHostname: sr.mtls.doNotSetSniHostname,
+    enabled: false,
+    tlsSettings: {
+      case: 'tlsPemSettings',
+      value: create(TLSPEMSettingsSchema, { ca, key, cert }),
+    },
   });
 };
 
 /**
  * The Schema Registry section stores PEM uploads only, so unlike the
- * connection step's buildTLSSettings there is no file-path variant. The raw
- * PEM private key goes into the request as-is.
+ * connection step's buildTLSSettings there is no file-path variant in the UI.
+ * The raw PEM private key goes into the request as-is; an empty key with a
+ * cert present means "keep the key stored server-side" (edit flow). File-path
+ * settings hydrated from an rpk-created link are round-tripped verbatim.
  */
-const buildSrTlsSettings = (sr: SchemaRegistryFormValues): TLSSettings => {
+const buildSrTlsSettings = (sr: SchemaRegistryFormValues): TLSSettings | undefined => {
+  if (!sr.useTls) {
+    return buildDisabledSrTlsSettings(sr);
+  }
+
+  if (sr.mtls.filePaths) {
+    return create(TLSSettingsSchema, {
+      doNotSetSniHostname: sr.mtls.doNotSetSniHostname,
+      enabled: true,
+      tlsSettings: {
+        case: 'tlsFileSettings',
+        value: create(TLSFileSettingsSchema, sr.mtls.filePaths),
+      },
+    });
+  }
+
   const ca = srCertificatePem(sr.mtls.ca);
   const cert = srCertificatePem(sr.mtls.clientCert);
   const key = srCertificatePem(sr.mtls.clientKey);
 
   if (!(ca || cert || key)) {
-    return create(TLSSettingsSchema, { enabled: true });
+    return create(TLSSettingsSchema, { doNotSetSniHostname: sr.mtls.doNotSetSniHostname, enabled: true });
   }
 
   return create(TLSSettingsSchema, {
+    doNotSetSniHostname: sr.mtls.doNotSetSniHostname,
     enabled: true,
     tlsSettings: {
       case: 'tlsPemSettings',
@@ -106,7 +187,7 @@ export const buildShadowSchemaRegistryApiOptions = (
             },
           })
         : undefined,
-    tlsSettings: sr.useTls ? buildSrTlsSettings(sr) : undefined,
+    tlsSettings: buildSrTlsSettings(sr),
     tailInterval: durationFromString(sr.syncBehavior.tailInterval),
     fullSyncInterval: durationFromString(sr.syncBehavior.fullSyncInterval),
     // 0 = unset; the cluster default applies.
@@ -137,7 +218,9 @@ export const buildShadowSchemaRegistryApiOptions = (
           })
         : undefined,
     unsupportedSchemaFeaturePolicy: SR_UNSUPPORTED_FEATURE_POLICY[sr.syncBehavior.unsupportedSchemaFeatures],
-    paused: false,
+    // Hydrated on edit so rebuilding the message doesn't unpause a paused
+    // sync; create always carries the initialValues false.
+    paused: sr.paused,
   });
 };
 

--- a/frontend/src/components/pages/shadowlinks/create/shadowlink-create-page.test.tsx
+++ b/frontend/src/components/pages/shadowlinks/create/shadowlink-create-page.test.tsx
@@ -63,8 +63,7 @@ vi.mock('sonner', () => ({
 }));
 
 import { useCreateShadowLinkMutation } from 'react-query/api/shadowlink';
-import type { EndpointCompatibility } from 'state/rest-interfaces';
-import { Feature, useSupportedFeaturesStore } from 'state/supported-features';
+import { useSupportedFeaturesStore } from 'state/supported-features';
 
 import { isEmbedded } from '../../../../config';
 import { getBasePath } from '../../../../utils/env';
@@ -75,25 +74,8 @@ import {
   addTopicFilterCreate,
   enableTLS,
   navigateToConfigurationStep,
+  setSchemaRegistrySyncGateSupported as seedSchemaRegistrySyncGate,
 } from '../shadowlink-test-helpers';
-
-/**
- * Pin the SR sync gate so the Schema Registry section renders deterministically:
- * supported=false shows the legacy switch, supported=true the redesigned section.
- */
-const seedSchemaRegistrySyncGate = (isSupported: boolean) => {
-  const compatibility: EndpointCompatibility = {
-    kafkaVersion: 'v26.2.0',
-    endpoints: [
-      {
-        endpoint: Feature.ShadowLinkSchemaRegistrySync.endpoint,
-        method: Feature.ShadowLinkSchemaRegistrySync.method,
-        isSupported,
-      },
-    ],
-  };
-  useSupportedFeaturesStore.getState().setEndpointCompatibility(compatibility);
-};
 
 const pristineFeatureStoreState = useSupportedFeaturesStore.getState();
 const resetSchemaRegistrySyncGate = () => {

--- a/frontend/src/components/pages/shadowlinks/details/config/configuration-schema-registry.test.tsx
+++ b/frontend/src/components/pages/shadowlinks/details/config/configuration-schema-registry.test.tsx
@@ -47,7 +47,7 @@ describe('ConfigurationSchemaRegistry', () => {
       />
     );
 
-    expect(screen.getByTestId('schema-registry-mode-badge')).toHaveTextContent('_schemas topic');
+    expect(screen.getByTestId('schema-registry-mode-badge')).toHaveTextContent('Redpanda');
     expect(screen.getByTestId('schema-registry-status-badge')).toHaveTextContent('Enabled');
     expect(screen.getByTestId('schema-registry-topic-description')).toHaveTextContent(
       "Replicate the source cluster's _schemas topic, which replaces the shadow cluster's Schema Registry."
@@ -85,7 +85,7 @@ describe('ConfigurationSchemaRegistry', () => {
       paused: false,
     });
 
-    expect(screen.getByTestId('schema-registry-mode-badge')).toHaveTextContent('Sync over API');
+    expect(screen.getByTestId('schema-registry-mode-badge')).toHaveTextContent('Other');
     expect(screen.getByTestId('schema-registry-status-badge')).toHaveTextContent('Enabled');
     expect(screen.getByTestId('sr-config-source-url-value')).toHaveTextContent(
       'https://psrc-x1234.us-east-1.aws.confluent.cloud'
@@ -170,7 +170,7 @@ describe('ConfigurationSchemaRegistry', () => {
       paused: true,
     });
 
-    expect(screen.getByTestId('schema-registry-mode-badge')).toHaveTextContent('Sync over API');
+    expect(screen.getByTestId('schema-registry-mode-badge')).toHaveTextContent('Other');
     expect(screen.getByTestId('schema-registry-status-badge')).toHaveTextContent('Paused');
   });
 

--- a/frontend/src/components/pages/shadowlinks/details/config/configuration-schema-registry.tsx
+++ b/frontend/src/components/pages/shadowlinks/details/config/configuration-schema-registry.tsx
@@ -335,7 +335,7 @@ export const ConfigurationSchemaRegistry = ({ syncOptions }: ConfigurationSchema
     badges = (
       <>
         <Badge testId="schema-registry-mode-badge" tone="info" variant="subtle">
-          Sync over API
+          Other
         </Badge>
         {statusBadge}
       </>
@@ -344,8 +344,8 @@ export const ConfigurationSchemaRegistry = ({ syncOptions }: ConfigurationSchema
   } else if (mode?.case === 'shadowSchemaRegistryTopic') {
     badges = (
       <>
-        <Badge className="font-mono" testId="schema-registry-mode-badge" tone="info" variant="subtle">
-          _schemas topic
+        <Badge testId="schema-registry-mode-badge" tone="info" variant="subtle">
+          Redpanda
         </Badge>
         <Badge testId="schema-registry-status-badge" tone="success" variant="subtle">
           Enabled

--- a/frontend/src/components/pages/shadowlinks/edit/build-update-request.test.ts
+++ b/frontend/src/components/pages/shadowlinks/edit/build-update-request.test.ts
@@ -28,7 +28,7 @@ import { describe, expect, test } from 'vitest';
 
 import { buildControlplaneUpdateRequest, buildDataplaneUpdateRequest } from './shadowlink-edit-utils';
 import type { FormValues } from '../create/model';
-import { AUTH_METHOD, initialValues, TLS_MODE } from '../create/model';
+import { AUTH_METHOD, initialValues, SCHEMA_REGISTRY_MODE, TLS_MODE } from '../create/model';
 
 // Base form values for testing
 const baseFormValues: FormValues = {
@@ -471,5 +471,41 @@ describe('buildDataplaneUpdateRequest', () => {
 
       expect(result.updateMask?.paths).toEqual([]);
     });
+  });
+});
+
+describe('schema registry api mode through both builders', () => {
+  const apiFormValues = (): FormValues => ({
+    ...baseFormValues,
+    schemaRegistry: {
+      ...initialValues.schemaRegistry,
+      mode: SCHEMA_REGISTRY_MODE.API,
+      sourceUrl: 'http://sr.example.com',
+      useTls: false,
+      paused: true,
+    },
+  });
+
+  test('controlplane request carries the api oneof with the stripped mask path', () => {
+    const request = buildControlplaneUpdateRequest('test-id-123', apiFormValues(), baseFormValues);
+
+    expect(request.updateMask?.paths).toEqual(['schema_registry_sync_options']);
+    const mode = request.shadowLink?.schemaRegistrySyncOptions?.schemaRegistryShadowingMode;
+    expect(mode?.case).toBe('shadowSchemaRegistryApi');
+    if (mode?.case === 'shadowSchemaRegistryApi') {
+      expect(mode.value.sourceUrl).toBe('http://sr.example.com');
+      expect(mode.value.paused).toBe(true);
+    }
+  });
+
+  test('dataplane request carries the api oneof with the prefixed mask path', () => {
+    const request = buildDataplaneUpdateRequest('test-shadow-link', apiFormValues(), createBaseShadowLink());
+
+    expect(request.updateMask?.paths).toEqual(['configurations.schema_registry_sync_options']);
+    const mode = request.shadowLink?.configurations?.schemaRegistrySyncOptions?.schemaRegistryShadowingMode;
+    expect(mode?.case).toBe('shadowSchemaRegistryApi');
+    if (mode?.case === 'shadowSchemaRegistryApi') {
+      expect(mode.value.paused).toBe(true);
+    }
   });
 });

--- a/frontend/src/components/pages/shadowlinks/edit/get-update-values-for-schema-registry.test.ts
+++ b/frontend/src/components/pages/shadowlinks/edit/get-update-values-for-schema-registry.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { describe, expect, test } from 'vitest';
+
+import { getUpdateValuesForSchemaRegistry } from './shadowlink-edit-utils';
+import {
+  type FormValues,
+  initialValues,
+  SCHEMA_REGISTRY_MODE,
+  type SchemaRegistryFormValues,
+  SR_AUTH_METHOD,
+} from '../create/model';
+
+const SR_MASK_PATH = 'configurations.schema_registry_sync_options';
+
+const noneValues = (): FormValues => structuredClone(initialValues);
+
+const topicValues = (): FormValues => {
+  const values = structuredClone(initialValues);
+  values.enableSchemaRegistrySync = true;
+  values.schemaRegistry.mode = SCHEMA_REGISTRY_MODE.TOPIC;
+  return values;
+};
+
+const apiValues = (overrides: Partial<SchemaRegistryFormValues> = {}): FormValues => {
+  const values = structuredClone(initialValues);
+  values.schemaRegistry = {
+    ...values.schemaRegistry,
+    mode: SCHEMA_REGISTRY_MODE.API,
+    sourceUrl: 'https://sr.example.com',
+    authMethod: SR_AUTH_METHOD.BASIC,
+    basicCredentials: { username: 'sr-replicator', password: '' },
+    mtls: {
+      ...values.schemaRegistry.mtls,
+      ca: { pemContent: 'CA_PEM', fileName: '' },
+      clientCert: { pemContent: 'CERT_PEM', fileName: '' },
+      existingKeyConfigured: true,
+      existingKeyFingerprint: 'fp=',
+    },
+    scopeMode: 'specify',
+    contexts: ['.prod'],
+    subjects: [],
+    syncBehavior: { ...values.schemaRegistry.syncBehavior, tailInterval: '10s' },
+    paused: true,
+    ...overrides,
+  };
+  return values;
+};
+
+describe('getUpdateValuesForSchemaRegistry', () => {
+  test('untouched forms emit no mask in any mode', () => {
+    for (const build of [noneValues, topicValues, apiValues]) {
+      const result = getUpdateValuesForSchemaRegistry(build(), build());
+      expect(result.fieldMaskPaths).toEqual([]);
+    }
+  });
+
+  test('none to topic emits the mask with the topic oneof', () => {
+    const result = getUpdateValuesForSchemaRegistry(topicValues(), noneValues());
+    expect(result.fieldMaskPaths).toEqual([SR_MASK_PATH]);
+    expect(result.value?.schemaRegistryShadowingMode?.case).toBe('shadowSchemaRegistryTopic');
+  });
+
+  test('topic to none emits the mask with no value', () => {
+    const result = getUpdateValuesForSchemaRegistry(noneValues(), topicValues());
+    expect(result.fieldMaskPaths).toEqual([SR_MASK_PATH]);
+    expect(result.value).toBeUndefined();
+  });
+
+  test('none to api emits the mask with the full api oneof', () => {
+    const result = getUpdateValuesForSchemaRegistry(apiValues(), noneValues());
+    expect(result.fieldMaskPaths).toEqual([SR_MASK_PATH]);
+    expect(result.value?.schemaRegistryShadowingMode?.case).toBe('shadowSchemaRegistryApi');
+    if (result.value?.schemaRegistryShadowingMode?.case === 'shadowSchemaRegistryApi') {
+      const api = result.value.schemaRegistryShadowingMode.value;
+      expect(api.sourceUrl).toBe('https://sr.example.com');
+      // paused survives the rebuild instead of resetting to false
+      expect(api.paused).toBe(true);
+    }
+  });
+
+  test('api to none emits the mask with no value', () => {
+    const result = getUpdateValuesForSchemaRegistry(noneValues(), apiValues());
+    expect(result.fieldMaskPaths).toEqual([SR_MASK_PATH]);
+    expect(result.value).toBeUndefined();
+  });
+
+  test('an api field edit emits the mask and keeps paused', () => {
+    const edited = apiValues({
+      syncBehavior: { ...initialValues.schemaRegistry.syncBehavior, tailInterval: '30s' },
+    });
+    const result = getUpdateValuesForSchemaRegistry(edited, apiValues());
+    expect(result.fieldMaskPaths).toEqual([SR_MASK_PATH]);
+    if (result.value?.schemaRegistryShadowingMode?.case === 'shadowSchemaRegistryApi') {
+      expect(result.value.schemaRegistryShadowingMode.value.tailInterval).toMatchObject({ seconds: 30n });
+      expect(result.value.schemaRegistryShadowingMode.value.paused).toBe(true);
+    }
+  });
+
+  test('an unrelated api edit round-trips TLS material stored with TLS disabled', () => {
+    // rpk/Admin API links can store file-path TLS with enabled: false; the
+    // mask replaces the whole parent message, so the material must survive
+    // edits to other fields.
+    const disabledTls = (): FormValues =>
+      apiValues({
+        useTls: false,
+        mtls: {
+          ...initialValues.schemaRegistry.mtls,
+          filePaths: { caPath: '/etc/tls/ca.pem', keyPath: '/etc/tls/client.key', certPath: '/etc/tls/client.pem' },
+        },
+        basicCredentials: { username: 'sr-replicator', password: 'retyped' },
+      });
+
+    const untouched = getUpdateValuesForSchemaRegistry(disabledTls(), disabledTls());
+    expect(untouched.fieldMaskPaths).toEqual([]);
+
+    const edited = disabledTls();
+    edited.schemaRegistry.syncBehavior = { ...edited.schemaRegistry.syncBehavior, tailInterval: '30s' };
+    const result = getUpdateValuesForSchemaRegistry(edited, disabledTls());
+    expect(result.fieldMaskPaths).toEqual(['configurations.schema_registry_sync_options']);
+    if (result.value?.schemaRegistryShadowingMode?.case === 'shadowSchemaRegistryApi') {
+      const tls = result.value.schemaRegistryShadowingMode.value.tlsSettings;
+      expect(tls?.enabled).toBe(false);
+      expect(tls?.tlsSettings?.case).toBe('tlsFileSettings');
+    }
+  });
+
+  test('typing a password emits the mask; an empty field keeps it silent', () => {
+    const typed = apiValues({ basicCredentials: { username: 'sr-replicator', password: 'new-secret' } });
+    expect(getUpdateValuesForSchemaRegistry(typed, apiValues()).fieldMaskPaths).toEqual([SR_MASK_PATH]);
+    expect(getUpdateValuesForSchemaRegistry(apiValues(), apiValues()).fieldMaskPaths).toEqual([]);
+  });
+
+  test('scratch values typed into a mode that is not submitted emit no mask', () => {
+    // The user toured the api tab on a topic link, typed, then switched back.
+    const touredButTopic = topicValues();
+    touredButTopic.schemaRegistry.sourceUrl = 'https://left-over.example.com';
+    touredButTopic.schemaRegistry.contexts = ['.scratch'];
+
+    const result = getUpdateValuesForSchemaRegistry(touredButTopic, topicValues());
+    expect(result.fieldMaskPaths).toEqual([]);
+    expect(result.value?.schemaRegistryShadowingMode?.case).toBe('shadowSchemaRegistryTopic');
+  });
+
+  test('uploading a replacement key emits the mask', () => {
+    const replaced = apiValues();
+    replaced.schemaRegistry.mtls.clientKey = { pemContent: 'NEW_KEY_PEM', fileName: 'client.key' };
+
+    const result = getUpdateValuesForSchemaRegistry(replaced, apiValues());
+    expect(result.fieldMaskPaths).toEqual([SR_MASK_PATH]);
+  });
+
+  test('removing the stored mtls pair emits the mask without PEM material', () => {
+    const removed = apiValues();
+    removed.schemaRegistry.mtls = {
+      ...removed.schemaRegistry.mtls,
+      ca: undefined,
+      clientCert: undefined,
+      existingKeyConfigured: false,
+      existingKeyFingerprint: '',
+    };
+
+    const result = getUpdateValuesForSchemaRegistry(removed, apiValues());
+    expect(result.fieldMaskPaths).toEqual([SR_MASK_PATH]);
+    if (result.value?.schemaRegistryShadowingMode?.case === 'shadowSchemaRegistryApi') {
+      expect(result.value.schemaRegistryShadowingMode.value.tlsSettings?.tlsSettings?.case).toBeUndefined();
+    }
+  });
+});

--- a/frontend/src/components/pages/shadowlinks/edit/schema-registry-edit-section.test.tsx
+++ b/frontend/src/components/pages/shadowlinks/edit/schema-registry-edit-section.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import userEvent from '@testing-library/user-event';
+import { Form } from 'components/redpanda-ui/components/form';
+import { useForm } from 'react-hook-form';
+import { useSupportedFeaturesStore } from 'state/supported-features';
+import { render, screen } from 'test-utils';
+
+import { SchemaRegistryEditSection, type SchemaRegistryEditSectionProps } from './schema-registry-edit-section';
+import { FormSchema, type FormValues, initialValues, SCHEMA_REGISTRY_MODE } from '../create/model';
+import { setSchemaRegistrySyncGateSupported as setSrSyncSupported } from '../shadowlink-test-helpers';
+
+const hydratedApiValues = (): FormValues => {
+  const values = structuredClone(initialValues);
+  values.schemaRegistry.mode = SCHEMA_REGISTRY_MODE.API;
+  values.schemaRegistry.sourceUrl = 'https://sr.example.com';
+  values.schemaRegistry.scopeMode = 'specify';
+  values.schemaRegistry.contexts = ['.prod'];
+  values.schemaRegistry.syncBehavior.tailInterval = '10s';
+  return values;
+};
+
+const hydratedTopicValues = (): FormValues => {
+  const values = structuredClone(initialValues);
+  values.schemaRegistry.mode = SCHEMA_REGISTRY_MODE.TOPIC;
+  values.enableSchemaRegistrySync = true;
+  return values;
+};
+
+const TestWrapper = ({
+  defaultValues = initialValues,
+  ...props
+}: SchemaRegistryEditSectionProps & { defaultValues?: FormValues }) => {
+  const form = useForm<FormValues>({
+    resolver: zodResolver(FormSchema),
+    defaultValues,
+  });
+
+  return (
+    <Form {...form}>
+      <form>
+        <SchemaRegistryEditSection {...props} />
+      </form>
+    </Form>
+  );
+};
+
+describe('SchemaRegistryEditSection', () => {
+  beforeEach(() => {
+    useSupportedFeaturesStore.setState({ endpointCompatibility: null, shadowLinkSchemaRegistrySync: false });
+  });
+
+  describe('gate closed (older backend)', () => {
+    beforeEach(() => {
+      setSrSyncSupported(false);
+    });
+
+    test('renders the legacy switch for a topic-mode link', () => {
+      render(<TestWrapper defaultValues={hydratedTopicValues()} originalMode={SCHEMA_REGISTRY_MODE.TOPIC} />);
+
+      expect(screen.getByTestId('sr-enable-switch')).toBeInTheDocument();
+      expect(screen.queryByTestId('shadow-schema-registry-section')).not.toBeInTheDocument();
+    });
+
+    test('keeps the read-only card for an api-mode link', () => {
+      render(<TestWrapper defaultValues={hydratedApiValues()} originalMode={SCHEMA_REGISTRY_MODE.API} />);
+
+      expect(screen.getByTestId('sr-api-mode-readonly')).toBeInTheDocument();
+      expect(screen.queryByTestId('sr-enable-switch')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('gate open', () => {
+    beforeEach(() => {
+      setSrSyncSupported(true);
+    });
+
+    test('renders the full editor hydrated from an api-mode link', () => {
+      render(<TestWrapper defaultValues={hydratedApiValues()} originalMode={SCHEMA_REGISTRY_MODE.API} />);
+
+      expect(screen.getByTestId('shadow-schema-registry-section')).toBeInTheDocument();
+      expect(screen.queryByTestId('sr-api-mode-readonly')).not.toBeInTheDocument();
+      expect(screen.getByTestId('sr-source-url-input')).toHaveValue('https://sr.example.com');
+      expect(screen.getByTestId('sr-contexts-input-chip-.prod')).toBeInTheDocument();
+    });
+
+    test('locks the opposite mode tab and shows the hint', () => {
+      render(<TestWrapper defaultValues={hydratedApiValues()} originalMode={SCHEMA_REGISTRY_MODE.API} />);
+
+      expect(screen.getByTestId('sr-mode-topic-tab')).toHaveAttribute('aria-disabled', 'true');
+      expect(screen.getByTestId('sr-mode-none-tab')).not.toHaveAttribute('aria-disabled', 'true');
+      expect(screen.getByTestId('sr-mode-locked-hint')).toBeInTheDocument();
+    });
+
+    test('leaves all mode tabs enabled when the link had no SR shadowing', () => {
+      render(<TestWrapper originalMode={SCHEMA_REGISTRY_MODE.NONE} />);
+
+      expect(screen.getByTestId('sr-mode-topic-tab')).not.toHaveAttribute('aria-disabled', 'true');
+      expect(screen.getByTestId('sr-mode-api-tab')).not.toHaveAttribute('aria-disabled', 'true');
+      expect(screen.queryByTestId('sr-mode-locked-hint')).not.toBeInTheDocument();
+    });
+
+    test('warns when leaving topic mode and clears the warning on return', async () => {
+      const user = userEvent.setup();
+      render(<TestWrapper defaultValues={hydratedTopicValues()} originalMode={SCHEMA_REGISTRY_MODE.TOPIC} />);
+
+      expect(screen.queryByTestId('sr-mode-transition-topic-alert')).not.toBeInTheDocument();
+
+      await user.click(screen.getByTestId('sr-mode-none-tab'));
+      expect(screen.getByTestId('sr-mode-transition-topic-alert')).toBeInTheDocument();
+
+      await user.click(screen.getByTestId('sr-mode-topic-tab'));
+      expect(screen.queryByTestId('sr-mode-transition-topic-alert')).not.toBeInTheDocument();
+    });
+
+    test('warns that api settings are discarded when switching to none', async () => {
+      const user = userEvent.setup();
+      render(<TestWrapper defaultValues={hydratedApiValues()} originalMode={SCHEMA_REGISTRY_MODE.API} />);
+
+      await user.click(screen.getByTestId('sr-mode-none-tab'));
+      expect(screen.getByTestId('sr-mode-transition-api-alert')).toBeInTheDocument();
+    });
+
+    test('reconciles a legacy switch-off made before the gate opened', () => {
+      // The switch was toggled off while the gate was closed: the boolean is
+      // false but the mode still says topic. The tabs must not disagree with
+      // what would be submitted.
+      const staleValues = hydratedTopicValues();
+      staleValues.enableSchemaRegistrySync = false;
+
+      render(<TestWrapper defaultValues={staleValues} originalMode={SCHEMA_REGISTRY_MODE.TOPIC} />);
+
+      expect(screen.getByTestId('sr-mode-description')).toHaveTextContent('Schema Registry shadowing is off');
+    });
+  });
+});

--- a/frontend/src/components/pages/shadowlinks/edit/schema-registry-edit-section.tsx
+++ b/frontend/src/components/pages/shadowlinks/edit/schema-registry-edit-section.tsx
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { Alert, AlertDescription } from 'components/redpanda-ui/components/alert';
+import { TriangleAlert } from 'lucide-react';
+import { useFormContext, useWatch } from 'react-hook-form';
+import { useSupportedFeaturesStore } from 'state/supported-features';
+
+import { ShadowSchemaRegistrySection } from '../create/configuration/schema-registry/shadow-schema-registry-section';
+import { LegacySchemaRegistrySection } from '../create/configuration/schema-registry-step';
+import { type FormValues, SCHEMA_REGISTRY_MODE, type SchemaRegistryMode } from '../create/model';
+
+/**
+ * Direct topic<->api switches are not supported; the link must go through
+ * None (and a save) first. From None both modes are reachable.
+ */
+const lockedModes = (originalMode: SchemaRegistryMode): SchemaRegistryMode[] => {
+  if (originalMode === SCHEMA_REGISTRY_MODE.TOPIC) {
+    return [SCHEMA_REGISTRY_MODE.API];
+  }
+  if (originalMode === SCHEMA_REGISTRY_MODE.API) {
+    return [SCHEMA_REGISTRY_MODE.TOPIC];
+  }
+  return [];
+};
+
+const ModeTransitionAlert = ({ originalMode }: { originalMode: SchemaRegistryMode }) => {
+  const { control } = useFormContext<FormValues>();
+  const mode = useWatch({ control, name: 'schemaRegistry.mode' });
+
+  if (originalMode === SCHEMA_REGISTRY_MODE.TOPIC && mode !== SCHEMA_REGISTRY_MODE.TOPIC) {
+    return (
+      <Alert testId="sr-mode-transition-topic-alert" variant="warning">
+        <TriangleAlert />
+        <AlertDescription>
+          Turning off Redpanda schema shadowing does not remove the _schemas shadow topic if it was already added. To
+          stop shadowing it, fail over or delete the shadow topic after saving.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+  if (originalMode === SCHEMA_REGISTRY_MODE.API && mode !== SCHEMA_REGISTRY_MODE.API) {
+    return (
+      <Alert testId="sr-mode-transition-api-alert" variant="warning">
+        <TriangleAlert />
+        <AlertDescription>
+          Saving will discard the stored Schema Registry connection settings, including credentials, scope, and sync
+          behavior.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+  return null;
+};
+
+export type SchemaRegistryEditSectionProps = {
+  /** The mode hydrated from the server; drives locked tabs and transition warnings. */
+  originalMode: SchemaRegistryMode;
+};
+
+export const SchemaRegistryEditSection = ({ originalMode }: SchemaRegistryEditSectionProps) => {
+  // Requires Redpanda >= 26.2.0. Fails closed: on older or unknown backends
+  // the edit page keeps the legacy switch / read-only card, which cannot
+  // touch an existing api-mode configuration.
+  const showRedesigned = useSupportedFeaturesStore((s) => s.shadowLinkSchemaRegistrySync);
+
+  if (!showRedesigned) {
+    // Gate-OFF fallback: an api-mode link on an older backend stays read-only.
+    return <LegacySchemaRegistrySection readOnlyApiMode={originalMode === SCHEMA_REGISTRY_MODE.API} />;
+  }
+
+  return (
+    <ShadowSchemaRegistrySection
+      disabledModes={lockedModes(originalMode)}
+      modeNotice={<ModeTransitionAlert originalMode={originalMode} />}
+    />
+  );
+};

--- a/frontend/src/components/pages/shadowlinks/edit/shadowing-tab.tsx
+++ b/frontend/src/components/pages/shadowlinks/edit/shadowing-tab.tsx
@@ -9,18 +9,21 @@
  * by the Apache License, Version 2.0
  */
 
+import { SchemaRegistryEditSection } from './schema-registry-edit-section';
 import { AclsStep } from '../create/configuration/acls-step';
 import { ConsumerOffsetStep } from '../create/configuration/consumer-offset-step';
-import { LegacySchemaRegistrySection } from '../create/configuration/schema-registry-step';
 import { TopicsStep } from '../create/configuration/topics-step';
+import { SCHEMA_REGISTRY_MODE, type SchemaRegistryMode } from '../create/model';
 
-export const ShadowingTab = ({ schemaRegistryApiMode = false }: { schemaRegistryApiMode?: boolean }) => (
+export const ShadowingTab = ({
+  schemaRegistryOriginalMode = SCHEMA_REGISTRY_MODE.NONE,
+}: {
+  schemaRegistryOriginalMode?: SchemaRegistryMode;
+}) => (
   <div className="space-y-4">
     <TopicsStep />
     <AclsStep />
     <ConsumerOffsetStep />
-    {/* Always the legacy switch: the edit request builder can't express the
-        version-gated API sync mode for now, only the create wizard can. */}
-    <LegacySchemaRegistrySection readOnlyApiMode={schemaRegistryApiMode} />
+    <SchemaRegistryEditSection originalMode={schemaRegistryOriginalMode} />
   </div>
 );

--- a/frontend/src/components/pages/shadowlinks/edit/shadowlink-edit-page.test.tsx
+++ b/frontend/src/components/pages/shadowlinks/edit/shadowlink-edit-page.test.tsx
@@ -19,6 +19,7 @@ import {
   FilterType,
   NameFilterSchema,
   PatternType,
+  SchemaRegistrySyncOptionsSchema,
   ScramConfigSchema,
   ScramMechanism,
   SecuritySettingsSyncOptionsSchema,
@@ -75,6 +76,7 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
 });
 
 import { useEditShadowLink } from 'react-query/api/shadowlink';
+import { useSupportedFeaturesStore } from 'state/supported-features';
 import { renderWithFileRoutes } from 'test-utils';
 
 import { buildDefaultFormValues } from '../mappers/dataplane';
@@ -88,6 +90,7 @@ import {
   enableMTLS,
   enableSchemaRegistrySync,
   enableTLS,
+  setSchemaRegistrySyncGateSupported,
   toggleExcludeDefault,
   updateAdvancedOption,
   updateMetadataMaxAge,
@@ -280,43 +283,45 @@ const testCases: TestCase[] = [
   },
 ];
 
+const mockEditHook = (mockUpdateShadowLink: ReturnType<typeof vi.fn>, mockShadowLink: ShadowLink) => {
+  vi.mocked(useEditShadowLink).mockReturnValue({
+    formValues: buildDefaultFormValues(mockShadowLink),
+    isLoading: false,
+    error: null,
+    isUpdating: false,
+    hasData: true,
+    updateShadowLink: mockUpdateShadowLink,
+    dataplaneUpdate: {
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+      reset: vi.fn(),
+    } as any,
+    controlplaneUpdate: {
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+      reset: vi.fn(),
+    } as any,
+  });
+};
+
 describe('ShadowLinkEditPage', () => {
   const mockUpdateShadowLink = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockUpdateShadowLink.mockImplementation((_request) => Promise.resolve({}));
+    // The SR feature gate defaults to closed; api-mode tests seed it open.
+    useSupportedFeaturesStore.setState({ endpointCompatibility: null, shadowLinkSchemaRegistrySync: false });
   });
 
   test.each(testCases)('$description', async ({ actions, expectedFieldMaskPaths, verify }) => {
     const user = userEvent.setup();
     const mockShadowLink = createMockShadowLink();
-    const formValues = buildDefaultFormValues(mockShadowLink);
-
-    // Mock useEditShadowLink hook
-    vi.mocked(useEditShadowLink).mockReturnValue({
-      formValues,
-      isLoading: false,
-      error: null,
-      isUpdating: false,
-      hasData: true,
-      isSchemaRegistryApiMode: false,
-      updateShadowLink: mockUpdateShadowLink,
-      dataplaneUpdate: {
-        isPending: false,
-        isSuccess: false,
-        isError: false,
-        error: null,
-        reset: vi.fn(),
-      } as any,
-      controlplaneUpdate: {
-        isPending: false,
-        isSuccess: false,
-        isError: false,
-        error: null,
-        reset: vi.fn(),
-      } as any,
-    });
+    mockEditHook(mockUpdateShadowLink, mockShadowLink);
 
     renderEditPage(mockShadowLink);
 
@@ -357,5 +362,141 @@ describe('ShadowLinkEditPage', () => {
 
     // Run custom verification function
     verify(updateRequest, expect);
+  });
+
+  describe('schema registry api mode', () => {
+    const createApiModeShadowLink = (): ShadowLink => {
+      const link = createMockShadowLink();
+      if (link.configurations) {
+        link.configurations.schemaRegistrySyncOptions = create(SchemaRegistrySyncOptionsSchema, {
+          schemaRegistryShadowingMode: {
+            case: 'shadowSchemaRegistryApi',
+            value: {
+              sourceUrl: 'https://sr.example.com',
+              authOptions: {
+                authOptions: {
+                  case: 'basic',
+                  value: { username: 'sr-replicator', password: '', passwordSet: true },
+                },
+              },
+              tlsSettings: { enabled: true },
+              tailInterval: { seconds: 10n },
+              sourceFilter: { contexts: ['.prod'] },
+              paused: true,
+            },
+          },
+        });
+      }
+      return link;
+    };
+
+    const openSrSyncBehavior = async (user: ReturnType<typeof userEvent.setup>) => {
+      await user.click(screen.getByTestId('tab-shadowing'));
+      await screen.findByTestId('sr-source-url-input');
+      await user.click(screen.getByTestId('sr-sync-behavior-trigger'));
+      await screen.findByTestId('sr-tail-interval-input');
+    };
+
+    test('edits an api-mode link with a retyped password and emits only the SR mask', async () => {
+      setSchemaRegistrySyncGateSupported(true);
+      const user = userEvent.setup();
+      const mockShadowLink = createApiModeShadowLink();
+      mockEditHook(mockUpdateShadowLink, mockShadowLink);
+
+      renderEditPage(mockShadowLink);
+      await openSrSyncBehavior(user);
+
+      // The topic tab is locked for an api-mode link.
+      expect(screen.getByTestId('sr-mode-topic-tab')).toHaveAttribute('aria-disabled', 'true');
+      expect(screen.getByTestId('sr-source-url-input')).toHaveValue('https://sr.example.com');
+
+      const tailInput = screen.getByTestId('sr-tail-interval-input');
+      expect(tailInput).toHaveValue('10s');
+      await user.clear(tailInput);
+      await user.type(tailInput, '30s');
+      await user.type(screen.getByTestId('sr-basic-password-input'), 'retyped-secret');
+
+      await user.click(screen.getByText('Save'));
+
+      await waitFor(() => {
+        expect(mockUpdateShadowLink).toHaveBeenCalledTimes(1);
+      });
+
+      const formValuesArg = mockUpdateShadowLink.mock.calls[0][0];
+      const { buildDataplaneUpdateRequest } = await import('./shadowlink-edit-utils');
+      const updateRequest = buildDataplaneUpdateRequest(SHADOW_LINK_NAME, formValuesArg, mockShadowLink);
+
+      expect(updateRequest.updateMask?.paths).toEqual(['configurations.schema_registry_sync_options']);
+      const mode = updateRequest.shadowLink?.configurations?.schemaRegistrySyncOptions?.schemaRegistryShadowingMode;
+      expect(mode?.case).toBe('shadowSchemaRegistryApi');
+      if (mode?.case === 'shadowSchemaRegistryApi') {
+        expect(mode.value.tailInterval).toMatchObject({ seconds: 30n });
+        expect(mode.value.authOptions?.authOptions?.case).toBe('basic');
+        if (mode.value.authOptions?.authOptions?.case === 'basic') {
+          expect(mode.value.authOptions.authOptions.value.password).toBe('retyped-secret');
+        }
+        // paused was hydrated and must survive the rebuild
+        expect(mode.value.paused).toBe(true);
+      }
+    });
+
+    test('blocks saving an api-mode link until the password is re-entered', async () => {
+      setSchemaRegistrySyncGateSupported(true);
+      const user = userEvent.setup();
+      const mockShadowLink = createApiModeShadowLink();
+      mockEditHook(mockUpdateShadowLink, mockShadowLink);
+
+      renderEditPage(mockShadowLink);
+      await openSrSyncBehavior(user);
+
+      const tailInput = screen.getByTestId('sr-tail-interval-input');
+      await user.clear(tailInput);
+      await user.type(tailInput, '30s');
+
+      await user.click(screen.getByText('Save'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Password is required when HTTP Basic is enabled')).toBeInTheDocument();
+      });
+      expect(mockUpdateShadowLink).not.toHaveBeenCalled();
+    });
+
+    test('keeps the read-only card for an api-mode link when the gate is closed', async () => {
+      const user = userEvent.setup();
+      const mockShadowLink = createApiModeShadowLink();
+      mockEditHook(mockUpdateShadowLink, mockShadowLink);
+
+      renderEditPage(mockShadowLink);
+      await user.click(screen.getByTestId('tab-shadowing'));
+
+      await screen.findByTestId('sr-api-mode-readonly');
+      expect(screen.queryByTestId('sr-mode-api-tab')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('sr-enable-switch')).not.toBeInTheDocument();
+    });
+
+    test('saves unrelated edits on an api-mode link when the gate is closed', async () => {
+      // The hydrated basic-auth password can never be re-entered behind the
+      // read-only card, so its validation must not block the rest of the form.
+      const user = userEvent.setup();
+      const mockShadowLink = createApiModeShadowLink();
+      mockEditHook(mockUpdateShadowLink, mockShadowLink);
+
+      renderEditPage(mockShadowLink);
+      await screen.findByTestId('bootstrap-server-input-0');
+      await addTopicFilter(user, screen, 'unrelated-topic');
+
+      await user.click(screen.getByText('Save'));
+
+      await waitFor(() => {
+        expect(mockUpdateShadowLink).toHaveBeenCalledTimes(1);
+      });
+
+      const formValuesArg = mockUpdateShadowLink.mock.calls[0][0];
+      const { buildDataplaneUpdateRequest } = await import('./shadowlink-edit-utils');
+      const updateRequest = buildDataplaneUpdateRequest(SHADOW_LINK_NAME, formValuesArg, mockShadowLink);
+
+      // Only the topic change goes out; the untouched SR slice emits no mask.
+      expect(updateRequest.updateMask?.paths).toEqual(['configurations.topic_metadata_sync_options']);
+    });
   });
 });

--- a/frontend/src/components/pages/shadowlinks/edit/shadowlink-edit-page.tsx
+++ b/frontend/src/components/pages/shadowlinks/edit/shadowlink-edit-page.tsx
@@ -18,13 +18,14 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from 'components/redpanda-ui
 import { useEffect, useState } from 'react';
 import { type FieldErrors, useForm } from 'react-hook-form';
 import { toast } from 'sonner';
+import { useSupportedFeaturesStore } from 'state/supported-features';
 import { uiState } from 'state/ui-state';
 
 import { ShadowingTab } from './shadowing-tab';
 import { SourceTab } from './source-tab';
 import { TopicConfigTab } from './topic-config-tab';
 import { useEditShadowLink } from '../../../../react-query/api/shadowlink';
-import { FormSchema, type FormValues } from '../create/model';
+import { FormSchema, FormSchemaWithoutSchemaRegistryRules, type FormValues } from '../create/model';
 import { ShadowLinkLoadErrorState } from '../list/shadowlink-empty-state';
 
 /**
@@ -50,6 +51,7 @@ const getTabForField = (fieldName: string): string => {
     aclsMode: 'shadowing',
     aclFilters: 'shadowing',
     enableSchemaRegistrySync: 'shadowing',
+    schemaRegistry: 'shadowing',
     // Topic config tab fields
     topicProperties: 'topic-config',
     excludeDefault: 'topic-config',
@@ -77,17 +79,8 @@ export const ShadowLinkEditPage = () => {
   }
 
   // Use the unified edit hook that handles embedded/dataplane logic
-  const {
-    formValues,
-    isLoading,
-    error,
-    isUpdating,
-    hasData,
-    isSchemaRegistryApiMode,
-    updateShadowLink,
-    dataplaneUpdate,
-    controlplaneUpdate,
-  } = useEditShadowLink(name);
+  const { formValues, isLoading, error, isUpdating, hasData, updateShadowLink, dataplaneUpdate, controlplaneUpdate } =
+    useEditShadowLink(name);
 
   // Set up mutation callbacks
   useEffect(() => {
@@ -120,9 +113,15 @@ export const ShadowLinkEditPage = () => {
   // Track current active tab
   const [currentTab, setCurrentTab] = useState<string>('source');
 
+  // While the SR feature gate is closed, the redesigned Schema Registry
+  // section isn't rendered, so its rules must not run: an api-mode link
+  // hydrates a basic-auth password that is never returned and has no input
+  // to re-enter it, which would otherwise block saving every other field.
+  const srGateOpen = useSupportedFeaturesStore((s) => s.shadowLinkSchemaRegistrySync);
+
   // Initialize form with values that automatically update when shadowLink data changes
   const form = useForm<FormValues>({
-    resolver: zodResolver(FormSchema),
+    resolver: zodResolver(srGateOpen ? FormSchema : FormSchemaWithoutSchemaRegistryRules),
     values: formValues,
     mode: 'onChange',
   });
@@ -213,7 +212,7 @@ export const ShadowLinkEditPage = () => {
             <TabsContent value="all">
               <div className="space-y-4">
                 <SourceTab />
-                <ShadowingTab schemaRegistryApiMode={isSchemaRegistryApiMode} />
+                <ShadowingTab schemaRegistryOriginalMode={formValues?.schemaRegistry.mode} />
                 <TopicConfigTab />
               </div>
             </TabsContent>
@@ -223,7 +222,7 @@ export const ShadowLinkEditPage = () => {
             </TabsContent>
 
             <TabsContent value="shadowing">
-              <ShadowingTab schemaRegistryApiMode={isSchemaRegistryApiMode} />
+              <ShadowingTab schemaRegistryOriginalMode={formValues?.schemaRegistry.mode} />
             </TabsContent>
 
             <TabsContent value="topic-config">

--- a/frontend/src/components/pages/shadowlinks/edit/shadowlink-edit-utils.ts
+++ b/frontend/src/components/pages/shadowlinks/edit/shadowlink-edit-utils.ts
@@ -13,7 +13,7 @@ import {
   ShadowLinkUpdateSchema as CpShadowLinkUpdateSchema,
   UpdateShadowLinkRequestSchema as CpUpdateShadowLinkRequestSchema,
 } from '@buf/redpandadata_cloud.bufbuild_es/redpanda/api/controlplane/v1/shadow_link_pb';
-import { create } from '@bufbuild/protobuf';
+import { create, equals } from '@bufbuild/protobuf';
 import { FieldMaskSchema } from '@bufbuild/protobuf/wkt';
 import type { ShadowLink } from 'protogen/redpanda/api/dataplane/v1/shadowlink_pb';
 import {
@@ -24,7 +24,7 @@ import {
   NameFilterSchema,
   PatternType,
   PlainConfigSchema,
-  SchemaRegistrySyncOptions_ShadowSchemaRegistryTopicSchema,
+  type SchemaRegistrySyncOptions,
   SchemaRegistrySyncOptionsSchema,
   ScramConfigSchema,
   SecuritySettingsSyncOptionsSchema,
@@ -43,6 +43,7 @@ import {
 
 import type { FormValues } from '../create/model';
 import { AUTH_METHOD, TLS_MODE } from '../create/model';
+import { buildSchemaRegistrySyncOptions } from '../create/schema-registry-request';
 import { buildDefaultFormValues } from '../mappers/dataplane';
 
 /**
@@ -463,36 +464,33 @@ export const getUpdateValuesForACLs = (
   };
 };
 
+const srSyncOptionsChanged = (
+  next: SchemaRegistrySyncOptions | undefined,
+  previous: SchemaRegistrySyncOptions | undefined
+): boolean => {
+  if (next === undefined || previous === undefined) {
+    return next !== previous;
+  }
+  return !equals(SchemaRegistrySyncOptionsSchema, next, previous);
+};
+
 /**
- * Get update values for Schema Registry category
- * Compares form values with original values and returns schema + field mask paths
+ * Get update values for Schema Registry category.
+ * Both sides of the comparison are built from form values (current vs
+ * hydrated originals), so hydration normalizations cancel out and scratch
+ * values typed into a mode that isn't submitted never produce a mask. The
+ * mask replaces the whole message, hence the single parent path.
  */
 export const getUpdateValuesForSchemaRegistry = (
   values: FormValues,
   originalValues: FormValues
-): UpdateResult<ReturnType<typeof create<typeof SchemaRegistrySyncOptionsSchema>> | undefined> => {
-  const fieldMaskPaths: string[] = [];
-
-  // Compare schema registry sync enabled state
-  const schemaRegistryChanged = values.enableSchemaRegistrySync !== originalValues.enableSchemaRegistrySync;
-
-  if (schemaRegistryChanged) {
-    fieldMaskPaths.push('configurations.schema_registry_sync_options');
-  }
-
-  // Build schema registry sync options (only set if enabled)
-  const schemaRegistrySyncOptions = values.enableSchemaRegistrySync
-    ? create(SchemaRegistrySyncOptionsSchema, {
-        schemaRegistryShadowingMode: {
-          case: 'shadowSchemaRegistryTopic',
-          value: create(SchemaRegistrySyncOptions_ShadowSchemaRegistryTopicSchema, {}),
-        },
-      })
-    : undefined;
+): UpdateResult<SchemaRegistrySyncOptions | undefined> => {
+  const value = buildSchemaRegistrySyncOptions(values);
+  const original = buildSchemaRegistrySyncOptions(originalValues);
 
   return {
-    value: schemaRegistrySyncOptions,
-    fieldMaskPaths,
+    value,
+    fieldMaskPaths: srSyncOptionsChanged(value, original) ? ['configurations.schema_registry_sync_options'] : [],
   };
 };
 

--- a/frontend/src/components/pages/shadowlinks/mappers/controlplane.test.ts
+++ b/frontend/src/components/pages/shadowlinks/mappers/controlplane.test.ts
@@ -15,7 +15,8 @@ import { timestampFromDate } from '@bufbuild/protobuf/wkt';
 import { UnsupportedSchemaFeaturePolicy } from 'protogen/redpanda/core/admin/v2/shadow_link_pb';
 import { describe, expect, test } from 'vitest';
 
-import { fromControlplaneShadowLink } from './controlplane';
+import { buildDefaultFormValuesFromControlplane, fromControlplaneShadowLink } from './controlplane';
+import { FormSchema, initialValues, SCHEMA_REGISTRY_MODE } from '../create/model';
 import type { UnifiedSchemaRegistryApiOptions } from '../model';
 
 type SchemaRegistrySyncOptionsInit = NonNullable<
@@ -140,5 +141,57 @@ describe('fromControlplaneShadowLink schema registry sync options', () => {
     });
 
     expect(api.destinationMapping).toEqual({ case: 'identity' });
+  });
+});
+
+describe('buildDefaultFormValuesFromControlplane schema registry hydration', () => {
+  test('hydrates an api-mode link and stays form-valid', () => {
+    const formValues = buildDefaultFormValuesFromControlplane(
+      buildShadowLink({
+        schemaRegistryShadowingMode: {
+          case: 'shadowSchemaRegistryApi',
+          value: {
+            sourceUrl: 'https://sr.example.com',
+            tlsSettings: {
+              enabled: true,
+              tlsSettings: {
+                case: 'tlsPemSettings',
+                value: { ca: 'CA_PEM', cert: 'CERT_PEM', keyFingerprint: 'fp=' },
+              },
+            },
+            fullSyncInterval: { seconds: 300n },
+            destination: {
+              mapping: { case: 'exact', value: { mappings: [{ source: '.prod', destination: '.dr' }] } },
+            },
+            paused: true,
+          },
+        },
+      })
+    );
+
+    expect(formValues.enableSchemaRegistrySync).toBe(false);
+    expect(formValues.schemaRegistry.mode).toBe(SCHEMA_REGISTRY_MODE.API);
+    expect(formValues.schemaRegistry.sourceUrl).toBe('https://sr.example.com');
+    expect(formValues.schemaRegistry.mtls.existingKeyConfigured).toBe(true);
+    expect(formValues.schemaRegistry.destinationContextsMode).toBe('map');
+    expect(formValues.schemaRegistry.contextMappings).toEqual([{ source: '.prod', destination: '.dr' }]);
+    expect(formValues.schemaRegistry.syncBehavior.fullSyncInterval).toBe('5m');
+    expect(formValues.schemaRegistry.paused).toBe(true);
+    // The hydrated form must be submittable without touching unrelated fields.
+    expect(FormSchema.safeParse(formValues).success).toBe(true);
+  });
+
+  test('hydrates topic and none modes and stays form-valid', () => {
+    const topicValues = buildDefaultFormValuesFromControlplane(
+      buildShadowLink({ schemaRegistryShadowingMode: { case: 'shadowSchemaRegistryTopic', value: {} } })
+    );
+    expect(topicValues.enableSchemaRegistrySync).toBe(true);
+    expect(topicValues.schemaRegistry.mode).toBe(SCHEMA_REGISTRY_MODE.TOPIC);
+    expect(FormSchema.safeParse(topicValues).success).toBe(true);
+
+    const noneValues = buildDefaultFormValuesFromControlplane(buildShadowLink(undefined));
+    expect(noneValues.enableSchemaRegistrySync).toBe(false);
+    expect(noneValues.schemaRegistry).toEqual(initialValues.schemaRegistry);
+    expect(FormSchema.safeParse(noneValues).success).toBe(true);
   });
 });

--- a/frontend/src/components/pages/shadowlinks/mappers/controlplane.ts
+++ b/frontend/src/components/pages/shadowlinks/mappers/controlplane.ts
@@ -19,8 +19,8 @@ import { timestampDate } from '@bufbuild/protobuf/wkt';
 import { FilterType, PatternType, ScramMechanism } from 'protogen/redpanda/core/admin/v2/shadow_link_pb';
 import { ACLOperation, ACLPattern, ACLPermissionType, ACLResource } from 'protogen/redpanda/core/common/v1/acl_pb';
 
-import { mapSchemaRegistrySyncOptions } from './schema-registry';
-import { AUTH_METHOD, type FormValues, initialValues, TLS_MODE } from '../create/model';
+import { mapSchemaRegistrySyncOptions, mapSchemaRegistrySyncOptionsToFormValues } from './schema-registry';
+import { AUTH_METHOD, type FormValues, TLS_MODE } from '../create/model';
 import {
   mapControlplaneStateToUnified,
   type UnifiedAuthenticationConfiguration,
@@ -428,18 +428,8 @@ const buildControlplaneACLsValues = (
  */
 const buildControlplaneSchemaRegistryValues = (
   shadowLink: ControlplaneShadowLink
-): Pick<FormValues, 'enableSchemaRegistrySync' | 'schemaRegistry'> => {
-  const schemaRegistrySyncOptions = shadowLink.schemaRegistrySyncOptions;
-  const isEnabled = schemaRegistrySyncOptions?.schemaRegistryShadowingMode?.case === 'shadowSchemaRegistryTopic';
-
-  return {
-    enableSchemaRegistrySync: isEnabled,
-    // The edit flow only exposes the legacy switch for now; the redesigned section's
-    // fields stay at their defaults. Deep-copy so callers can't mutate the
-    // shared module-level initialValues through the returned reference.
-    schemaRegistry: structuredClone(initialValues.schemaRegistry),
-  };
-};
+): Pick<FormValues, 'enableSchemaRegistrySync' | 'schemaRegistry'> =>
+  mapSchemaRegistrySyncOptionsToFormValues(shadowLink.schemaRegistrySyncOptions);
 
 /**
  * Build form values from controlplane shadow link data

--- a/frontend/src/components/pages/shadowlinks/mappers/dataplane.test.ts
+++ b/frontend/src/components/pages/shadowlinks/mappers/dataplane.test.ts
@@ -18,7 +18,8 @@ import {
 } from 'protogen/redpanda/core/admin/v2/shadow_link_pb';
 import { describe, expect, test } from 'vitest';
 
-import { fromDataplaneShadowLink } from './dataplane';
+import { buildDefaultFormValues, fromDataplaneShadowLink } from './dataplane';
+import { FormSchema, initialValues, SCHEMA_REGISTRY_MODE } from '../create/model';
 import type { UnifiedSchemaRegistryApiOptions } from '../model';
 
 const buildShadowLink = (schemaRegistrySyncOptions?: MessageInitShape<typeof SchemaRegistrySyncOptionsSchema>) =>
@@ -152,5 +153,66 @@ describe('fromDataplaneShadowLink schema registry sync options', () => {
     });
 
     expect(api.destinationMapping).toEqual({ case: 'identity' });
+  });
+});
+
+describe('buildDefaultFormValues schema registry hydration', () => {
+  const buildLinkWithConnection = (
+    schemaRegistrySyncOptions?: MessageInitShape<typeof SchemaRegistrySyncOptionsSchema>
+  ) =>
+    create(ShadowLinkSchema, {
+      name: 'test-link',
+      uid: 'uid-1',
+      configurations: {
+        clientOptions: { bootstrapServers: ['localhost:9092'] },
+        schemaRegistrySyncOptions,
+      },
+    });
+
+  test('hydrates an api-mode link and stays form-valid', () => {
+    const formValues = buildDefaultFormValues(
+      buildLinkWithConnection({
+        schemaRegistryShadowingMode: {
+          case: 'shadowSchemaRegistryApi',
+          value: {
+            sourceUrl: 'https://sr.example.com',
+            tlsSettings: {
+              enabled: true,
+              tlsSettings: {
+                case: 'tlsPemSettings',
+                value: { ca: 'CA_PEM', cert: 'CERT_PEM', keyFingerprint: 'fp=' },
+              },
+            },
+            tailInterval: { seconds: 10n },
+            sourceFilter: { contexts: ['.prod'] },
+            paused: true,
+          },
+        },
+      })
+    );
+
+    expect(formValues.enableSchemaRegistrySync).toBe(false);
+    expect(formValues.schemaRegistry.mode).toBe(SCHEMA_REGISTRY_MODE.API);
+    expect(formValues.schemaRegistry.sourceUrl).toBe('https://sr.example.com');
+    expect(formValues.schemaRegistry.mtls.existingKeyConfigured).toBe(true);
+    expect(formValues.schemaRegistry.scopeMode).toBe('specify');
+    expect(formValues.schemaRegistry.syncBehavior.tailInterval).toBe('10s');
+    expect(formValues.schemaRegistry.paused).toBe(true);
+    // The hydrated form must be submittable without touching unrelated fields.
+    expect(FormSchema.safeParse(formValues).success).toBe(true);
+  });
+
+  test('hydrates topic and none modes and stays form-valid', () => {
+    const topicValues = buildDefaultFormValues(
+      buildLinkWithConnection({ schemaRegistryShadowingMode: { case: 'shadowSchemaRegistryTopic', value: {} } })
+    );
+    expect(topicValues.enableSchemaRegistrySync).toBe(true);
+    expect(topicValues.schemaRegistry.mode).toBe(SCHEMA_REGISTRY_MODE.TOPIC);
+    expect(FormSchema.safeParse(topicValues).success).toBe(true);
+
+    const noneValues = buildDefaultFormValues(buildLinkWithConnection(undefined));
+    expect(noneValues.enableSchemaRegistrySync).toBe(false);
+    expect(noneValues.schemaRegistry).toEqual(initialValues.schemaRegistry);
+    expect(FormSchema.safeParse(noneValues).success).toBe(true);
   });
 });

--- a/frontend/src/components/pages/shadowlinks/mappers/dataplane.ts
+++ b/frontend/src/components/pages/shadowlinks/mappers/dataplane.ts
@@ -29,9 +29,13 @@ import { FilterType, PatternType } from 'protogen/redpanda/core/admin/v2/shadow_
 import { ACLOperation, ACLPattern, ACLPermissionType, ACLResource } from 'protogen/redpanda/core/common/v1/acl_pb';
 import type { TLSSettings } from 'protogen/redpanda/core/common/v1/tls_pb';
 
-import { mapSchemaRegistrySyncOptions, mapTLSSettings } from './schema-registry';
+import {
+  mapSchemaRegistrySyncOptions,
+  mapSchemaRegistrySyncOptionsToFormValues,
+  mapTLSSettings,
+} from './schema-registry';
 import type { FormValues } from '../create/model';
-import { AUTH_METHOD, initialValues, TLS_MODE } from '../create/model';
+import { AUTH_METHOD, TLS_MODE } from '../create/model';
 import {
   mapConsoleStateToUnified,
   type UnifiedAuthenticationConfiguration,
@@ -472,18 +476,8 @@ export const buildDefaultACLsValues = (
  */
 export const buildDefaultSchemaRegistryValues = (
   shadowLink: DataplaneShadowLink
-): Pick<FormValues, 'enableSchemaRegistrySync' | 'schemaRegistry'> => {
-  const schemaRegistrySyncOptions = shadowLink.configurations?.schemaRegistrySyncOptions;
-  const isEnabled = schemaRegistrySyncOptions?.schemaRegistryShadowingMode?.case === 'shadowSchemaRegistryTopic';
-
-  return {
-    enableSchemaRegistrySync: isEnabled,
-    // The edit flow only exposes the legacy switch for now; the redesigned section's
-    // fields stay at their defaults. Deep-copy so callers can't mutate the
-    // shared module-level initialValues through the returned reference.
-    schemaRegistry: structuredClone(initialValues.schemaRegistry),
-  };
-};
+): Pick<FormValues, 'enableSchemaRegistrySync' | 'schemaRegistry'> =>
+  mapSchemaRegistrySyncOptionsToFormValues(shadowLink.configurations?.schemaRegistrySyncOptions);
 
 /**
  * Build default form values from existing shadow link data (dataplane)

--- a/frontend/src/components/pages/shadowlinks/mappers/schema-registry.test.ts
+++ b/frontend/src/components/pages/shadowlinks/mappers/schema-registry.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { create, type MessageInitShape } from '@bufbuild/protobuf';
+import { DurationSchema } from '@bufbuild/protobuf/wkt';
+import {
+  SchemaRegistrySyncOptionsSchema,
+  UnsupportedSchemaFeaturePolicy,
+} from 'protogen/redpanda/core/admin/v2/shadow_link_pb';
+import { describe, expect, test } from 'vitest';
+
+import { formatDurationForInput, mapSchemaRegistrySyncOptionsToFormValues } from './schema-registry';
+import { initialValues, SCHEMA_REGISTRY_MODE, SR_AUTH_METHOD } from '../create/model';
+import { durationFromString } from '../create/schema-registry-request';
+
+const duration = (seconds: number, nanos = 0) => create(DurationSchema, { seconds: BigInt(seconds), nanos });
+
+const apiSyncOptions = (
+  api: NonNullable<
+    Extract<
+      MessageInitShape<typeof SchemaRegistrySyncOptionsSchema>['schemaRegistryShadowingMode'],
+      { case: 'shadowSchemaRegistryApi' }
+    >
+  >['value']
+) =>
+  create(SchemaRegistrySyncOptionsSchema, {
+    schemaRegistryShadowingMode: { case: 'shadowSchemaRegistryApi', value: api },
+  });
+
+describe('formatDurationForInput', () => {
+  test('maps unset and zero durations to empty (cluster default)', () => {
+    expect(formatDurationForInput(undefined)).toBe('');
+    expect(formatDurationForInput(duration(0))).toBe('');
+  });
+
+  test('formats the largest evenly-dividing unit', () => {
+    expect(formatDurationForInput(duration(10))).toBe('10s');
+    expect(formatDurationForInput(duration(90))).toBe('90s');
+    expect(formatDurationForInput(duration(300))).toBe('5m');
+    expect(formatDurationForInput(duration(3660))).toBe('61m');
+    expect(formatDurationForInput(duration(3600))).toBe('1h');
+    expect(formatDurationForInput(duration(0, 500_000_000))).toBe('500ms');
+    expect(formatDurationForInput(duration(1, 500_000_000))).toBe('1500ms');
+  });
+
+  test('formats sub-millisecond durations exactly (settable via rpk)', () => {
+    expect(formatDurationForInput(duration(0, 500_000))).toBe('500us');
+    expect(formatDurationForInput(duration(0, 512))).toBe('512ns');
+    expect(formatDurationForInput(duration(0, 1500))).toBe('1500ns');
+    expect(formatDurationForInput(duration(1, 500_000))).toBe('1000500us');
+  });
+
+  test('round-trips through durationFromString', () => {
+    for (const input of [
+      duration(10),
+      duration(300),
+      duration(3600),
+      duration(0, 500_000_000),
+      duration(0, 500_000),
+      duration(0, 512),
+      duration(1, 500_000),
+    ]) {
+      expect(durationFromString(formatDurationForInput(input))).toMatchObject({
+        seconds: input.seconds,
+        nanos: input.nanos,
+      });
+    }
+  });
+});
+
+describe('mapSchemaRegistrySyncOptionsToFormValues', () => {
+  test('maps absent options and unset mode to none defaults', () => {
+    for (const options of [
+      undefined,
+      create(SchemaRegistrySyncOptionsSchema, { schemaRegistryShadowingMode: { case: undefined } }),
+    ]) {
+      const result = mapSchemaRegistrySyncOptionsToFormValues(options);
+      expect(result.enableSchemaRegistrySync).toBe(false);
+      expect(result.schemaRegistry).toEqual(initialValues.schemaRegistry);
+    }
+  });
+
+  test('maps topic mode to the legacy switch plus topic tab', () => {
+    const result = mapSchemaRegistrySyncOptionsToFormValues(
+      create(SchemaRegistrySyncOptionsSchema, {
+        schemaRegistryShadowingMode: { case: 'shadowSchemaRegistryTopic', value: {} },
+      })
+    );
+    expect(result.enableSchemaRegistrySync).toBe(true);
+    expect(result.schemaRegistry).toEqual({ ...initialValues.schemaRegistry, mode: SCHEMA_REGISTRY_MODE.TOPIC });
+  });
+
+  test('maps a minimal api message to api defaults', () => {
+    const result = mapSchemaRegistrySyncOptionsToFormValues(apiSyncOptions({ sourceUrl: 'http://sr.example.com' }));
+    expect(result.enableSchemaRegistrySync).toBe(false);
+    expect(result.schemaRegistry).toEqual({
+      ...initialValues.schemaRegistry,
+      mode: SCHEMA_REGISTRY_MODE.API,
+      sourceUrl: 'http://sr.example.com',
+      useTls: false,
+    });
+  });
+
+  test('hydrates basic auth without seeding the password', () => {
+    const result = mapSchemaRegistrySyncOptionsToFormValues(
+      apiSyncOptions({
+        sourceUrl: 'http://sr.example.com',
+        authOptions: {
+          authOptions: {
+            case: 'basic',
+            value: { username: 'sr-replicator', password: 'should-never-appear', passwordSet: true },
+          },
+        },
+      })
+    );
+    expect(result.schemaRegistry.authMethod).toBe(SR_AUTH_METHOD.BASIC);
+    expect(result.schemaRegistry.basicCredentials).toEqual({ username: 'sr-replicator', password: '' });
+  });
+
+  test('hydrates returned PEMs and marks the redacted key as kept server-side', () => {
+    const result = mapSchemaRegistrySyncOptionsToFormValues(
+      apiSyncOptions({
+        sourceUrl: 'https://sr.example.com',
+        tlsSettings: {
+          enabled: true,
+          tlsSettings: {
+            case: 'tlsPemSettings',
+            value: { ca: 'CA_PEM', cert: 'CERT_PEM', key: '', keyFingerprint: 'abc123=' },
+          },
+        },
+      })
+    );
+    expect(result.schemaRegistry.useTls).toBe(true);
+    expect(result.schemaRegistry.mtls.ca).toEqual({ pemContent: 'CA_PEM', fileName: '' });
+    expect(result.schemaRegistry.mtls.clientCert).toEqual({ pemContent: 'CERT_PEM', fileName: '' });
+    expect(result.schemaRegistry.mtls.clientKey).toBeUndefined();
+    expect(result.schemaRegistry.mtls.existingKeyConfigured).toBe(true);
+    expect(result.schemaRegistry.mtls.existingKeyFingerprint).toBe('abc123=');
+  });
+
+  test('marks a kept key from the cert alone when the fingerprint is missing', () => {
+    const result = mapSchemaRegistrySyncOptionsToFormValues(
+      apiSyncOptions({
+        sourceUrl: 'https://sr.example.com',
+        tlsSettings: {
+          enabled: true,
+          tlsSettings: { case: 'tlsPemSettings', value: { cert: 'CERT_PEM' } },
+        },
+      })
+    );
+    expect(result.schemaRegistry.mtls.existingKeyConfigured).toBe(true);
+    expect(result.schemaRegistry.mtls.existingKeyFingerprint).toBe('');
+  });
+
+  test('hydrates a returned key directly instead of the kept marker', () => {
+    const result = mapSchemaRegistrySyncOptionsToFormValues(
+      apiSyncOptions({
+        sourceUrl: 'https://sr.example.com',
+        tlsSettings: {
+          enabled: true,
+          tlsSettings: { case: 'tlsPemSettings', value: { cert: 'CERT_PEM', key: 'KEY_PEM' } },
+        },
+      })
+    );
+    expect(result.schemaRegistry.mtls.clientKey).toEqual({ pemContent: 'KEY_PEM', fileName: '' });
+    expect(result.schemaRegistry.mtls.existingKeyConfigured).toBe(false);
+  });
+
+  test('hydrates file-path TLS settings verbatim', () => {
+    const result = mapSchemaRegistrySyncOptionsToFormValues(
+      apiSyncOptions({
+        sourceUrl: 'https://sr.example.com',
+        tlsSettings: {
+          enabled: true,
+          tlsSettings: {
+            case: 'tlsFileSettings',
+            value: { caPath: '/etc/tls/ca.pem', keyPath: '/etc/tls/client.key', certPath: '/etc/tls/client.pem' },
+          },
+        },
+      })
+    );
+    expect(result.schemaRegistry.mtls.filePaths).toEqual({
+      caPath: '/etc/tls/ca.pem',
+      keyPath: '/etc/tls/client.key',
+      certPath: '/etc/tls/client.pem',
+    });
+    expect(result.schemaRegistry.mtls.ca).toBeUndefined();
+    expect(result.schemaRegistry.mtls.clientCert).toBeUndefined();
+    expect(result.schemaRegistry.mtls.existingKeyConfigured).toBe(false);
+  });
+
+  test('round-trips doNotSetSniHostname', () => {
+    const result = mapSchemaRegistrySyncOptionsToFormValues(
+      apiSyncOptions({
+        sourceUrl: 'https://sr.example.com',
+        tlsSettings: { doNotSetSniHostname: true, enabled: true },
+      })
+    );
+    expect(result.schemaRegistry.mtls.doNotSetSniHostname).toBe(true);
+  });
+
+  test('infers useTls from an https scheme when TLS settings are absent', () => {
+    const result = mapSchemaRegistrySyncOptionsToFormValues(apiSyncOptions({ sourceUrl: 'https://sr.example.com' }));
+    expect(result.schemaRegistry.useTls).toBe(true);
+  });
+
+  test('keeps TLS on with system trust store when the oneof is unset', () => {
+    const result = mapSchemaRegistrySyncOptionsToFormValues(
+      apiSyncOptions({ sourceUrl: 'https://sr.example.com', tlsSettings: { enabled: true } })
+    );
+    expect(result.schemaRegistry.useTls).toBe(true);
+    expect(result.schemaRegistry.mtls).toEqual(initialValues.schemaRegistry.mtls);
+  });
+
+  test('maps a present-but-empty source filter to the entire registry', () => {
+    const result = mapSchemaRegistrySyncOptionsToFormValues(
+      apiSyncOptions({ sourceUrl: 'http://sr.example.com', sourceFilter: { contexts: [], subjects: [] } })
+    );
+    expect(result.schemaRegistry.scopeMode).toBe('all');
+    expect(result.schemaRegistry.contexts).toEqual([]);
+  });
+
+  test('maps a populated source filter to specify scope', () => {
+    const result = mapSchemaRegistrySyncOptionsToFormValues(
+      apiSyncOptions({
+        sourceUrl: 'http://sr.example.com',
+        sourceFilter: { contexts: ['.prod'], subjects: ['orders-value', ':.prod:orders-value'] },
+      })
+    );
+    expect(result.schemaRegistry.scopeMode).toBe('specify');
+    expect(result.schemaRegistry.contexts).toEqual(['.prod']);
+    expect(result.schemaRegistry.subjects).toEqual(['orders-value', ':.prod:orders-value']);
+  });
+
+  test('maps identity, unset, and empty-exact destinations to preserve', () => {
+    for (const destination of [
+      undefined,
+      { mapping: { case: 'identity' as const, value: {} } },
+      { mapping: { case: 'exact' as const, value: { mappings: [] } } },
+    ]) {
+      const result = mapSchemaRegistrySyncOptionsToFormValues(
+        apiSyncOptions({ sourceUrl: 'http://sr.example.com', destination })
+      );
+      expect(result.schemaRegistry.destinationContextsMode).toBe('preserve');
+      expect(result.schemaRegistry.contextMappings).toEqual([]);
+    }
+  });
+
+  test('maps exact destination mappings to map rows', () => {
+    const result = mapSchemaRegistrySyncOptionsToFormValues(
+      apiSyncOptions({
+        sourceUrl: 'http://sr.example.com',
+        destination: {
+          mapping: { case: 'exact', value: { mappings: [{ source: '.prod', destination: '.dr' }] } },
+        },
+      })
+    );
+    expect(result.schemaRegistry.destinationContextsMode).toBe('map');
+    expect(result.schemaRegistry.contextMappings).toEqual([{ source: '.prod', destination: '.dr' }]);
+  });
+
+  test('maps sync behavior fields including cluster defaults', () => {
+    const result = mapSchemaRegistrySyncOptionsToFormValues(
+      apiSyncOptions({
+        sourceUrl: 'http://sr.example.com',
+        tailInterval: duration(10),
+        fullSyncInterval: duration(300),
+        maxSourceRequestsPerSecond: 30,
+        unsupportedSchemaFeaturePolicy: UnsupportedSchemaFeaturePolicy.REMOVE,
+      })
+    );
+    expect(result.schemaRegistry.syncBehavior).toEqual({
+      tailInterval: '10s',
+      fullSyncInterval: '5m',
+      maxSourceRequestRate: '30',
+      unsupportedSchemaFeatures: 'remove',
+    });
+  });
+
+  test('maps zero rate and unspecified policy to the fail default', () => {
+    for (const policy of [UnsupportedSchemaFeaturePolicy.UNSPECIFIED, UnsupportedSchemaFeaturePolicy.FAIL]) {
+      const result = mapSchemaRegistrySyncOptionsToFormValues(
+        apiSyncOptions({ sourceUrl: 'http://sr.example.com', unsupportedSchemaFeaturePolicy: policy })
+      );
+      expect(result.schemaRegistry.syncBehavior).toEqual({
+        tailInterval: '',
+        fullSyncInterval: '',
+        maxSourceRequestRate: '',
+        unsupportedSchemaFeatures: 'fail',
+      });
+    }
+  });
+
+  test('round-trips paused', () => {
+    const result = mapSchemaRegistrySyncOptionsToFormValues(
+      apiSyncOptions({ sourceUrl: 'http://sr.example.com', paused: true })
+    );
+    expect(result.schemaRegistry.paused).toBe(true);
+  });
+});

--- a/frontend/src/components/pages/shadowlinks/mappers/schema-registry.ts
+++ b/frontend/src/components/pages/shadowlinks/mappers/schema-registry.ts
@@ -18,13 +18,21 @@
  */
 
 import { type Duration, timestampDate } from '@bufbuild/protobuf/wkt';
-import type {
-  SchemaRegistryAuthOptions,
-  SchemaRegistryContextDestination,
-  SchemaRegistrySourceFilter,
+import {
+  type SchemaRegistryAuthOptions,
+  type SchemaRegistryContextDestination,
+  type SchemaRegistrySourceFilter,
+  UnsupportedSchemaFeaturePolicy,
 } from 'protogen/redpanda/core/admin/v2/shadow_link_pb';
 import type { TLSSettings } from 'protogen/redpanda/core/common/v1/tls_pb';
 
+import {
+  type FormValues,
+  initialValues,
+  SCHEMA_REGISTRY_MODE,
+  type SchemaRegistryFormValues,
+  SR_AUTH_METHOD,
+} from '../create/model';
 import type { UnifiedSchemaRegistryApiOptions, UnifiedSchemaRegistrySyncOptions, UnifiedTLSSettings } from '../model';
 
 /**
@@ -163,6 +171,140 @@ function mapSchemaRegistryApiOptions(api: SchemaRegistryApiOptionsMessage): Unif
     unsupportedSchemaFeaturePolicy: api.unsupportedSchemaFeaturePolicy,
     paused: api.paused,
   };
+}
+
+/**
+ * Format a proto Duration as the largest single-unit string the sync-behavior
+ * inputs accept ("90s", "5m") so it round-trips through durationFromString.
+ * Zero or unset durations map to '' so the cluster default applies.
+ *
+ * Deliberately hand-rolled: protobuf-es durationMs rounds sub-millisecond
+ * nanos away (rpk accepts any Go duration, so those values exist and must
+ * round-trip exactly), pretty-ms emits either multi-unit strings the input
+ * grammar rejects ("1m 30s") or lossy compact ones (90s -> "1m"), and
+ * date-fns formatDuration produces prose ("5 minutes").
+ */
+export function formatDurationForInput(duration: Duration | undefined): string {
+  if (!duration) {
+    return '';
+  }
+  const seconds = Number(duration.seconds);
+  if (seconds < 0 || duration.nanos < 0 || (seconds === 0 && duration.nanos === 0)) {
+    return '';
+  }
+
+  if (duration.nanos !== 0) {
+    // Sub-second precision present, so the largest exact unit is at most ms.
+    const totalNs = seconds * 1_000_000_000 + duration.nanos;
+    if (totalNs % 1000 !== 0) {
+      return `${totalNs}ns`;
+    }
+    const totalUs = totalNs / 1000;
+    if (totalUs % 1000 !== 0) {
+      return `${totalUs}us`;
+    }
+    return `${totalUs / 1000}ms`;
+  }
+
+  if (seconds % 60 !== 0) {
+    return `${seconds}s`;
+  }
+  const minutes = seconds / 60;
+  if (minutes % 60 !== 0) {
+    return `${minutes}m`;
+  }
+  return `${minutes / 60}h`;
+}
+
+function mapTlsToMtlsSlice(tls: TLSSettings | undefined): SchemaRegistryFormValues['mtls'] {
+  const base = structuredClone(initialValues.schemaRegistry.mtls);
+  // Round-tripped so rebuilding the whole message doesn't reset the flag.
+  base.doNotSetSniHostname = Boolean(tls?.doNotSetSniHostname);
+  const settings = tls?.tlsSettings;
+
+  if (settings?.case === 'tlsFileSettings') {
+    const files = settings.value;
+    return {
+      ...base,
+      filePaths: { caPath: files.caPath, keyPath: files.keyPath, certPath: files.certPath },
+    };
+  }
+  if (settings?.case === 'tlsPemSettings') {
+    const pem = settings.value;
+    return {
+      ...base,
+      ca: pem.ca ? { pemContent: pem.ca, fileName: '' } : undefined,
+      clientCert: pem.cert ? { pemContent: pem.cert, fileName: '' } : undefined,
+      clientKey: pem.key ? { pemContent: pem.key, fileName: '' } : undefined,
+      // The key is redacted on GET; a fingerprint marks a key kept
+      // server-side. A returned cert implies the same (the proto requires
+      // key and cert to be provided together), covering backends that omit
+      // the fingerprint.
+      existingKeyConfigured: !pem.key && Boolean(pem.keyFingerprint || pem.cert),
+      existingKeyFingerprint: pem.keyFingerprint ?? '',
+    };
+  }
+  return base;
+}
+
+function applyApiOptionsToFormSlice(api: SchemaRegistryApiOptionsMessage): SchemaRegistryFormValues {
+  const basic = api.authOptions?.authOptions?.case === 'basic' ? api.authOptions.authOptions.value : undefined;
+  const filter = api.sourceFilter;
+  const hasFilter = Boolean(filter && ((filter.contexts?.length ?? 0) > 0 || (filter.subjects?.length ?? 0) > 0));
+  const exactMappings =
+    api.destination?.mapping?.case === 'exact' ? (api.destination.mapping.value.mappings ?? []) : [];
+
+  // Every field is set explicitly (no base spread) so adding a schema field
+  // without deciding its hydration fails to compile.
+  return {
+    mode: SCHEMA_REGISTRY_MODE.API,
+    sourceUrl: api.sourceUrl,
+    authMethod: basic ? SR_AUTH_METHOD.BASIC : SR_AUTH_METHOD.NONE,
+    // The password is never returned; like the connection credentials it is
+    // re-entered on save.
+    basicCredentials: { username: basic?.username ?? '', password: '' },
+    // TLS settings may be omitted entirely (e.g. rpk-created links); infer
+    // the toggle from the URL scheme so the hydrated form passes the URL/TLS
+    // cross-check untouched.
+    useTls: api.tlsSettings ? api.tlsSettings.enabled : api.sourceUrl.trim().toLowerCase().startsWith('https:'),
+    mtls: mapTlsToMtlsSlice(api.tlsSettings),
+    scopeMode: hasFilter ? 'specify' : 'all',
+    contexts: hasFilter ? [...(filter?.contexts ?? [])] : [],
+    subjects: hasFilter ? [...(filter?.subjects ?? [])] : [],
+    destinationContextsMode: exactMappings.length > 0 ? 'map' : 'preserve',
+    contextMappings: exactMappings.map((mapping) => ({ source: mapping.source, destination: mapping.destination })),
+    syncBehavior: {
+      tailInterval: formatDurationForInput(api.tailInterval),
+      fullSyncInterval: formatDurationForInput(api.fullSyncInterval),
+      maxSourceRequestRate: api.maxSourceRequestsPerSecond > 0 ? String(api.maxSourceRequestsPerSecond) : '',
+      unsupportedSchemaFeatures:
+        api.unsupportedSchemaFeaturePolicy === UnsupportedSchemaFeaturePolicy.REMOVE ? 'remove' : 'fail',
+    },
+    paused: api.paused,
+  };
+}
+
+/**
+ * Hydrate the schemaRegistry form slice from the server message, for the edit
+ * flow. Secrets are never seeded into form state: the password stays '' and a
+ * stored client key is represented only by existingKeyConfigured /
+ * existingKeyFingerprint (sending them empty on update keeps the stored
+ * values).
+ */
+export function mapSchemaRegistrySyncOptionsToFormValues(
+  options: SchemaRegistrySyncOptionsMessage | undefined
+): Pick<FormValues, 'enableSchemaRegistrySync' | 'schemaRegistry'> {
+  const mode = options?.schemaRegistryShadowingMode;
+
+  if (mode?.case === 'shadowSchemaRegistryTopic') {
+    const schemaRegistry = structuredClone(initialValues.schemaRegistry);
+    schemaRegistry.mode = SCHEMA_REGISTRY_MODE.TOPIC;
+    return { enableSchemaRegistrySync: true, schemaRegistry };
+  }
+  if (mode?.case === 'shadowSchemaRegistryApi') {
+    return { enableSchemaRegistrySync: false, schemaRegistry: applyApiOptionsToFormSlice(mode.value) };
+  }
+  return { enableSchemaRegistrySync: false, schemaRegistry: structuredClone(initialValues.schemaRegistry) };
 }
 
 /**

--- a/frontend/src/components/pages/shadowlinks/shadowlink-test-helpers.ts
+++ b/frontend/src/components/pages/shadowlinks/shadowlink-test-helpers.ts
@@ -12,6 +12,26 @@
 import { waitFor } from '@testing-library/react';
 import type userEvent from '@testing-library/user-event';
 import { FilterType, PatternType } from 'protogen/redpanda/core/admin/v2/shadow_link_pb';
+import { Feature, useSupportedFeaturesStore } from 'state/supported-features';
+
+/**
+ * Seed the real supported-features store the way the app does at boot, so the
+ * Schema Registry sync gate exercises the actual endpoint-compatibility
+ * fail-closed logic instead of a mock: a supported endpoint opens the gate,
+ * anything else (unsupported, absent, or a never-loaded null store) closes it.
+ */
+export const setSchemaRegistrySyncGateSupported = (isSupported: boolean) => {
+  useSupportedFeaturesStore.getState().setEndpointCompatibility({
+    kafkaVersion: 'v26.2.0',
+    endpoints: [
+      {
+        endpoint: Feature.ShadowLinkSchemaRegistrySync.endpoint,
+        method: Feature.ShadowLinkSchemaRegistrySync.method,
+        isSupported,
+      },
+    ],
+  });
+};
 
 /**
  * Regex patterns for test IDs

--- a/frontend/src/components/ui/secret/secret-selector.test.tsx
+++ b/frontend/src/components/ui/secret/secret-selector.test.tsx
@@ -101,4 +101,48 @@ describe('SecretSelector', () => {
     const trigger = screen.getByRole('combobox');
     expect(trigger).toHaveTextContent('MY_NEW_SECRET');
   });
+
+  test('rejects short values by default (API-key style secrets)', async () => {
+    const user = userEvent.setup();
+
+    render(<SecretSelector {...defaultProps} availableSecrets={[]} value="" />);
+    await user.click(screen.getByRole('button', { name: /create secret/i }));
+
+    await user.type(screen.getByLabelText(/secret name/i), 'MY_SECRET');
+    await user.type(screen.getByLabelText(/secret value/i), 'short');
+
+    await waitFor(() => {
+      expect(screen.getByText('Secret value must be at least 20 characters')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: /^create secret$/i })).toBeDisabled();
+  });
+
+  test('accepts short values when minValueLength allows them (e.g. Basic passwords)', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<SecretSelector {...defaultProps} availableSecrets={[]} minValueLength={1} onChange={onChange} value="" />);
+    await user.click(screen.getByRole('button', { name: /create secret/i }));
+
+    await user.type(screen.getByLabelText(/secret name/i), 'SR_PASSWORD');
+    await user.type(screen.getByLabelText(/secret value/i), 'short');
+
+    const submitButton = screen.getByRole('button', { name: /^create secret$/i });
+    await waitFor(() => {
+      expect(submitButton).toBeEnabled();
+    });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith('SR_PASSWORD');
+    });
+  });
+
+  test('forwards form wiring props to the combobox trigger', () => {
+    render(<SecretSelector {...defaultProps} aria-describedby="hint" id="password-field" value="" />);
+
+    const trigger = screen.getByRole('combobox');
+    expect(trigger).toHaveAttribute('id', 'password-field');
+    expect(trigger).toHaveAttribute('aria-describedby', 'hint');
+  });
 });

--- a/frontend/src/components/ui/secret/secret-selector.tsx
+++ b/frontend/src/components/ui/secret/secret-selector.tsx
@@ -46,7 +46,7 @@ import {
 	CreateSecretRequestSchema as CreateSecretRequestSchemaDataPlane,
 	type Scope,
 } from "protogen/redpanda/api/dataplane/v1/secret_pb";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useCreateSecretMutation } from "react-query/api/secret";
 import { toast } from "sonner";
@@ -101,24 +101,37 @@ type SecretSelectorProps = {
 	scopes: Scope[];
 	/** Custom text for dialog and form fields */
 	customText: SecretSelectorCustomText;
-};
+	/**
+	 * Minimum length for a newly created secret value. Defaults to 20 (API-key
+	 * style secrets); pass 1 for secrets with no inherent length, e.g. HTTP
+	 * Basic passwords.
+	 */
+	minValueLength?: number;
+} & Omit<
+	React.ComponentPropsWithoutRef<typeof SelectTrigger>,
+	"value" | "onChange" | "children" | "placeholder"
+>;
 
-const NewSecretFormSchema = z.object({
-	name: z
-		.string()
-		.min(1, "Secret name is required")
-		.max(255, "Secret name must be fewer than 255 characters")
-		.regex(
-			/^[A-Za-z][A-Za-z0-9_]*$/,
-			"Secret name must start with a letter and contain only letters, numbers, and underscores",
-		),
-	value: z
-		.string()
-		.min(1, "Secret value is required")
-		.min(20, "Secret value must be at least 20 characters"),
-});
+const buildNewSecretFormSchema = (minValueLength: number) =>
+	z.object({
+		name: z
+			.string()
+			.min(1, "Secret name is required")
+			.max(255, "Secret name must be fewer than 255 characters")
+			.regex(
+				/^[A-Za-z][A-Za-z0-9_]*$/,
+				"Secret name must start with a letter and contain only letters, numbers, and underscores",
+			),
+		value: z
+			.string()
+			.min(1, "Secret value is required")
+			.min(
+				minValueLength,
+				`Secret value must be at least ${minValueLength} characters`,
+			),
+	});
 
-type NewSecretFormData = z.infer<typeof NewSecretFormSchema>;
+type NewSecretFormData = z.infer<ReturnType<typeof buildNewSecretFormSchema>>;
 
 export const SecretSelector: React.FC<SecretSelectorProps> = ({
 	value,
@@ -128,13 +141,21 @@ export const SecretSelector: React.FC<SecretSelectorProps> = ({
 	onSecretCreated,
 	scopes,
 	customText,
+	minValueLength = 20,
+	// Anything else (id, aria-*) comes from form wiring such as FormControl and
+	// must reach the combobox trigger so labels announce it.
+	...triggerProps
 }) => {
 	const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
 	const { mutateAsync: createSecret, isPending: isCreateSecretPending } =
 		useCreateSecretMutation();
 
+	const newSecretFormSchema = useMemo(
+		() => buildNewSecretFormSchema(minValueLength),
+		[minValueLength],
+	);
 	const form = useForm<NewSecretFormData>({
-		resolver: zodResolver(NewSecretFormSchema),
+		resolver: zodResolver(newSecretFormSchema),
 		defaultValues: {
 			name: "",
 			value: "",
@@ -211,7 +232,7 @@ export const SecretSelector: React.FC<SecretSelectorProps> = ({
 						onValueChange={onChange}
 						value={extractSecretName(value)}
 					>
-						<SelectTrigger className="flex-1">
+						<SelectTrigger className="flex-1" {...triggerProps}>
 							<SelectValue placeholder={placeholder} />
 						</SelectTrigger>
 						<SelectContent>

--- a/frontend/src/react-query/api/shadowlink.test.tsx
+++ b/frontend/src/react-query/api/shadowlink.test.tsx
@@ -40,11 +40,16 @@ vi.mock('./controlplane/shadowlink', () => ({
   })),
 }));
 
-// Mock the controlplane mapper for fallback scenario
-vi.mock('components/pages/shadowlinks/mappers/controlplane', () => ({
-  fromControlplaneShadowLink: vi.fn(),
-  buildDefaultFormValuesFromControlplane: vi.fn(),
-}));
+// Mock the controlplane mapper for the fallback scenario. Form-value building
+// delegates to the real mapper so useEditShadowLink tests exercise actual
+// hydration (vi.clearAllMocks clears calls, not this implementation).
+vi.mock('components/pages/shadowlinks/mappers/controlplane', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('components/pages/shadowlinks/mappers/controlplane')>();
+  return {
+    fromControlplaneShadowLink: vi.fn(),
+    buildDefaultFormValuesFromControlplane: vi.fn(actual.buildDefaultFormValuesFromControlplane),
+  };
+});
 
 import { fromControlplaneShadowLink } from 'components/pages/shadowlinks/mappers/controlplane';
 // Import after mocks are set up
@@ -284,7 +289,10 @@ describe('useEditShadowLink', () => {
     return renderHook(() => useEditShadowLink('test-shadow-link'), { wrapper });
   };
 
-  test('detects API mode from controlplane data in embedded mode', async () => {
+  // The edit page derives all API-mode behavior (locked tabs, gate-off
+  // read-only card) from the hydrated form values, so the mode must survive
+  // hydration from controlplane data.
+  test('hydrates API mode from controlplane data in embedded mode', async () => {
     mockIsEmbedded.mockReturnValue(true);
     mockUseControlplaneGetShadowLinkByNameQuery.mockReturnValue({
       data: {
@@ -306,10 +314,10 @@ describe('useEditShadowLink', () => {
     await waitFor(() => {
       expect(result.current.hasData).toBe(true);
     });
-    expect(result.current.isSchemaRegistryApiMode).toBe(true);
+    expect(result.current.formValues?.schemaRegistry.mode).toBe('api');
   });
 
-  test('does not flag API mode for a topic-mode controlplane link in embedded mode', async () => {
+  test('hydrates topic mode (not api) for a topic-mode controlplane link in embedded mode', async () => {
     mockIsEmbedded.mockReturnValue(true);
     mockUseControlplaneGetShadowLinkByNameQuery.mockReturnValue({
       data: {
@@ -328,7 +336,7 @@ describe('useEditShadowLink', () => {
     await waitFor(() => {
       expect(result.current.hasData).toBe(true);
     });
-    expect(result.current.isSchemaRegistryApiMode).toBe(false);
+    expect(result.current.formValues?.schemaRegistry.mode).toBe('topic');
   });
 });
 

--- a/frontend/src/react-query/api/shadowlink.ts
+++ b/frontend/src/react-query/api/shadowlink.ts
@@ -394,7 +394,6 @@ export const useEditShadowLink = (
   error: ConnectError | null;
   isUpdating: boolean;
   hasData: boolean;
-  isSchemaRegistryApiMode: boolean;
   updateShadowLink: (values: FormValues) => Promise<unknown>;
   dataplaneUpdate: ReturnType<typeof useUpdateShadowLinkMutation>;
   controlplaneUpdate: ReturnType<typeof useControlplaneUpdateShadowLinkMutation>;
@@ -446,23 +445,12 @@ export const useEditShadowLink = (
   // Check if data is available based on mode
   const hasData = embedded ? !!controlplaneShadowLink : !!shadowLink;
 
-  // Detect API mode from whichever source the edit form is built from. The
-  // create wizard cannot produce API-mode links in embedded mode, but the
-  // controlplane proto models the case, so links created via rpk/cloud API can
-  // carry it — without this check their API config could be overwritten with
-  // topic mode from the edit form.
-  const schemaRegistryShadowingMode = embedded
-    ? controlplaneShadowLink?.schemaRegistrySyncOptions?.schemaRegistryShadowingMode
-    : shadowLink?.configurations?.schemaRegistrySyncOptions?.schemaRegistryShadowingMode;
-  const isSchemaRegistryApiMode = schemaRegistryShadowingMode?.case === 'shadowSchemaRegistryApi';
-
   return {
     formValues,
     isLoading: embedded ? controlplaneQuery.isLoading : dataplaneQuery.isLoading,
     error: embedded ? controlplaneQuery.error : dataplaneQuery.error,
     isUpdating: embedded ? controlplaneUpdate.isPending : dataplaneUpdate.isPending,
     hasData,
-    isSchemaRegistryApiMode,
     updateShadowLink: submitUpdate,
     dataplaneUpdate,
     controlplaneUpdate,


### PR DESCRIPTION
The edit page only exposed the legacy _schemas switch; API-mode links were read-only. Render the redesigned section on edit, behind the same feature gate as the create wizard.

Secrets are never seeded into the form: sending them empty on update keeps the stored values. Fields without a UI (paused, SNI opt-out, file-path TLS) are round-tripped so a message rebuild does not reset them. Direct topic<->api switches are unsupported by the backend, so those tabs are locked.

While the gate is closed the SR validation rules are skipped so the api-mode slice does not block saving other fields.

**Before:**

<img width="925" height="170" alt="image" src="https://github.com/user-attachments/assets/874bc0a1-7f72-4a9b-a592-fb84819e6967" />


**Now:**
<img width="930" height="834" alt="image" src="https://github.com/user-attachments/assets/6518ace0-8341-4153-a7f9-b012ea874bf8" />

^ Note that the _schemas tab is unavailable to prevent users from switching modes as stated above.