### PR TITLE
Point kafkaConnect test image at Docker Hub instead of Cloudsmith

### DIFF
--- a/test-images.json
+++ b/test-images.json
@@ -9,7 +9,7 @@
       "tag": "v0.0.0-20260315git94f368c"
     },
     "kafkaConnect": {
-      "repository": "docker.cloudsmith.io/redpanda/connectors-unsupported/connectors",
+      "repository": "redpandadata/connectors-unsupported",
       "tag": "latest"
     },
     "owlShop": {


### PR DESCRIPTION
connectors-unsupported moved off Cloudsmith to public Docker Hub (redpandadata/connectors-unsupported) in a companion cloudv2 change. Repointed here too since backend/pkg/testutil/images.go and frontend/tests/shared/test-images.mjs both read this file to spin up a real Kafka Connect container for tests.

Verified end-to-end, not just edited: ran the actual KafkaConnectImage() loader against this file and confirmed it resolves to redpandadata/connectors-unsupported:latest.