### PR TITLE
config(sql): add maxConnectionsPerUser knob for per-user SQL pools

### DIFF
--- a/backend/pkg/config/sql.go
+++ b/backend/pkg/config/sql.go
@@ -25,10 +25,14 @@ type SQL struct {
 	Authentication HTTPAuthentication `yaml:"authentication"`
 	TLS            TLS                `yaml:"tls"`
 
-	// MaxConnections is the global cap on physical connections Console holds
-	// against Redpanda SQL across all connection pools, guarding the engine's
-	// shared max_connections budget. Default: 100.
+	// MaxConnections caps the physical connections Console holds against
+	// Redpanda SQL: the shared pool size in static-credential mode, the global
+	// ceiling across all per-user pools in impersonation mode. Default: 100.
 	MaxConnections int `yaml:"maxConnections"`
+
+	// MaxConnectionsPerUser is each caller's pool size in impersonation mode.
+	// Default: 10.
+	MaxConnectionsPerUser int `yaml:"maxConnectionsPerUser"`
 }
 
 // RegisterFlags registers flags for sensitive SQL authentication inputs.
@@ -42,6 +46,9 @@ func (c *SQL) SetDefaults() {
 	c.TLS.SetDefaults()
 	if c.MaxConnections == 0 {
 		c.MaxConnections = 100
+	}
+	if c.MaxConnectionsPerUser == 0 {
+		c.MaxConnectionsPerUser = 10
 	}
 }
 
@@ -68,6 +75,15 @@ func (c *SQL) Validate() error {
 
 	if c.MaxConnections <= 0 {
 		return fmt.Errorf("sql.maxConnections must be positive, got %d", c.MaxConnections)
+	}
+
+	if c.MaxConnectionsPerUser <= 0 {
+		return fmt.Errorf("sql.maxConnectionsPerUser must be positive, got %d", c.MaxConnectionsPerUser)
+	}
+
+	if c.MaxConnectionsPerUser > c.MaxConnections {
+		return fmt.Errorf("sql.maxConnectionsPerUser (%d) must not exceed sql.maxConnections (%d)",
+			c.MaxConnectionsPerUser, c.MaxConnections)
 	}
 
 	return nil

--- a/backend/pkg/config/sql_test.go
+++ b/backend/pkg/config/sql_test.go
@@ -27,6 +27,7 @@ func TestSQL_SetDefaults(t *testing.T) {
 		t.Error("expected TLS defaults to be applied")
 	}
 	require.Equal(t, 100, c.MaxConnections)
+	require.Equal(t, 10, c.MaxConnectionsPerUser)
 }
 
 func TestSQL_Validate(t *testing.T) {
@@ -46,21 +47,40 @@ func TestSQL_Validate(t *testing.T) {
 		},
 		{
 			name: "enabled with url is valid",
-			cfg:  SQL{Enabled: true, URL: "rpsql:5432", MaxConnections: 100},
+			cfg:  SQL{Enabled: true, URL: "rpsql:5432", MaxConnections: 100, MaxConnectionsPerUser: 4},
 		},
 		{
 			name:    "zero maxConnections is invalid",
-			cfg:     SQL{Enabled: true, URL: "rpsql:5432"},
+			cfg:     SQL{Enabled: true, URL: "rpsql:5432", MaxConnectionsPerUser: 10},
 			wantErr: true,
 		},
 		{
 			name:    "negative maxConnections is invalid",
-			cfg:     SQL{Enabled: true, URL: "rpsql:5432", MaxConnections: -1},
+			cfg:     SQL{Enabled: true, URL: "rpsql:5432", MaxConnections: -1, MaxConnectionsPerUser: 10},
 			wantErr: true,
 		},
 		{
 			name: "custom maxConnections is valid",
-			cfg:  SQL{Enabled: true, URL: "rpsql:5432", MaxConnections: 250},
+			cfg:  SQL{Enabled: true, URL: "rpsql:5432", MaxConnections: 250, MaxConnectionsPerUser: 10},
+		},
+		{
+			name:    "zero maxConnectionsPerUser is invalid",
+			cfg:     SQL{Enabled: true, URL: "rpsql:5432", MaxConnections: 100},
+			wantErr: true,
+		},
+		{
+			name:    "negative maxConnectionsPerUser is invalid",
+			cfg:     SQL{Enabled: true, URL: "rpsql:5432", MaxConnections: 100, MaxConnectionsPerUser: -1},
+			wantErr: true,
+		},
+		{
+			name:    "maxConnectionsPerUser exceeding maxConnections is invalid",
+			cfg:     SQL{Enabled: true, URL: "rpsql:5432", MaxConnections: 10, MaxConnectionsPerUser: 11},
+			wantErr: true,
+		},
+		{
+			name: "maxConnectionsPerUser equal to maxConnections is valid",
+			cfg:  SQL{Enabled: true, URL: "rpsql:5432", MaxConnections: 10, MaxConnectionsPerUser: 10},
 		},
 		{
 			name: "impersonateUser with static bearer is invalid",
@@ -83,10 +103,11 @@ func TestSQL_Validate(t *testing.T) {
 		{
 			name: "impersonateUser alone is valid",
 			cfg: SQL{
-				Enabled:        true,
-				URL:            "rpsql:5432",
-				MaxConnections: 100,
-				Authentication: HTTPAuthentication{ImpersonateUser: true},
+				Enabled:               true,
+				URL:                   "rpsql:5432",
+				MaxConnections:        100,
+				MaxConnectionsPerUser: 10,
+				Authentication:        HTTPAuthentication{ImpersonateUser: true},
 			},
 		},
 	}


### PR DESCRIPTION
maxConnectionsPerUser sizes each caller's
dedicated pool when Console impersonates users
against Redpanda SQL (default 10). maxConnections
doubles as the shared pool size when static
credentials are used; validation rejects a
per-user value above the global cap.