### PR TITLE
Bug - improving consumer group row

### DIFF
--- a/frontend/src/components/pages/consumers/group-list.tsx
+++ b/frontend/src/components/pages/consumers/group-list.tsx
@@ -9,7 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
-import { DataTable, Flex, Grid, SearchField, Tag, Text } from '@redpanda-data/ui';
+import { DataTable, Flex, SearchField, Tag, Text } from '@redpanda-data/ui';
 import { Link } from '@tanstack/react-router';
 import { parseAsString, useQueryState } from 'nuqs';
 import type { FC } from 'react';
@@ -178,10 +178,10 @@ const GroupId = (p: { group: GroupDescription }) => {
   }
 
   return (
-    <Grid alignItems="center" gap={2} templateColumns="auto 1fr">
-      <Tag>Protocol: {protocol}</Tag>
+    <Flex alignItems="center" flexWrap="wrap" gap={2}>
+      <Tag flexShrink={0}>Protocol: {protocol}</Tag>
       {groupIdEl}
-    </Grid>
+    </Flex>
   );
 };
 


### PR DESCRIPTION
Fixing a bug where consumer group rows on narrow screens would wrap in a not very nice way.

<img width="50%" alt="Screenshot 2026-07-28 at 8 39 56 AM" src="https://github.com/user-attachments/assets/bd88d586-d286-4f0c-83ff-d5ac7ce09c0b" />
