### PR TITLE
ci: trigger docs quickstart tests on release tags

### DIFF
--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -63,6 +63,18 @@ jobs:
           repository: redpanda-data/console-enterprise
           event-type: push
           client-payload: '{"branch": "${{ github.ref_name }}", "commit_sha": "${{ github.sha }}"}'
+      - name: Trigger docs quickstart tests on release
+        # The docs repo runs its Doc Detective quickstart (which drives the
+        # Console UI end to end) against this Console version, so UI changes
+        # that break documented procedures and screenshots surface at release
+        # time instead of in the docs repo's nightly run.
+        uses: peter-evans/repository-dispatch@v4
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        with:
+          token: ${{ env.ACTIONS_BOT_TOKEN }}
+          repository: redpanda-data/docs
+          event-type: trigger-tests
+          client-payload: '{"console_version": "${{ github.ref_name }}"}'
       - name: Set pending enterprise CI status
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: actions/github-script@v9


### PR DESCRIPTION
## Summary

Proposal from the docs team: on `v*` release tags, also send a `trigger-tests` repository dispatch to `redpanda-data/docs` with the tag as `console_version`.

## Why

The docs repo runs a Doc Detective quickstart test that drives the Console UI end to end (login, topics, filters, user creation, screenshots for the docs). When a Console release changes the UI, documented procedures and screenshots can silently break. The most recent example: a UI rework changed the topic detail tabs and the create-user dialog, which broke the docs test in a way that only surfaced through the docs repo's nightly run, and the published screenshots drifted out of date for months (fixed in redpanda-data/docs#1846).

With this dispatch, the docs repo tests the new Console version at release time and files an issue in the docs repo when documented flows or screenshots break. The receiving side already supports this: redpanda-data/docs#1848 maps the `console_version` payload to the test's version override.

## Open question for the Console team (why this PR is a draft)

At tag-push time, is the release image for the new tag already published to `docker.redpanda.com/redpandadata/console`? If images publish later in the release pipeline (for example in console-enterprise), this dispatch would race image availability, and the right place for it is at the end of that pipeline instead. Happy to move it — the payload contract stays the same.

No new secrets: uses the same `actions_bot_token` and dispatch action as the existing steps in this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
