### PR TITLE
backend: bump twmb/avro from v1.4.1 to v1.8.0

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/redpanda v0.42.0
-	github.com/twmb/avro v1.4.1
+	github.com/twmb/avro v1.8.0
 	github.com/twmb/franz-go v1.21.2
 	github.com/twmb/franz-go/pkg/kadm v1.18.0
 	github.com/twmb/franz-go/pkg/kfake v0.0.0-20251115002817-3affad808a82

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -454,8 +454,8 @@ github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYI
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
-github.com/twmb/avro v1.4.1 h1:pzXZivLS0YkI7lntpxnu6aYkNJBUJ3vSp6uzEGLeQOI=
-github.com/twmb/avro v1.4.1/go.mod h1:X0fT1dY2xcbV4YuCE4mYro+qljHl4kUF5uA/2z1rgSk=
+github.com/twmb/avro v1.8.0 h1:UMWLg+nH4P3yad5Om7yFSohYLy2RG1s7BcFFiOvmK9Q=
+github.com/twmb/avro v1.8.0/go.mod h1:X0fT1dY2xcbV4YuCE4mYro+qljHl4kUF5uA/2z1rgSk=
 github.com/twmb/franz-go v1.7.0/go.mod h1:PMze0jNfNghhih2XHbkmTFykbMF5sJqmNJB31DOOzro=
 github.com/twmb/franz-go v1.21.2 h1:WrvV/spF48JzcRylqDQy02Vm6V6W4lhtD9Y4BOYNMu4=
 github.com/twmb/franz-go v1.21.2/go.mod h1:rfoMTnVk7107fhTGxfEKIHP/e7tPe6oyij/ywzO0czk=


### PR DESCRIPTION
Bumps `github.com/twmb/avro` from v1.4.1 to v1.8.0 and refreshes go.sum.

No code changes are required. Console only uses `Parse`, `SchemaCache.Parse`, `Decode`, `Encode`, `DecodeJSON`, `EncodeJSON` and `String`, and none of those changed across the four releases. The APIs added in that span (`Root`, the new `ocf` options, `CustomType`) are unused here.

Verified with `go build ./pkg/serde/` and `go test -count=1 ./pkg/serde/`, both passing.