### PR TITLE
Bug - RPCN Re-adding in doc to pipeline sidebar

### DIFF
--- a/frontend/src/components/pages/rp-connect/pipeline/pipeline-structure-tree.test.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/pipeline-structure-tree.test.tsx
@@ -160,7 +160,6 @@ describe('PipelineStructureTree', () => {
     );
     expect(docsLink).toHaveAttribute('target', '_blank');
     expect(docsLink).toHaveAttribute('rel', 'noopener noreferrer');
-    // Nested components and container groups are components too, so they link as well.
     expect(screen.getByRole('button', { name: 'http documentation' })).toHaveAttribute(
       'href',
       'https://docs.redpanda.com/cloud-data-platform/develop/connect/components/processors/http/'
@@ -177,7 +176,12 @@ describe('PipelineStructureTree', () => {
   it('opens the docs link without also selecting the row', async () => {
     const onSelectNode = vi.fn();
     render(<PipelineStructureTree configYaml={NESTED} onSelectNode={onSelectNode} />);
-    await userEvent.click(screen.getByRole('button', { name: 'kafka_franz documentation' }));
+    const docsLink = screen.getByRole('button', { name: 'kafka_franz documentation' });
+    await userEvent.click(docsLink);
+    expect(onSelectNode).not.toHaveBeenCalled();
+    // Enter must reach the link, not the row's select handler (which would preventDefault it).
+    act(() => docsLink.focus());
+    await userEvent.keyboard('{Enter}');
     expect(onSelectNode).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/components/pages/rp-connect/pipeline/pipeline-structure-tree.test.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/pipeline-structure-tree.test.tsx
@@ -150,6 +150,37 @@ describe('PipelineStructureTree', () => {
     expect(highlightId).toBe(editableId);
   });
 
+  // The registry Button renders `as="a"` with role="button" (Base UI), so query by that role.
+  it('links each component row to its reference docs', () => {
+    render(<PipelineStructureTree configYaml={NESTED} />);
+    const docsLink = screen.getByRole('button', { name: 'kafka_franz documentation' });
+    expect(docsLink).toHaveAttribute(
+      'href',
+      'https://docs.redpanda.com/cloud-data-platform/develop/connect/components/inputs/kafka_franz/'
+    );
+    expect(docsLink).toHaveAttribute('target', '_blank');
+    expect(docsLink).toHaveAttribute('rel', 'noopener noreferrer');
+    // Nested components and container groups are components too, so they link as well.
+    expect(screen.getByRole('button', { name: 'http documentation' })).toHaveAttribute(
+      'href',
+      'https://docs.redpanda.com/cloud-data-platform/develop/connect/components/processors/http/'
+    );
+    expect(screen.getByRole('button', { name: 'switch documentation' })).toBeInTheDocument();
+  });
+
+  it('omits the docs link on structural rows that name no component', () => {
+    render(<PipelineStructureTree configYaml={NESTED} />);
+    const caseRow = screen.getByRole('treeitem', { name: 'case 1' });
+    expect(caseRow.querySelector('a')).toBeNull();
+  });
+
+  it('opens the docs link without also selecting the row', async () => {
+    const onSelectNode = vi.fn();
+    render(<PipelineStructureTree configYaml={NESTED} onSelectNode={onSelectNode} />);
+    await userEvent.click(screen.getByRole('button', { name: 'kafka_franz documentation' }));
+    expect(onSelectNode).not.toHaveBeenCalled();
+  });
+
   it('keeps the last valid outline, flagged, when an edit makes the YAML invalid', () => {
     const { rerender } = render(<PipelineStructureTree configYaml={NESTED} />);
     expect(screen.getByText('switch')).toBeInTheDocument();

--- a/frontend/src/components/pages/rp-connect/pipeline/pipeline-structure-tree.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/pipeline-structure-tree.tsx
@@ -77,8 +77,8 @@ function collectVisibleIds(maps: NodeMaps, collapsedIds: Set<string>): string[] 
   return ids;
 }
 
-// Enter/Space must reach the docs link itself — the row handler would otherwise preventDefault
-// (to select the node) and swallow the navigation. Arrow keys still bubble, so row nav keeps working.
+// The row handler preventDefaults Enter/Space to select the node, which would swallow the link's
+// navigation; arrow keys still bubble, so row navigation keeps working from a focused link.
 function stopRowSelectKeys(e: React.KeyboardEvent): void {
   if (e.key === 'Enter' || e.key === ' ') {
     e.stopPropagation();
@@ -96,14 +96,13 @@ const RowStatusDot = ({ hasError, unsaved }: { hasError?: boolean; unsaved?: boo
   return null;
 };
 
-/** Hover/focus-revealed link to a component's reference docs, trailing its row. */
 const NodeDocsLink = ({ label, href }: { label: string; href: string }) => (
   <Button
     aria-label={`${label} documentation`}
     as="a"
     className="shrink-0 text-muted-foreground opacity-0 transition-opacity focus-visible:opacity-100 group-hover:opacity-100"
     href={href}
-    // The row is a click target that jumps the YAML cursor — opening docs shouldn't also do that.
+    // Clicking the row jumps the YAML cursor — opening docs must not also do that.
     onClick={(e: React.MouseEvent) => e.stopPropagation()}
     onKeyDown={stopRowSelectKeys}
     rel="noopener noreferrer"

--- a/frontend/src/components/pages/rp-connect/pipeline/pipeline-structure-tree.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/pipeline-structure-tree.tsx
@@ -10,14 +10,16 @@
  */
 
 import type { ComponentName } from 'assets/connectors/component-logo-map';
+import { Button } from 'components/redpanda-ui/components/button';
 import { cn } from 'components/redpanda-ui/lib/utils';
-import { Box, ChevronDown, ChevronRight, Plus } from 'lucide-react';
+import { BookOpenIcon, Box, ChevronDown, ChevronRight, Plus } from 'lucide-react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { InvalidConfigNotice } from './invalid-config-notice';
 import { sectionAccent } from './pipeline-flow-canvas-nodes';
 import { useResilientParse } from './use-resilient-parse';
 import { ConnectorLogo } from '../onboarding/connector-logo';
+import { getNodeDocsUrl } from '../utils/connector-docs';
 import { buildChildrenMap, type PipelineFlowNode } from '../utils/pipeline-flow-parser';
 
 const SECTION_TITLES: Record<string, string> = {
@@ -74,6 +76,44 @@ function collectVisibleIds(maps: NodeMaps, collapsedIds: Set<string>): string[] 
   }
   return ids;
 }
+
+// Enter/Space must reach the docs link itself — the row handler would otherwise preventDefault
+// (to select the node) and swallow the navigation. Arrow keys still bubble, so row nav keeps working.
+function stopRowSelectKeys(e: React.KeyboardEvent): void {
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.stopPropagation();
+  }
+}
+
+/** Error takes precedence over the unsaved dot, so a row never shows both. */
+const RowStatusDot = ({ hasError, unsaved }: { hasError?: boolean; unsaved?: boolean }) => {
+  if (hasError) {
+    return <span aria-hidden className="size-2 shrink-0 rounded-full bg-destructive" title="Has errors" />;
+  }
+  if (unsaved) {
+    return <span aria-hidden className="size-2 shrink-0 rounded-full bg-informative" title="Unsaved changes" />;
+  }
+  return null;
+};
+
+/** Hover/focus-revealed link to a component's reference docs, trailing its row. */
+const NodeDocsLink = ({ label, href }: { label: string; href: string }) => (
+  <Button
+    aria-label={`${label} documentation`}
+    as="a"
+    className="shrink-0 text-muted-foreground opacity-0 transition-opacity focus-visible:opacity-100 group-hover:opacity-100"
+    href={href}
+    // The row is a click target that jumps the YAML cursor — opening docs shouldn't also do that.
+    onClick={(e: React.MouseEvent) => e.stopPropagation()}
+    onKeyDown={stopRowSelectKeys}
+    rel="noopener noreferrer"
+    size="icon-xs"
+    target="_blank"
+    variant="ghost"
+  >
+    <BookOpenIcon />
+  </Button>
+);
 
 type TreeKeyNav = { visibleIds: string[]; maps: NodeMaps; collapsedIds: Set<string> };
 
@@ -153,6 +193,7 @@ const NodeRow = ({
   const selected = selectedId === node.id;
   const hasError = errorNodeIds?.has(node.id);
   const unsaved = unsavedNodeIds?.has(node.id);
+  const docsUrl = getNodeDocsUrl(node);
 
   return (
     <>
@@ -211,13 +252,8 @@ const NodeRow = ({
               {node.labelText}
             </span>
           ) : null}
-          {/* Error takes precedence over the unsaved dot, so a node never shows both. */}
-          {hasError ? (
-            <span aria-hidden className="size-2 shrink-0 rounded-full bg-destructive" title="Has errors" />
-          ) : null}
-          {unsaved && !hasError ? (
-            <span aria-hidden className="size-2 shrink-0 rounded-full bg-informative" title="Unsaved changes" />
-          ) : null}
+          <RowStatusDot hasError={hasError} unsaved={unsaved} />
+          {docsUrl ? <NodeDocsLink href={docsUrl} label={node.label} /> : null}
         </span>
       </div>
       {hasChildren && !collapsed

--- a/frontend/src/components/pages/rp-connect/utils/connector-docs.test.ts
+++ b/frontend/src/components/pages/rp-connect/utils/connector-docs.test.ts
@@ -65,7 +65,7 @@ describe('getNodeDocsUrl', () => {
     );
   });
 
-  it('links a container group (it is a component too)', () => {
+  it('links a container group, which is a component too', () => {
     expect(getNodeDocsUrl({ kind: 'group', label: 'switch', section: 'processor' })).toBe(
       'https://docs.redpanda.com/cloud-data-platform/develop/connect/components/processors/switch/'
     );
@@ -86,8 +86,7 @@ describe('getNodeDocsUrl', () => {
     expect(getNodeDocsUrl({ kind: 'leaf', label: 'none', section: 'output' })).toBeUndefined();
   });
 
-  it('returns undefined for singleton resources, which are labelled by their YAML key', () => {
-    // `buffer:`/`metrics:` rows carry the key as their label, not an implementation name.
+  it('returns undefined for resource nodes labelled by their YAML key, not an implementation', () => {
     expect(getNodeDocsUrl({ kind: 'leaf', label: 'buffer', section: 'resource' })).toBeUndefined();
     expect(
       getNodeDocsUrl({ kind: 'leaf', label: 'cache_resources', section: 'resource', resourceKey: 'cache_resources' })

--- a/frontend/src/components/pages/rp-connect/utils/connector-docs.test.ts
+++ b/frontend/src/components/pages/rp-connect/utils/connector-docs.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { getConnectorDocsUrl } from './connector-docs';
+import { getConnectorDocsUrl, getNodeDocsUrl } from './connector-docs';
 
 describe('getConnectorDocsUrl', () => {
   it('builds correct URL for input connectors', () => {
@@ -55,5 +55,42 @@ describe('getConnectorDocsUrl', () => {
 
   it('returns undefined for empty section', () => {
     expect(getConnectorDocsUrl('', 'kafka')).toBeUndefined();
+  });
+});
+
+describe('getNodeDocsUrl', () => {
+  it('links a component node through its section', () => {
+    expect(getNodeDocsUrl({ kind: 'leaf', label: 'kafka_franz', section: 'input' })).toBe(
+      'https://docs.redpanda.com/cloud-data-platform/develop/connect/components/inputs/kafka_franz/'
+    );
+  });
+
+  it('links a container group (it is a component too)', () => {
+    expect(getNodeDocsUrl({ kind: 'group', label: 'switch', section: 'processor' })).toBe(
+      'https://docs.redpanda.com/cloud-data-platform/develop/connect/components/processors/switch/'
+    );
+  });
+
+  it('links a resource node through the *_resources key it was defined under', () => {
+    expect(getNodeDocsUrl({ kind: 'leaf', label: 'memory', section: 'resource', resourceKey: 'cache_resources' })).toBe(
+      'https://docs.redpanda.com/cloud-data-platform/develop/connect/components/caches/memory/'
+    );
+    expect(
+      getNodeDocsUrl({ kind: 'leaf', label: 'local', section: 'resource', resourceKey: 'rate_limit_resources' })
+    ).toBe('https://docs.redpanda.com/cloud-data-platform/develop/connect/components/rate_limits/local/');
+  });
+
+  it('returns undefined for structural nodes that name no component', () => {
+    expect(getNodeDocsUrl({ kind: 'section', label: 'input', section: 'input' })).toBeUndefined();
+    expect(getNodeDocsUrl({ kind: 'group', label: 'case 1', section: 'processor', isCase: true })).toBeUndefined();
+    expect(getNodeDocsUrl({ kind: 'leaf', label: 'none', section: 'output' })).toBeUndefined();
+  });
+
+  it('returns undefined for singleton resources, which are labelled by their YAML key', () => {
+    // `buffer:`/`metrics:` rows carry the key as their label, not an implementation name.
+    expect(getNodeDocsUrl({ kind: 'leaf', label: 'buffer', section: 'resource' })).toBeUndefined();
+    expect(
+      getNodeDocsUrl({ kind: 'leaf', label: 'cache_resources', section: 'resource', resourceKey: 'cache_resources' })
+    ).toBeUndefined();
   });
 });

--- a/frontend/src/components/pages/rp-connect/utils/connector-docs.ts
+++ b/frontend/src/components/pages/rp-connect/utils/connector-docs.ts
@@ -11,7 +11,11 @@
 
 import { docsLinks } from 'utils/docs-links';
 
+import type { PipelineFlowNode } from './pipeline-flow-parser';
+
 const DOCS_BASE = docsLinks.cloud.connectComponents;
+// `cache_resources` → `cache`: the component section an array-resource entry belongs to.
+const RESOURCES_KEY_SUFFIX = /_resources$/;
 // Sections whose docs path is the naive plural (`${section}s`); metrics/tracer don't follow that rule.
 const DOCS_SECTIONS = new Set(['input', 'output', 'processor', 'cache', 'rate_limit']);
 
@@ -21,4 +25,32 @@ export function getConnectorDocsUrl(section: string, connectorName: string): str
     return;
   }
   return `${DOCS_BASE}/${section}s/${connectorName}/`;
+}
+
+type DocsNode = Pick<PipelineFlowNode, 'kind' | 'label' | 'section' | 'isCase' | 'resourceKey'>;
+
+/** Whether a node names a component at all — structural rows have no reference page to link to. */
+function isDocumentableNode(node: DocsNode): boolean {
+  // Section headers, `switch` case wrappers and empty-section placeholders are structural.
+  return node.kind !== 'section' && !node.isCase && node.label !== 'none' && node.label !== '';
+}
+
+/**
+ * Docs URL for a parsed pipeline node (structure tree / canvas card), or undefined when the node
+ * isn't a documented component. Resource rows resolve through the `*_resources` key they were
+ * defined under, since `resource` isn't itself a component section.
+ */
+export function getNodeDocsUrl(node: DocsNode): string | undefined {
+  if (!isDocumentableNode(node)) {
+    return;
+  }
+  if (node.section === 'resource') {
+    // Only array resources name a component; singletons (`buffer:`, `metrics:`, …) are labelled by
+    // their YAML key, and an unnamed array entry falls back to that key too — neither is a component.
+    if (!node.resourceKey || node.label === node.resourceKey) {
+      return;
+    }
+    return getConnectorDocsUrl(node.resourceKey.replace(RESOURCES_KEY_SUFFIX, ''), node.label);
+  }
+  return getConnectorDocsUrl(node.section ?? '', node.label);
 }

--- a/frontend/src/components/pages/rp-connect/utils/connector-docs.ts
+++ b/frontend/src/components/pages/rp-connect/utils/connector-docs.ts
@@ -14,10 +14,10 @@ import { docsLinks } from 'utils/docs-links';
 import type { PipelineFlowNode } from './pipeline-flow-parser';
 
 const DOCS_BASE = docsLinks.cloud.connectComponents;
-// `cache_resources` → `cache`: the component section an array-resource entry belongs to.
-const RESOURCES_KEY_SUFFIX = /_resources$/;
 // Sections whose docs path is the naive plural (`${section}s`); metrics/tracer don't follow that rule.
 const DOCS_SECTIONS = new Set(['input', 'output', 'processor', 'cache', 'rate_limit']);
+// `cache_resources` → the `cache` section its entries belong to.
+const RESOURCES_KEY_SUFFIX = /_resources$/;
 
 /** Docs URL for a connector, or undefined for sections whose upstream path isn't the naive plural. */
 export function getConnectorDocsUrl(section: string, connectorName: string): string | undefined {
@@ -29,24 +29,15 @@ export function getConnectorDocsUrl(section: string, connectorName: string): str
 
 type DocsNode = Pick<PipelineFlowNode, 'kind' | 'label' | 'section' | 'isCase' | 'resourceKey'>;
 
-/** Whether a node names a component at all — structural rows have no reference page to link to. */
-function isDocumentableNode(node: DocsNode): boolean {
-  // Section headers, `switch` case wrappers and empty-section placeholders are structural.
-  return node.kind !== 'section' && !node.isCase && node.label !== 'none' && node.label !== '';
-}
-
-/**
- * Docs URL for a parsed pipeline node (structure tree / canvas card), or undefined when the node
- * isn't a documented component. Resource rows resolve through the `*_resources` key they were
- * defined under, since `resource` isn't itself a component section.
- */
+/** Docs URL for a parsed pipeline node, or undefined when the node names no documented component. */
 export function getNodeDocsUrl(node: DocsNode): string | undefined {
-  if (!isDocumentableNode(node)) {
+  // Section headers, `switch` case wrappers and empty-section placeholders name no component.
+  if (node.kind === 'section' || node.isCase || node.label === 'none') {
     return;
   }
   if (node.section === 'resource') {
-    // Only array resources name a component; singletons (`buffer:`, `metrics:`, …) are labelled by
-    // their YAML key, and an unnamed array entry falls back to that key too — neither is a component.
+    // `resource` is not a component section, so resolve through the `*_resources` key. Singletons
+    // (`buffer:`, `metrics:`) and unnamed entries are labelled by that key itself — not components.
     if (!node.resourceKey || node.label === node.resourceKey) {
       return;
     }


### PR DESCRIPTION
# Bug — Re-add docs links to the RPCN YAML sidebar

## What regressed

Before the visual editor landed (#2553, UX-1338), the right-hand lane of the YAML
pipeline editor rendered `PipelineFlowDiagram`, and each of its component cards
carried a hover-revealed 📖 link to that component's reference docs.

That PR replaced the lane with `PipelineStructureTree` (a compact outline that fits
deep nesting into a narrow column). The docs affordance didn't come along — it
survived only in the visual editor's node inspector header, so YAML-mode users lost
one-click access to component reference pages entirely.

## What this does

Re-adds the docs link to every component row in the YAML sidebar's structure tree,
revealed on row hover or on the link's own keyboard focus.

**`utils/connector-docs.ts`** — new `getNodeDocsUrl(node)` on top of the existing
`getConnectorDocsUrl(section, name)`, resolving a *parsed pipeline node* to its
reference page:
**`pipeline/pipeline-structure-tree.tsx`** — `NodeDocsLink` trailing each row.

Also extracted the two status-dot ternaries into `RowStatusDot`, which removes the
duplicated `unsaved && !hasError` condition and keeps `NodeRow` under the
cognitive-complexity lint gate.

### Video

https://github.com/user-attachments/assets/afb57ff4-5329-443b-9008-ff715bd006f9


