### PR TITLE
fix: refresh cluster overview when create-topic dialog opens

### DIFF
--- a/frontend/src/components/pages/topics/create-topic-dialog.test.tsx
+++ b/frontend/src/components/pages/topics/create-topic-dialog.test.tsx
@@ -239,6 +239,52 @@ describe('CreateTopicDialog', () => {
     expect(screen.getByTestId('onOk-button')).toBeInTheDocument();
   });
 
+  test('Shows "Min in-sync replicas" field for Kafka clusters (UX-1460)', async () => {
+    renderDialog();
+
+    expect(screen.getByTestId('topic-min-insync-replicas')).toBeInTheDocument();
+  });
+
+  test('Hides "Min in-sync replicas" field for Redpanda clusters (UX-1460)', async () => {
+    const { api } = await import('../../../state/backend-api');
+    // biome-ignore lint/suspicious/noExplicitAny: test override
+    (api as any).isRedpanda = true;
+    // biome-ignore lint/suspicious/noExplicitAny: test override
+    (api as any).clusterOverview = { kafka: { distribution: 'REDPANDA' } };
+
+    renderDialog();
+
+    expect(screen.queryByTestId('topic-min-insync-replicas')).not.toBeInTheDocument();
+
+    // Restore api defaults so other tests are not affected
+    // biome-ignore lint/suspicious/noExplicitAny: test cleanup
+    (api as any).isRedpanda = false;
+    // biome-ignore lint/suspicious/noExplicitAny: test cleanup
+    (api as any).clusterOverview = null;
+  });
+
+  test('Refreshes cluster overview whenever the dialog opens, so isRedpanda is never stale (UX-1460)', async () => {
+    const { api } = await import('../../../state/backend-api');
+    const onClose = vi.fn();
+
+    // Dialog mounts closed: the unconditional mount effect still fires once.
+    const { rerender } = renderDialog(false, onClose);
+
+    await waitFor(() => {
+      expect(api.refreshClusterOverview).toHaveBeenCalled();
+    });
+
+    (api.refreshClusterOverview as ReturnType<typeof vi.fn>).mockClear();
+
+    // Reopening the dialog (e.g. after closing it without a page refresh) must
+    // re-fetch the cluster overview rather than relying on a stale cached value.
+    rerender(<CreateTopicDialog isOpen={true} onClose={onClose} />);
+
+    await waitFor(() => {
+      expect(api.refreshClusterOverview).toHaveBeenCalled();
+    });
+  });
+
   test('Additional config rows can be added and removed', async () => {
     const user = userEvent.setup();
     renderDialog();

--- a/frontend/src/components/pages/topics/create-topic-dialog.tsx
+++ b/frontend/src/components/pages/topics/create-topic-dialog.tsx
@@ -569,11 +569,13 @@ export function CreateTopicDialog({ isOpen, onClose }: { isOpen: boolean; onClos
 
   useEffect(() => {
     api.refreshCluster();
+    api.refreshClusterOverview();
   }, []);
 
   useEffect(() => {
     if (isOpen) {
       api.refreshCluster();
+      api.refreshClusterOverview();
       form.reset();
       setResult(null);
     }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -867,7 +867,7 @@
   resolved "https://registry.npmjs.org/@chakra-ui/shared-utils/-/shared-utils-2.0.5.tgz"
   integrity sha512-4/Wur0FqDov7Y0nCXl7HbHzCg4aq86h+SXdoUeuCMD3dSj7dpsVnStLYhng1vxvlbUnLpdF4oz5Myt3i/a7N3Q==
 
-"@chakra-ui/styled-system@2.9.2", "@chakra-ui/styled-system@>=2.0.0", "@chakra-ui/styled-system@>=2.8.0":
+"@chakra-ui/styled-system@2.9.2":
   version "2.9.2"
   resolved "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.9.2.tgz"
   integrity sha512-To/Z92oHpIE+4nk11uVMWqo2GGRS86coeMmjxtpnErmWRdLcp1WVCVRAvn+ZwpLiNR+reWFr2FFqJRsREuZdAg==
@@ -3499,7 +3499,7 @@
     seroval "^1.5.4"
     seroval-plugins "^1.5.4"
 
-"@tanstack/router-core@1.171.14":
+"@tanstack/router-core@1.171.14", "@tanstack/router-core@^1.170.0":
   version "1.171.14"
   resolved "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.171.14.tgz"
   integrity sha512-Mo3hwx0qB0cJsVYGDjG0+Ouf7VV74h/vsoDMGztdlyzDanp4gBA2s7IVvm6hFrmQM6GpD9F0Z7SqD7OldfLE7g==
@@ -4442,12 +4442,12 @@ accepts@~1.3.4:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
-"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8, acorn@^8.11.0, acorn@^8.14.0, acorn@^8.15.0, acorn@^8.4.1:
+acorn@^8.11.0, acorn@^8.15.0, acorn@^8.4.1:
   version "8.15.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
 
-acorn@^8.10.0, acorn@^8.16.0:
+"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8, acorn@^8.10.0, acorn@^8.14.0, acorn@^8.16.0:
   version "8.16.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
@@ -4927,7 +4927,7 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
-"browserslist@>= 4.21.0", browserslist@^4.26.2, browserslist@^4.27.0:
+browserslist@^4.26.2, browserslist@^4.27.0:
   version "4.28.0"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.28.0.tgz"
   integrity sha512-tbydkR/CxfMwelN0vwdP/pLkDwyAASZ+VfWm4EOwlB6SWhx1sYnWLqo8N5j0rAzPfzfRaxt0mM/4wPU/Su84RQ==
@@ -5666,7 +5666,7 @@ data-uri-to-buffer@^4.0.0:
   resolved "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz"
   integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
 
-date-fns@^2.30.0:
+date-fns@2.x, "date-fns@^2.28.0 || ^3.0.0", date-fns@^2.30.0:
   version "2.30.0"
   resolved "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz"
   integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
@@ -5678,7 +5678,7 @@ date-fns@^4.1.0:
   resolved "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz"
   integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
 
-date-fns@2.x, "date-fns@^2.28.0 || ^3.0.0", date-fns@^4.0.0, date-fns@^4.3.0:
+date-fns@^4.0.0, date-fns@^4.3.0:
   version "4.4.0"
   resolved "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz"
   integrity sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==
@@ -6548,7 +6548,7 @@ fraction.js@^5.3.4:
   resolved "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz"
   integrity sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==
 
-framer-motion@>=4.0.0, framer-motion@^10.16.4:
+framer-motion@^10.16.4:
   version "10.18.0"
   resolved "https://registry.npmjs.org/framer-motion/-/framer-motion-10.18.0.tgz"
   integrity sha512-oGlDh1Q1XqYPksuTD/usb0I70hq95OUzmL9+6Zd+Hs4XV0oaISBa/UUMSjYiq6m8EUF32132mOJ8xVZS+I0S6w==
@@ -6557,7 +6557,7 @@ framer-motion@>=4.0.0, framer-motion@^10.16.4:
   dependencies:
     tslib "^2.4.0"
 
-framer-motion@^12.40.0:
+framer-motion@>=4.0.0, framer-motion@^12.40.0:
   version "12.40.0"
   resolved "https://registry.npmjs.org/framer-motion/-/framer-motion-12.40.0.tgz"
   integrity sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==
@@ -9738,12 +9738,12 @@ react-highlight-words@^0.21.0:
     highlight-words-core "^1.2.0"
     memoize-one "^4.0.0"
 
-react-hook-form@^7.0.0, react-hook-form@^7.48.2:
+react-hook-form@^7.48.2:
   version "7.66.0"
   resolved "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.66.0.tgz"
   integrity sha512-xXBqsWGKrY46ZqaHDo+ZUYiMUgi8suYu5kdrS20EG8KiL7VRQitEbNjm+UcrDYrNi1YLyfpmAeGjCZYXLT9YBw==
 
-react-hook-form@^7.55.0, react-hook-form@^7.76.1:
+react-hook-form@^7.0.0, react-hook-form@^7.55.0, react-hook-form@^7.76.1:
   version "7.78.0"
   resolved "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.78.0.tgz"
   integrity sha512-EEZqc+N23moyzTlz61Pj+JvcXo76ICkpfOZo8JZw+sM4+wLQGh6nI2Ms+PdMOYNluFu0ghlM7B8mCzhRYtJCnA==
@@ -10498,12 +10498,7 @@ semver@^7.3.5, semver@^7.5.3:
   resolved "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz"
   integrity sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==
 
-semver@^7.5.4:
-  version "7.7.4"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz"
-  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
-
-semver@^7.8.5:
+semver@^7.5.4, semver@^7.8.5:
   version "7.8.5"
   resolved "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz"
   integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==


### PR DESCRIPTION
## Summary
- `api.isRedpanda` was only refreshed as a side effect of successfully creating a topic, not when the create-topic dialog opens
- On a fresh page load, this caused the Kafka-only "Min in-sync replicas" field to incorrectly render in the create-topic dialog for Redpanda clusters, until a topic had already been created once in that session
- Now calls `api.refreshClusterOverview()` on mount and whenever the dialog opens, so `isRedpanda` (and the field's visibility) is never based on stale state

Fixes UX-1460 (https://redpandadata.atlassian.net/browse/UX-1460)

## Test plan
- [x] Added test asserting the field shows on Kafka clusters
- [x] Added test asserting the field is hidden on Redpanda clusters
- [x] Added regression test asserting `refreshClusterOverview` is called whenever the dialog opens (verified it fails without the fix)
- [x] `bun run test:integration create-topic-dialog` passes (11/11)
- [x] `bun run lint` clean on changed files