### PR TITLE
Debug dialog: visual debuggers

### DIFF
--- a/frontend/src/components/debug-helper/debug-dialog.tsx
+++ b/frontend/src/components/debug-helper/debug-dialog.tsx
@@ -402,7 +402,7 @@ function StorageEntryRow({ storageKey, value }: { storageKey: string; value: str
         </CollapsibleTrigger>
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
           <div className="flex min-w-0 items-center gap-1.5">
-            <code className="min-w-0 flex-1 truncate font-medium font-mono text-xs" title={storageKey}>
+            <code className="min-w-0 flex-1 truncate font-medium font-mono text-body-sm" title={storageKey}>
               {storageKey}
             </code>
             <Badge className="shrink-0" size="sm" variant="simple-outline">
@@ -410,7 +410,9 @@ function StorageEntryRow({ storageKey, value }: { storageKey: string; value: str
             </Badge>
           </div>
           {!expanded && (
-            <div className="min-w-0 truncate font-mono text-muted-foreground text-xs">{formatted.split('\n')[0]}</div>
+            <div className="min-w-0 truncate font-mono text-body-sm text-muted-foreground">
+              {formatted.split('\n')[0]}
+            </div>
           )}
           <CollapsibleContent>
             <SimpleCodeBlock
@@ -602,7 +604,7 @@ function FlagToggle({
   return (
     <div
       className={cn(
-        'inline-flex h-7 items-center gap-1.5 rounded-full border px-2 font-medium text-xs transition-colors',
+        'inline-flex h-7 items-center gap-1.5 rounded-full border px-2 font-medium text-body-sm transition-colors',
         checked
           ? 'border-outline-success bg-background-success-subtle text-success'
           : 'border-border bg-background text-muted-foreground'
@@ -687,7 +689,7 @@ function FeatureFlagsPanel({ onMutate }: { onMutate: () => void }) {
                 <div className="flex h-5 min-w-0 items-center gap-1.5">
                   <code
                     className={cn(
-                      'min-w-0 flex-1 truncate font-medium font-mono text-xs',
+                      'min-w-0 flex-1 truncate font-medium font-mono text-body-sm',
                       !effectiveValue && 'text-muted-foreground'
                     )}
                     title={key}
@@ -915,7 +917,7 @@ export function DebugDialog({ open, onOpenChange }: { open: boolean; onOpenChang
             <div className="flex flex-1 flex-col gap-3 overflow-y-auto p-2">
               {NAV_GROUPS.map(({ label, items }) => (
                 <div key={label}>
-                  <div className="px-2 pb-1 font-semibold text-[10px] text-muted-foreground/70 uppercase tracking-wider">
+                  <div className="px-2 pb-1 font-semibold text-caption text-muted-foreground/70 uppercase tracking-wider">
                     {label}
                   </div>
                   <div className="flex flex-col gap-0.5">
@@ -944,7 +946,7 @@ export function DebugDialog({ open, onOpenChange }: { open: boolean; onOpenChang
                 </div>
               ))}
             </div>
-            <div className="flex items-center gap-1.5 border-t px-3 py-2 text-muted-foreground text-xs">
+            <div className="flex items-center gap-1.5 border-t px-3 py-2 text-body-sm text-muted-foreground">
               <KbdGroup>
                 <Kbd size="xs">⌃/⌘</Kbd>
                 <Kbd size="xs">⇧</Kbd>

--- a/frontend/src/components/debug-helper/debug-dialog.tsx
+++ b/frontend/src/components/debug-helper/debug-dialog.tsx
@@ -52,6 +52,7 @@ import {
   Trash2,
   Zap,
 } from 'lucide-react';
+import { AnimatePresence, MotionConfig, motion } from 'motion/react';
 import { Fragment, useCallback, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { toast } from 'sonner';
@@ -115,6 +116,22 @@ function readStorageEntries(storage: Storage): { key: string; value: string }[] 
 function useForceUpdate(): () => void {
   const [, setTick] = useState(0);
   return useCallback(() => setTick((n) => n + 1), []);
+}
+
+// Scale/fade pop for small elements that mount and unmount (badges, count dots).
+// Render inside an <AnimatePresence> so the exit animation can play.
+function PopIn({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <motion.span
+      animate={{ opacity: 1, scale: 1 }}
+      className={cn('inline-flex', className)}
+      exit={{ opacity: 0, scale: 0.5 }}
+      initial={{ opacity: 0, scale: 0.5 }}
+      transition={{ duration: 0.15, ease: 'easeOut' }}
+    >
+      {children}
+    </motion.span>
+  );
 }
 
 function EmptyState({ children }: { children: React.ReactNode }) {
@@ -695,11 +712,15 @@ function FeatureFlagsPanel({ onMutate }: { onMutate: () => void }) {
                   >
                     {key}
                   </code>
-                  {isOverridden ? (
-                    <Badge className="shrink-0" size="sm" variant="warning-inverted">
-                      overridden
-                    </Badge>
-                  ) : null}
+                  <AnimatePresence initial={false}>
+                    {isOverridden ? (
+                      <PopIn className="shrink-0" key="overridden">
+                        <Badge size="sm" variant="warning-inverted">
+                          overridden
+                        </Badge>
+                      </PopIn>
+                    ) : null}
+                  </AnimatePresence>
                 </div>
                 <div className="flex items-center gap-1.5">
                   <FlagToggle
@@ -710,18 +731,22 @@ function FeatureFlagsPanel({ onMutate }: { onMutate: () => void }) {
                       onMutate();
                     }}
                   />
-                  {isOverridden ? (
-                    <Button
-                      onClick={() => {
-                        setFlagOverride(key, null);
-                        onMutate();
-                      }}
-                      size="xs"
-                      variant="secondary-ghost"
-                    >
-                      Reset
-                    </Button>
-                  ) : null}
+                  <AnimatePresence initial={false}>
+                    {isOverridden ? (
+                      <PopIn key="reset">
+                        <Button
+                          onClick={() => {
+                            setFlagOverride(key, null);
+                            onMutate();
+                          }}
+                          size="xs"
+                          variant="secondary-ghost"
+                        >
+                          Reset
+                        </Button>
+                      </PopIn>
+                    ) : null}
+                  </AnimatePresence>
                   <span className="ml-auto shrink-0 text-body-sm text-muted-foreground">
                     default {defaultValue ? 'on' : 'off'}
                   </span>
@@ -851,11 +876,15 @@ function OverviewPanel({ onNavigate }: { onNavigate: (panel: PanelId) => void })
               <ItemTitle>{label}</ItemTitle>
               <ItemDescription>{value}</ItemDescription>
             </ItemContent>
-            {active ? (
-              <Badge size="sm" variant="warning-inverted">
-                active
-              </Badge>
-            ) : null}
+            <AnimatePresence initial={false}>
+              {active ? (
+                <PopIn key="active">
+                  <Badge size="sm" variant="warning-inverted">
+                    active
+                  </Badge>
+                </PopIn>
+              ) : null}
+            </AnimatePresence>
             <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
           </Item>
         </Fragment>
@@ -937,7 +966,13 @@ export function DebugDialog({ open, onOpenChange }: { open: boolean; onOpenChang
                         >
                           {icon}
                           <span className="min-w-0 flex-1 truncate">{itemLabel}</span>
-                          <CountDot count={count} size="sm" variant="warning" />
+                          <AnimatePresence initial={false}>
+                            {count > 0 ? (
+                              <PopIn key="count">
+                                <CountDot count={count} size="sm" variant="warning" />
+                              </PopIn>
+                            ) : null}
+                          </AnimatePresence>
                         </button>
                       );
                     })}
@@ -960,7 +995,19 @@ export function DebugDialog({ open, onOpenChange }: { open: boolean; onOpenChang
               <div className="font-semibold text-body">{title}</div>
               <div className="text-body-sm text-muted-foreground">{description}</div>
             </div>
-            <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">{renderPanel()}</div>
+            <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+              <AnimatePresence initial={false} mode="wait">
+                <motion.div
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: 4 }}
+                  initial={{ opacity: 0, y: 4 }}
+                  key={panel}
+                  transition={{ duration: 0.12, ease: 'easeOut' }}
+                >
+                  {renderPanel()}
+                </motion.div>
+              </AnimatePresence>
+            </div>
           </div>
         </div>
       </DialogContent>
@@ -982,7 +1029,13 @@ function DebugLauncher({ onClick }: { onClick: () => void }) {
       type="button"
     >
       <DebugPanda className="h-[22px] w-[22px]" />
-      <CountDot className="absolute -top-1 -right-1" count={activeCount} size="sm" variant="warning" />
+      <AnimatePresence initial={false}>
+        {activeCount > 0 ? (
+          <PopIn className="absolute -top-1 -right-1" key="count">
+            <CountDot count={activeCount} size="sm" variant="warning" />
+          </PopIn>
+        ) : null}
+      </AnimatePresence>
     </button>,
     document.body
   );
@@ -1003,9 +1056,9 @@ export function DebugHelperRoot() {
   }
 
   return (
-    <>
+    <MotionConfig reducedMotion="user">
       {!open && <DebugLauncher onClick={() => setOpen(true)} />}
       <DebugDialog onOpenChange={setOpen} open={open} />
-    </>
+    </MotionConfig>
   );
 }

--- a/frontend/src/components/debug-helper/debug-dialog.tsx
+++ b/frontend/src/components/debug-helper/debug-dialog.tsx
@@ -105,7 +105,7 @@ function readStorageEntries(storage: Storage): { key: string; value: string }[] 
   const entries: { key: string; value: string }[] = [];
   for (let i = 0; i < storage.length; i++) {
     const key = storage.key(i);
-    if (key != null) {
+    if (key !== null) {
       entries.push({ key, value: storage.getItem(key) ?? '' });
     }
   }
@@ -186,9 +186,9 @@ function ConfigFixtureRow({ fixture }: { fixture: ConnectConfigFixture }) {
           </Button>
         </ItemActions>
       </ItemHeader>
-      {previewing && (
+      {previewing ? (
         <SimpleCodeBlock className="my-0" code={fixture.yaml} language="yaml" maxHeight="sm" size="sm" width="full" />
-      )}
+      ) : null}
     </Item>
   );
 }
@@ -307,6 +307,7 @@ function SimulatePanel({ onClose }: { onClose: () => void }) {
             Throw in event handler
           </Button>
           <Button
+            // biome-ignore lint/complexity/noVoid: an unhandled rejection is the point of this button
             onClick={() => void Promise.reject(new Error('DebugDialog: synthetic unhandled rejection'))}
             size="sm"
             variant="destructive"
@@ -328,7 +329,7 @@ function SimulatePanel({ onClose }: { onClose: () => void }) {
         </div>
       </DebugSection>
 
-      {renderThrow && <ErrorThrower />}
+      {renderThrow ? <ErrorThrower /> : null}
     </div>
   );
 }
@@ -410,7 +411,7 @@ function StorageEntryRow({ storageKey, value }: { storageKey: string; value: str
               {formatBytes(sizeBytes)}
             </Badge>
           </div>
-          {!expanded && (
+          {expanded ? null : (
             <div className="min-w-0 truncate font-mono text-body-sm text-muted-foreground">
               {formatted.split('\n')[0]}
             </div>
@@ -436,9 +437,9 @@ function StorageEntryRow({ storageKey, value }: { storageKey: string; value: str
           >
             Copy
           </Button>
-          {isMultiline && !expanded && (
+          {isMultiline && !expanded ? (
             <Button icon={<Eye />} onClick={() => setExpanded(true)} size="xs" variant="secondary-ghost" />
-          )}
+          ) : null}
         </div>
       </div>
     </Collapsible>
@@ -460,14 +461,12 @@ function StorageSection({
   onConfirmClear: () => void;
   filter: string;
 }) {
-  const entries = useMemo(() => {
-    const all = readStorageEntries(storage).sort((a, b) => a.key.localeCompare(b.key));
-    const q = filter.trim().toLowerCase();
-    if (!q) {
-      return all;
-    }
-    return all.filter((e) => e.key.toLowerCase().includes(q) || e.value.toLowerCase().includes(q));
-  }, [storage, filter]);
+  // Computed on every render (no memo): the Storage object is a stable reference,
+  // so memoizing on it would keep serving deleted entries after a Clear.
+  const q = filter.trim().toLowerCase();
+  const entries = readStorageEntries(storage)
+    .sort((a, b) => a.key.localeCompare(b.key))
+    .filter((e) => !q || e.key.toLowerCase().includes(q) || e.value.toLowerCase().includes(q));
 
   return (
     <div className="overflow-hidden rounded-md border">
@@ -591,8 +590,7 @@ function EnvironmentPanel() {
   );
 }
 
-// Combined control + status in one element, mirroring the RPCN pipeline run toggle:
-// a pill whose chrome, switch, and label all read the on/off state together.
+// Control + status in one pill, mirroring the RPCN pipeline run toggle.
 function FlagToggle({
   id,
   checked,
@@ -686,7 +684,7 @@ function FeatureFlagsPanel({ onMutate }: { onMutate: () => void }) {
                 size="xs"
                 variant="outline"
               >
-                {/* Fixed h-5 so the row height doesn't jump when the badge (h-5) appears. */}
+                {/* h-5 matches the badge so the row doesn't grow when it appears */}
                 <div className="flex h-5 min-w-0 items-center gap-1.5">
                   <code
                     className={cn(
@@ -697,11 +695,11 @@ function FeatureFlagsPanel({ onMutate }: { onMutate: () => void }) {
                   >
                     {key}
                   </code>
-                  {isOverridden && (
+                  {isOverridden ? (
                     <Badge className="shrink-0" size="sm" variant="warning-inverted">
                       overridden
                     </Badge>
-                  )}
+                  ) : null}
                 </div>
                 <div className="flex items-center gap-1.5">
                   <FlagToggle
@@ -712,7 +710,7 @@ function FeatureFlagsPanel({ onMutate }: { onMutate: () => void }) {
                       onMutate();
                     }}
                   />
-                  {isOverridden && (
+                  {isOverridden ? (
                     <Button
                       onClick={() => {
                         setFlagOverride(key, null);
@@ -723,7 +721,7 @@ function FeatureFlagsPanel({ onMutate }: { onMutate: () => void }) {
                     >
                       Reset
                     </Button>
-                  )}
+                  ) : null}
                   <span className="ml-auto shrink-0 text-body-sm text-muted-foreground">
                     default {defaultValue ? 'on' : 'off'}
                   </span>
@@ -841,8 +839,7 @@ function OverviewPanel({ onNavigate }: { onNavigate: (panel: PanelId) => void })
     <ItemGroup className="overflow-hidden rounded-md border">
       {rows.map(({ panel, icon, label, value, active }, index) => (
         <Fragment key={panel}>
-          {/* Rendered as a bare bottom border (not the divider token) so it picks up the same
-              default border-color as the surrounding `border` container in both themes. */}
+          {/* Bare border-b (not the divider token) so it matches the container's border color in both themes */}
           {index > 0 ? <ItemSeparator className="border-b bg-transparent" /> : null}
           <Item
             className="cursor-pointer rounded-none border-0 text-left hover:bg-muted/50"
@@ -873,7 +870,6 @@ export function DebugDialog({ open, onOpenChange }: { open: boolean; onOpenChang
 
   const close = useCallback(() => onOpenChange(false), [onOpenChange]);
 
-  // Live counts surface in the nav rail so active subsystems are visible from anywhere.
   const railCounts: Partial<Record<PanelId, number>> = {
     visual: getEnabledVisualDebuggers().length,
     flags: Object.keys(getFlagOverrides()).length,
@@ -899,6 +895,8 @@ export function DebugDialog({ open, onOpenChange }: { open: boolean; onOpenChang
         return null;
     }
   };
+
+  const { title, description } = PANEL_META[panel];
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
@@ -959,8 +957,8 @@ export function DebugDialog({ open, onOpenChange }: { open: boolean; onOpenChang
 
           <div className="flex min-w-0 flex-1 flex-col">
             <div className="border-b px-5 pt-4 pb-3">
-              <div className="font-semibold text-body">{PANEL_META[panel].title}</div>
-              <div className="text-body-sm text-muted-foreground">{PANEL_META[panel].description}</div>
+              <div className="font-semibold text-body">{title}</div>
+              <div className="text-body-sm text-muted-foreground">{description}</div>
             </div>
             <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">{renderPanel()}</div>
           </div>
@@ -970,11 +968,8 @@ export function DebugDialog({ open, onOpenChange }: { open: boolean; onOpenChang
   );
 }
 
-// Small floating launcher (TanStack-devtools style) so the dialog stays reachable
-// without remembering the hotkey. Sits above the TanStack corner buttons and shows
-// an amber count when any visual debugger or flag override is active. Portaled to
-// document.body — in embedded mode the DebugHelper mount lives in a hidden host
-// container, which the dialog already escapes via its own portal.
+// Floating launcher, portaled to document.body: in embedded mode this component
+// mounts inside a hidden host container (the dialog escapes via its own portal).
 function DebugLauncher({ onClick }: { onClick: () => void }) {
   const activeCount = getEnabledVisualDebuggers().length + Object.keys(getFlagOverrides()).length;
 
@@ -987,15 +982,13 @@ function DebugLauncher({ onClick }: { onClick: () => void }) {
       type="button"
     >
       <DebugPanda className="h-[22px] w-[22px]" />
-      {activeCount > 0 && (
-        <CountDot className="absolute -top-1 -right-1" count={activeCount} size="sm" variant="warning" />
-      )}
+      <CountDot className="absolute -top-1 -right-1" count={activeCount} size="sm" variant="warning" />
     </button>,
     document.body
   );
 }
 
-export function DebugHelper() {
+export function DebugHelperRoot() {
   const [open, setOpen] = useState(false);
 
   useHotKey({

--- a/frontend/src/components/debug-helper/debug-dialog.tsx
+++ b/frontend/src/components/debug-helper/debug-dialog.tsx
@@ -54,6 +54,7 @@ import {
   Zap,
 } from 'lucide-react';
 import { Fragment, useCallback, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { toast } from 'sonner';
 
 import { CONNECT_CONFIG_FIXTURES, type ConnectConfigFixture } from './connect-config-fixtures';
@@ -969,6 +970,31 @@ export function DebugDialog({ open, onOpenChange }: { open: boolean; onOpenChang
   );
 }
 
+// Small floating launcher (TanStack-devtools style) so the dialog stays reachable
+// without remembering the hotkey. Sits above the TanStack corner buttons and shows
+// an amber count when any visual debugger or flag override is active. Portaled to
+// document.body — in embedded mode the DebugHelper mount lives in a hidden host
+// container, which the dialog already escapes via its own portal.
+function DebugLauncher({ onClick }: { onClick: () => void }) {
+  const activeCount = getEnabledVisualDebuggers().length + Object.keys(getFlagOverrides()).length;
+
+  return createPortal(
+    <button
+      aria-label="Open debug helpers (Ctrl/Cmd+Shift+D)"
+      className="fixed right-[52px] bottom-[68px] z-40 flex h-[32px] w-[32px] cursor-pointer items-center justify-center rounded-full border bg-background text-muted-foreground opacity-70 shadow-md transition-all hover:text-foreground hover:opacity-100 hover:shadow-lg"
+      onClick={onClick}
+      title="Debug helpers — ⌃/⌘⇧D"
+      type="button"
+    >
+      <Bug className="h-[16px] w-[16px]" />
+      {activeCount > 0 && (
+        <CountDot className="absolute -top-1 -right-1" count={activeCount} size="sm" variant="warning" />
+      )}
+    </button>,
+    document.body
+  );
+}
+
 export function DebugHelper() {
   const [open, setOpen] = useState(false);
 
@@ -983,5 +1009,10 @@ export function DebugHelper() {
     return null;
   }
 
-  return <DebugDialog onOpenChange={setOpen} open={open} />;
+  return (
+    <>
+      {!open && <DebugLauncher onClick={() => setOpen(true)} />}
+      <DebugDialog onOpenChange={setOpen} open={open} />
+    </>
+  );
 }

--- a/frontend/src/components/debug-helper/debug-dialog.tsx
+++ b/frontend/src/components/debug-helper/debug-dialog.tsx
@@ -12,32 +12,31 @@
 import { useRouterState } from '@tanstack/react-router';
 import { Badge } from 'components/redpanda-ui/components/badge';
 import { Button } from 'components/redpanda-ui/components/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from 'components/redpanda-ui/components/card';
 import { SimpleCodeBlock } from 'components/redpanda-ui/components/code-block';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from 'components/redpanda-ui/components/collapsible';
-import {
-  Dialog,
-  DialogBody,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from 'components/redpanda-ui/components/dialog';
+import { CountDot } from 'components/redpanda-ui/components/count-dot';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from 'components/redpanda-ui/components/dialog';
+import { Empty, EmptyDescription } from 'components/redpanda-ui/components/empty';
 import { Input } from 'components/redpanda-ui/components/input';
 import {
   Item,
   ItemActions,
   ItemContent,
   ItemDescription,
+  ItemGroup,
   ItemHeader,
+  ItemMedia,
+  ItemSeparator,
   ItemTitle,
 } from 'components/redpanda-ui/components/item';
 import { Kbd, KbdGroup } from 'components/redpanda-ui/components/kbd';
+import { Label } from 'components/redpanda-ui/components/label';
 import { Switch } from 'components/redpanda-ui/components/switch';
 import { Table, TableBody, TableCell, TableRow } from 'components/redpanda-ui/components/table';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from 'components/redpanda-ui/components/tabs';
 import { InlineCode } from 'components/redpanda-ui/components/typography';
+import { cn } from 'components/redpanda-ui/lib/utils';
 import {
-  AppWindow,
   Bug,
   Check,
   ChevronDown,
@@ -45,16 +44,16 @@ import {
   Clipboard,
   ClipboardCopy,
   Cog,
+  Database,
   Eye,
   FileCode,
   Flag,
   Info,
   RotateCw,
   Trash2,
-  Wrench,
   Zap,
 } from 'lucide-react';
-import { useCallback, useMemo, useState } from 'react';
+import { Fragment, useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
 import { CONNECT_CONFIG_FIXTURES, type ConnectConfigFixture } from './connect-config-fixtures';
@@ -93,7 +92,7 @@ function copyToClipboard(text: string, successMsg = 'Copied to clipboard') {
 }
 
 function emitConsole(level: 'log' | 'info' | 'warn' | 'error', message: string): void {
-  // biome-ignore lint/suspicious/noConsole: intentional debug helper for the Simulate tab
+  // biome-ignore lint/suspicious/noConsole: intentional debug helper for the Simulate panel
   console[level](message);
 }
 
@@ -118,7 +117,11 @@ function useForceUpdate(): () => void {
 }
 
 function EmptyState({ children }: { children: React.ReactNode }) {
-  return <div className="px-3 py-6 text-center text-body-sm text-muted-foreground">{children}</div>;
+  return (
+    <Empty className="gap-2 md:p-6">
+      <EmptyDescription className="text-body-sm">{children}</EmptyDescription>
+    </Empty>
+  );
 }
 
 function DebugSection({
@@ -131,13 +134,19 @@ function DebugSection({
   children: React.ReactNode;
 }) {
   return (
-    <div className="overflow-hidden rounded-md border bg-card">
-      <div className="border-b bg-muted/30 px-3 py-2">
-        <div className="font-medium text-body-sm">{title}</div>
-        {description ? <div className="text-body-sm text-muted-foreground">{description}</div> : null}
-      </div>
-      <div className="p-3">{children}</div>
-    </div>
+    <Card className="w-full max-w-full gap-0 overflow-hidden rounded-md p-0" variant="standard">
+      <CardHeader className="bg-muted/30 px-3 py-2" spacing="tight">
+        <CardTitle>
+          <span className="font-medium text-body-sm">{title}</span>
+        </CardTitle>
+        {description ? (
+          <CardDescription>
+            <span className="text-body-sm">{description}</span>
+          </CardDescription>
+        ) : null}
+      </CardHeader>
+      <CardContent className="border-t p-3">{children}</CardContent>
+    </Card>
   );
 }
 
@@ -183,7 +192,7 @@ function ConfigFixtureRow({ fixture }: { fixture: ConnectConfigFixture }) {
   );
 }
 
-function ConnectConfigsTab() {
+function ConnectConfigsPanel() {
   const [filter, setFilter] = useState('');
   const filtered = useMemo(() => {
     const q = filter.trim().toLowerCase();
@@ -198,10 +207,6 @@ function ConnectConfigsTab() {
 
   return (
     <div className="flex flex-col gap-2.5">
-      <div className="text-body-sm text-muted-foreground">
-        Pre-built Connect pipeline YAMLs for stress-testing the editor and validation. Click <strong>Copy YAML</strong>,
-        then paste into the editor on the create or edit page.
-      </div>
       <Input
         onChange={(e) => setFilter(e.target.value)}
         placeholder="Filter by name, tag, or description…"
@@ -257,14 +262,10 @@ const TOAST_ACTIONS: { label: string; variant: ButtonVariant; run: () => void }[
   },
 ];
 
-function SimulateTab({ onClose }: { onClose: () => void }) {
+function SimulatePanel({ onClose }: { onClose: () => void }) {
   const [renderThrow, setRenderThrow] = useState(false);
   return (
     <div className="flex flex-col gap-4">
-      <div className="text-body-sm text-muted-foreground">
-        Trigger app-level side effects to verify toasts, error boundaries, and console output.
-      </div>
-
       <DebugSection
         description="Fire each toast variant to verify rendering, stacking, and rich colors."
         title="Toasts"
@@ -331,16 +332,11 @@ function SimulateTab({ onClose }: { onClose: () => void }) {
   );
 }
 
-function VisualTab() {
-  const forceUpdate = useForceUpdate();
+function VisualPanel({ onMutate }: { onMutate: () => void }) {
   const enabled = getEnabledVisualDebuggers();
 
   return (
     <div className="flex flex-col gap-2.5">
-      <div className="text-body-sm text-muted-foreground">
-        CSS-only overlays applied to the whole document, including this dialog. They persist for this browser tab and
-        re-apply on reload; a new tab starts clean.
-      </div>
       <div>
         <Button
           disabled={enabled.length === 0}
@@ -348,7 +344,7 @@ function VisualTab() {
           onClick={() => {
             clearVisualDebuggers();
             toast.success('Disabled all visual debuggers');
-            forceUpdate();
+            onMutate();
           }}
           size="xs"
           variant="destructive-ghost"
@@ -363,7 +359,7 @@ function VisualTab() {
               checked={enabled.includes(id)}
               onCheckedChange={(checked) => {
                 setVisualDebugger(id, checked);
-                forceUpdate();
+                onMutate();
               }}
             />
             <div className="flex min-w-0 flex-1 flex-col gap-0.5">
@@ -512,7 +508,7 @@ function StorageSection({
   );
 }
 
-function StorageTab() {
+function StoragePanel() {
   const [confirmingClear, setConfirmingClear] = useState<null | 'local' | 'session'>(null);
   const [filter, setFilter] = useState('');
   const forceUpdate = useForceUpdate();
@@ -528,9 +524,6 @@ function StorageTab() {
 
   return (
     <div className="flex flex-col gap-2.5">
-      <div className="text-body-sm text-muted-foreground">
-        Inspect or clear browser storage. Clearing will sign you out of preferences and reset feature toggles.
-      </div>
       <Input onChange={(e) => setFilter(e.target.value)} placeholder="Filter by key or value…" value={filter} />
       <StorageSection
         confirming={confirmingClear === 'local'}
@@ -552,7 +545,7 @@ function StorageTab() {
   );
 }
 
-function EnvironmentTab() {
+function EnvironmentPanel() {
   const router = useRouterState();
   const info = {
     nodeEnv: process.env.NODE_ENV ?? '(unset)',
@@ -568,9 +561,6 @@ function EnvironmentTab() {
   };
   return (
     <div className="flex flex-col gap-2.5">
-      <div className="text-body-sm text-muted-foreground">
-        Snapshot of build, route, and runtime env. Useful when filing bugs.
-      </div>
       <Table size="sm">
         <TableBody>
           {Object.entries(info).map(([k, v]) => (
@@ -598,9 +588,41 @@ function EnvironmentTab() {
   );
 }
 
-function FeatureFlagsTab() {
+// Combined control + status in one element, mirroring the RPCN pipeline run toggle:
+// a pill whose chrome, switch, and label all read the on/off state together.
+function FlagToggle({
+  id,
+  checked,
+  onCheckedChange,
+}: {
+  id: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}) {
+  return (
+    <div
+      className={cn(
+        'inline-flex h-7 items-center gap-1.5 rounded-full border px-2 font-medium text-xs transition-colors',
+        checked
+          ? 'border-outline-success bg-background-success-subtle text-success'
+          : 'border-border bg-background text-muted-foreground'
+      )}
+    >
+      <Switch
+        checked={checked}
+        className={cn(checked && 'data-[checked]:bg-success')}
+        id={id}
+        onCheckedChange={onCheckedChange}
+      />
+      <Label className="cursor-pointer" htmlFor={id}>
+        {checked ? 'On' : 'Off'}
+      </Label>
+    </div>
+  );
+}
+
+function FeatureFlagsPanel({ onMutate }: { onMutate: () => void }) {
   const [filter, setFilter] = useState('');
-  const forceUpdate = useForceUpdate();
 
   const overrides = getFlagOverrides();
   const effective = getEffectiveFlags();
@@ -615,14 +637,10 @@ function FeatureFlagsTab() {
   }, [allKeys, filter]);
 
   const hasAnyOverride = Object.keys(overrides).length > 0;
+  const enabledCount = allKeys.filter((key) => effective[key]).length;
 
   return (
     <div className="flex flex-col gap-2.5">
-      <div className="text-body-sm text-muted-foreground">
-        Override <InlineCode>config.featureFlags</InlineCode> locally. Persists to <InlineCode>localStorage</InlineCode>{' '}
-        and re-applies on reload. Most components only read flags during render, so a reload is recommended after
-        toggling.
-      </div>
       <Input onChange={(e) => setFilter(e.target.value)} placeholder="Filter by flag name…" value={filter} />
       <div className="flex flex-wrap items-center gap-1.5">
         <Button icon={<RotateCw />} onClick={() => window.location.reload()} size="xs" variant="primary">
@@ -634,233 +652,316 @@ function FeatureFlagsTab() {
           onClick={() => {
             clearFlagOverrides();
             toast.success('Cleared all feature-flag overrides');
-            forceUpdate();
+            onMutate();
           }}
           size="xs"
           variant="destructive-ghost"
         >
           Clear all overrides ({Object.keys(overrides).length})
         </Button>
+        <div className="ml-auto text-body-sm text-muted-foreground">
+          {enabledCount} of {allKeys.length} on
+        </div>
       </div>
-      <div className="overflow-hidden rounded-md border">
-        {filtered.length === 0 ? (
+      {filtered.length === 0 ? (
+        <div className="rounded-md border">
           <EmptyState>No flags match “{filter}”.</EmptyState>
-        ) : (
-          filtered.map((key) => {
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 gap-2">
+          {filtered.map((key) => {
             const isOverridden = key in overrides;
             const defaultValue = FEATURE_FLAGS[key];
             const effectiveValue = effective[key];
             return (
-              <div className="flex items-center gap-2.5 border-b px-3 py-1.5 last:border-0" key={key}>
-                <Switch
-                  checked={effectiveValue}
-                  onCheckedChange={(checked) => {
-                    setFlagOverride(key, checked);
-                    forceUpdate();
-                  }}
-                />
-                <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-                  <div className="flex flex-wrap items-center gap-1.5">
-                    <code className="font-medium font-mono text-xs">{key}</code>
-                    {isOverridden && (
-                      <Badge size="sm" variant="warning-inverted">
-                        overridden
-                      </Badge>
-                    )}
-                  </div>
-                  <div className="text-body-sm text-muted-foreground">
-                    default: <InlineCode>{String(defaultValue)}</InlineCode> · effective:{' '}
-                    <InlineCode>{String(effectiveValue)}</InlineCode>
-                  </div>
-                </div>
-                {isOverridden && (
-                  <Button
-                    onClick={() => {
-                      setFlagOverride(key, null);
-                      forceUpdate();
-                    }}
-                    size="xs"
-                    variant="secondary-ghost"
-                  >
-                    Reset
-                  </Button>
+              <Item
+                className={cn(
+                  'flex-col items-stretch gap-2 transition-colors',
+                  effectiveValue ? 'border-outline-success bg-background-success-subtle/50' : 'bg-muted/40'
                 )}
-              </div>
+                key={key}
+                size="xs"
+                variant="outline"
+              >
+                {/* Fixed h-5 so the row height doesn't jump when the badge (h-5) appears. */}
+                <div className="flex h-5 min-w-0 items-center gap-1.5">
+                  <code
+                    className={cn(
+                      'min-w-0 flex-1 truncate font-medium font-mono text-xs',
+                      !effectiveValue && 'text-muted-foreground'
+                    )}
+                    title={key}
+                  >
+                    {key}
+                  </code>
+                  {isOverridden && (
+                    <Badge className="shrink-0" size="sm" variant="warning-inverted">
+                      overridden
+                    </Badge>
+                  )}
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <FlagToggle
+                    checked={effectiveValue}
+                    id={`flag-toggle-${key}`}
+                    onCheckedChange={(checked) => {
+                      setFlagOverride(key, checked);
+                      onMutate();
+                    }}
+                  />
+                  {isOverridden && (
+                    <Button
+                      onClick={() => {
+                        setFlagOverride(key, null);
+                        onMutate();
+                      }}
+                      size="xs"
+                      variant="secondary-ghost"
+                    >
+                      Reset
+                    </Button>
+                  )}
+                  <span className="ml-auto shrink-0 text-body-sm text-muted-foreground">
+                    default {defaultValue ? 'on' : 'off'}
+                  </span>
+                </div>
+              </Item>
             );
-          })
-        )}
-      </div>
+          })}
+        </div>
+      )}
     </div>
   );
 }
 
-type SubTab = { value: string; label: string; icon: React.ReactNode; content: React.ReactNode };
+type PanelId = 'overview' | 'simulate' | 'visual' | 'flags' | 'storage' | 'env' | 'configs';
 
-// Second-level underline tabs, flush against the top-level bar. The inner content gets its own padding.
-function SubTabs({ tabs }: { tabs: SubTab[] }) {
-  const [active, setActive] = useState(tabs[0]?.value ?? '');
+const PANEL_META: Record<PanelId, { title: string; description: string }> = {
+  overview: {
+    title: 'Overview',
+    description: 'Live status of every debug subsystem. Select a row to open it.',
+  },
+  simulate: {
+    title: 'Simulate',
+    description: 'Trigger app-level side effects to verify toasts, error boundaries, and console output.',
+  },
+  visual: {
+    title: 'Visual debuggers',
+    description:
+      'CSS-only overlays on the whole document, this dialog included. They persist for this browser tab and re-apply on reload.',
+  },
+  flags: {
+    title: 'Feature flags',
+    description:
+      'Override config.featureFlags locally. Overrides persist to localStorage; reload after toggling — most components read flags during render.',
+  },
+  storage: {
+    title: 'Storage',
+    description: 'Inspect or clear localStorage and sessionStorage. Clearing resets preferences and feature toggles.',
+  },
+  env: {
+    title: 'Environment',
+    description: 'Build, route, and runtime snapshot. Copy it into bug reports.',
+  },
+  configs: {
+    title: 'Connect configs',
+    description:
+      'Pre-built pipeline YAMLs for stress-testing the editor and validation. Copy one, then paste it into the editor on the create or edit page.',
+  },
+};
 
-  if (tabs.length <= 1) {
-    return <div className="px-4 py-4">{tabs[0]?.content}</div>;
-  }
+const NAV_GROUPS: { label: string; items: { id: PanelId; label: string; icon: React.ReactNode }[] }[] = [
+  {
+    label: 'General',
+    items: [
+      { id: 'overview', label: 'Overview', icon: <Info className="h-3.5 w-3.5 shrink-0" /> },
+      { id: 'simulate', label: 'Simulate', icon: <Zap className="h-3.5 w-3.5 shrink-0" /> },
+    ],
+  },
+  {
+    label: 'Toggles',
+    items: [
+      { id: 'visual', label: 'Visual', icon: <Eye className="h-3.5 w-3.5 shrink-0" /> },
+      { id: 'flags', label: 'Feature flags', icon: <Flag className="h-3.5 w-3.5 shrink-0" /> },
+    ],
+  },
+  {
+    label: 'Inspect',
+    items: [
+      { id: 'storage', label: 'Storage', icon: <Database className="h-3.5 w-3.5 shrink-0" /> },
+      { id: 'env', label: 'Environment', icon: <Cog className="h-3.5 w-3.5 shrink-0" /> },
+    ],
+  },
+  {
+    label: 'Connect',
+    items: [{ id: 'configs', label: 'Configs', icon: <FileCode className="h-3.5 w-3.5 shrink-0" /> }],
+  },
+];
+
+function OverviewPanel({ onNavigate }: { onNavigate: (panel: PanelId) => void }) {
+  const overlayCount = getEnabledVisualDebuggers().length;
+  const overrideCount = Object.keys(getFlagOverrides()).length;
+  const sha = env.REACT_APP_CONSOLE_GIT_SHA ? env.REACT_APP_CONSOLE_GIT_SHA.slice(0, 7) : 'local dev build';
+
+  const rows: { panel: PanelId; icon: React.ReactNode; label: string; value: string; active: boolean }[] = [
+    {
+      panel: 'visual',
+      icon: <Eye className="h-4 w-4" />,
+      label: 'Visual debuggers',
+      value: overlayCount > 0 ? `${overlayCount} overlay${overlayCount === 1 ? '' : 's'} enabled` : 'None enabled',
+      active: overlayCount > 0,
+    },
+    {
+      panel: 'flags',
+      icon: <Flag className="h-4 w-4" />,
+      label: 'Feature flags',
+      value: overrideCount > 0 ? `${overrideCount} overridden` : 'All defaults',
+      active: overrideCount > 0,
+    },
+    {
+      panel: 'storage',
+      icon: <Database className="h-4 w-4" />,
+      label: 'Browser storage',
+      value: `${window.localStorage.length} local · ${window.sessionStorage.length} session keys`,
+      active: false,
+    },
+    {
+      panel: 'env',
+      icon: <Cog className="h-4 w-4" />,
+      label: 'Build',
+      value: sha,
+      active: false,
+    },
+  ];
 
   return (
-    <Tabs className="gap-0" onValueChange={setActive} value={active}>
-      <div className="sticky top-10 z-10 bg-muted/40 backdrop-blur-sm">
-        <TabsList className="bg-transparent" variant="underline">
-          {tabs.map(({ value, label, icon }) => (
-            <TabsTrigger key={value} value={value} variant="underline">
-              {icon}
-              {label}
-            </TabsTrigger>
-          ))}
-        </TabsList>
-      </div>
-      <div className="px-4 py-4">
-        {tabs.map(({ value, content }) => (
-          <TabsContent key={value} value={value}>
-            {content}
-          </TabsContent>
-        ))}
-      </div>
-    </Tabs>
+    <ItemGroup className="overflow-hidden rounded-md border">
+      {rows.map(({ panel, icon, label, value, active }, index) => (
+        <Fragment key={panel}>
+          {/* Rendered as a bare bottom border (not the divider token) so it picks up the same
+              default border-color as the surrounding `border` container in both themes. */}
+          {index > 0 ? <ItemSeparator className="border-b bg-transparent" /> : null}
+          <Item
+            className="cursor-pointer rounded-none border-0 text-left hover:bg-muted/50"
+            render={<button onClick={() => onNavigate(panel)} type="button" />}
+            size="sm"
+          >
+            <ItemMedia variant="icon">{icon}</ItemMedia>
+            <ItemContent className="gap-0.5">
+              <ItemTitle>{label}</ItemTitle>
+              <ItemDescription>{value}</ItemDescription>
+            </ItemContent>
+            {active ? (
+              <Badge size="sm" variant="warning-inverted">
+                active
+              </Badge>
+            ) : null}
+            <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          </Item>
+        </Fragment>
+      ))}
+    </ItemGroup>
   );
 }
-
-function OverviewTab() {
-  return (
-    <div className="flex flex-col gap-4">
-      <div className="text-body-sm text-muted-foreground">
-        A development-only toolbox for exercising Console's UI and inspecting local state. It ships in dev builds only
-        and is never bundled into production.
-      </div>
-
-      <DebugSection title="What's inside">
-        <ul className="flex flex-col gap-1.5">
-          <li className="text-muted-foreground text-sm">
-            <strong className="text-foreground">General</strong> — simulate toasts and errors, toggle visual debug
-            overlays (grayscale, outlines, grid…), inspect or clear browser storage, and snapshot the build and runtime
-            environment.
-          </li>
-          <li className="text-muted-foreground text-sm">
-            <strong className="text-foreground">Flags</strong> — override feature flags locally; changes persist to
-            localStorage and re-apply on reload.
-          </li>
-          <li className="text-muted-foreground text-sm">
-            <strong className="text-foreground">Connect</strong> — copy pre-built pipeline YAMLs to stress-test the
-            editor and validation.
-          </li>
-        </ul>
-      </DebugSection>
-
-      <DebugSection title="Tips">
-        <span className="flex flex-wrap items-center gap-1.5 text-muted-foreground text-sm">
-          Toggle this dialog anytime with
-          <KbdGroup>
-            <Kbd size="xs">⌃/⌘</Kbd>
-            <Kbd size="xs">⇧</Kbd>
-            <Kbd size="xs">D</Kbd>
-          </KbdGroup>
-        </span>
-      </DebugSection>
-    </div>
-  );
-}
-
-function GeneralTab({ onClose }: { onClose: () => void }) {
-  return (
-    <SubTabs
-      tabs={[
-        { value: 'overview', label: 'Overview', icon: <Info className="mr-1 h-3 w-3" />, content: <OverviewTab /> },
-        {
-          value: 'simulate',
-          label: 'Simulate',
-          icon: <Zap className="mr-1 h-3 w-3" />,
-          content: <SimulateTab onClose={onClose} />,
-        },
-        { value: 'visual', label: 'Visual', icon: <Eye className="mr-1 h-3 w-3" />, content: <VisualTab /> },
-        { value: 'storage', label: 'Storage', icon: <Trash2 className="mr-1 h-3 w-3" />, content: <StorageTab /> },
-        { value: 'env', label: 'Env', icon: <Cog className="mr-1 h-3 w-3" />, content: <EnvironmentTab /> },
-      ]}
-    />
-  );
-}
-
-function ConnectTab() {
-  return (
-    <SubTabs
-      tabs={[
-        {
-          value: 'configs',
-          label: 'Configs',
-          icon: <FileCode className="mr-1 h-3 w-3" />,
-          content: <ConnectConfigsTab />,
-        },
-      ]}
-    />
-  );
-}
-
-type Tab = 'general' | 'flags' | 'connect';
 
 export function DebugDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) {
-  const [tab, setTab] = useState<Tab>('general');
+  const [panel, setPanel] = useState<PanelId>('overview');
+  const forceUpdate = useForceUpdate();
 
   const close = useCallback(() => onOpenChange(false), [onOpenChange]);
 
+  // Live counts surface in the nav rail so active subsystems are visible from anywhere.
+  const railCounts: Partial<Record<PanelId, number>> = {
+    visual: getEnabledVisualDebuggers().length,
+    flags: Object.keys(getFlagOverrides()).length,
+  };
+
+  const renderPanel = () => {
+    switch (panel) {
+      case 'overview':
+        return <OverviewPanel onNavigate={setPanel} />;
+      case 'simulate':
+        return <SimulatePanel onClose={close} />;
+      case 'visual':
+        return <VisualPanel onMutate={forceUpdate} />;
+      case 'flags':
+        return <FeatureFlagsPanel onMutate={forceUpdate} />;
+      case 'storage':
+        return <StoragePanel />;
+      case 'env':
+        return <EnvironmentPanel />;
+      case 'configs':
+        return <ConnectConfigsPanel />;
+      default:
+        return null;
+    }
+  };
+
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogContent height="xl" size="xl">
+      <DialogContent className="sm:max-w-5xl" height="xl" size="xl">
         <DialogHeader align="left" spacing="tight">
           <DialogTitle className="flex items-center gap-2">
             <Bug className="h-4 w-4" />
             Debug helpers
+            <Badge size="sm" variant="simple-outline">
+              dev only
+            </Badge>
           </DialogTitle>
         </DialogHeader>
 
-        <DialogBody padding="none" scrollShadow={false}>
-          <Tabs className="gap-0" onValueChange={(v) => setTab(v as Tab)} value={tab}>
-            <div className="sticky top-0 z-20 bg-background">
-              <TabsList variant="underline">
-                <TabsTrigger value="general" variant="underline">
-                  <Wrench className="mr-1 h-3 w-3" /> General
-                </TabsTrigger>
-                <TabsTrigger value="flags" variant="underline">
-                  <Flag className="mr-1 h-3 w-3" /> Flags
-                </TabsTrigger>
-                <TabsTrigger value="connect" variant="underline">
-                  <AppWindow className="mr-1 h-3 w-3" /> Connect
-                </TabsTrigger>
-              </TabsList>
+        <div className="flex min-h-0 flex-1 border-t">
+          <nav aria-label="Debug sections" className="flex w-44 shrink-0 flex-col border-r bg-muted/30">
+            <div className="flex flex-1 flex-col gap-3 overflow-y-auto p-2">
+              {NAV_GROUPS.map(({ label, items }) => (
+                <div key={label}>
+                  <div className="px-2 pb-1 font-semibold text-[10px] text-muted-foreground/70 uppercase tracking-wider">
+                    {label}
+                  </div>
+                  <div className="flex flex-col gap-0.5">
+                    {items.map(({ id, label: itemLabel, icon }) => {
+                      const count = railCounts[id] ?? 0;
+                      const active = panel === id;
+                      return (
+                        <button
+                          className={cn(
+                            'flex h-7 w-full cursor-pointer items-center gap-2 rounded-md px-2 text-left text-body-sm transition-colors',
+                            active
+                              ? 'bg-muted font-medium text-foreground'
+                              : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
+                          )}
+                          key={id}
+                          onClick={() => setPanel(id)}
+                          type="button"
+                        >
+                          {icon}
+                          <span className="min-w-0 flex-1 truncate">{itemLabel}</span>
+                          <CountDot count={count} size="sm" variant="warning" />
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
             </div>
+            <div className="flex items-center gap-1.5 border-t px-3 py-2 text-muted-foreground text-xs">
+              <KbdGroup>
+                <Kbd size="xs">⌃/⌘</Kbd>
+                <Kbd size="xs">⇧</Kbd>
+                <Kbd size="xs">D</Kbd>
+              </KbdGroup>
+              toggles
+            </div>
+          </nav>
 
-            <TabsContent value="general">
-              <GeneralTab onClose={close} />
-            </TabsContent>
-            <TabsContent value="flags">
-              <div className="px-4 py-4">
-                <FeatureFlagsTab />
-              </div>
-            </TabsContent>
-            <TabsContent value="connect">
-              <ConnectTab />
-            </TabsContent>
-          </Tabs>
-        </DialogBody>
-
-        <DialogFooter direction="row" justify="between">
-          <span className="flex items-center gap-2">
-            <div className="text-body-sm text-muted-foreground">toggle</div>
-            <KbdGroup>
-              <Kbd size="xs">⌃/⌘</Kbd>
-              <Kbd size="xs">⇧</Kbd>
-              <Kbd size="xs">D</Kbd>
-            </KbdGroup>
-          </span>
-          <Button onClick={close} size="sm" variant="secondary-ghost">
-            Close
-          </Button>
-        </DialogFooter>
+          <div className="flex min-w-0 flex-1 flex-col">
+            <div className="border-b px-5 pt-4 pb-3">
+              <div className="font-semibold text-body">{PANEL_META[panel].title}</div>
+              <div className="text-body-sm text-muted-foreground">{PANEL_META[panel].description}</div>
+            </div>
+            <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">{renderPanel()}</div>
+          </div>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/components/debug-helper/debug-dialog.tsx
+++ b/frontend/src/components/debug-helper/debug-dialog.tsx
@@ -65,6 +65,12 @@ import {
   getOverrides as getFlagOverrides,
   setOverride as setFlagOverride,
 } from './feature-flag-overrides';
+import {
+  clearVisualDebuggers,
+  getEnabledVisualDebuggers,
+  setVisualDebugger,
+  VISUAL_DEBUGGERS,
+} from './visual-debuggers';
 import { useHotKey } from '../../hooks/use-hot-key';
 import env, { IsDev } from '../../utils/env';
 import { FEATURE_FLAGS } from '../constants';
@@ -321,6 +327,52 @@ function SimulateTab({ onClose }: { onClose: () => void }) {
       </DebugSection>
 
       {renderThrow && <ErrorThrower />}
+    </div>
+  );
+}
+
+function VisualTab() {
+  const forceUpdate = useForceUpdate();
+  const enabled = getEnabledVisualDebuggers();
+
+  return (
+    <div className="flex flex-col gap-2.5">
+      <div className="text-body-sm text-muted-foreground">
+        CSS-only overlays applied to the whole document, including this dialog. They persist for this browser tab and
+        re-apply on reload; a new tab starts clean.
+      </div>
+      <div>
+        <Button
+          disabled={enabled.length === 0}
+          icon={<Trash2 />}
+          onClick={() => {
+            clearVisualDebuggers();
+            toast.success('Disabled all visual debuggers');
+            forceUpdate();
+          }}
+          size="xs"
+          variant="destructive-ghost"
+        >
+          Disable all ({enabled.length})
+        </Button>
+      </div>
+      <div className="overflow-hidden rounded-md border">
+        {VISUAL_DEBUGGERS.map(({ id, label, description }) => (
+          <div className="flex items-center gap-2.5 border-b px-3 py-1.5 last:border-0" key={id}>
+            <Switch
+              checked={enabled.includes(id)}
+              onCheckedChange={(checked) => {
+                setVisualDebugger(id, checked);
+                forceUpdate();
+              }}
+            />
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+              <div className="font-medium text-body-sm">{label}</div>
+              <div className="text-body-sm text-muted-foreground">{description}</div>
+            </div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }
@@ -686,8 +738,9 @@ function OverviewTab() {
       <DebugSection title="What's inside">
         <ul className="flex flex-col gap-1.5">
           <li className="text-muted-foreground text-sm">
-            <strong className="text-foreground">General</strong> — simulate toasts and errors, inspect or clear browser
-            storage, and snapshot the build and runtime environment.
+            <strong className="text-foreground">General</strong> — simulate toasts and errors, toggle visual debug
+            overlays (grayscale, outlines, grid…), inspect or clear browser storage, and snapshot the build and runtime
+            environment.
           </li>
           <li className="text-muted-foreground text-sm">
             <strong className="text-foreground">Flags</strong> — override feature flags locally; changes persist to
@@ -725,6 +778,7 @@ function GeneralTab({ onClose }: { onClose: () => void }) {
           icon: <Zap className="mr-1 h-3 w-3" />,
           content: <SimulateTab onClose={onClose} />,
         },
+        { value: 'visual', label: 'Visual', icon: <Eye className="mr-1 h-3 w-3" />, content: <VisualTab /> },
         { value: 'storage', label: 'Storage', icon: <Trash2 className="mr-1 h-3 w-3" />, content: <StorageTab /> },
         { value: 'env', label: 'Env', icon: <Cog className="mr-1 h-3 w-3" />, content: <EnvironmentTab /> },
       ]}

--- a/frontend/src/components/debug-helper/debug-dialog.tsx
+++ b/frontend/src/components/debug-helper/debug-dialog.tsx
@@ -37,7 +37,6 @@ import { Table, TableBody, TableCell, TableRow } from 'components/redpanda-ui/co
 import { InlineCode } from 'components/redpanda-ui/components/typography';
 import { cn } from 'components/redpanda-ui/lib/utils';
 import {
-  Bug,
   Check,
   ChevronDown,
   ChevronRight,
@@ -58,6 +57,7 @@ import { createPortal } from 'react-dom';
 import { toast } from 'sonner';
 
 import { CONNECT_CONFIG_FIXTURES, type ConnectConfigFixture } from './connect-config-fixtures';
+import { DebugPanda } from './debug-panda';
 import {
   clearOverrides as clearFlagOverrides,
   getAllFlagKeys,
@@ -905,7 +905,7 @@ export function DebugDialog({ open, onOpenChange }: { open: boolean; onOpenChang
       <DialogContent className="sm:max-w-5xl" height="xl" size="xl">
         <DialogHeader align="left" spacing="tight">
           <DialogTitle className="flex items-center gap-2">
-            <Bug className="h-4 w-4" />
+            <DebugPanda className="h-5 w-5" />
             Debug helpers
             <Badge size="sm" variant="simple-outline">
               dev only
@@ -981,12 +981,12 @@ function DebugLauncher({ onClick }: { onClick: () => void }) {
   return createPortal(
     <button
       aria-label="Open debug helpers (Ctrl/Cmd+Shift+D)"
-      className="fixed right-[52px] bottom-[68px] z-40 flex h-[32px] w-[32px] cursor-pointer items-center justify-center rounded-full border bg-background text-muted-foreground opacity-70 shadow-md transition-all hover:text-foreground hover:opacity-100 hover:shadow-lg"
+      className="fixed right-[56px] bottom-[64px] z-40 flex h-[40px] w-[40px] cursor-pointer items-center justify-center rounded-full border bg-gradient-to-b from-background to-muted text-muted-foreground opacity-85 shadow-md transition-all hover:text-foreground hover:opacity-100 hover:shadow-lg"
       onClick={onClick}
       title="Debug helpers — ⌃/⌘⇧D"
       type="button"
     >
-      <Bug className="h-[16px] w-[16px]" />
+      <DebugPanda className="h-[22px] w-[22px]" />
       {activeCount > 0 && (
         <CountDot className="absolute -top-1 -right-1" count={activeCount} size="sm" variant="warning" />
       )}

--- a/frontend/src/components/debug-helper/debug-helper.tsx
+++ b/frontend/src/components/debug-helper/debug-helper.tsx
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { lazy, Suspense } from 'react';
+
+// Eager on purpose: the flag-override accessor must replace config.featureFlags
+// before the first render reads it, and persisted visual-debugger classes should
+// re-apply before paint. Both modules are tiny and self-guard on IsDev, so they
+// cost a few KB in production but never run there.
+import './feature-flag-overrides';
+import './visual-debuggers';
+
+import { IsDev } from '../../utils/env';
+
+// The dialog UI and its Connect YAML fixtures are the heavy part (~100KB of
+// source). They load as a separate chunk that production users never fetch —
+// gated at runtime (not build time) so a REACT_APP_DEV_HINT build can still
+// summon the helpers.
+const LazyDebugHelper = lazy(() => import('./debug-dialog').then((m) => ({ default: m.DebugHelper })));
+
+export function DebugHelper() {
+  if (!IsDev) {
+    return null;
+  }
+  return (
+    <Suspense fallback={null}>
+      <LazyDebugHelper />
+    </Suspense>
+  );
+}

--- a/frontend/src/components/debug-helper/debug-helper.tsx
+++ b/frontend/src/components/debug-helper/debug-helper.tsx
@@ -13,18 +13,15 @@ import { lazy, Suspense } from 'react';
 
 // Eager on purpose: the flag-override accessor must replace config.featureFlags
 // before the first render reads it, and persisted visual-debugger classes should
-// re-apply before paint. Both modules are tiny and self-guard on IsDev, so they
-// cost a few KB in production but never run there.
+// re-apply before paint. Both self-guard on IsDev.
 import './feature-flag-overrides';
 import './visual-debuggers';
 
 import { IsDev } from '../../utils/env';
 
-// The dialog UI and its Connect YAML fixtures are the heavy part (~100KB of
-// source). They load as a separate chunk that production users never fetch —
-// gated at runtime (not build time) so a REACT_APP_DEV_HINT build can still
-// summon the helpers.
-const LazyDebugHelper = lazy(() => import('./debug-dialog').then((m) => ({ default: m.DebugHelper })));
+// The dialog UI and its YAML fixtures load as a separate chunk that production
+// never fetches — gated at runtime so a REACT_APP_DEV_HINT build still works.
+const LazyDebugHelper = lazy(() => import('./debug-dialog').then((m) => ({ default: m.DebugHelperRoot })));
 
 export function DebugHelper() {
   if (!IsDev) {

--- a/frontend/src/components/debug-helper/debug-panda.tsx
+++ b/frontend/src/components/debug-helper/debug-panda.tsx
@@ -10,27 +10,25 @@
  */
 
 /**
- * Mascot for the dev-only debug helpers: a small flat red-panda face. Drawn to
- * stay legible from 16px up — bold shapes, no strokes thinner than ~1px at 1x.
- * Decorative only; hosts provide their own accessible labels.
+ * Debug-helpers mascot: a flat red panda peering through a magnifying glass,
+ * drawn to stay legible from 16px up. Decorative — hosts provide the labels.
  */
 export function DebugPanda({ className }: { className?: string }) {
   return (
     <svg aria-hidden="true" className={className} fill="none" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
-      {/* ears — sharp triangles whose bases sit inside the head ellipse, so the
-          head drawn after them covers the joint and they connect seamlessly */}
+      {/* ears — bases sit inside the head ellipse so the head covers the joint */}
       <path d="M4.6 3.4 12.5 8.8 6 13.5Z" fill="#A34424" />
       <path d="M27.4 3.4 19.5 8.8 26 13.5Z" fill="#A34424" />
       <path d="M5.7 5 10.3 8.1 7 10.6Z" fill="#FCF0E4" />
       <path d="M26.3 5 21.7 8.1 25 10.6Z" fill="#FCF0E4" />
-      {/* head — fills the canvas, no rim stroke */}
+      {/* head */}
       <ellipse cx="16" cy="19" fill="#DE6B35" rx="12.5" ry="11" />
       {/* cream face mask */}
       <ellipse cx="16" cy="24" fill="#FCF0E4" rx="9.5" ry="6" />
       <circle cx="10" cy="14.4" fill="#FCF0E4" r="2.2" />
       {/* sclera behind the magnified eye — reads as the eye seen through the lens */}
       <circle cx="21.4" cy="16.8" fill="#FCF0E4" r="4.3" />
-      {/* cheek tear-streak (left only — the lens owns the right side) */}
+      {/* tear-streak (left only; the lens owns the right side) */}
       <path d="M10.6 20.6c-.4 2-1.2 3.6-2.4 5.2" stroke="#C75B2F" strokeLinecap="round" strokeWidth="2" />
       {/* bare eye (left) */}
       <circle cx="10.4" cy="17" fill="#43241B" r="1.8" />

--- a/frontend/src/components/debug-helper/debug-panda.tsx
+++ b/frontend/src/components/debug-helper/debug-panda.tsx
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+/**
+ * Mascot for the dev-only debug helpers: a small flat red-panda face. Drawn to
+ * stay legible from 16px up — bold shapes, no strokes thinner than ~1px at 1x.
+ * Decorative only; hosts provide their own accessible labels.
+ */
+export function DebugPanda({ className }: { className?: string }) {
+  return (
+    <svg aria-hidden="true" className={className} fill="none" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+      {/* ears — sharp triangles whose bases sit inside the head ellipse, so the
+          head drawn after them covers the joint and they connect seamlessly */}
+      <path d="M4.6 3.4 12.5 8.8 6 13.5Z" fill="#A34424" />
+      <path d="M27.4 3.4 19.5 8.8 26 13.5Z" fill="#A34424" />
+      <path d="M5.7 5 10.3 8.1 7 10.6Z" fill="#FCF0E4" />
+      <path d="M26.3 5 21.7 8.1 25 10.6Z" fill="#FCF0E4" />
+      {/* head — fills the canvas, no rim stroke */}
+      <ellipse cx="16" cy="19" fill="#DE6B35" rx="12.5" ry="11" />
+      {/* cream face mask */}
+      <ellipse cx="16" cy="24" fill="#FCF0E4" rx="9.5" ry="6" />
+      <circle cx="10" cy="14.4" fill="#FCF0E4" r="2.2" />
+      {/* sclera behind the magnified eye — reads as the eye seen through the lens */}
+      <circle cx="21.4" cy="16.8" fill="#FCF0E4" r="4.3" />
+      {/* cheek tear-streak (left only — the lens owns the right side) */}
+      <path d="M10.6 20.6c-.4 2-1.2 3.6-2.4 5.2" stroke="#C75B2F" strokeLinecap="round" strokeWidth="2" />
+      {/* bare eye (left) */}
+      <circle cx="10.4" cy="17" fill="#43241B" r="1.8" />
+      <circle cx="11" cy="16.4" fill="#FFFFFF" r="0.6" />
+      {/* nose + mouth, nudged left to balance the lens */}
+      <path
+        d="M13.6 21.6h2.8a.85.85 0 0 1 .66 1.38l-1.4 1.68a.9.9 0 0 1-1.38 0l-1.4-1.68a.85.85 0 0 1 .66-1.38Z"
+        fill="#43241B"
+      />
+      <path d="M13 26c1.35 1 2.65 1 4 0" stroke="#43241B" strokeLinecap="round" strokeWidth="1" />
+      {/* magnifying glass over the right eye — the eye behind it drawn magnified */}
+      <circle cx="21.6" cy="16.6" fill="#CDE7F2" fillOpacity="0.3" r="6" />
+      <circle cx="21.3" cy="17.2" fill="#43241B" r="3.2" />
+      <circle cx="22.5" cy="16" fill="#FFFFFF" r="1" />
+      <line stroke="#56677A" strokeLinecap="round" strokeWidth="2.5" x1="25.8" x2="29.4" y1="20.8" y2="24.4" />
+      <circle cx="21.6" cy="16.6" fill="none" r="6" stroke="#56677A" strokeWidth="2" />
+    </svg>
+  );
+}

--- a/frontend/src/components/debug-helper/visual-debuggers.ts
+++ b/frontend/src/components/debug-helper/visual-debuggers.ts
@@ -1,0 +1,193 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { IsDev } from '../../utils/env';
+
+export type VisualDebuggerId = 'grayscale' | 'outlines' | 'blur' | 'grid' | 'no-motion' | 'testids' | 'a11y';
+
+export type VisualDebugger = {
+  id: VisualDebuggerId;
+  label: string;
+  description: string;
+};
+
+export const VISUAL_DEBUGGERS: VisualDebugger[] = [
+  {
+    id: 'grayscale',
+    label: 'Grayscale',
+    description: 'Render the whole app in grayscale to check contrast and that nothing relies on color alone.',
+  },
+  {
+    id: 'outlines',
+    label: 'Element outlines',
+    description: 'Lime outline on every element to reveal layout structure, nesting depth, and phantom wrappers.',
+  },
+  {
+    id: 'blur',
+    label: 'Squint test (blur)',
+    description: 'Blur the app to judge visual hierarchy — what still reads is what actually has weight.',
+  },
+  {
+    id: 'grid',
+    label: '8px baseline grid',
+    description: 'Overlay an 8px grid to spot spacing and alignment drift.',
+  },
+  {
+    id: 'no-motion',
+    label: 'Disable animations',
+    description:
+      'Force CSS animations and transitions to near-zero duration to catch flicker and bad resting states. Completion events still fire.',
+  },
+  {
+    id: 'testids',
+    label: 'Missing test IDs',
+    description: 'Dashed orange outline on interactive elements without data-testid — Playwright selector gaps.',
+  },
+  {
+    id: 'a11y',
+    label: 'A11y smells',
+    description:
+      'Dashed red outline on CSS-detectable issues: images without alt, empty unlabeled buttons/links, positive tabindex.',
+  },
+];
+
+const STORAGE_KEY = '__debug_visual_debuggers';
+const STYLE_ELEMENT_ID = '__debug-visual-styles';
+
+// Filters on the root element do NOT create a containing block for fixed-position
+// descendants (unlike on any other element), so grayscale/blur on <html> won't
+// break dialogs, toasts, or sticky headers.
+const DEBUG_CSS = `
+html.__debug-grayscale { filter: grayscale(1); }
+html.__debug-blur { filter: blur(3px); }
+html.__debug-grayscale.__debug-blur { filter: grayscale(1) blur(3px); }
+
+html.__debug-outlines * {
+  outline: 1px solid #84cc16 !important;
+  outline-offset: -1px !important;
+}
+
+html.__debug-grid::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 2147483647;
+  pointer-events: none;
+  background-image:
+    repeating-linear-gradient(to right, rgba(217, 70, 239, 0.25) 0 1px, transparent 1px 8px),
+    repeating-linear-gradient(to bottom, rgba(217, 70, 239, 0.25) 0 1px, transparent 1px 8px);
+}
+
+html.__debug-no-motion *,
+html.__debug-no-motion *::before,
+html.__debug-no-motion *::after {
+  animation-duration: 0.01ms !important;
+  animation-delay: 0ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.01ms !important;
+  transition-delay: 0ms !important;
+  scroll-behavior: auto !important;
+}
+
+html.__debug-testids :is(button, a[href], input, select, textarea, [role='button'], [role='tab'], [role='menuitem'], [role='switch'], [role='checkbox'], [role='combobox']):not([data-testid]) {
+  outline: 2px dashed #f97316 !important;
+  outline-offset: 1px !important;
+}
+
+html.__debug-a11y img:not([alt]),
+html.__debug-a11y :is(button, a):empty:not([aria-label]):not([aria-labelledby]):not([title]),
+html.__debug-a11y [tabindex]:not([tabindex='0']):not([tabindex='-1']) {
+  outline: 2px dashed #ef4444 !important;
+  outline-offset: 1px !important;
+}
+`;
+
+const KNOWN_IDS: ReadonlySet<string> = new Set(VISUAL_DEBUGGERS.map((d) => d.id));
+
+function classFor(id: VisualDebuggerId): string {
+  return `__debug-${id}`;
+}
+
+function readEnabled(): VisualDebuggerId[] {
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter((id): id is VisualDebuggerId => typeof id === 'string' && KNOWN_IDS.has(id));
+  } catch {
+    return [];
+  }
+}
+
+function writeEnabled(ids: VisualDebuggerId[]): void {
+  if (ids.length === 0) {
+    window.sessionStorage.removeItem(STORAGE_KEY);
+  } else {
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+  }
+}
+
+function ensureStyles(): void {
+  if (document.getElementById(STYLE_ELEMENT_ID)) {
+    return;
+  }
+  const el = document.createElement('style');
+  el.id = STYLE_ELEMENT_ID;
+  el.textContent = DEBUG_CSS;
+  document.head.appendChild(el);
+}
+
+function applyDomState(enabled: VisualDebuggerId[]): void {
+  ensureStyles();
+  for (const { id } of VISUAL_DEBUGGERS) {
+    document.documentElement.classList.toggle(classFor(id), enabled.includes(id));
+  }
+}
+
+export function getEnabledVisualDebuggers(): VisualDebuggerId[] {
+  return readEnabled();
+}
+
+export function setVisualDebugger(id: VisualDebuggerId, enabled: boolean): void {
+  const current = new Set(readEnabled());
+  if (enabled) {
+    current.add(id);
+  } else {
+    current.delete(id);
+  }
+  // Keep storage in the registry's declaration order so re-apply is deterministic.
+  const next = VISUAL_DEBUGGERS.map((d) => d.id).filter((d) => current.has(d));
+  writeEnabled(next);
+  applyDomState(next);
+}
+
+export function clearVisualDebuggers(): void {
+  writeEnabled([]);
+  applyDomState([]);
+}
+
+// Re-apply persisted debuggers at module load so a reload keeps the overlays
+// without waiting for the dialog to mount.
+if (IsDev && typeof window !== 'undefined') {
+  try {
+    const enabled = readEnabled();
+    if (enabled.length > 0) {
+      applyDomState(enabled);
+    }
+  } catch {
+    // sessionStorage / DOM unavailable.
+  }
+}

--- a/frontend/src/components/debug-helper/visual-debuggers.ts
+++ b/frontend/src/components/debug-helper/visual-debuggers.ts
@@ -62,9 +62,8 @@ export const VISUAL_DEBUGGERS: VisualDebugger[] = [
 const STORAGE_KEY = '__debug_visual_debuggers';
 const STYLE_ELEMENT_ID = '__debug-visual-styles';
 
-// Filters on the root element do NOT create a containing block for fixed-position
-// descendants (unlike on any other element), so grayscale/blur on <html> won't
-// break dialogs, toasts, or sticky headers.
+// Root-element filters don't create a containing block for fixed-position
+// descendants, so grayscale/blur on <html> won't break dialogs or toasts.
 const DEBUG_CSS = `
 html.__debug-grayscale { filter: grayscale(1); }
 html.__debug-blur { filter: blur(3px); }
@@ -168,7 +167,6 @@ export function setVisualDebugger(id: VisualDebuggerId, enabled: boolean): void 
   } else {
     current.delete(id);
   }
-  // Keep storage in the registry's declaration order so re-apply is deterministic.
   const next = VISUAL_DEBUGGERS.map((d) => d.id).filter((d) => current.has(d));
   writeEnabled(next);
   applyDomState(next);
@@ -179,8 +177,7 @@ export function clearVisualDebuggers(): void {
   applyDomState([]);
 }
 
-// Re-apply persisted debuggers at module load so a reload keeps the overlays
-// without waiting for the dialog to mount.
+// Re-apply persisted debuggers at module load so overlays survive a reload.
 if (IsDev && typeof window !== 'undefined') {
   try {
     const enabled = readEnabled();

--- a/frontend/src/components/debug-helper/visual-debuggers.ts
+++ b/frontend/src/components/debug-helper/visual-debuggers.ts
@@ -11,7 +11,7 @@
 
 import { IsDev } from '../../utils/env';
 
-export type VisualDebuggerId = 'grayscale' | 'outlines' | 'blur' | 'grid' | 'no-motion' | 'testids' | 'a11y';
+export type VisualDebuggerId = 'grayscale' | 'outlines' | 'blur' | 'grid' | 'testids' | 'a11y';
 
 export type VisualDebugger = {
   id: VisualDebuggerId;
@@ -39,12 +39,6 @@ export const VISUAL_DEBUGGERS: VisualDebugger[] = [
     id: 'grid',
     label: '8px baseline grid',
     description: 'Overlay an 8px grid to spot spacing and alignment drift.',
-  },
-  {
-    id: 'no-motion',
-    label: 'Disable animations',
-    description:
-      'Force CSS animations and transitions to near-zero duration to catch flicker and bad resting states. Completion events still fire.',
   },
   {
     id: 'testids',
@@ -83,17 +77,6 @@ html.__debug-grid::after {
   background-image:
     repeating-linear-gradient(to right, rgba(217, 70, 239, 0.25) 0 1px, transparent 1px 8px),
     repeating-linear-gradient(to bottom, rgba(217, 70, 239, 0.25) 0 1px, transparent 1px 8px);
-}
-
-html.__debug-no-motion *,
-html.__debug-no-motion *::before,
-html.__debug-no-motion *::after {
-  animation-duration: 0.01ms !important;
-  animation-delay: 0ms !important;
-  animation-iteration-count: 1 !important;
-  transition-duration: 0.01ms !important;
-  transition-delay: 0ms !important;
-  scroll-behavior: auto !important;
 }
 
 html.__debug-testids :is(button, a[href], input, select, textarea, [role='button'], [role='tab'], [role='menuitem'], [role='switch'], [role='checkbox'], [role='combobox']):not([data-testid]) {

--- a/frontend/src/federation/federated-routes.tsx
+++ b/frontend/src/federation/federated-routes.tsx
@@ -14,7 +14,7 @@ import type { QueryClient } from '@tanstack/react-query';
 import { createRootRouteWithContext, Outlet, useLocation, useMatches } from '@tanstack/react-router';
 import { NuqsAdapter } from 'nuqs/adapters/tanstack-router';
 
-import { DebugHelper } from '../components/debug-helper/debug-dialog';
+import { DebugHelper } from '../components/debug-helper/debug-helper';
 import AppFooter from '../components/layout/footer';
 import AppPageHeader from '../components/layout/header';
 import { LicenseNotification } from '../components/license/license-notification';

--- a/frontend/src/globals.css
+++ b/frontend/src/globals.css
@@ -34,6 +34,42 @@
   --chakra-colors-chakra-border-color: var(--color-border);
 }
 
+/* Dev-only bottom-right cluster for floating debug triggers, raised clear of the
+   host's Feedback tab in the corner: the router-devtools pill (scaled down) sits
+   at bottom 48px, with the query-devtools circle and the Console debug-helpers
+   launcher (positioned via its own classes) in a horizontal row above it.
+   These selectors only match dev builds — inert in production. */
+/* The container carries 4px padding around the button — offset by -4 so the
+   visible circle sits at right 12 / bottom 68, flush with the launcher's grid. */
+.tsqd-open-btn-container {
+  right: 8px !important;
+  bottom: 64px !important;
+  opacity: 0.7;
+  transition: opacity 150ms;
+}
+.tsqd-open-btn-container:hover {
+  opacity: 1;
+}
+/* Compact the trigger to match the debug-helpers launcher (32px); the logo is a
+   viewBox svg, so it scales with the button. */
+.tsqd-open-btn,
+.tsqd-open-btn svg {
+  width: 32px !important;
+  height: 32px !important;
+}
+
+button[aria-label="Open TanStack Router Devtools"] {
+  right: 12px !important;
+  bottom: 36px !important;
+  transform: scale(0.85);
+  transform-origin: bottom right;
+  opacity: 0.7;
+  transition: opacity 150ms;
+}
+button[aria-label="Open TanStack Router Devtools"]:hover {
+  opacity: 1;
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/frontend/src/globals.css
+++ b/frontend/src/globals.css
@@ -35,9 +35,8 @@
 }
 
 /* Dev-only bottom-right cluster for floating debug triggers, raised clear of the
-   host's Feedback tab in the corner: the router-devtools pill (scaled down) sits
-   at bottom 48px, with the query-devtools circle and the Console debug-helpers
-   launcher (positioned via its own classes) in a horizontal row above it.
+   host's Feedback tab: router-devtools pill at the bottom, query-devtools circle
+   and the debug-helpers launcher (positioned via its own classes) in a row above.
    These selectors only match dev builds — inert in production. */
 /* The container carries 4px padding around the button — offset by -4 so the
    visible circle sits at right 12 / bottom 68, flush with the launcher's grid. */
@@ -50,8 +49,7 @@
 .tsqd-open-btn-container:hover {
   opacity: 1;
 }
-/* Compact the trigger to match the debug-helpers launcher (32px); the logo is a
-   viewBox svg, so it scales with the button. */
+/* Compact the trigger; the logo is a viewBox svg, so it scales with the button. */
 .tsqd-open-btn,
 .tsqd-open-btn svg {
   width: 32px !important;

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -19,7 +19,7 @@ import { TooltipProvider } from 'components/redpanda-ui/components/tooltip';
 import { isEmbedded } from 'config';
 import { NuqsAdapter } from 'nuqs/adapters/tanstack-router';
 
-import { DebugHelper } from '../components/debug-helper/debug-dialog';
+import { DebugHelper } from '../components/debug-helper/debug-helper';
 import AppFooter from '../components/layout/footer';
 import AppPageHeader from '../components/layout/header';
 import { SidebarLayout } from '../components/layout/sidebar';

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -54,10 +54,10 @@ function RootLayout() {
         <ErrorBoundary>
           <RequireAuth>{isEmbedded() ? <EmbeddedLayout /> : <SelfHostedLayout />}</RequireAuth>
         </ErrorBoundary>
-        {IsDev && <DebugHelper />}
+        {IsDev ? <DebugHelper /> : null}
       </NuqsAdapter>
 
-      {IsDev && <TanStackRouterDevtools position="bottom-right" />}
+      {IsDev ? <TanStackRouterDevtools position="bottom-right" /> : null}
     </>
   );
 }


### PR DESCRIPTION
## Debug dialog: visual debuggers

Adds a **Visual** subtab to the dev-only debug dialog (`⌘⇧D` → General → Visual) with CSS-only overlay toggles for the whole document:

- **Grayscale** — check contrast and that nothing relies on color alone
- **Element outlines** — lime outline on every element to reveal layout structure and phantom wrappers
- **Squint test (blur)** — judge visual hierarchy
- **8px baseline grid** — spot spacing/alignment drift
- **Disable animations** — near-zero durations (completion events still fire), catches flicker and bad resting states
- **Missing test IDs** — highlights interactive elements without `data-testid` (Playwright selector gaps)
- **A11y smells** — images without `alt`, empty unlabeled buttons/links, positive `tabindex`

### How it works

- New `visual-debuggers.ts` module: toggles `__debug-*` classes on `<html>`, styled by a single injected `<style>` element.
- State persists to `sessionStorage` and re-applies on reload; a fresh tab starts clean. "Disable all" resets everything.
- Grayscale/blur filters sit on the root element specifically — root filters don't create a containing block, so fixed-position dialogs/toasts keep working.

Dev builds only — ships nothing to production.


### Video


https://github.com/user-attachments/assets/5f4e3427-f14d-4436-9e71-212a9ac3fcef


##### Cleaning up debug help section
<img width="33%" alt="Screenshot 2026-07-22 at 9 11 25 AM" src="https://github.com/user-attachments/assets/f3285d06-f1e5-4d20-b582-502b379620c7" />

<img width="33%" alt="Screenshot 2026-07-22 at 9 53 49 AM" src="https://github.com/user-attachments/assets/93462aad-4d8f-46d5-9868-d26137bce34e" />
