### PR TITLE
[release-2.8] backend: migrate avro library from hamba/avro to twmb/avro

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -27,12 +27,10 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/schema v1.4.1
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0
-	github.com/hamba/avro/v2 v2.27.0
 	github.com/jarcoal/httpmock v1.3.1
 	github.com/jcmturner/gokrb5/v8 v8.4.4
 	github.com/jhump/protoreflect v1.16.0
 	github.com/knadh/koanf v1.5.0
-	github.com/linkedin/goavro v2.1.0+incompatible
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/prometheus/client_golang v1.20.5
 	github.com/redpanda-data/benthos/v4 v4.42.0
@@ -125,7 +123,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
-	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/cel-go v0.22.1 // indirect
 	github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad // indirect
 	github.com/gorilla/handlers v1.5.2 // indirect
@@ -140,7 +137,6 @@ require (
 	github.com/jcmturner/gofork v1.7.6 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/klauspost/compress v1.19.2 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
@@ -158,8 +154,6 @@ require (
 	github.com/moby/sys/user v0.3.0 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/moby/term v0.5.0 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
@@ -189,6 +183,7 @@ require (
 	github.com/tilinna/z85 v1.0.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.14 // indirect
 	github.com/tklauser/numcpus v0.9.0 // indirect
+	github.com/twmb/avro v1.8.0
 	github.com/urfave/cli/v2 v2.27.5 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
@@ -209,7 +204,6 @@ require (
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
-	gopkg.in/linkedin/goavro.v1 v1.0.5 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -300,8 +300,6 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
-github.com/hamba/avro/v2 v2.27.0 h1:IAM4lQ0VzUIKBuo4qlAiLKfqALSrFC+zi1iseTtbBKU=
-github.com/hamba/avro/v2 v2.27.0/go.mod h1:jN209lopfllfrz7IGoZErlDz+AyUJ3vrBePQFZwYf5I=
 github.com/hashicorp/consul/api v1.13.0/go.mod h1:ZlVrynguJKcYr54zGaDbaL3fOvKC9m72FhPvA8T35KQ=
 github.com/hashicorp/consul/sdk v0.8.0/go.mod h1:GBvyrGALthsZObzUGsfgHZQDXjg4lOjagTIwIR1vPms=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -389,8 +387,6 @@ github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
-github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
-github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
@@ -421,8 +417,6 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/linkedin/goavro v2.1.0+incompatible h1:DV2aUlj2xZiuxQyvag8Dy7zjY69ENjS66bWkSfdpddY=
-github.com/linkedin/goavro v2.1.0+incompatible/go.mod h1:bBCwI2eGYpUI/4820s67MElg9tdeLbINjLjiM2xZFYM=
 github.com/linkedin/goavro/v2 v2.13.0 h1:L8eI8GcuciwUkt41Ej62joSZS4kKaYIUdze+6for9NU=
 github.com/linkedin/goavro/v2 v2.13.0/go.mod h1:KXx+erlq+RPlGSPmLF7xGo6SAbh8sCQ53x064+ioxhk=
 github.com/lufia/plan9stats v0.0.0-20240909124753-873cd0166683 h1:7UMa6KCCMjZEMDtTVdcGu0B1GmmC7QJKiCCjyTAWQy0=
@@ -486,12 +480,9 @@ github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcY
 github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=
 github.com/moby/term v0.5.0/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
-github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
-github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
@@ -641,6 +632,8 @@ github.com/tklauser/go-sysconf v0.3.14 h1:g5vzr9iPFFz24v2KZXs/pvpvh8/V9Fw6vQK5ZZ
 github.com/tklauser/go-sysconf v0.3.14/go.mod h1:1ym4lWMLUOhuBOPGtRcJm7tEGX4SCYNEEEtghGG/8uY=
 github.com/tklauser/numcpus v0.9.0 h1:lmyCHtANi8aRUgkckBgoDk1nHCux3n2cgkJLXdQGPDo=
 github.com/tklauser/numcpus v0.9.0/go.mod h1:SN6Nq1O3VychhC1npsWostA+oW+VOQTxZrS604NSRyI=
+github.com/twmb/avro v1.8.0 h1:UMWLg+nH4P3yad5Om7yFSohYLy2RG1s7BcFFiOvmK9Q=
+github.com/twmb/avro v1.8.0/go.mod h1:X0fT1dY2xcbV4YuCE4mYro+qljHl4kUF5uA/2z1rgSk=
 github.com/twmb/franz-go v1.7.0/go.mod h1:PMze0jNfNghhih2XHbkmTFykbMF5sJqmNJB31DOOzro=
 github.com/twmb/franz-go v1.18.0 h1:25FjMZfdozBywVX+5xrWC2W+W76i0xykKjTdEeD2ejw=
 github.com/twmb/franz-go v1.18.0/go.mod h1:zXCGy74M0p5FbXsLeASdyvfLFsBvTubVqctIaa5wQ+I=
@@ -930,8 +923,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
-gopkg.in/linkedin/goavro.v1 v1.0.5 h1:BJa69CDh0awSsLUmZ9+BowBdokpduDZSM9Zk8oKHfN4=
-gopkg.in/linkedin/goavro.v1 v1.0.5/go.mod h1:Aw5GdAbizjOEl0kAMHV9iHmA8reZzW/OKuJAl4Hb9F0=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=

--- a/backend/pkg/schema/service.go
+++ b/backend/pkg/schema/service.go
@@ -19,10 +19,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hamba/avro/v2"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/desc/protoparse"
 	"github.com/santhosh-tekuri/jsonschema/v5"
+	"github.com/twmb/avro"
 	"github.com/twmb/go-cache/cache"
 	"go.uber.org/zap"
 	"golang.org/x/sync/singleflight"
@@ -43,7 +43,7 @@ type Service struct {
 	// schemaBySubjectVersion caches schema response by subject and version. Caching schemas
 	// by subjects is needed to lookup references in avro schemas.
 	schemaBySubjectVersion *cache.Cache[string, *SchemaVersionedResponse]
-	avroSchemaByID         *cache.Cache[uint32, avro.Schema]
+	avroSchemaByID         *cache.Cache[uint32, *avro.Schema]
 	jsonSchemaByID         *cache.Cache[uint32, *jsonschema.Schema]
 
 	// for protobuf schema refreshing and compiling
@@ -64,7 +64,7 @@ func NewService(cfg config.Schema, logger *zap.Logger) (*Service, error) {
 		logger:                 logger,
 		requestGroup:           singleflight.Group{},
 		registryClient:         client,
-		avroSchemaByID:         cache.New[uint32, avro.Schema](cache.MaxAge(5*time.Minute), cache.MaxErrorAge(time.Second)),
+		avroSchemaByID:         cache.New[uint32, *avro.Schema](cache.MaxAge(5*time.Minute), cache.MaxErrorAge(time.Second)),
 		schemaBySubjectVersion: cache.New[string, *SchemaVersionedResponse](cache.MaxAge(5*time.Minute), cache.MaxErrorAge(time.Second)),
 		jsonSchemaByID:         cache.New[uint32, *jsonschema.Schema](cache.MaxAge(5*time.Minute), cache.MaxErrorAge(time.Second)),
 	}, nil
@@ -236,15 +236,15 @@ func (s *Service) IsEnabled() bool {
 
 // GetAvroSchemaByID loads the schema by the given schemaID and tries to parse the schema
 // contents to an avro.Schema, so that it can be used for decoding Avro encoded messages.
-func (s *Service) GetAvroSchemaByID(ctx context.Context, schemaID uint32) (avro.Schema, error) {
-	codecCached, err, _ := s.avroSchemaByID.Get(schemaID, func() (avro.Schema, error) {
+func (s *Service) GetAvroSchemaByID(ctx context.Context, schemaID uint32) (*avro.Schema, error) {
+	codecCached, err, _ := s.avroSchemaByID.Get(schemaID, func() (*avro.Schema, error) {
 		schemaRes, err := s.registryClient.GetSchemaByID(ctx, schemaID)
 		if err != nil {
 			s.logger.Warn("failed to fetch avro schema", zap.Uint32("schema_id", schemaID), zap.Error(err))
 			return nil, fmt.Errorf("failed to get schema from registry: %w", err)
 		}
 
-		codec, err := s.ParseAvroSchemaWithReferences(ctx, schemaRes, avro.DefaultSchemaCache)
+		codec, err := s.ParseAvroSchemaWithReferences(ctx, schemaRes)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse schema: %w", err)
 		}
@@ -336,45 +336,57 @@ func (s *Service) GetSchemaByID(ctx context.Context, id uint32) (*SchemaResponse
 // to other schemas. References will be resolved by requesting and parsing them
 // recursively. If any of the referenced schemas can't be fetched or parsed an
 // error will be returned.
-func (s *Service) ParseAvroSchemaWithReferences(ctx context.Context, schema *SchemaResponse, schemaCache *avro.SchemaCache) (avro.Schema, error) {
-	if len(schema.References) == 0 {
-		return avro.Parse(schema.Schema)
+func (s *Service) ParseAvroSchemaWithReferences(ctx context.Context, schema *SchemaResponse) (*avro.Schema, error) {
+	// Parse into a cache scoped to this operation so that named types from one
+	// schema can never leak into the parsing of an unrelated schema.
+	var cache avro.SchemaCache
+	if err := s.parseAvroReferences(ctx, &cache, schema, make(map[string]bool)); err != nil {
+		return nil, err
 	}
+	return cache.Parse(schema.Schema)
+}
 
-	// Fetch and parse all schema references recursively. All schemas that have
-	// been parsed successfully will be cached by the avro library.
+// parseAvroReferences recursively fetches and parses all schema references
+// into the cache so they are available when parsing the parent schema.
+// The stack only guards against reference cycles; duplicate parses across
+// shared subgraphs are handled by the avro.SchemaCache itself.
+func (s *Service) parseAvroReferences(ctx context.Context, cache *avro.SchemaCache, schema *SchemaResponse, stack map[string]bool) error {
 	for _, reference := range schema.References {
+		refKey := fmt.Sprintf("%s:%d", reference.Subject, reference.Version)
+		if stack[refKey] {
+			return fmt.Errorf("circular avro schema reference detected for subject %q version %d", reference.Subject, reference.Version)
+		}
+		stack[refKey] = true
+
 		schemaRef, err := s.GetSchemaBySubjectAndVersion(ctx, reference.Subject, strconv.Itoa(reference.Version))
 		if err != nil {
-			return nil, err
+			delete(stack, refKey)
+			return err
 		}
-
-		if _, err := s.ParseAvroSchemaWithReferences(
-			ctx,
-			&SchemaResponse{
-				Schema:     schemaRef.Schema,
-				References: schemaRef.References,
-			},
-			schemaCache,
-		); err != nil {
-			return nil, fmt.Errorf(
-				"failed to parse schema reference (subject: %q, version %d): %w",
-				reference.Subject, reference.Version, err,
-			)
+		if len(schemaRef.References) > 0 {
+			refRes := &SchemaResponse{Schema: schemaRef.Schema, References: schemaRef.References}
+			if err := s.parseAvroReferences(ctx, cache, refRes, stack); err != nil {
+				delete(stack, refKey)
+				return fmt.Errorf("failed to parse schema reference (subject: %q, version %d): %w",
+					reference.Subject, reference.Version, err)
+			}
 		}
+		if _, err := cache.Parse(schemaRef.Schema); err != nil {
+			delete(stack, refKey)
+			return fmt.Errorf("failed to parse schema reference (subject: %q, version %d): %w",
+				reference.Subject, reference.Version, err)
+		}
+		delete(stack, refKey)
 	}
-
-	// Parse the main schema in the end after solving all references
-	return avro.Parse(schema.Schema)
+	return nil
 }
 
 // ValidateAvroSchema tries to parse the given avro schema with the avro library.
 // If there's an issue with the given schema, it will be returned to the user
 // so that they can fix the schema string.
 func (s *Service) ValidateAvroSchema(ctx context.Context, sch Schema) error {
-	tempCache := avro.SchemaCache{}
 	schemaRes := &SchemaResponse{Schema: sch.Schema, References: sch.References}
-	_, err := s.ParseAvroSchemaWithReferences(ctx, schemaRes, &tempCache)
+	_, err := s.ParseAvroSchemaWithReferences(ctx, schemaRes)
 	return err
 }
 

--- a/backend/pkg/schema/service_test.go
+++ b/backend/pkg/schema/service_test.go
@@ -63,7 +63,7 @@ func TestService_GetAvroSchemaByID(t *testing.T) {
 		})
 
 	actual, err := s.GetAvroSchemaByID(context.Background(), 1000)
-	expectedSchemaString := "{\"name\":\"parent.schema\",\"type\":\"record\",\"fields\":[{\"name\":\"reference\",\"type\":{\"name\":\"referenced.schema\",\"type\":\"enum\",\"symbols\":[\"FOO\"]}}]}"
+	expectedSchemaString := "{\"fields\":[{\"name\":\"reference\",\"type\":{\"name\":\"schema\",\"namespace\":\"referenced\",\"symbols\":[\"FOO\"],\"type\":\"enum\"}}],\"name\":\"parent.schema\",\"type\":\"record\"}"
 	assert.NoError(t, err, "expected no error when fetching avro schema by id")
 	assert.Equal(t, actual.String(), expectedSchemaString)
 }
@@ -125,4 +125,49 @@ func TestService_GetProtoDescriptors_ShouldContinueWithValidSchemasWhenSomeHaveB
 	assert.Len(t, descriptors, 1, "should have 1 valid descriptor (broken ones skipped)")
 	assert.Contains(t, descriptors, 100, "should contain the valid UserEvent schema")
 	// Schema 200 (order-events-value) should be skipped due to broken reference
+}
+
+func TestService_ParseAvroSchemaWithReferences_DiamondReferences(t *testing.T) {
+	baseURL := testSchemaRegistryBaseURL
+	logger, _ := zap.NewProduction()
+	s, _ := NewService(config.Schema{
+		Enabled: true,
+		URLs:    []string{baseURL},
+	}, logger)
+
+	httpClient := (*s.registryClient.client).GetClient()
+	httpmock.ActivateNonDefault(httpClient)
+	defer httpmock.DeactivateAndReset()
+
+	// Left and Right both reference Leaf; Root references Left and Right.
+	// Parsing must tolerate Leaf being resolved twice via different paths.
+	registerSubject := func(subject, schema string, references []map[string]any) {
+		httpmock.RegisterResponder("GET", baseURL+"/subjects/"+subject+"/versions/1",
+			func(*http.Request) (*http.Response, error) {
+				return httpmock.NewJsonResponse(http.StatusOK, map[string]any{
+					"schema":     schema,
+					"subject":    subject,
+					"version":    1,
+					"schemaType": "AVRO",
+					"references": references,
+				})
+			})
+	}
+
+	leafRef := []map[string]any{{"name": "Leaf", "subject": "leaf-schema", "version": 1}}
+	registerSubject("leaf-schema", `{"type": "record", "name": "Leaf", "fields": [{"name": "value", "type": "string"}]}`, nil)
+	registerSubject("left-schema", `{"type": "record", "name": "Left", "fields": [{"name": "leaf", "type": "Leaf"}]}`, leafRef)
+	registerSubject("right-schema", `{"type": "record", "name": "Right", "fields": [{"name": "leaf", "type": "Leaf"}]}`, leafRef)
+
+	rootSchema := &SchemaResponse{
+		Schema: `{"type": "record", "name": "Root", "fields": [{"name": "left", "type": "Left"}, {"name": "right", "type": "Right"}]}`,
+		References: []SchemaReference{
+			{Name: "Left", Subject: "left-schema", Version: 1},
+			{Name: "Right", Subject: "right-schema", Version: 1},
+		},
+	}
+
+	result, err := s.ParseAvroSchemaWithReferences(context.Background(), rootSchema)
+	require.NoError(t, err)
+	require.NotNil(t, result)
 }

--- a/backend/pkg/serde/avro.go
+++ b/backend/pkg/serde/avro.go
@@ -12,12 +12,9 @@ package serde
 import (
 	"context"
 	"encoding/binary"
-	"encoding/json"
 	"errors"
 	"fmt"
 
-	"github.com/hamba/avro/v2"
-	"github.com/linkedin/goavro"
 	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/redpanda-data/console/backend/pkg/schema"
@@ -58,12 +55,12 @@ func (d AvroSerde) DeserializePayload(ctx context.Context, record *kgo.Record, p
 	}
 
 	var obj any
-	err = avro.Unmarshal(schema, payload[5:], &obj)
+	_, err = schema.Decode(payload[5:], &obj)
 	if err != nil {
 		return &RecordPayload{}, fmt.Errorf("decoding avro: %w", err)
 	}
 
-	jsonBytes, err := json.Marshal(obj)
+	jsonBytes, err := schema.EncodeJSON(obj)
 	if err != nil {
 		return &RecordPayload{}, fmt.Errorf("serializing avro: %w", err)
 	}
@@ -102,15 +99,11 @@ func (d AvroSerde) SerializeObject(ctx context.Context, obj any, _ PayloadType, 
 		}
 
 		if startsWithJSON {
-			codec, err := goavro.NewCodec(schema.String())
-			if err != nil {
-				return nil, fmt.Errorf("parsing avro schema: %w", err)
+			var native any
+			if err := schema.DecodeJSON(trimmed, &native); err != nil {
+				return nil, fmt.Errorf("deserializing: %w", err)
 			}
-
-			obj, _, err = codec.NativeFromTextual(trimmed)
-			if err != nil {
-				return nil, fmt.Errorf("deserializing avro json: %w", err)
-			}
+			obj = native
 		}
 	case string:
 		trimmed, startsWithJSON, err := trimJSONInputString(v)
@@ -119,19 +112,15 @@ func (d AvroSerde) SerializeObject(ctx context.Context, obj any, _ PayloadType, 
 		}
 
 		if startsWithJSON {
-			codec, err := goavro.NewCodec(schema.String())
-			if err != nil {
-				return nil, fmt.Errorf("parsing avro schema: %w", err)
+			var native any
+			if err := schema.DecodeJSON([]byte(trimmed), &native); err != nil {
+				return nil, fmt.Errorf("deserializing: %w", err)
 			}
-
-			obj, _, err = codec.NativeFromTextual([]byte(trimmed))
-			if err != nil {
-				return nil, fmt.Errorf("deserializing avro json: %w", err)
-			}
+			obj = native
 		}
 	}
 
-	b, err := avro.Marshal(schema, obj)
+	b, err := schema.Encode(obj)
 	if err != nil {
 		return nil, fmt.Errorf("failed to serialize avro: %w", err)
 	}

--- a/backend/pkg/serde/avro_test.go
+++ b/backend/pkg/serde/avro_test.go
@@ -16,9 +16,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/hamba/avro/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/twmb/avro"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sr"
 	"go.uber.org/zap"
@@ -85,10 +85,11 @@ func TestAvroSerde_DeserializePayload(t *testing.T) {
 		3000,
 		&SimpleRecord{},
 		sr.EncodeFn(func(v any) ([]byte, error) {
-			return avro.Marshal(avroSchema, v.(*SimpleRecord))
+			return avroSchema.Encode(v.(*SimpleRecord))
 		}),
 		sr.DecodeFn(func(b []byte, v any) error {
-			return avro.Unmarshal(avroSchema, b, v.(*SimpleRecord))
+			_, err := avroSchema.Decode(b, v.(*SimpleRecord))
+			return err
 		}),
 	)
 
@@ -97,10 +98,11 @@ func TestAvroSerde_DeserializePayload(t *testing.T) {
 		1001,
 		&SimpleRecord{},
 		sr.EncodeFn(func(v any) ([]byte, error) {
-			return avro.Marshal(avroSchema, v.(*SimpleRecord))
+			return avroSchema.Encode(v.(*SimpleRecord))
 		}),
 		sr.DecodeFn(func(b []byte, v any) error {
-			return avro.Unmarshal(avroSchema, b, v.(*SimpleRecord))
+			_, err := avroSchema.Decode(b, v.(*SimpleRecord))
+			return err
 		}),
 	)
 
@@ -147,11 +149,11 @@ func TestAvroSerde_DeserializePayload(t *testing.T) {
 				obj, ok := (payload.DeserializedPayload).(map[string]any)
 				require.Truef(t, ok, "parsed payload is not of type map[string]any")
 
-				data, err := avro.Marshal(avroSchema, obj)
+				data, err := avroSchema.Encode(obj)
 				require.NoError(t, err)
 
 				out := SimpleRecord{}
-				err = avro.Unmarshal(avroSchema, data, &out)
+				_, err = avroSchema.Decode(data, &out)
 				require.NoError(t, err)
 
 				assert.Equal(t, int64(27), out.A)
@@ -327,10 +329,11 @@ func TestAvroSerde_SerializeObject(t *testing.T) {
 			2000,
 			&SimpleRecord{},
 			sr.EncodeFn(func(v any) ([]byte, error) {
-				return avro.Marshal(avroSchema, v.(*SimpleRecord))
+				return avroSchema.Encode(v.(*SimpleRecord))
 			}),
 			sr.DecodeFn(func(b []byte, v any) error {
-				return avro.Unmarshal(avroSchema, b, v.(*SimpleRecord))
+				_, err := avroSchema.Decode(b, v.(*SimpleRecord))
+				return err
 			}),
 		)
 
@@ -351,10 +354,11 @@ func TestAvroSerde_SerializeObject(t *testing.T) {
 			2000,
 			&SimpleRecord{},
 			sr.EncodeFn(func(v any) ([]byte, error) {
-				return avro.Marshal(avroSchema, v.(*SimpleRecord))
+				return avroSchema.Encode(v.(*SimpleRecord))
 			}),
 			sr.DecodeFn(func(b []byte, v any) error {
-				return avro.Unmarshal(avroSchema, b, v.(*SimpleRecord))
+				_, err := avroSchema.Decode(b, v.(*SimpleRecord))
+				return err
 			}),
 		)
 
@@ -372,7 +376,8 @@ func TestAvroSerde_SerializeObject(t *testing.T) {
 
 		b, err := serde.SerializeObject(context.Background(), `{"p":"q","r":12}`, PayloadTypeValue, WithSchemaID(2000))
 		require.Error(t, err)
-		assert.Equal(t, `deserializing avro json: cannot decode textual record "org.hamba.avro.simple": cannot decode textual map: cannot determine codec: "p"`, err.Error())
+		assert.ErrorContains(t, err, "deserializing:")
+		assert.ErrorContains(t, err, "missing required field \"a\"")
 		assert.Nil(t, b)
 	})
 
@@ -384,10 +389,11 @@ func TestAvroSerde_SerializeObject(t *testing.T) {
 			2000,
 			&SimpleRecord{},
 			sr.EncodeFn(func(v any) ([]byte, error) {
-				return avro.Marshal(avroSchema, v.(*SimpleRecord))
+				return avroSchema.Encode(v.(*SimpleRecord))
 			}),
 			sr.DecodeFn(func(b []byte, v any) error {
-				return avro.Unmarshal(avroSchema, b, v.(*SimpleRecord))
+				_, err := avroSchema.Decode(b, v.(*SimpleRecord))
+				return err
 			}),
 		)
 

--- a/backend/pkg/serde/service_integration_test.go
+++ b/backend/pkg/serde/service_integration_test.go
@@ -26,12 +26,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hamba/avro/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/redpanda"
+	"github.com/twmb/avro"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sr"
@@ -1178,7 +1178,7 @@ func (s *SerdeIntegrationTestSuite) TestDeserializeRecord() {
 		assert.Equal(string(PayloadEncodingXML), dr.Value.Troubleshooting[3].SerdeName)
 		assert.Equal("first byte indicates this it not valid XML", dr.Value.Troubleshooting[3].Message)
 		assert.Equal(string(PayloadEncodingAvro), dr.Value.Troubleshooting[4].SerdeName)
-		assert.Contains(dr.Value.Troubleshooting[4].Message, "getting avro schema from registry: failed to parse schema: avro: unknown type:")
+		assert.Contains(dr.Value.Troubleshooting[4].Message, "getting avro schema from registry: failed to parse schema:")
 		assert.Equal(string(PayloadEncodingProtobuf), dr.Value.Troubleshooting[5].SerdeName)
 		assert.Equal("failed to get message descriptor for payload: no prototype found for the given topic 'test.redpanda.console.serde_schema_protobuf'. Check your configured protobuf mappings", dr.Value.Troubleshooting[5].Message)
 
@@ -1580,7 +1580,7 @@ func (s *SerdeIntegrationTestSuite) TestDeserializeRecord() {
 		assert.Equal(string(PayloadEncodingXML), dr.Value.Troubleshooting[3].SerdeName)
 		assert.Equal("first byte indicates this it not valid XML", dr.Value.Troubleshooting[3].Message)
 		assert.Equal(string(PayloadEncodingAvro), dr.Value.Troubleshooting[4].SerdeName)
-		assert.Contains(dr.Value.Troubleshooting[4].Message, "getting avro schema from registry: failed to parse schema: avro: unknown type:")
+		assert.Contains(dr.Value.Troubleshooting[4].Message, "getting avro schema from registry: failed to parse schema:")
 		assert.Equal(string(PayloadEncodingProtobuf), dr.Value.Troubleshooting[5].SerdeName)
 		assert.Equal("failed to get message descriptor for payload: no prototype found for the given topic 'test.redpanda.console.serde_schema_protobuf_multi'. Check your configured protobuf mappings", dr.Value.Troubleshooting[5].Message)
 
@@ -1789,7 +1789,7 @@ func (s *SerdeIntegrationTestSuite) TestDeserializeRecord() {
 		assert.Equal(string(PayloadEncodingXML), dr.Value.Troubleshooting[3].SerdeName)
 		assert.Equal("first byte indicates this it not valid XML", dr.Value.Troubleshooting[3].Message)
 		assert.Equal(string(PayloadEncodingAvro), dr.Value.Troubleshooting[4].SerdeName)
-		assert.Contains(dr.Value.Troubleshooting[4].Message, "getting avro schema from registry: failed to parse schema: avro: unknown type:")
+		assert.Contains(dr.Value.Troubleshooting[4].Message, "getting avro schema from registry: failed to parse schema:")
 		assert.Equal(string(PayloadEncodingProtobuf), dr.Value.Troubleshooting[5].SerdeName)
 		assert.Equal("failed to get message descriptor for payload: no prototype found for the given topic 'test.redpanda.console.serde_schema_protobuf_nest'. Check your configured protobuf mappings", dr.Value.Troubleshooting[5].Message)
 
@@ -2666,7 +2666,9 @@ func (s *SerdeIntegrationTestSuite) TestDeserializeRecord() {
 			]
 		}`
 
-		eventDataSchema, err := avro.Parse(eventDataSchemaStr)
+		var schemaCache avro.SchemaCache
+
+		eventDataSchema, err := schemaCache.Parse(eventDataSchemaStr)
 		require.NoError(err)
 		require.NotEmpty(eventDataSchema)
 
@@ -2698,7 +2700,7 @@ func (s *SerdeIntegrationTestSuite) TestDeserializeRecord() {
 			]
 		}`
 
-		userSchema, err := avro.Parse(userSchemaStr)
+		userSchema, err := schemaCache.Parse(userSchemaStr)
 		require.NoError(err)
 		require.NotEmpty(userSchema)
 
@@ -2745,7 +2747,7 @@ func (s *SerdeIntegrationTestSuite) TestDeserializeRecord() {
 			]
 		}`
 
-		orderSchema, err := avro.Parse(orderSchemaStr)
+		orderSchema, err := schemaCache.Parse(orderSchemaStr)
 		require.NoError(err)
 		require.NotEmpty(orderSchema)
 
@@ -2814,10 +2816,11 @@ func (s *SerdeIntegrationTestSuite) TestDeserializeRecord() {
 			ssOrder.ID,
 			&OrderRecord{},
 			sr.EncodeFn(func(v any) ([]byte, error) {
-				return avro.Marshal(orderSchema, v.(*OrderRecord))
+				return orderSchema.Encode(v.(*OrderRecord))
 			}),
 			sr.DecodeFn(func(b []byte, v any) error {
-				return avro.Unmarshal(orderSchema, b, v.(*OrderRecord))
+				_, err := orderSchema.Decode(b, v.(*OrderRecord))
+				return err
 			}),
 		)
 
@@ -4286,7 +4289,9 @@ func (s *SerdeIntegrationTestSuite) TestSerializeRecord() {
 			]
 		}`
 
-		eventDataSchema, err := avro.Parse(eventDataSchemaStr)
+		var schemaCache avro.SchemaCache
+
+		eventDataSchema, err := schemaCache.Parse(eventDataSchemaStr)
 		require.NoError(err)
 		require.NotEmpty(eventDataSchema)
 
@@ -4318,7 +4323,7 @@ func (s *SerdeIntegrationTestSuite) TestSerializeRecord() {
 			]
 		}`
 
-		userSchema, err := avro.Parse(userSchemaStr)
+		userSchema, err := schemaCache.Parse(userSchemaStr)
 		require.NoError(err)
 		require.NotEmpty(userSchema)
 
@@ -4365,7 +4370,7 @@ func (s *SerdeIntegrationTestSuite) TestSerializeRecord() {
 			]
 		}`
 
-		orderSchema, err := avro.Parse(orderSchemaStr)
+		orderSchema, err := schemaCache.Parse(orderSchemaStr)
 		require.NoError(err)
 		require.NotEmpty(orderSchema)
 
@@ -4454,10 +4459,11 @@ func (s *SerdeIntegrationTestSuite) TestSerializeRecord() {
 			ssOrder.ID,
 			&OrderRecord{},
 			sr.EncodeFn(func(v any) ([]byte, error) {
-				return avro.Marshal(orderSchema, v.(*OrderRecord))
+				return orderSchema.Encode(v.(*OrderRecord))
 			}),
 			sr.DecodeFn(func(b []byte, v any) error {
-				return avro.Unmarshal(orderSchema, b, v.(*OrderRecord))
+				_, err := orderSchema.Decode(b, v.(*OrderRecord))
+				return err
 			}),
 		)
 

--- a/frontend/src/components/misc/KowlJsonView.tsx
+++ b/frontend/src/components/misc/KowlJsonView.tsx
@@ -44,15 +44,23 @@ export const KowlJsonView = observer(
   (props: {
     srcObj: object | string | null | undefined;
     style?: CSSProperties;
+    // escapeLatin1 re-escapes code points in 0x80-0xFF as \u00XX so bytes from
+    // Avro's JSON bytes encoding survive copy-paste out of the viewer. Without
+    // this, JSON.stringify emits the code point as a literal glyph and the
+    // clipboard receives the UTF-8 encoding, not the original byte.
+    escapeLatin1?: boolean;
   }) => {
     const containerRef = useRef<HTMLDivElement | null>(null);
     const editorRef = useRef<IStandaloneCodeEditor | null>(null);
     const frameRef = useRef<number | null>(null);
     const lastSizeRef = useRef({ width: 0, height: 0 });
-    const str = useMemo(
-      () => (typeof props.srcObj === 'string' ? props.srcObj : JSON.stringify(props.srcObj, undefined, 4)),
-      [props.srcObj],
-    );
+    const str = useMemo(() => {
+      const raw = typeof props.srcObj === 'string' ? props.srcObj : JSON.stringify(props.srcObj, undefined, 4);
+      if (!props.escapeLatin1) {
+        return raw;
+      }
+      return raw.replace(/[\u0080-\u00ff]/g, (c) => `\\u00${c.charCodeAt(0).toString(16).padStart(2, '0')}`);
+    }, [props.srcObj, props.escapeLatin1]);
 
     const scheduleLayout = useCallback(() => {
       if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);

--- a/frontend/src/components/pages/topics/Tab.Messages/index.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/index.tsx
@@ -1733,7 +1733,10 @@ const PayloadComponent = observer(
         );
       }
 
-      return <KowlJsonView srcObj={val} />;
+      // Avro JSON encodes bytes fields as \u00XX escape sequences. Re-escape
+      // Latin-1 code points in the viewer so copy-paste yields the original
+      // bytes rather than their UTF-8 encoding.
+      return <KowlJsonView escapeLatin1={payload.encoding === 'avro'} srcObj={val} />;
     } catch (e) {
       return <span style={{ color: 'red' }}>Error in RenderExpandedMessage: {(e as Error).message ?? String(e)}</span>;
     }


### PR DESCRIPTION
Replace hamba/avro and linkedin/goavro with twmb/avro v1.8.0 across the serde and schema packages.

The serde now decodes with Schema.Decode and renders payloads with the schema-aware Schema.EncodeJSON: bytes and fixed fields encode as \u00XX strings, NaN and Infinity encode as strings instead of failing, and logical-type
durations keep their original millis or micros values. JSON input is serialized through Schema.DecodeJSON, removing the goavro codec.

Schema references now parse into a per-call avro.SchemaCache rather than a process-global cache, with a cycle guard and support for diamond-shaped reference graphs. Schemas that under-declare references and only parsed through global cache pollution now fail deterministically.

The frontend JSON viewer gains an escapeLatin1 prop, enabled for avro payloads, so \u00XX byte escapes survive display and copy-paste instead of being converted to UTF-8 glyphs.

GetAvroSchemaByID returns *avro.Schema and ParseAvroSchemaWithReferences drops its schemaCache parameter.

Functional ports of #2271, #2351, #2606, and #2425

**Example**

Using rpk to show that the messages are serialized, and next to it Console successfully deserializing the payload

<img width="1650" height="833" alt="image" src="https://github.com/user-attachments/assets/32641126-8a33-48db-8eb3-85ea086a1e81" />
