### PR TITLE
feat(sql): cancel a running query from the results pane

### DIFF
--- a/frontend/src/components/pages/sql/sql-results.test.tsx
+++ b/frontend/src/components/pages/sql/sql-results.test.tsx
@@ -136,3 +136,25 @@ describe('SqlResults create-table hint', () => {
     expect(screen.queryByRole('button', { name: 'Add a topic to SQL' })).toBeNull();
   });
 });
+
+describe('SqlResults run cancellation', () => {
+  test('the running state shows a Cancel button that stops the run', async () => {
+    const onCancel = vi.fn();
+    render(<SqlResults onCancel={onCancel} run={{ state: 'running', token: 1 }} sqlRole={viewer} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  test('the running state hides Cancel when no handler is provided', () => {
+    render(<SqlResults run={{ state: 'running', token: 1 }} sqlRole={viewer} />);
+    expect(screen.queryByRole('button', { name: 'Cancel' })).toBeNull();
+  });
+
+  test('the canceled state renders a neutral notice, not an error', () => {
+    render(<SqlResults run={{ state: 'canceled', token: 1 }} sqlRole={viewer} />);
+    expect(screen.getByText('Query canceled')).toBeInTheDocument();
+    expect(screen.queryByText('Query failed')).toBeNull();
+  });
+});

--- a/frontend/src/components/pages/sql/sql-results.tsx
+++ b/frontend/src/components/pages/sql/sql-results.tsx
@@ -30,6 +30,7 @@ import { InlineCode } from 'components/redpanda-ui/components/typography';
 import { cn } from 'components/redpanda-ui/lib/utils';
 import {
   Braces,
+  CircleSlash,
   CircleX,
   Clock,
   Database,
@@ -60,12 +61,14 @@ import type {
 } from './sql-types';
 
 export type SqlResultsProps = {
-  /** Current run state: idle | running | error | success. */
+  /** Current run state: idle | running | canceled | error | success. */
   run: QueryRun;
   /** Effective role; gates the admin "Add a topic" CTA on CREATE errors. */
   sqlRole: SqlRole;
   /** Admin entry point for the add-topic wizard. */
   onAddTable?: () => void;
+  /** Stops the in-flight run; renders the Cancel button while running. */
+  onCancel?: () => void;
   /** Whether the Redpanda catalog has any tables; drives the idle empty state. */
   hasTables?: boolean;
 };
@@ -416,7 +419,7 @@ function SuccessGrid({ run }: { run: QueryRunSuccess }) {
   );
 }
 
-export function SqlResults({ run, sqlRole, onAddTable, hasTables = true }: SqlResultsProps) {
+export function SqlResults({ run, sqlRole, onAddTable, onCancel, hasTables = true }: SqlResultsProps) {
   if (run.state === 'idle') {
     // No tables in the catalog yet: nothing to query, so prompt the caller to
     // create one from a topic. Admins get the wizard CTA; viewers get told who can.
@@ -475,6 +478,27 @@ export function SqlResults({ run, sqlRole, onAddTable, hasTables = true }: SqlRe
             <Spinner className="size-6 text-action-primary" />
           </EmptyMedia>
           <EmptyTitle>Running query…</EmptyTitle>
+        </EmptyHeader>
+        {onCancel ? (
+          <EmptyContent>
+            <Button onClick={onCancel} size="sm" variant="secondary-outline">
+              <X /> Cancel
+            </Button>
+          </EmptyContent>
+        ) : null}
+      </Empty>
+    );
+  }
+
+  if (run.state === 'canceled') {
+    return (
+      <Empty className="h-full">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <CircleSlash />
+          </EmptyMedia>
+          <EmptyTitle>Query canceled</EmptyTitle>
+          <EmptyDescription>The query was stopped before it finished.</EmptyDescription>
         </EmptyHeader>
       </Empty>
     );

--- a/frontend/src/components/pages/sql/sql-types.ts
+++ b/frontend/src/components/pages/sql/sql-types.ts
@@ -86,6 +86,8 @@ export type BridgeInfo = {
 
 type QueryRunIdle = { state: 'idle' };
 type QueryRunRunning = { state: 'running'; token: number };
+/** The caller stopped the run via the Cancel button. */
+type QueryRunCanceled = { state: 'canceled'; token: number };
 type QueryRunError = {
   state: 'error';
   token: number;
@@ -109,7 +111,7 @@ export type QueryRunSuccess = {
   bridge?: BridgeInfo;
 };
 
-export type QueryRun = QueryRunIdle | QueryRunRunning | QueryRunError | QueryRunSuccess;
+export type QueryRun = QueryRunIdle | QueryRunRunning | QueryRunCanceled | QueryRunError | QueryRunSuccess;
 
 // Drives admin-only affordances (e.g. the "Add a topic" CTA).
 export type SqlRole = 'admin' | 'viewer';

--- a/frontend/src/components/pages/sql/sql-workspace.tsx
+++ b/frontend/src/components/pages/sql/sql-workspace.tsx
@@ -11,6 +11,7 @@
 
 import { create } from '@bufbuild/protobuf';
 import { timestampFromDate } from '@bufbuild/protobuf/wkt';
+import { Code } from '@connectrpc/connect';
 import { useNavigate } from '@tanstack/react-router';
 import { Badge } from 'components/redpanda-ui/components/badge';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from 'components/redpanda-ui/components/resizable';
@@ -136,6 +137,12 @@ export function SqlWorkspace({ sqlRole: sqlRoleProp }: SqlWorkspaceProps) {
   // Per-instance monotonic run token: drops out-of-order responses without
   // sharing state across concurrently-mounted SqlWorkspace instances.
   const latestRunToken = useRef(0);
+  // Aborter for the in-flight editor run. Aborting the request cancels the
+  // query on the engine (the backend sends a wire-protocol CancelRequest when
+  // the caller disconnects), so this powers the Cancel button, supersession by
+  // a newer run, and unmount cleanup.
+  const abortRef = useRef<AbortController | null>(null);
+  useEffect(() => () => abortRef.current?.abort(), []);
   const {
     expanded,
     toggleExpanded,
@@ -290,33 +297,53 @@ export function SqlWorkspace({ sqlRole: sqlRoleProp }: SqlWorkspaceProps) {
 
       setRun({ state: 'running', token });
       const start = performance.now();
-      executeQuery.mutate(create(ExecuteQueryRequestSchema, { statement: sql }), {
-        onSuccess: (res) => {
-          if (latestRunToken.current !== token) {
-            return;
-          }
-          const columns = res.columns.map(columnDefFromProto);
-          const rows = res.rows.map((row) => resultRowFromProto(row, columns));
-          setRun({
-            state: 'success',
-            token,
-            columns,
-            rows,
-            totalRows: rows.length,
-            elapsedMs: Math.round(performance.now() - start),
-            truncated: res.truncated,
-          });
-        },
-        onError: (error) => {
-          if (latestRunToken.current !== token) {
-            return;
-          }
-          setRun({ state: 'error', token, title: 'Query failed', message: error.message, hint: hintFromError(error) });
-        },
-      });
+      // Abort a still-running previous run: its response would be dropped by the
+      // token guard anyway, and aborting also stops it on the engine.
+      abortRef.current?.abort();
+      const aborter = new AbortController();
+      abortRef.current = aborter;
+      executeQuery.mutate(
+        { request: create(ExecuteQueryRequestSchema, { statement: sql }), signal: aborter.signal },
+        {
+          onSuccess: (res) => {
+            if (latestRunToken.current !== token) {
+              return;
+            }
+            const columns = res.columns.map(columnDefFromProto);
+            const rows = res.rows.map((row) => resultRowFromProto(row, columns));
+            setRun({
+              state: 'success',
+              token,
+              columns,
+              rows,
+              totalRows: rows.length,
+              elapsedMs: Math.round(performance.now() - start),
+              truncated: res.truncated,
+            });
+          },
+          onError: (error) => {
+            if (latestRunToken.current !== token) {
+              return;
+            }
+            if (error.code === Code.Canceled) {
+              setRun({ state: 'canceled', token });
+              return;
+            }
+            setRun({
+              state: 'error',
+              token,
+              title: 'Query failed',
+              message: error.message,
+              hint: hintFromError(error),
+            });
+          },
+        }
+      );
     },
     [completionCatalogs, executeQuery]
   );
+
+  const onCancelRun = useCallback(() => abortRef.current?.abort(), []);
 
   const onQueryTable = useCallback((catalog: Catalog, table: TableRef) => {
     // Redpanda SQL (Oxla) addresses catalog-qualified tables with the `=>`
@@ -369,14 +396,17 @@ export function SqlWorkspace({ sqlRole: sqlRoleProp }: SqlWorkspaceProps) {
       // Shares one builder with the wizard's "this will run" preview so the two
       // can't drift.
       const statement = createTableSql(tableName, topic);
-      executeQuery.mutate(create(ExecuteQueryRequestSchema, { statement }), {
-        onSuccess: async () => {
-          await invalidateSqlCatalog();
-          toast.success(`Table ${tableName} created`);
-          closeWizard();
-        },
-        onError: (error) => setWizardError(error.message),
-      });
+      executeQuery.mutate(
+        { request: create(ExecuteQueryRequestSchema, { statement }) },
+        {
+          onSuccess: async () => {
+            await invalidateSqlCatalog();
+            toast.success(`Table ${tableName} created`);
+            closeWizard();
+          },
+          onError: (error) => setWizardError(error.message),
+        }
+      );
     },
     [executeQuery, invalidateSqlCatalog, closeWizard]
   );
@@ -441,6 +471,7 @@ export function SqlWorkspace({ sqlRole: sqlRoleProp }: SqlWorkspaceProps) {
                 <SqlResults
                   hasTables={hasTables}
                   onAddTable={openWizard}
+                  onCancel={onCancelRun}
                   run={run.state === 'success' ? { ...run, bridge } : run}
                   sqlRole={sqlRole}
                 />

--- a/frontend/src/react-query/api/sql.tsx
+++ b/frontend/src/react-query/api/sql.tsx
@@ -10,13 +10,16 @@
  */
 
 import { create } from '@bufbuild/protobuf';
-import { createConnectQueryKey, useMutation, useQuery } from '@connectrpc/connect-query';
-import { useQueryClient } from '@tanstack/react-query';
+import type { ConnectError } from '@connectrpc/connect';
+import { callUnaryMethod, createConnectQueryKey, useQuery, useTransport } from '@connectrpc/connect-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { GetTopicConfigurationsRequestSchema } from 'protogen/redpanda/api/dataplane/v1/topic_pb';
 import { getTopicConfigurations } from 'protogen/redpanda/api/dataplane/v1/topic-TopicService_connectquery';
 import {
   type DescribeTableRequest,
   DescribeTableRequestSchema,
+  type ExecuteQueryRequest,
+  type ExecuteQueryResponse,
   GetSqlIdentityRequestSchema,
   type ListCatalogsRequest,
   ListCatalogsRequestSchema,
@@ -93,7 +96,15 @@ export const useTopicIcebergQuery = (topicName: string, options?: SqlQueryOption
 };
 
 // Errors surface inline (run panel / wizard), so no toast on failure.
-export const useExecuteQueryMutation = () => useMutation(executeQuery);
+// A plain TanStack mutation over callUnaryMethod rather than connect-query's
+// useMutation, which exposes no per-call AbortSignal; aborting the request is
+// what lets the Cancel button stop the query on the engine.
+export const useExecuteQueryMutation = () => {
+  const transport = useTransport();
+  return useMutation<ExecuteQueryResponse, ConnectError, { request: ExecuteQueryRequest; signal?: AbortSignal }>({
+    mutationFn: ({ request, signal }) => callUnaryMethod(transport, executeQuery, request, { signal }),
+  });
+};
 
 // Returns a function that refreshes the catalog/table listings, e.g. after a
 // CREATE TABLE so the new table shows up in the tree.


### PR DESCRIPTION
The running state in the results pane gains a
Cancel button that aborts the in-flight
ExecuteQuery request; the server reacts to the
disconnect by sending a wire-protocol
CancelRequest, so the engine stops computing
instead of running to completion. The mutation
moved off connect-query's useMutation, which
exposes no per-call AbortSignal, onto a TanStack
mutation over callUnaryMethod. Starting a new run
or unmounting the workspace aborts too, so
navigating away no longer leaves a query running
for hours. A canceled run renders a neutral
"Query canceled" notice instead of an error.

**Example**

<img width="301" height="217" alt="image" src="https://github.com/user-attachments/assets/2ef71c36-e385-4aab-a6d7-f1f4e2c77c55" />
<img width="344" height="211" alt="image" src="https://github.com/user-attachments/assets/304b39d0-0113-4304-ad33-b9c2c5ad4299" />
<img width="492" height="158" alt="image" src="https://github.com/user-attachments/assets/5705867a-4516-4672-ba90-942e2e1cdc14" />
