### PR TITLE
Fix blank screen on /trial-expired when license check fails 

### DIFF
--- a/frontend/src/components/require-auth.test.tsx
+++ b/frontend/src/components/require-auth.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { Code, ConnectError } from '@connectrpc/connect';
+import { act, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import RequireAuth from './require-auth';
+import { config as appConfig } from '../config';
+import { useApiStore } from '../state/backend-api';
+import { render } from '../test-utils';
+import { AppFeatures } from '../utils/env';
+
+const LICENSE_EXPIRED_ERROR = new ConnectError('enterprise license expired', Code.FailedPrecondition);
+
+function setPath(path: string) {
+  window.history.pushState({}, '', path);
+}
+
+describe('RequireAuth', () => {
+  const initialSingleSignOn = AppFeatures.SINGLE_SIGN_ON;
+  const initialAuthClient = appConfig.authenticationClient;
+
+  beforeEach(() => {
+    AppFeatures.SINGLE_SIGN_ON = true;
+    // getIdentity() never settles - tests drive userData/userDataError directly
+    // instead of racing a real fetch.
+    appConfig.authenticationClient = {
+      getIdentity: () => new Promise(() => {}),
+    } as unknown as typeof appConfig.authenticationClient;
+    act(() => {
+      useApiStore.setState({ userData: undefined, userDataError: null, isUserDataFetchInProgress: false });
+    });
+    setPath('/');
+  });
+
+  afterEach(() => {
+    AppFeatures.SINGLE_SIGN_ON = initialSingleSignOn;
+    appConfig.authenticationClient = initialAuthClient;
+    // The previous test's tree is unmounted by the global `cleanup()` afterEach,
+    // which runs after this one - the component may still be mounted here, so
+    // this reset must be wrapped in act() too.
+    act(() => {
+      useApiStore.setState({ userData: undefined, userDataError: null, isUserDataFetchInProgress: false });
+    });
+    setPath('/');
+  });
+
+  test('renders /trial-expired instead of a blank screen when the redirect leaves userData unresolved', () => {
+    setPath('/trial-expired');
+    useApiStore.setState({ userData: undefined, userDataError: LICENSE_EXPIRED_ERROR });
+
+    render(
+      <RequireAuth>
+        <div data-testid="trial-expired-content">license expired page</div>
+      </RequireAuth>
+    );
+
+    expect(screen.getByTestId('trial-expired-content')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument();
+  });
+
+  test('renders /upload-license under the same conditions', () => {
+    setPath('/upload-license');
+    useApiStore.setState({ userData: undefined, userDataError: LICENSE_EXPIRED_ERROR });
+
+    render(
+      <RequireAuth>
+        <div data-testid="upload-license-content">upload license page</div>
+      </RequireAuth>
+    );
+
+    expect(screen.getByTestId('upload-license-content')).toBeInTheDocument();
+  });
+
+  test('does not bypass the auth gate for unrelated routes', () => {
+    setPath('/topics');
+    useApiStore.setState({ userData: undefined, userDataError: LICENSE_EXPIRED_ERROR });
+
+    render(
+      <RequireAuth>
+        <div data-testid="topics-content">topics page</div>
+      </RequireAuth>
+    );
+
+    expect(screen.queryByTestId('topics-content')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+  });
+
+  test('recovers once userDataError is set after mount, instead of staying on the blank placeholder forever', () => {
+    setPath('/topics');
+    useApiStore.setState({ userData: undefined, userDataError: null });
+
+    render(
+      <RequireAuth>
+        <div data-testid="topics-content">topics page</div>
+      </RequireAuth>
+    );
+
+    // Neither the gated content nor an error UI has shown up yet - the
+    // (fetch never resolves) placeholder is up.
+    expect(screen.queryByTestId('topics-content')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument();
+
+    // Simulates refreshUserData()'s catch branch: userData stays undefined,
+    // only userDataError changes. Before the fix, RequireAuth only
+    // subscribed to `userData`, so this update never re-rendered the
+    // component and it stayed on the blank placeholder forever.
+    act(() => {
+      useApiStore.setState({ userDataError: LICENSE_EXPIRED_ERROR });
+    });
+
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/require-auth.tsx
+++ b/frontend/src/components/require-auth.tsx
@@ -36,6 +36,16 @@ function loginHandling(): JSX.Element | null {
     return null; // already in login process, don't interrupt!
   }
 
+  // These pages handle license state themselves and must render even if the
+  // triggering license-expired error left `userData` stuck at `undefined`
+  // (e.g. the very first request, such as getIdentity, fails with
+  // FailedPrecondition/REASON_ENTERPRISE_LICENSE_EXPIRED). Without this bypass
+  // the user gets redirected here but sees a blank preLogin screen forever,
+  // since userData never changes to trigger a re-render.
+  if (path.startsWith('/trial-expired') || path.startsWith('/upload-license')) {
+    return null;
+  }
+
   if (api.userData === null && !path.startsWith('/login')) {
     devPrint('known not logged in, hard redirect');
     window.location.pathname = `${getBasePath()}/login`; // definitely not logged in, and in wrong url: hard redirect!
@@ -76,6 +86,10 @@ const RequireAuth = ({ children }: { children: ReactNode }) => {
   // Subscribe to the API store so this component re-renders when userData changes
   // (e.g. from undefined -> null when not authenticated, triggering the login redirect)
   useApiStoreHook((s) => s.userData); // re-render when userData changes
+  // userDataError can change while userData stays undefined (transient error branch
+  // in refreshUserData's catch); without this, loginHandling never re-runs and the
+  // preLogin placeholder is shown forever instead of ConnectionErrorUI.
+  useApiStoreHook((s) => s.userDataError);
 
   const r = loginHandling(); // Complete login, or fetch user if needed
   if (r) {


### PR DESCRIPTION

<img width="1483" height="974" alt="Screenshot 2026-08-12 at 12 55 39" src="https://github.com/user-attachments/assets/927342d1-202c-45a2-948d-47500db3b8e9" />


RequireAuth gated every route behind userData resolution and only subscribed to userData for re-renders. When the license-expired interceptor redirected to /trial-expired after the initial getIdentity() call failed, userData stayed undefined and only userDataError changed, so RequireAuth never re-rendered and got stuck on the blank preLogin placeholder. Bypass the auth gate for /trial-expired and /upload-license (they manage their own license state), and subscribe to userDataError too so any future transient-error case resolves into ConnectionErrorUI instead of hanging.