### PR TITLE
Fix: Handle empty retained partitions

### DIFF
--- a/backend/pkg/console/list_messages.go
+++ b/backend/pkg/console/list_messages.go
@@ -427,12 +427,16 @@ func (s *Service) calculateConsumeRequests(
 					slog.String("topic", listReq.TopicName),
 					slog.Int("partition_id", int(startOffset.Partition)))
 			}
-			if offset < 0 {
+			if endOffset.Offset <= startOffset.Offset {
+				p.StartOffset = startOffset.Offset
+				break
+			}
+			if offset < 0 || offset >= endOffset.Offset {
 				// If there's no newer message than the given offset is -1 here, let's replace this with the newest
 				// consumable offset which equals to high water mark - 1.
 				offset = endOffset.Offset - 1
 			}
-			p.StartOffset = offset
+			p.StartOffset = max(offset, startOffset.Offset)
 		default:
 			// Either custom offset or resolved offset by timestamp is given
 			p.StartOffset = max(listReq.StartOffset,

--- a/backend/pkg/console/list_messages_test.go
+++ b/backend/pkg/console/list_messages_test.go
@@ -16,6 +16,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 func TestCalculateConsumeRequests_AllPartitions_FewNewestMessages(t *testing.T) {
@@ -52,6 +55,65 @@ func TestCalculateConsumeRequests_AllPartitions_FewNewestMessages(t *testing.T) 
 	actual, err := svc.calculateConsumeRequests(t.Context(), nil, req, []int32{0, 1, 2}, startOffsets, endOffsets)
 	require.NoError(t, err)
 	assert.Equal(t, expected, actual, "expected other result for unbalanced message distribution - all partition IDs")
+}
+
+func TestCalculateConsumeRequests_TimestampEmptyRetainedPartition(t *testing.T) {
+	const (
+		topicName = "test-topic"
+		timestamp = int64(1785733373576)
+	)
+
+	fakeCluster, err := kfake.NewCluster(kfake.NumBrokers(1), kfake.SeedTopics(1, topicName))
+	require.NoError(t, err)
+	t.Cleanup(fakeCluster.Close)
+
+	client, err := kgo.NewClient(kgo.SeedBrokers(fakeCluster.ListenAddrs()...))
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+
+	fakeCluster.Control(func(req kmsg.Request) (kmsg.Response, error, bool) {
+		fakeCluster.KeepControl()
+
+		listOffsetsReq, ok := req.(*kmsg.ListOffsetsRequest)
+		if !ok {
+			return nil, nil, false
+		}
+
+		require.Len(t, listOffsetsReq.Topics, 1)
+		assert.Equal(t, topicName, listOffsetsReq.Topics[0].Topic)
+		require.Len(t, listOffsetsReq.Topics[0].Partitions, 1)
+		assert.Equal(t, timestamp, listOffsetsReq.Topics[0].Partitions[0].Timestamp)
+
+		res := listOffsetsReq.ResponseKind().(*kmsg.ListOffsetsResponse)
+		res.Topics = []kmsg.ListOffsetsResponseTopic{kmsg.NewListOffsetsResponseTopic()}
+		res.Topics[0].Topic = topicName
+		res.Topics[0].Partitions = []kmsg.ListOffsetsResponseTopicPartition{kmsg.NewListOffsetsResponseTopicPartition()}
+		res.Topics[0].Partitions[0].Partition = 0
+		res.Topics[0].Partitions[0].Timestamp = timestamp
+		// Kafka returns -1 when timestamp lookup finds no retained record.
+		res.Topics[0].Partitions[0].Offset = -1
+
+		return res, nil, true
+	})
+
+	// Retention has removed every record, so the low and high watermarks are equal.
+	offsets := kadm.ListedOffsets{
+		topicName: {
+			0: {Topic: topicName, Partition: 0, Offset: 150},
+		},
+	}
+	req := &ListMessageRequest{
+		TopicName:      topicName,
+		PartitionID:    partitionsAll,
+		StartOffset:    StartOffsetTimestamp,
+		StartTimestamp: timestamp,
+		MessageCount:   10,
+	}
+
+	// Pass the same offsets as earliest and latest to model an empty partition.
+	actual, err := (&Service{}).calculateConsumeRequests(t.Context(), client, req, []int32{0}, offsets, offsets)
+	require.NoError(t, err)
+	assert.Empty(t, actual)
 }
 
 func TestCalculateConsumeRequests_AllPartitions_Unbalanced(t *testing.T) {


### PR DESCRIPTION
## Issue
When reading topic messages, Console can calculate an invalid start offset if retention has already deleted all records from a partition. One example is a topic with:
```text
Size:               0 B
Estimated messages: 0
Cleanup Policy:     Delete
Retention Time:     ~3 days
Retention Size:     Infinite
```
After the retention window passes, Kafka can delete all messages from the topic. At that point the partition has no readable records.
<img width="1149" height="518" alt="image" src="https://github.com/user-attachments/assets/a7d878ae-58e4-411b-9c27-cb081b8313a4" />
Error from backend:
```
{"time":"2026-08-03T15:21:21.059645+07:00","level":"INFO","msg":"assigning partitions","logger":"kafka_client","why":"new assignments from direct consumer","how":0,"input":{"code.review.jobs":{"0":{"At":149,"Epoch":-1,"CurrentEpoch":0},"1":{"At":91,"Epoch":-1,"CurrentEpoch":0}}}}
{"time":"2026-08-03T15:21:21.094099+07:00","level":"INFO","msg":"received OFFSET_OUT_OF_RANGE on the first fetch, resetting to the configured ConsumeResetOffset","logger":"kafka_client","broker":"1","topic":"code.review.jobs","partition":1,"prior_offset":91}
{"time":"2026-08-03T15:21:21.094099+07:00","level":"INFO","msg":"received OFFSET_OUT_OF_RANGE on the first fetch, resetting to the configured ConsumeResetOffset","logger":"kafka_client","broker":"2","topic":"code.review.jobs","partition":0,"prior_offset":149}
{"time":"2026-08-03T15:21:21.094161+07:00","level":"INFO","msg":"immediate metadata update triggered","logger":"kafka_client","why":"fetch had inner topic errors from broker 1: OFFSET_OUT_OF_RANGE{code.review.jobs[1]}"}
{"time":"2026-08-03T15:21:55.956222+07:00","level":"ERROR","msg":"errors while fetching records","topic_name":"","partition":-1,"error":"context deadline exceeded"}
```
In that state Kafka reports the same earliest and latest offsets, for example:
```text
earliest offset = 150
latest offset   = 150
```
This PR treats partitions with `latest <= earliest` as empty before choosing a read offset, so Console does not request an offset outside the retained range.
Before fix, run test `TestCalculateConsumeRequests_TimestampEmptyRetainedPartition`, got error:
```
go test -count=1 ./pkg/console -run 'TestCalculateConsumeRequests_TimestampEmptyRetainedPartition'
--- FAIL: TestCalculateConsumeRequests_TimestampEmptyRetainedPartition (0.00s)
    list_messages_test.go:114:
                Error Trace:    /Users/lap60627/Documents/PTO/console/backend/pkg/console/list_messages_test.go:114
                Error:          Should be empty, but was map[0:0x182bbc2def90]
                Test:           TestCalculateConsumeRequests_TimestampEmptyRetainedPartition
FAIL
FAIL    github.com/redpanda-data/console/backend/pkg/console    1.737s
FAIL
```
After fix, run test `TestCalculateConsumeRequests_TimestampEmptyRetainedPartition` successfully:
```
go test -count=1 ./pkg/console -run 'TestCalculateConsumeRequests_TimestampEmptyRetainedPartition'
ok      github.com/redpanda-data/console/backend/pkg/console    1.079s
```
<img width="1146" height="408" alt="image" src="https://github.com/user-attachments/assets/bf9f05ac-6839-4f14-b5a7-fb1fb52ce48a" />
