### PR TITLE
frontend/rpcn: render field descriptions as prose, link each field to its docs

### DIFF
--- a/frontend/src/components/pages/rp-connect/onboarding/connect-command-palette-utils.test.ts
+++ b/frontend/src/components/pages/rp-connect/onboarding/connect-command-palette-utils.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 
 import {
   aliasTermsForName,
-  asciidocToMarkdown,
   buildEmptyMessage,
   byProminence,
   COMPONENT_ALIASES,
@@ -114,30 +113,6 @@ describe('searchableText', () => {
     expect(text).toContain('rest endpoints');
     expect(text).toContain('network');
     expect(text).toBe(text.toLowerCase());
-  });
-});
-
-describe('asciidocToMarkdown', () => {
-  it('turns AsciiDoc section titles into Markdown headings instead of leaking "=="', () => {
-    const out = asciidocToMarkdown('== Performance\nThis output benefits from batching.');
-    expect(out).toBe('#### Performance\nThis output benefits from batching.');
-    expect(out).not.toContain('== ');
-  });
-
-  it('handles multiple heading levels and keeps paragraphs separated', () => {
-    const out = asciidocToMarkdown('Intro paragraph.\n\n=== Delivery Guarantees\nAt least once.');
-    expect(out).toBe('Intro paragraph.\n\n#### Delivery Guarantees\nAt least once.');
-  });
-
-  it('converts link/xref macros to label text and bare URL macros to Markdown links', () => {
-    expect(asciidocToMarkdown('See xref:guides:about.adoc[the guide] for details.')).toBe('See the guide for details.');
-    expect(asciidocToMarkdown('Uses https://github.com/twmb/franz-go[franz-go] under the hood.')).toBe(
-      'Uses [franz-go](https://github.com/twmb/franz-go) under the hood.'
-    );
-  });
-
-  it('converts AsciiDoc bullets to Markdown list items', () => {
-    expect(asciidocToMarkdown('* first\n* second')).toBe('- first\n- second');
   });
 });
 

--- a/frontend/src/components/pages/rp-connect/onboarding/connect-command-palette-utils.ts
+++ b/frontend/src/components/pages/rp-connect/onboarding/connect-command-palette-utils.ts
@@ -174,37 +174,6 @@ export function matchRank(component: ConnectComponentSpec, query: string, text: 
   return text.includes(query) ? 3 : -1;
 }
 
-// Reduce one-line AsciiDoc summaries (link macros, code spans) to plain label text on a single line.
-export function cleanText(text: string): string {
-  return text
-    .replace(/(?:xref|link):[^\s[]*\[([^\]]*)\]/g, '$1')
-    .replace(/https?:\/\/[^\s[]+\[([^\]]*)\]/g, '$1')
-    .replace(/`([^`]+)`/g, '$1')
-    .replace(/\s+/g, ' ')
-    .trim();
-}
-
-// Convert the AsciiDoc constructs Connect uses (titles, link macros, bullets) to Markdown for react-markdown.
-// Unlike cleanText, newlines are preserved so titles/paragraphs stay distinct.
-export function asciidocToMarkdown(raw: string): string {
-  return (
-    raw
-      .replace(/\r\n/g, '\n')
-      // Link macros → label text.
-      .replace(/(?:xref|link):[^\s[\]]*\[([^\]]*)\]/g, '$1')
-      // Bare URL macro → Markdown link.
-      .replace(/(https?:\/\/[^\s[\]]+)\[([^\]]*)\]/g, '[$2]($1)')
-      // Section titles (`==`/`===`/… Title) → small heading.
-      .replace(/^=+\s+(.{1,60})$/gm, '#### $1')
-      // Strip leftover markers from over-long titles.
-      .replace(/^=+\s+/gm, '')
-      // List markers → bullets.
-      .replace(/^\*\s+/gm, '- ')
-      .replace(/\n{3,}/g, '\n\n')
-      .trim()
-  );
-}
-
 const STARTS_WITH_VOWEL_REGEX = /^[aeiou]/;
 
 // Humanize + pluralize snake_case labels, joined with "or": ['cache', 'rate_limit'] → 'caches or rate limits'.

--- a/frontend/src/components/pages/rp-connect/onboarding/connect-command-palette.tsx
+++ b/frontend/src/components/pages/rp-connect/onboarding/connect-command-palette.tsx
@@ -31,7 +31,7 @@ import {
 } from './connect-command-palette-utils';
 import { ConnectorLogo } from './connector-logo';
 import type { ConnectComponentSpec, ConnectComponentType, ExtendedConnectComponentSpec } from '../types/schema';
-import { asciidocToMarkdown, cleanText } from '../utils/asciidoc';
+import { asciidocToMarkdown, markdownToPlainText } from '../utils/asciidoc';
 import { getCategoryDisplayName } from '../utils/categories';
 import { getConnectorDocsUrl } from '../utils/connector-docs';
 import { componentStatusToString, parseSchema } from '../utils/schema';
@@ -162,10 +162,10 @@ function DetailPane({ component }: { component?: ConnectComponentSpec }) {
   }
 
   const categories = (component.categories ?? []).map(getCategoryDisplayName).filter(Boolean);
-  const summary = cleanText(component.summary ?? '');
+  const summary = markdownToPlainText(asciidocToMarkdown(component.summary ?? ''));
   const descriptionMd = component.description ? asciidocToMarkdown(component.description) : '';
   // Skip the description when it just repeats the summary.
-  const showDescription = descriptionMd !== '' && cleanText(component.description ?? '') !== summary;
+  const showDescription = descriptionMd !== '' && markdownToPlainText(descriptionMd) !== summary;
   const docsUrl = getConnectorDocsUrl(component.type, component.name);
 
   return (

--- a/frontend/src/components/pages/rp-connect/onboarding/connect-command-palette.tsx
+++ b/frontend/src/components/pages/rp-connect/onboarding/connect-command-palette.tsx
@@ -21,10 +21,8 @@ import ReactMarkdown, { type Components } from 'react-markdown';
 import { pluralizeWithNumber } from 'utils/string';
 
 import {
-  asciidocToMarkdown,
   buildEmptyMessage,
   byProminence,
-  cleanText,
   computeSuggested,
   matchRank,
   pushRecent,
@@ -33,6 +31,7 @@ import {
 } from './connect-command-palette-utils';
 import { ConnectorLogo } from './connector-logo';
 import type { ConnectComponentSpec, ConnectComponentType, ExtendedConnectComponentSpec } from '../types/schema';
+import { asciidocToMarkdown, cleanText } from '../utils/asciidoc';
 import { getCategoryDisplayName } from '../utils/categories';
 import { getConnectorDocsUrl } from '../utils/connector-docs';
 import { componentStatusToString, parseSchema } from '../utils/schema';

--- a/frontend/src/components/pages/rp-connect/pipeline/field-description.test.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/field-description.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import userEvent from '@testing-library/user-event';
+import { render, screen } from 'test-utils';
+import { describe, expect, test } from 'vitest';
+
+import { FieldDescription } from './field-description';
+import type { RawFieldSpec } from '../types/schema';
+
+const field = (overrides: Partial<RawFieldSpec>): RawFieldSpec =>
+  ({ name: 'topics', type: 'string', kind: 'scalar', ...overrides }) as RawFieldSpec;
+
+// The `input: redpanda` topics field: a one-line short description over a multi-paragraph AsciiDoc one.
+const LONG_TOPICS_DESCRIPTION =
+  '\nA list of topics to consume from. Multiple comma separated topics can be listed in a single element. ' +
+  'When a `consumer_group` is specified partitions are automatically distributed across consumers of a topic, ' +
+  'otherwise all partitions are consumed.\n\nAlternatively, it is possible to specify explicit partitions.';
+
+const SHORT_TOPICS_DESCRIPTION =
+  'A list of topics to consume from. Multiple comma-separated topics may share one element.';
+
+const SHOW_MORE_RE = /show more/i;
+const ALTERNATIVELY_RE = /Alternatively, it is possible/;
+const TOPICS_LEAD_RE = /A list of topics to consume from/;
+const SHOW_LESS_RE = /show less/i;
+
+describe('FieldDescription', () => {
+  test('prefers the short description over the long one', () => {
+    render(
+      <FieldDescription
+        spec={field({ description: LONG_TOPICS_DESCRIPTION, shortDescription: SHORT_TOPICS_DESCRIPTION })}
+      />
+    );
+
+    expect(screen.getByText(SHORT_TOPICS_DESCRIPTION)).toBeInTheDocument();
+    expect(screen.queryByText(ALTERNATIVELY_RE)).not.toBeInTheDocument();
+    // A one-liner needs no expander.
+    expect(screen.queryByRole('button', { name: SHOW_MORE_RE })).not.toBeInTheDocument();
+  });
+
+  test('falls back to the long description when no short one is served', () => {
+    render(<FieldDescription spec={field({ description: LONG_TOPICS_DESCRIPTION })} />);
+
+    expect(screen.getByText(TOPICS_LEAD_RE)).toBeInTheDocument();
+  });
+
+  test('treats a blank short description as absent', () => {
+    render(
+      <FieldDescription spec={field({ description: 'An identifier for the client.', shortDescription: '   ' })} />
+    );
+
+    expect(screen.getByText('An identifier for the client.')).toBeInTheDocument();
+  });
+
+  test('renders nothing when the field carries no prose', () => {
+    const { container } = render(<FieldDescription spec={field({})} />);
+
+    // The render wrapper contributes a hidden Chakra env node, so assert on visible text.
+    expect(container.textContent).toBe('');
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  test('collapses a long fallback description behind an expander', async () => {
+    const user = userEvent.setup();
+    render(<FieldDescription spec={field({ description: LONG_TOPICS_DESCRIPTION })} />);
+
+    const toggle = screen.getByRole('button', { name: SHOW_MORE_RE });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    // Collapsed is the flattened single-line rendering, so the trailing paragraph is clipped by CSS
+    // but the code span markup is already gone.
+    expect(screen.queryByText('consumer_group', { selector: 'code' })).not.toBeInTheDocument();
+
+    await user.click(toggle);
+
+    expect(screen.getByRole('button', { name: SHOW_LESS_RE })).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('consumer_group', { selector: 'code' })).toBeInTheDocument();
+    expect(screen.getByText(ALTERNATIVELY_RE)).toBeInTheDocument();
+  });
+
+  test('renders a short fallback description as Markdown with no expander', () => {
+    render(<FieldDescription spec={field({ description: 'Set the `topic` to publish to.' })} />);
+
+    expect(screen.getByText('topic', { selector: 'code' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: SHOW_MORE_RE })).not.toBeInTheDocument();
+  });
+
+  test('links a bare URL macro out of the AsciiDoc source', () => {
+    render(
+      <FieldDescription spec={field({ description: 'Uses https://github.com/twmb/franz-go[franz-go] internally.' })} />
+    );
+
+    const link = screen.getByRole('link', { name: 'franz-go' });
+    expect(link).toHaveAttribute('href', 'https://github.com/twmb/franz-go');
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  test('keeps angle-bracket placeholders that Markdown would otherwise swallow', () => {
+    render(<FieldDescription spec={field({ description: 'Defaults to `cdc_metadata_<stream_id>`.' })} />);
+
+    expect(screen.getByText('cdc_metadata_<stream_id>', { selector: 'code' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/pages/rp-connect/pipeline/field-description.test.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/field-description.test.tsx
@@ -105,6 +105,17 @@ describe('FieldDescription', () => {
     expect(link).toHaveAttribute('target', '_blank');
   });
 
+  test('links a URL macro whose label contains brackets', () => {
+    render(
+      <FieldDescription
+        spec={field({ description: 'A DSN: https://example.com/dsn[`user[:pass\\]@host`] applies.' })}
+      />
+    );
+
+    // A code span binds tighter than the link, so the `]` inside the label doesn't end it.
+    expect(screen.getByRole('link', { name: 'user[:pass]@host' })).toHaveAttribute('href', 'https://example.com/dsn');
+  });
+
   test('keeps angle-bracket placeholders that Markdown would otherwise swallow', () => {
     render(<FieldDescription spec={field({ description: 'Defaults to `cdc_metadata_<stream_id>`.' })} />);
 

--- a/frontend/src/components/pages/rp-connect/pipeline/field-description.test.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/field-description.test.tsx
@@ -88,32 +88,19 @@ describe('FieldDescription', () => {
     expect(screen.getByText(ALTERNATIVELY_RE)).toBeInTheDocument();
   });
 
-  test('renders a short fallback description as Markdown with no expander', () => {
-    render(<FieldDescription spec={field({ description: 'Set the `topic` to publish to.' })} />);
-
-    expect(screen.getByText('topic', { selector: 'code' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: SHOW_MORE_RE })).not.toBeInTheDocument();
-  });
-
-  test('links a bare URL macro out of the AsciiDoc source', () => {
-    render(
+  test('links URL macros out of the AsciiDoc source, bracketed labels included', () => {
+    const { unmount } = render(
       <FieldDescription spec={field({ description: 'Uses https://github.com/twmb/franz-go[franz-go] internally.' })} />
     );
 
     const link = screen.getByRole('link', { name: 'franz-go' });
     expect(link).toHaveAttribute('href', 'https://github.com/twmb/franz-go');
     expect(link).toHaveAttribute('target', '_blank');
-  });
+    unmount();
 
-  test('links a URL macro whose label contains brackets', () => {
-    render(
-      <FieldDescription
-        spec={field({ description: 'A DSN: https://example.com/dsn[`user[:pass\\]@host`] applies.' })}
-      />
-    );
-
-    // A code span binds tighter than the link, so the `]` inside the label doesn't end it.
-    expect(screen.getByRole('link', { name: 'user[:pass]@host' })).toHaveAttribute('href', 'https://example.com/dsn');
+    // A code span binds tighter than the link, so a `]` inside the label doesn't end it.
+    render(<FieldDescription spec={field({ description: 'A DSN: https://x.com/dsn[`user[:pass\\]@host`].' })} />);
+    expect(screen.getByRole('link', { name: 'user[:pass]@host' })).toHaveAttribute('href', 'https://x.com/dsn');
   });
 
   test('keeps angle-bracket placeholders that Markdown would otherwise swallow', () => {
@@ -138,6 +125,7 @@ describe('FieldDescription', () => {
     // One block, so the link reads as part of the help text instead of claiming a row of its own.
     const link = screen.getByRole('link', { name: TOPICS_DOCS_RE });
     expect(link.parentElement?.textContent).toBe('Set the topic to publish to. Docs');
+    expect(screen.getByText('topic', { selector: 'code' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: SHOW_MORE_RE })).not.toBeInTheDocument();
   });
 
@@ -152,15 +140,12 @@ describe('FieldDescription', () => {
     expect(screen.getByRole('link', { name: TOPICS_DOCS_RE })).toBeInTheDocument();
   });
 
-  test('offers the docs link even for a field the schema documents nowhere else', () => {
-    render(<FieldDescription docsUrl={TOPICS_DOCS_URL} spec={field({})} />);
-
+  test('offers the docs link with no prose at all, and none when the component has no docs page', () => {
+    const { unmount } = render(<FieldDescription docsUrl={TOPICS_DOCS_URL} spec={field({})} />);
     expect(screen.getByRole('link', { name: TOPICS_DOCS_RE })).toBeInTheDocument();
-  });
+    unmount();
 
-  test('renders no docs link for a component without a docs page', () => {
     render(<FieldDescription spec={field({ shortDescription: SHORT_TOPICS_DESCRIPTION })} />);
-
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/pages/rp-connect/pipeline/field-description.test.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/field-description.test.tsx
@@ -32,6 +32,9 @@ const SHOW_MORE_RE = /show more/i;
 const ALTERNATIVELY_RE = /Alternatively, it is possible/;
 const TOPICS_LEAD_RE = /A list of topics to consume from/;
 const SHOW_LESS_RE = /show less/i;
+const TOPICS_DOCS_RE = /topics documentation/i;
+const TOPICS_DOCS_URL =
+  'https://docs.redpanda.com/cloud-data-platform/develop/connect/components/inputs/redpanda/#topics';
 
 describe('FieldDescription', () => {
   test('prefers the short description over the long one', () => {
@@ -106,5 +109,36 @@ describe('FieldDescription', () => {
     render(<FieldDescription spec={field({ description: 'Defaults to `cdc_metadata_<stream_id>`.' })} />);
 
     expect(screen.getByText('cdc_metadata_<stream_id>', { selector: 'code' })).toBeInTheDocument();
+  });
+
+  test('deep-links the field on the connector docs page, named for the field', () => {
+    render(<FieldDescription docsUrl={TOPICS_DOCS_URL} spec={field({ shortDescription: SHORT_TOPICS_DESCRIPTION })} />);
+
+    const link = screen.getByRole('link', { name: TOPICS_DOCS_RE });
+    expect(link).toHaveAttribute('href', TOPICS_DOCS_URL);
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  test('keeps the docs link reachable while a long description is collapsed', async () => {
+    const user = userEvent.setup();
+    render(<FieldDescription docsUrl={TOPICS_DOCS_URL} spec={field({ description: LONG_TOPICS_DESCRIPTION })} />);
+
+    expect(screen.getByRole('link', { name: TOPICS_DOCS_RE })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: SHOW_MORE_RE }));
+
+    expect(screen.getByRole('link', { name: TOPICS_DOCS_RE })).toBeInTheDocument();
+  });
+
+  test('offers the docs link even for a field the schema documents nowhere else', () => {
+    render(<FieldDescription docsUrl={TOPICS_DOCS_URL} spec={field({})} />);
+
+    expect(screen.getByRole('link', { name: TOPICS_DOCS_RE })).toBeInTheDocument();
+  });
+
+  test('renders no docs link for a component without a docs page', () => {
+    render(<FieldDescription spec={field({ shortDescription: SHORT_TOPICS_DESCRIPTION })} />);
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/pages/rp-connect/pipeline/field-description.test.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/field-description.test.tsx
@@ -64,7 +64,7 @@ describe('FieldDescription', () => {
   test('renders nothing when the field carries no prose', () => {
     const { container } = render(<FieldDescription spec={field({})} />);
 
-    // The render wrapper contributes a hidden Chakra env node, so assert on visible text.
+    // The render wrapper adds a hidden Chakra node, so assert on text rather than an empty DOM.
     expect(container.textContent).toBe('');
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
@@ -75,8 +75,7 @@ describe('FieldDescription', () => {
 
     const toggle = screen.getByRole('button', { name: SHOW_MORE_RE });
     expect(toggle).toHaveAttribute('aria-expanded', 'false');
-    // Collapsed is the flattened single-line rendering, so the trailing paragraph is clipped by CSS
-    // but the code span markup is already gone.
+    // Collapsed is the flattened single-line rendering: no code spans, trailing paragraph clipped by CSS.
     expect(screen.queryByText('consumer_group', { selector: 'code' })).not.toBeInTheDocument();
 
     await user.click(toggle);

--- a/frontend/src/components/pages/rp-connect/pipeline/field-description.test.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/field-description.test.tsx
@@ -119,6 +119,17 @@ describe('FieldDescription', () => {
     expect(link).toHaveAttribute('target', '_blank');
   });
 
+  test('trails the link on the sentence when the description is a single paragraph', () => {
+    render(
+      <FieldDescription docsUrl={TOPICS_DOCS_URL} spec={field({ description: 'Set the `topic` to publish to.' })} />
+    );
+
+    // One block, so the link reads as part of the help text instead of claiming a row of its own.
+    const link = screen.getByRole('link', { name: TOPICS_DOCS_RE });
+    expect(link.parentElement?.textContent).toBe('Set the topic to publish to. Docs');
+    expect(screen.queryByRole('button', { name: SHOW_MORE_RE })).not.toBeInTheDocument();
+  });
+
   test('keeps the docs link reachable while a long description is collapsed', async () => {
     const user = userEvent.setup();
     render(<FieldDescription docsUrl={TOPICS_DOCS_URL} spec={field({ description: LONG_TOPICS_DESCRIPTION })} />);

--- a/frontend/src/components/pages/rp-connect/pipeline/field-description.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/field-description.tsx
@@ -17,11 +17,9 @@ import ReactMarkdown, { type Components } from 'react-markdown';
 import type { RawFieldSpec } from '../types/schema';
 import { asciidocToMarkdown, markdownToPlainText } from '../utils/asciidoc';
 
-// Descriptions longer than this (or spanning paragraphs) collapse behind "Show more"; schema prose
-// runs to a few thousand characters and buries the control it belongs to.
 const CLAMP_OVER_CHARS = 200;
 
-// Field prose sits under its control, so headings collapse to the same compact label as the body.
+// Field prose sits under its control: headings get no more weight than the body.
 const MarkdownHeading = ({ children }: { children?: React.ReactNode }) => (
   <div className="mt-1 font-medium text-body-sm text-foreground">{children}</div>
 );
@@ -51,8 +49,7 @@ const MARKDOWN_COMPONENTS: Components = {
   strong: ({ children }) => <strong className="font-medium text-foreground">{children}</strong>,
 };
 
-// Paragraphs unwrapped, so a single-paragraph description can flow inline with the docs link that
-// trails it. Everything else (code spans, links, emphasis) renders the same as in a block.
+// Paragraphs unwrapped, so a one-paragraph description can flow inline with its trailing docs link.
 const INLINE_MARKDOWN_COMPONENTS: Components = {
   ...MARKDOWN_COMPONENTS,
   p: ({ children }) => <>{children}</>,
@@ -65,13 +62,9 @@ const MarkdownBody = ({ markdown }: { markdown: string }) => (
 );
 
 /**
- * Trailing link to the field's own heading on the connector's docs page. Muted and named after the
- * field, so a form of twenty of these reads as help text rather than twenty calls to action.
- *
- * Laid out inline, not inline-flex: a flex box takes its baseline from the icon's bottom edge, which
- * drops the word below the baseline of the sentence it follows. Inline keeps one shared line box, so
- * `Docs` sits on the prose baseline and the icon is placed against it by `vertical-align`. The
- * underline is on the word alone — an ancestor's decoration would rule through the icon too.
+ * Link to the field's own heading on the connector's docs page. Inline, not inline-flex: a flex box
+ * baselines on the icon's bottom edge, which drops the word below the prose it follows. The underline
+ * is on the word alone so it doesn't rule through the icon.
  */
 const FieldDocsLink = ({ href, fieldName }: { href: string; fieldName?: string }) => (
   <Link
@@ -82,8 +75,7 @@ const FieldDocsLink = ({ href, fieldName }: { href: string; fieldName?: string }
     target="_blank"
     tone="current"
   >
-    {/* size-3 is the same rung as text-body-sm, so the icon never outweighs the word it labels;
-        -0.15em centres it on the cap height. */}
+    {/* size-3 is the text's own rung; -0.15em centres it on the cap height. */}
     <BookOpenIcon className="mr-1 inline size-3 align-[-0.15em]" />
     <span className="underline decoration-dotted underline-offset-[3px] group-hover:decoration-solid">Docs</span>
   </Link>
@@ -103,7 +95,7 @@ const LongDescription = ({ source, docsLink }: { source: string; docsLink: React
     };
   }, [source]);
 
-  // Not clampable means one paragraph and no block content, so it can carry the link on its line.
+  // One paragraph, no block content: it can carry the link on its own line.
   if (!clampable) {
     return (
       <div className="text-body-sm text-muted-foreground">
@@ -122,7 +114,6 @@ const LongDescription = ({ source, docsLink }: { source: string; docsLink: React
           <div className="line-clamp-2 text-body-sm text-muted-foreground">{preview}</div>
         )}
       </div>
-      {/* The expander already earns a row here, so the docs link joins it instead of adding one. */}
       <div className="flex items-baseline gap-3">
         <button
           aria-controls={bodyId}
@@ -140,16 +131,14 @@ const LongDescription = ({ source, docsLink }: { source: string; docsLink: React
 };
 
 /**
- * Help text under a config control. Prefers the schema's `short_description` — a markup-free
- * one-liner — and falls back to the AsciiDoc `description` that most fields are still limited to.
- * `docsUrl` deep-links the field's own heading on the connector's reference page.
+ * Help text under a config control. Prefers the markup-free `short_description`, falling back to the
+ * AsciiDoc `description` that most fields are still limited to.
  */
 export const FieldDescription = ({ spec, docsUrl }: { spec: RawFieldSpec; docsUrl?: string }) => {
   const docsLink = docsUrl ? <FieldDocsLink fieldName={spec.name} href={docsUrl} /> : null;
   const short = spec.shortDescription?.trim();
   if (short) {
     return (
-      // A one-liner and the link share a row rather than the link claiming its own.
       <div className="text-body-sm text-muted-foreground">
         {short} {docsLink}
       </div>

--- a/frontend/src/components/pages/rp-connect/pipeline/field-description.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/field-description.tsx
@@ -81,6 +81,13 @@ const FieldDocsLink = ({ href, fieldName }: { href: string; fieldName?: string }
   </Link>
 );
 
+// Help text and its trailing link share one line box, so the link reads as part of the sentence.
+const InlineHelp = ({ children, docsLink }: { children: React.ReactNode; docsLink: React.ReactNode }) => (
+  <div className="text-body-sm text-muted-foreground">
+    {children} {docsLink}
+  </div>
+);
+
 /** AsciiDoc `description`, rendered as Markdown and collapsed to two lines when it runs long. */
 const LongDescription = ({ source, docsLink }: { source: string; docsLink: React.ReactNode }) => {
   const [expanded, setExpanded] = useState(false);
@@ -98,9 +105,9 @@ const LongDescription = ({ source, docsLink }: { source: string; docsLink: React
   // One paragraph, no block content: it can carry the link on its own line.
   if (!clampable) {
     return (
-      <div className="text-body-sm text-muted-foreground">
-        <ReactMarkdown components={INLINE_MARKDOWN_COMPONENTS}>{markdown}</ReactMarkdown> {docsLink}
-      </div>
+      <InlineHelp docsLink={docsLink}>
+        <ReactMarkdown components={INLINE_MARKDOWN_COMPONENTS}>{markdown}</ReactMarkdown>
+      </InlineHelp>
     );
   }
 
@@ -138,11 +145,7 @@ export const FieldDescription = ({ spec, docsUrl }: { spec: RawFieldSpec; docsUr
   const docsLink = docsUrl ? <FieldDocsLink fieldName={spec.name} href={docsUrl} /> : null;
   const short = spec.shortDescription?.trim();
   if (short) {
-    return (
-      <div className="text-body-sm text-muted-foreground">
-        {short} {docsLink}
-      </div>
-    );
+    return <InlineHelp docsLink={docsLink}>{short}</InlineHelp>;
   }
   const description = spec.description?.trim();
   if (!description) {

--- a/frontend/src/components/pages/rp-connect/pipeline/field-description.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/field-description.tsx
@@ -10,6 +10,7 @@
  */
 
 import { Link } from 'components/redpanda-ui/components/typography';
+import { BookOpenIcon } from 'lucide-react';
 import { useId, useMemo, useState } from 'react';
 import ReactMarkdown, { type Components } from 'react-markdown';
 
@@ -56,8 +57,32 @@ const MarkdownBody = ({ markdown }: { markdown: string }) => (
   </div>
 );
 
+/**
+ * Trailing link to the field's own heading on the connector's docs page. Muted and named after the
+ * field, so a form of twenty of these reads as help text rather than twenty calls to action.
+ *
+ * Laid out inline, not inline-flex: a flex box takes its baseline from the icon's bottom edge, which
+ * drops the word below the baseline of the sentence it follows. Inline keeps one shared line box, so
+ * `Docs` sits on the prose baseline and the icon is placed against it by `vertical-align`. The
+ * underline is on the word alone — an ancestor's decoration would rule through the icon too.
+ */
+const FieldDocsLink = ({ href, fieldName }: { href: string; fieldName?: string }) => (
+  <Link
+    aria-label={fieldName ? `${fieldName} documentation` : 'Field documentation'}
+    className="group whitespace-nowrap text-body-sm text-muted-foreground no-underline hover:text-foreground"
+    href={href}
+    rel="noopener noreferrer"
+    target="_blank"
+    tone="current"
+  >
+    {/* size-3 matches the 12px text; -0.15em centres the icon on the word's cap height. */}
+    <BookOpenIcon className="mr-1 inline size-3 align-[-0.15em]" />
+    <span className="underline decoration-dotted underline-offset-[3px] group-hover:decoration-solid">Docs</span>
+  </Link>
+);
+
 /** AsciiDoc `description`, rendered as Markdown and collapsed to two lines when it runs long. */
-const LongDescription = ({ source }: { source: string }) => {
+const LongDescription = ({ source, docsLink }: { source: string; docsLink: React.ReactNode }) => {
   const [expanded, setExpanded] = useState(false);
   const bodyId = useId();
   const { markdown, preview, clampable } = useMemo(() => {
@@ -71,7 +96,12 @@ const LongDescription = ({ source }: { source: string }) => {
   }, [source]);
 
   if (!clampable) {
-    return <MarkdownBody markdown={markdown} />;
+    return (
+      <div className="flex flex-col items-start gap-0.5">
+        <MarkdownBody markdown={markdown} />
+        {docsLink}
+      </div>
+    );
   }
 
   return (
@@ -84,15 +114,19 @@ const LongDescription = ({ source }: { source: string }) => {
           <div className="line-clamp-2 text-body-sm text-muted-foreground">{preview}</div>
         )}
       </div>
-      <button
-        aria-controls={bodyId}
-        aria-expanded={expanded}
-        className="text-body-sm text-muted-foreground underline underline-offset-2 hover:text-foreground"
-        onClick={() => setExpanded((value) => !value)}
-        type="button"
-      >
-        {expanded ? 'Show less' : 'Show more'}
-      </button>
+      {/* The expander already earns a row here, so the docs link joins it instead of adding one. */}
+      <div className="flex items-center gap-3">
+        <button
+          aria-controls={bodyId}
+          aria-expanded={expanded}
+          className="text-body-sm text-muted-foreground underline underline-offset-2 hover:text-foreground"
+          onClick={() => setExpanded((value) => !value)}
+          type="button"
+        >
+          {expanded ? 'Show less' : 'Show more'}
+        </button>
+        {docsLink}
+      </div>
     </div>
   );
 };
@@ -100,15 +134,22 @@ const LongDescription = ({ source }: { source: string }) => {
 /**
  * Help text under a config control. Prefers the schema's `short_description` — a markup-free
  * one-liner — and falls back to the AsciiDoc `description` that most fields are still limited to.
+ * `docsUrl` deep-links the field's own heading on the connector's reference page.
  */
-export const FieldDescription = ({ spec }: { spec: RawFieldSpec }) => {
+export const FieldDescription = ({ spec, docsUrl }: { spec: RawFieldSpec; docsUrl?: string }) => {
+  const docsLink = docsUrl ? <FieldDocsLink fieldName={spec.name} href={docsUrl} /> : null;
   const short = spec.shortDescription?.trim();
   if (short) {
-    return <div className="text-body-sm text-muted-foreground">{short}</div>;
+    return (
+      // A one-liner and the link share a row rather than the link claiming its own.
+      <div className="text-body-sm text-muted-foreground">
+        {short} {docsLink}
+      </div>
+    );
   }
   const description = spec.description?.trim();
   if (!description) {
-    return null;
+    return docsLink;
   }
-  return <LongDescription source={description} />;
+  return <LongDescription docsLink={docsLink} source={description} />;
 };

--- a/frontend/src/components/pages/rp-connect/pipeline/field-description.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/field-description.tsx
@@ -14,13 +14,10 @@ import { useId, useMemo, useState } from 'react';
 import ReactMarkdown, { type Components } from 'react-markdown';
 
 import type { RawFieldSpec } from '../types/schema';
-import { asciidocToMarkdown, asciidocToPlainText } from '../utils/asciidoc';
+import { asciidocToMarkdown, markdownToPlainText } from '../utils/asciidoc';
 
-/**
- * Longer than this (or spanning paragraphs) and the description is collapsed behind "Show more":
- * schema descriptions run to a few thousand characters, which buries the control it belongs to.
- * Short descriptions cap at ~140 and are never clamped.
- */
+// Descriptions longer than this (or spanning paragraphs) collapse behind "Show more"; schema prose
+// runs to a few thousand characters and buries the control it belongs to.
 const CLAMP_OVER_CHARS = 200;
 
 // Field prose sits under its control, so headings collapse to the same compact label as the body.
@@ -42,7 +39,7 @@ const MARKDOWN_COMPONENTS: Components = {
     </Link>
   ),
   code: ({ children }) => (
-    // break-words, not break-all: only unbreakable strings (DSNs, URLs) wrap, short tokens stay whole.
+    // break-words, not break-all: only unbreakable strings (DSNs, URLs) wrap mid-token.
     <code className="break-words rounded bg-muted px-1 py-0.5 font-mono text-body-sm text-foreground">{children}</code>
   ),
   ul: ({ children }) => <ul className="list-disc space-y-0.5 pl-4 text-body-sm text-muted-foreground">{children}</ul>,
@@ -65,7 +62,7 @@ const LongDescription = ({ source }: { source: string }) => {
   const bodyId = useId();
   const { markdown, preview, clampable } = useMemo(() => {
     const converted = asciidocToMarkdown(source);
-    const plain = asciidocToPlainText(source);
+    const plain = markdownToPlainText(converted);
     return {
       markdown: converted,
       preview: plain,
@@ -83,7 +80,7 @@ const LongDescription = ({ source }: { source: string }) => {
         {expanded ? (
           <MarkdownBody markdown={markdown} />
         ) : (
-          // Collapsed shows the plain-text rendering: one text node, so line-clamp applies cleanly.
+          // Plain text collapsed: one text node, so line-clamp applies cleanly.
           <div className="line-clamp-2 text-body-sm text-muted-foreground">{preview}</div>
         )}
       </div>
@@ -102,8 +99,7 @@ const LongDescription = ({ source }: { source: string }) => {
 
 /**
  * Help text under a config control. Prefers the schema's `short_description` — a markup-free
- * one-liner written for inline display — and falls back to the AsciiDoc `description`, which most
- * fields are still limited to.
+ * one-liner — and falls back to the AsciiDoc `description` that most fields are still limited to.
  */
 export const FieldDescription = ({ spec }: { spec: RawFieldSpec }) => {
   const short = spec.shortDescription?.trim();

--- a/frontend/src/components/pages/rp-connect/pipeline/field-description.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/field-description.tsx
@@ -51,6 +51,13 @@ const MARKDOWN_COMPONENTS: Components = {
   strong: ({ children }) => <strong className="font-medium text-foreground">{children}</strong>,
 };
 
+// Paragraphs unwrapped, so a single-paragraph description can flow inline with the docs link that
+// trails it. Everything else (code spans, links, emphasis) renders the same as in a block.
+const INLINE_MARKDOWN_COMPONENTS: Components = {
+  ...MARKDOWN_COMPONENTS,
+  p: ({ children }) => <>{children}</>,
+};
+
 const MarkdownBody = ({ markdown }: { markdown: string }) => (
   <div className="flex flex-col gap-1">
     <ReactMarkdown components={MARKDOWN_COMPONENTS}>{markdown}</ReactMarkdown>
@@ -75,7 +82,8 @@ const FieldDocsLink = ({ href, fieldName }: { href: string; fieldName?: string }
     target="_blank"
     tone="current"
   >
-    {/* size-3 matches the 12px text; -0.15em centres the icon on the word's cap height. */}
+    {/* size-3 is the same rung as text-body-sm, so the icon never outweighs the word it labels;
+        -0.15em centres it on the cap height. */}
     <BookOpenIcon className="mr-1 inline size-3 align-[-0.15em]" />
     <span className="underline decoration-dotted underline-offset-[3px] group-hover:decoration-solid">Docs</span>
   </Link>
@@ -95,11 +103,11 @@ const LongDescription = ({ source, docsLink }: { source: string; docsLink: React
     };
   }, [source]);
 
+  // Not clampable means one paragraph and no block content, so it can carry the link on its line.
   if (!clampable) {
     return (
-      <div className="flex flex-col items-start gap-0.5">
-        <MarkdownBody markdown={markdown} />
-        {docsLink}
+      <div className="text-body-sm text-muted-foreground">
+        <ReactMarkdown components={INLINE_MARKDOWN_COMPONENTS}>{markdown}</ReactMarkdown> {docsLink}
       </div>
     );
   }
@@ -115,7 +123,7 @@ const LongDescription = ({ source, docsLink }: { source: string; docsLink: React
         )}
       </div>
       {/* The expander already earns a row here, so the docs link joins it instead of adding one. */}
-      <div className="flex items-center gap-3">
+      <div className="flex items-baseline gap-3">
         <button
           aria-controls={bodyId}
           aria-expanded={expanded}

--- a/frontend/src/components/pages/rp-connect/pipeline/field-description.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/field-description.tsx
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { Link } from 'components/redpanda-ui/components/typography';
+import { useId, useMemo, useState } from 'react';
+import ReactMarkdown, { type Components } from 'react-markdown';
+
+import type { RawFieldSpec } from '../types/schema';
+import { asciidocToMarkdown, asciidocToPlainText } from '../utils/asciidoc';
+
+/**
+ * Longer than this (or spanning paragraphs) and the description is collapsed behind "Show more":
+ * schema descriptions run to a few thousand characters, which buries the control it belongs to.
+ * Short descriptions cap at ~140 and are never clamped.
+ */
+const CLAMP_OVER_CHARS = 200;
+
+// Field prose sits under its control, so headings collapse to the same compact label as the body.
+const MarkdownHeading = ({ children }: { children?: React.ReactNode }) => (
+  <div className="mt-1 font-medium text-body-sm text-foreground">{children}</div>
+);
+
+const MARKDOWN_COMPONENTS: Components = {
+  h1: MarkdownHeading,
+  h2: MarkdownHeading,
+  h3: MarkdownHeading,
+  h4: MarkdownHeading,
+  h5: MarkdownHeading,
+  h6: MarkdownHeading,
+  p: ({ children }) => <div className="text-body-sm text-muted-foreground">{children}</div>,
+  a: ({ href, children }) => (
+    <Link className="text-body-sm" href={href} rel="noopener noreferrer" target="_blank">
+      {children}
+    </Link>
+  ),
+  code: ({ children }) => (
+    // break-words, not break-all: only unbreakable strings (DSNs, URLs) wrap, short tokens stay whole.
+    <code className="break-words rounded bg-muted px-1 py-0.5 font-mono text-body-sm text-foreground">{children}</code>
+  ),
+  ul: ({ children }) => <ul className="list-disc space-y-0.5 pl-4 text-body-sm text-muted-foreground">{children}</ul>,
+  ol: ({ children }) => (
+    <ol className="list-decimal space-y-0.5 pl-4 text-body-sm text-muted-foreground">{children}</ol>
+  ),
+  li: ({ children }) => <li>{children}</li>,
+  strong: ({ children }) => <strong className="font-medium text-foreground">{children}</strong>,
+};
+
+const MarkdownBody = ({ markdown }: { markdown: string }) => (
+  <div className="flex flex-col gap-1">
+    <ReactMarkdown components={MARKDOWN_COMPONENTS}>{markdown}</ReactMarkdown>
+  </div>
+);
+
+/** AsciiDoc `description`, rendered as Markdown and collapsed to two lines when it runs long. */
+const LongDescription = ({ source }: { source: string }) => {
+  const [expanded, setExpanded] = useState(false);
+  const bodyId = useId();
+  const { markdown, preview, clampable } = useMemo(() => {
+    const converted = asciidocToMarkdown(source);
+    const plain = asciidocToPlainText(source);
+    return {
+      markdown: converted,
+      preview: plain,
+      clampable: plain.length > CLAMP_OVER_CHARS || converted.includes('\n'),
+    };
+  }, [source]);
+
+  if (!clampable) {
+    return <MarkdownBody markdown={markdown} />;
+  }
+
+  return (
+    <div className="flex flex-col items-start gap-0.5">
+      <div id={bodyId}>
+        {expanded ? (
+          <MarkdownBody markdown={markdown} />
+        ) : (
+          // Collapsed shows the plain-text rendering: one text node, so line-clamp applies cleanly.
+          <div className="line-clamp-2 text-body-sm text-muted-foreground">{preview}</div>
+        )}
+      </div>
+      <button
+        aria-controls={bodyId}
+        aria-expanded={expanded}
+        className="text-body-sm text-muted-foreground underline underline-offset-2 hover:text-foreground"
+        onClick={() => setExpanded((value) => !value)}
+        type="button"
+      >
+        {expanded ? 'Show less' : 'Show more'}
+      </button>
+    </div>
+  );
+};
+
+/**
+ * Help text under a config control. Prefers the schema's `short_description` — a markup-free
+ * one-liner written for inline display — and falls back to the AsciiDoc `description`, which most
+ * fields are still limited to.
+ */
+export const FieldDescription = ({ spec }: { spec: RawFieldSpec }) => {
+  const short = spec.shortDescription?.trim();
+  if (short) {
+    return <div className="text-body-sm text-muted-foreground">{short}</div>;
+  }
+  const description = spec.description?.trim();
+  if (!description) {
+    return null;
+  }
+  return <LongDescription source={description} />;
+};

--- a/frontend/src/components/pages/rp-connect/pipeline/node-config-form.test.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/node-config-form.test.tsx
@@ -33,6 +33,9 @@ function renderForm(value: Record<string, unknown>, onConfigChange = vi.fn()) {
 }
 
 const CREATE_NEW_TOPIC_RE = /create new topic/i;
+const KAFKA_OUTPUT_DOCS = 'https://docs.redpanda.com/cloud-data-platform/develop/connect/components/outputs/kafka/';
+const TOPIC_DOCS_RE = /topic documentation/i;
+const BATCHING_COUNT_DOCS_RE = /count documentation/i;
 
 // The most recent config reported by the form (undefined if never called, null when clean).
 function lastReported(onConfigChange: ReturnType<typeof vi.fn>): unknown {
@@ -73,6 +76,20 @@ describe('NodeConfigForm — full schema', () => {
     const mechRow = screen.getByText('mechanism').closest('div');
     expect(mechRow).not.toBeNull();
     expect(mechRow?.querySelector('[title="Required"]')).toBeNull();
+  });
+
+  test('deep-links every field to its own heading on the connector docs page', async () => {
+    const user = userEvent.setup();
+    renderForm({ kafka: { topic: 't', addresses: ['a:9092'] } });
+
+    expect(screen.getByRole('link', { name: TOPIC_DOCS_RE })).toHaveAttribute('href', `${KAFKA_OUTPUT_DOCS}#topic`);
+
+    // A nested field is anchored by its whole path, as the docs generator ids it.
+    await user.click(screen.getByText('batching'));
+    expect(screen.getByRole('link', { name: BATCHING_COUNT_DOCS_RE })).toHaveAttribute(
+      'href',
+      `${KAFKA_OUTPUT_DOCS}#batching-count`
+    );
   });
 
   test('shows the schema default as a hint for optional fields', () => {

--- a/frontend/src/components/pages/rp-connect/pipeline/node-config-form.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/node-config-form.tsx
@@ -531,9 +531,7 @@ function buildComponentEntry({
   return next;
 }
 
-// Docs identity of the edited component, so a field can deep-link its own heading on that
-// component's reference page. Context for the same reason as ResourceFieldContext: the consumers are
-// leaf controls several generic layers down.
+// Context for the same reason as ResourceFieldContext: the consumers are leaf controls.
 type ComponentDocsIdentity = { section: string; componentName: string };
 const ComponentDocsContext = createContext<ComponentDocsIdentity | undefined>(undefined);
 

--- a/frontend/src/components/pages/rp-connect/pipeline/node-config-form.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/node-config-form.tsx
@@ -154,6 +154,8 @@ type ResourceFieldContextValue = {
   clusterTopicFields?: boolean;
   /** Opens the Add-topic dialog; the created topic is written into the component's topic field. */
   onCreateTopic?: () => void;
+  /** Docs URL for one field of the edited component, by its path. */
+  fieldDocsUrl?: (path: string[]) => string | undefined;
 };
 const ResourceFieldContext = createContext<ResourceFieldContextValue>({ labels: { cache: [], rate_limit: [] } });
 
@@ -531,15 +533,6 @@ function buildComponentEntry({
   return next;
 }
 
-// Context for the same reason as ResourceFieldContext: the consumers are leaf controls.
-type ComponentDocsIdentity = { section: string; componentName: string };
-const ComponentDocsContext = createContext<ComponentDocsIdentity | undefined>(undefined);
-
-const useFieldDocsUrl = (path: string[]): string | undefined => {
-  const component = useContext(ComponentDocsContext);
-  return component ? getFieldDocsUrl(component.section, component.componentName, path) : undefined;
-};
-
 const FieldLabel = ({ spec, htmlFor }: { spec: RawFieldSpec; htmlFor?: string }) => (
   <div className="flex items-center gap-2">
     <Label className="shrink-0 font-medium text-body" htmlFor={htmlFor}>
@@ -799,8 +792,8 @@ const SECRET_REF_EXAMPLE = getSecretSyntax('MY_SECRET');
 const ScalarField = ({ leaf, control }: { leaf: Leaf; control: Control<FormValues> }) => {
   const inputId = useId();
   const lintErrors = useContext(FieldLintErrorsContext);
-  const { clusterTopicFields } = useContext(ResourceFieldContext);
-  const docsUrl = useFieldDocsUrl(leaf.path);
+  const { clusterTopicFields, fieldDocsUrl } = useContext(ResourceFieldContext);
+  const docsUrl = fieldDocsUrl?.(leaf.path);
   // The topic picker's combobox can't take an id — don't point the label at a nonexistent one.
   const labelFor = clusterTopicFields && isTopicField(leaf.spec.name ?? '') ? undefined : inputId;
   return (
@@ -840,8 +833,8 @@ const ScalarField = ({ leaf, control }: { leaf: Leaf; control: Control<FormValue
 const ArrayField = ({ leaf, control }: { leaf: Leaf; control: Control<FormValues> }) => {
   const inputId = useId();
   const lintErrors = useContext(FieldLintErrorsContext);
-  const { clusterTopicFields } = useContext(ResourceFieldContext);
-  const docsUrl = useFieldDocsUrl(leaf.path);
+  const { clusterTopicFields, fieldDocsUrl } = useContext(ResourceFieldContext);
+  const docsUrl = fieldDocsUrl?.(leaf.path);
   const isTopics = Boolean(clusterTopicFields) && isTopicField(leaf.spec.name ?? '');
   return (
     <Controller
@@ -1150,6 +1143,7 @@ export function NodeConfigForm({
     componentResourceKind: resourceKindForComponentName(componentName),
     clusterTopicFields,
     onCreateTopic: clusterTopicFields ? onCreateTopic : undefined,
+    fieldDocsUrl: (path) => getFieldDocsUrl(spec.type, componentName, path),
   };
 
   const advancedLintSignature = advanced
@@ -1158,152 +1152,150 @@ export function NodeConfigForm({
     .join('\n');
 
   return (
-    <ComponentDocsContext.Provider value={{ section: spec.type, componentName }}>
-      <ResourceFieldContext.Provider value={resourceCtx}>
-        <FieldLintErrorsContext.Provider value={fieldErrors ?? NO_FIELD_ERRORS}>
-          {/* Committing per FIELD (not per node): the container listens for focus leaving any field
+    <ResourceFieldContext.Provider value={resourceCtx}>
+      <FieldLintErrorsContext.Provider value={fieldErrors ?? NO_FIELD_ERRORS}>
+        {/* Committing per FIELD (not per node): the container listens for focus leaving any field
             (bubbled focusout) and ⌘⏎, flushing the draft so the canvas card and lint react while
             the node is still selected. It is not itself interactive — the fields inside are. */}
-          {/* biome-ignore lint/a11y/noStaticElementInteractions: passive listener for events bubbling from the form controls. */}
-          {/* biome-ignore lint/a11y/noNoninteractiveElementInteractions: passive listener for events bubbling from the form controls. */}
-          <div
-            className="flex min-h-0 flex-1 flex-col"
-            onBlur={onCommitField ? commitNow : undefined}
-            onKeyDown={
-              onCommitField
-                ? (e) => {
-                    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
-                      e.preventDefault();
-                      commitNow();
-                    }
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: passive listener for events bubbling from the form controls. */}
+        {/* biome-ignore lint/a11y/noNoninteractiveElementInteractions: passive listener for events bubbling from the form controls. */}
+        <div
+          className="flex min-h-0 flex-1 flex-col"
+          onBlur={onCommitField ? commitNow : undefined}
+          onKeyDown={
+            onCommitField
+              ? (e) => {
+                  if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                    e.preventDefault();
+                    commitNow();
                   }
-                : undefined
-            }
-          >
-            <ScrollShadow contentClassName="space-y-4 px-4 py-4">
-              {/* Full-bleed to the scroll edges; padded fields follow. */}
-              {headerSlot ? <div className="-mx-4 -mt-4">{headerSlot}</div> : null}
-              <div className="flex flex-col gap-1.5">
-                <Label className="font-medium text-body" htmlFor={labelId}>
-                  label
-                </Label>
-                <Controller
-                  control={control}
-                  name="label"
-                  render={({ field, fieldState }) => (
-                    <>
-                      <Input
-                        aria-required={requireLabel || undefined}
-                        id={labelId}
-                        onChange={field.onChange}
-                        placeholder={
-                          requireLabel
-                            ? 'Name other nodes use to reference this resource'
-                            : 'Optional identifier for this component'
-                        }
-                        value={field.value}
-                      />
-                      {requireLabel && !field.value.trim() ? (
-                        <div className="text-body-sm text-destructive">
-                          A resource needs a label — nodes reference it by name. The saved label is kept.
-                        </div>
-                      ) : null}
-                      <FieldLintErrorList dirty={fieldState.isDirty} fieldKey="label" />
-                    </>
-                  )}
-                />
-              </div>
+                }
+              : undefined
+          }
+        >
+          <ScrollShadow contentClassName="space-y-4 px-4 py-4">
+            {/* Full-bleed to the scroll edges; padded fields follow. */}
+            {headerSlot ? <div className="-mx-4 -mt-4">{headerSlot}</div> : null}
+            <div className="flex flex-col gap-1.5">
+              <Label className="font-medium text-body" htmlFor={labelId}>
+                label
+              </Label>
+              <Controller
+                control={control}
+                name="label"
+                render={({ field, fieldState }) => (
+                  <>
+                    <Input
+                      aria-required={requireLabel || undefined}
+                      id={labelId}
+                      onChange={field.onChange}
+                      placeholder={
+                        requireLabel
+                          ? 'Name other nodes use to reference this resource'
+                          : 'Optional identifier for this component'
+                      }
+                      value={field.value}
+                    />
+                    {requireLabel && !field.value.trim() ? (
+                      <div className="text-body-sm text-destructive">
+                        A resource needs a label — nodes reference it by name. The saved label is kept.
+                      </div>
+                    ) : null}
+                    <FieldLintErrorList dirty={fieldState.isDirty} fieldKey="label" />
+                  </>
+                )}
+              />
+            </div>
 
-              {isListValued && hasChildList ? (
-                <ChildItemsList
-                  items={childItems as InspectorChildItem[]}
-                  label="Cases"
-                  onSelect={onSelectChild as (item: InspectorChildItem) => void}
-                />
-              ) : null}
-              {isListValued && !hasChildList ? (
-                <div className="rounded-md border border-border/60 border-dashed px-3 py-2">
-                  <div className="text-body-sm text-muted-foreground">
-                    This component's items (cases / processors) are edited on the canvas — select one to edit it.
-                  </div>
+            {isListValued && hasChildList ? (
+              <ChildItemsList
+                items={childItems as InspectorChildItem[]}
+                label="Cases"
+                onSelect={onSelectChild as (item: InspectorChildItem) => void}
+              />
+            ) : null}
+            {isListValued && !hasChildList ? (
+              <div className="rounded-md border border-border/60 border-dashed px-3 py-2">
+                <div className="text-body-sm text-muted-foreground">
+                  This component's items (cases / processors) are edited on the canvas — select one to edit it.
                 </div>
-              ) : null}
-
-              {isListValued
-                ? null
-                : required.map((f) => <SchemaField control={control} key={f.name} path={[]} spec={f} />)}
-
-              {isListValued ? null : (
-                <OptionalFieldsSection control={control} fields={optional} hasRequired={required.length > 0} />
-              )}
-
-              {!isListValued && advanced.length > 0 ? (
-                <FieldGroup defaultOpen={false} forceOpenSignal={advancedLintSignature} label="Advanced">
-                  {advanced.map((f) => (
-                    <SchemaField control={control} key={f.name} path={[]} spec={f} />
-                  ))}
-                </FieldGroup>
-              ) : null}
-
-              {!isListValued && componentFields.length > 0 && hasChildList ? (
-                <ChildItemsList
-                  items={childItems as InspectorChildItem[]}
-                  label="Steps"
-                  onSelect={onSelectChild as (item: InspectorChildItem) => void}
-                />
-              ) : null}
-
-              {!isListValued && showRaw ? (
-                <FieldGroup defaultOpen={false} label="Other settings (YAML)">
-                  <Controller
-                    control={control}
-                    name="raw"
-                    render={({ field }) => {
-                      const invalid = field.value.trim() !== '' && parseRawSection(true, field.value) === null;
-                      return (
-                        <div className="flex flex-col gap-1.5">
-                          <div className="h-[450px] overflow-hidden rounded-md border border-border">
-                            <YamlEditor
-                              onChange={(v) => field.onChange(v || '')}
-                              options={{ minimap: { enabled: false } }}
-                              transparentBackground
-                              value={field.value}
-                            />
-                          </div>
-                          {invalid ? (
-                            <div className="text-body-sm text-destructive">
-                              Invalid YAML — these settings won't be saved until fixed.
-                            </div>
-                          ) : null}
-                        </div>
-                      );
-                    }}
-                  />
-                </FieldGroup>
-              ) : null}
-            </ScrollShadow>
-            {/* Edits normally apply on field blur; this is the visible pending state plus a manual
-            trigger (and ⌘⏎) for applying without moving focus. */}
-            {onCommitField && isDirty ? (
-              <div className="flex shrink-0 items-center justify-between gap-2 border-border border-t bg-muted/40 px-4 py-2">
-                <span className="flex items-center gap-1.5 text-body-sm text-muted-foreground">
-                  <span aria-hidden className="size-1.5 rounded-full bg-informative" />
-                  Unsaved edits
-                </span>
-                <Button
-                  onClick={commitNow}
-                  size="sm"
-                  title="Apply now (⌘⏎) — edits also apply when you leave a field"
-                  type="button"
-                  variant="primary"
-                >
-                  Apply
-                </Button>
               </div>
             ) : null}
-          </div>
-        </FieldLintErrorsContext.Provider>
-      </ResourceFieldContext.Provider>
-    </ComponentDocsContext.Provider>
+
+            {isListValued
+              ? null
+              : required.map((f) => <SchemaField control={control} key={f.name} path={[]} spec={f} />)}
+
+            {isListValued ? null : (
+              <OptionalFieldsSection control={control} fields={optional} hasRequired={required.length > 0} />
+            )}
+
+            {!isListValued && advanced.length > 0 ? (
+              <FieldGroup defaultOpen={false} forceOpenSignal={advancedLintSignature} label="Advanced">
+                {advanced.map((f) => (
+                  <SchemaField control={control} key={f.name} path={[]} spec={f} />
+                ))}
+              </FieldGroup>
+            ) : null}
+
+            {!isListValued && componentFields.length > 0 && hasChildList ? (
+              <ChildItemsList
+                items={childItems as InspectorChildItem[]}
+                label="Steps"
+                onSelect={onSelectChild as (item: InspectorChildItem) => void}
+              />
+            ) : null}
+
+            {!isListValued && showRaw ? (
+              <FieldGroup defaultOpen={false} label="Other settings (YAML)">
+                <Controller
+                  control={control}
+                  name="raw"
+                  render={({ field }) => {
+                    const invalid = field.value.trim() !== '' && parseRawSection(true, field.value) === null;
+                    return (
+                      <div className="flex flex-col gap-1.5">
+                        <div className="h-[450px] overflow-hidden rounded-md border border-border">
+                          <YamlEditor
+                            onChange={(v) => field.onChange(v || '')}
+                            options={{ minimap: { enabled: false } }}
+                            transparentBackground
+                            value={field.value}
+                          />
+                        </div>
+                        {invalid ? (
+                          <div className="text-body-sm text-destructive">
+                            Invalid YAML — these settings won't be saved until fixed.
+                          </div>
+                        ) : null}
+                      </div>
+                    );
+                  }}
+                />
+              </FieldGroup>
+            ) : null}
+          </ScrollShadow>
+          {/* Edits normally apply on field blur; this is the visible pending state plus a manual
+            trigger (and ⌘⏎) for applying without moving focus. */}
+          {onCommitField && isDirty ? (
+            <div className="flex shrink-0 items-center justify-between gap-2 border-border border-t bg-muted/40 px-4 py-2">
+              <span className="flex items-center gap-1.5 text-body-sm text-muted-foreground">
+                <span aria-hidden className="size-1.5 rounded-full bg-informative" />
+                Unsaved edits
+              </span>
+              <Button
+                onClick={commitNow}
+                size="sm"
+                title="Apply now (⌘⏎) — edits also apply when you leave a field"
+                type="button"
+                variant="primary"
+              >
+                Apply
+              </Button>
+            </div>
+          ) : null}
+        </div>
+      </FieldLintErrorsContext.Provider>
+    </ResourceFieldContext.Provider>
   );
 }

--- a/frontend/src/components/pages/rp-connect/pipeline/node-config-form.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/node-config-form.tsx
@@ -32,6 +32,7 @@ import { type Control, Controller, type FieldPath, useForm, useWatch } from 'rea
 import { useListTopicsQuery } from 'react-query/api/topic';
 import { parse as parseYaml, stringify as yamlStringify } from 'yaml';
 
+import { FieldDescription } from './field-description';
 import type { FieldLintErrors } from './lint-field-mapping';
 import { ScrollShadow } from './scroll-shadow';
 import { getSecretSyntax, REDPANDA_TOPIC_AND_USER_COMPONENTS } from '../types/constants';
@@ -550,9 +551,6 @@ const FieldLabel = ({ spec, htmlFor }: { spec: RawFieldSpec; htmlFor?: string })
     ) : null}
   </div>
 );
-
-const FieldDescription = ({ spec }: { spec: RawFieldSpec }) =>
-  spec.description ? <div className="text-body-sm text-muted-foreground">{spec.description}</div> : null;
 
 // Mask fields the schema flags as secret (stamped from the raw config schema; the proto has no
 // secret field), plus a name heuristic as the union — the flag misses plausibly-sensitive fields

--- a/frontend/src/components/pages/rp-connect/pipeline/node-config-form.tsx
+++ b/frontend/src/components/pages/rp-connect/pipeline/node-config-form.tsx
@@ -37,6 +37,7 @@ import type { FieldLintErrors } from './lint-field-mapping';
 import { ScrollShadow } from './scroll-shadow';
 import { getSecretSyntax, REDPANDA_TOPIC_AND_USER_COMPONENTS } from '../types/constants';
 import type { ConnectComponentSpec, RawFieldSpec } from '../types/schema';
+import { getFieldDocsUrl } from '../utils/connector-docs';
 import {
   checkRequired,
   fieldHasOptions,
@@ -530,6 +531,17 @@ function buildComponentEntry({
   return next;
 }
 
+// Docs identity of the edited component, so a field can deep-link its own heading on that
+// component's reference page. Context for the same reason as ResourceFieldContext: the consumers are
+// leaf controls several generic layers down.
+type ComponentDocsIdentity = { section: string; componentName: string };
+const ComponentDocsContext = createContext<ComponentDocsIdentity | undefined>(undefined);
+
+const useFieldDocsUrl = (path: string[]): string | undefined => {
+  const component = useContext(ComponentDocsContext);
+  return component ? getFieldDocsUrl(component.section, component.componentName, path) : undefined;
+};
+
 const FieldLabel = ({ spec, htmlFor }: { spec: RawFieldSpec; htmlFor?: string }) => (
   <div className="flex items-center gap-2">
     <Label className="shrink-0 font-medium text-body" htmlFor={htmlFor}>
@@ -790,6 +802,7 @@ const ScalarField = ({ leaf, control }: { leaf: Leaf; control: Control<FormValue
   const inputId = useId();
   const lintErrors = useContext(FieldLintErrorsContext);
   const { clusterTopicFields } = useContext(ResourceFieldContext);
+  const docsUrl = useFieldDocsUrl(leaf.path);
   // The topic picker's combobox can't take an id — don't point the label at a nonexistent one.
   const labelFor = clusterTopicFields && isTopicField(leaf.spec.name ?? '') ? undefined : inputId;
   return (
@@ -818,7 +831,7 @@ const ScalarField = ({ leaf, control }: { leaf: Leaf; control: Control<FormValue
                 value.
               </div>
             ) : null}
-            <FieldDescription spec={leaf.spec} />
+            <FieldDescription docsUrl={docsUrl} spec={leaf.spec} />
           </div>
         );
       }}
@@ -830,6 +843,7 @@ const ArrayField = ({ leaf, control }: { leaf: Leaf; control: Control<FormValues
   const inputId = useId();
   const lintErrors = useContext(FieldLintErrorsContext);
   const { clusterTopicFields } = useContext(ResourceFieldContext);
+  const docsUrl = useFieldDocsUrl(leaf.path);
   const isTopics = Boolean(clusterTopicFields) && isTopicField(leaf.spec.name ?? '');
   return (
     <Controller
@@ -854,7 +868,7 @@ const ArrayField = ({ leaf, control }: { leaf: Leaf; control: Control<FormValues
               <TopicArrayPicker lines={lines} onAppend={(t) => field.onChange([...lines, t].join('\n'))} />
             ) : null}
             <FieldLintErrorList dirty={fieldState.isDirty} fieldKey={leaf.key} />
-            <FieldDescription spec={leaf.spec} />
+            <FieldDescription docsUrl={docsUrl} spec={leaf.spec} />
           </div>
         );
       }}
@@ -1146,150 +1160,152 @@ export function NodeConfigForm({
     .join('\n');
 
   return (
-    <ResourceFieldContext.Provider value={resourceCtx}>
-      <FieldLintErrorsContext.Provider value={fieldErrors ?? NO_FIELD_ERRORS}>
-        {/* Committing per FIELD (not per node): the container listens for focus leaving any field
+    <ComponentDocsContext.Provider value={{ section: spec.type, componentName }}>
+      <ResourceFieldContext.Provider value={resourceCtx}>
+        <FieldLintErrorsContext.Provider value={fieldErrors ?? NO_FIELD_ERRORS}>
+          {/* Committing per FIELD (not per node): the container listens for focus leaving any field
             (bubbled focusout) and ⌘⏎, flushing the draft so the canvas card and lint react while
             the node is still selected. It is not itself interactive — the fields inside are. */}
-        {/* biome-ignore lint/a11y/noStaticElementInteractions: passive listener for events bubbling from the form controls. */}
-        {/* biome-ignore lint/a11y/noNoninteractiveElementInteractions: passive listener for events bubbling from the form controls. */}
-        <div
-          className="flex min-h-0 flex-1 flex-col"
-          onBlur={onCommitField ? commitNow : undefined}
-          onKeyDown={
-            onCommitField
-              ? (e) => {
-                  if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
-                    e.preventDefault();
-                    commitNow();
+          {/* biome-ignore lint/a11y/noStaticElementInteractions: passive listener for events bubbling from the form controls. */}
+          {/* biome-ignore lint/a11y/noNoninteractiveElementInteractions: passive listener for events bubbling from the form controls. */}
+          <div
+            className="flex min-h-0 flex-1 flex-col"
+            onBlur={onCommitField ? commitNow : undefined}
+            onKeyDown={
+              onCommitField
+                ? (e) => {
+                    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                      e.preventDefault();
+                      commitNow();
+                    }
                   }
-                }
-              : undefined
-          }
-        >
-          <ScrollShadow contentClassName="space-y-4 px-4 py-4">
-            {/* Full-bleed to the scroll edges; padded fields follow. */}
-            {headerSlot ? <div className="-mx-4 -mt-4">{headerSlot}</div> : null}
-            <div className="flex flex-col gap-1.5">
-              <Label className="font-medium text-body" htmlFor={labelId}>
-                label
-              </Label>
-              <Controller
-                control={control}
-                name="label"
-                render={({ field, fieldState }) => (
-                  <>
-                    <Input
-                      aria-required={requireLabel || undefined}
-                      id={labelId}
-                      onChange={field.onChange}
-                      placeholder={
-                        requireLabel
-                          ? 'Name other nodes use to reference this resource'
-                          : 'Optional identifier for this component'
-                      }
-                      value={field.value}
-                    />
-                    {requireLabel && !field.value.trim() ? (
-                      <div className="text-body-sm text-destructive">
-                        A resource needs a label — nodes reference it by name. The saved label is kept.
-                      </div>
-                    ) : null}
-                    <FieldLintErrorList dirty={fieldState.isDirty} fieldKey="label" />
-                  </>
-                )}
-              />
-            </div>
-
-            {isListValued && hasChildList ? (
-              <ChildItemsList
-                items={childItems as InspectorChildItem[]}
-                label="Cases"
-                onSelect={onSelectChild as (item: InspectorChildItem) => void}
-              />
-            ) : null}
-            {isListValued && !hasChildList ? (
-              <div className="rounded-md border border-border/60 border-dashed px-3 py-2">
-                <div className="text-body-sm text-muted-foreground">
-                  This component's items (cases / processors) are edited on the canvas — select one to edit it.
-                </div>
-              </div>
-            ) : null}
-
-            {isListValued
-              ? null
-              : required.map((f) => <SchemaField control={control} key={f.name} path={[]} spec={f} />)}
-
-            {isListValued ? null : (
-              <OptionalFieldsSection control={control} fields={optional} hasRequired={required.length > 0} />
-            )}
-
-            {!isListValued && advanced.length > 0 ? (
-              <FieldGroup defaultOpen={false} forceOpenSignal={advancedLintSignature} label="Advanced">
-                {advanced.map((f) => (
-                  <SchemaField control={control} key={f.name} path={[]} spec={f} />
-                ))}
-              </FieldGroup>
-            ) : null}
-
-            {!isListValued && componentFields.length > 0 && hasChildList ? (
-              <ChildItemsList
-                items={childItems as InspectorChildItem[]}
-                label="Steps"
-                onSelect={onSelectChild as (item: InspectorChildItem) => void}
-              />
-            ) : null}
-
-            {!isListValued && showRaw ? (
-              <FieldGroup defaultOpen={false} label="Other settings (YAML)">
+                : undefined
+            }
+          >
+            <ScrollShadow contentClassName="space-y-4 px-4 py-4">
+              {/* Full-bleed to the scroll edges; padded fields follow. */}
+              {headerSlot ? <div className="-mx-4 -mt-4">{headerSlot}</div> : null}
+              <div className="flex flex-col gap-1.5">
+                <Label className="font-medium text-body" htmlFor={labelId}>
+                  label
+                </Label>
                 <Controller
                   control={control}
-                  name="raw"
-                  render={({ field }) => {
-                    const invalid = field.value.trim() !== '' && parseRawSection(true, field.value) === null;
-                    return (
-                      <div className="flex flex-col gap-1.5">
-                        <div className="h-[450px] overflow-hidden rounded-md border border-border">
-                          <YamlEditor
-                            onChange={(v) => field.onChange(v || '')}
-                            options={{ minimap: { enabled: false } }}
-                            transparentBackground
-                            value={field.value}
-                          />
+                  name="label"
+                  render={({ field, fieldState }) => (
+                    <>
+                      <Input
+                        aria-required={requireLabel || undefined}
+                        id={labelId}
+                        onChange={field.onChange}
+                        placeholder={
+                          requireLabel
+                            ? 'Name other nodes use to reference this resource'
+                            : 'Optional identifier for this component'
+                        }
+                        value={field.value}
+                      />
+                      {requireLabel && !field.value.trim() ? (
+                        <div className="text-body-sm text-destructive">
+                          A resource needs a label — nodes reference it by name. The saved label is kept.
                         </div>
-                        {invalid ? (
-                          <div className="text-body-sm text-destructive">
-                            Invalid YAML — these settings won't be saved until fixed.
-                          </div>
-                        ) : null}
-                      </div>
-                    );
-                  }}
+                      ) : null}
+                      <FieldLintErrorList dirty={fieldState.isDirty} fieldKey="label" />
+                    </>
+                  )}
                 />
-              </FieldGroup>
-            ) : null}
-          </ScrollShadow>
-          {/* Edits normally apply on field blur; this is the visible pending state plus a manual
+              </div>
+
+              {isListValued && hasChildList ? (
+                <ChildItemsList
+                  items={childItems as InspectorChildItem[]}
+                  label="Cases"
+                  onSelect={onSelectChild as (item: InspectorChildItem) => void}
+                />
+              ) : null}
+              {isListValued && !hasChildList ? (
+                <div className="rounded-md border border-border/60 border-dashed px-3 py-2">
+                  <div className="text-body-sm text-muted-foreground">
+                    This component's items (cases / processors) are edited on the canvas — select one to edit it.
+                  </div>
+                </div>
+              ) : null}
+
+              {isListValued
+                ? null
+                : required.map((f) => <SchemaField control={control} key={f.name} path={[]} spec={f} />)}
+
+              {isListValued ? null : (
+                <OptionalFieldsSection control={control} fields={optional} hasRequired={required.length > 0} />
+              )}
+
+              {!isListValued && advanced.length > 0 ? (
+                <FieldGroup defaultOpen={false} forceOpenSignal={advancedLintSignature} label="Advanced">
+                  {advanced.map((f) => (
+                    <SchemaField control={control} key={f.name} path={[]} spec={f} />
+                  ))}
+                </FieldGroup>
+              ) : null}
+
+              {!isListValued && componentFields.length > 0 && hasChildList ? (
+                <ChildItemsList
+                  items={childItems as InspectorChildItem[]}
+                  label="Steps"
+                  onSelect={onSelectChild as (item: InspectorChildItem) => void}
+                />
+              ) : null}
+
+              {!isListValued && showRaw ? (
+                <FieldGroup defaultOpen={false} label="Other settings (YAML)">
+                  <Controller
+                    control={control}
+                    name="raw"
+                    render={({ field }) => {
+                      const invalid = field.value.trim() !== '' && parseRawSection(true, field.value) === null;
+                      return (
+                        <div className="flex flex-col gap-1.5">
+                          <div className="h-[450px] overflow-hidden rounded-md border border-border">
+                            <YamlEditor
+                              onChange={(v) => field.onChange(v || '')}
+                              options={{ minimap: { enabled: false } }}
+                              transparentBackground
+                              value={field.value}
+                            />
+                          </div>
+                          {invalid ? (
+                            <div className="text-body-sm text-destructive">
+                              Invalid YAML — these settings won't be saved until fixed.
+                            </div>
+                          ) : null}
+                        </div>
+                      );
+                    }}
+                  />
+                </FieldGroup>
+              ) : null}
+            </ScrollShadow>
+            {/* Edits normally apply on field blur; this is the visible pending state plus a manual
             trigger (and ⌘⏎) for applying without moving focus. */}
-          {onCommitField && isDirty ? (
-            <div className="flex shrink-0 items-center justify-between gap-2 border-border border-t bg-muted/40 px-4 py-2">
-              <span className="flex items-center gap-1.5 text-body-sm text-muted-foreground">
-                <span aria-hidden className="size-1.5 rounded-full bg-informative" />
-                Unsaved edits
-              </span>
-              <Button
-                onClick={commitNow}
-                size="sm"
-                title="Apply now (⌘⏎) — edits also apply when you leave a field"
-                type="button"
-                variant="primary"
-              >
-                Apply
-              </Button>
-            </div>
-          ) : null}
-        </div>
-      </FieldLintErrorsContext.Provider>
-    </ResourceFieldContext.Provider>
+            {onCommitField && isDirty ? (
+              <div className="flex shrink-0 items-center justify-between gap-2 border-border border-t bg-muted/40 px-4 py-2">
+                <span className="flex items-center gap-1.5 text-body-sm text-muted-foreground">
+                  <span aria-hidden className="size-1.5 rounded-full bg-informative" />
+                  Unsaved edits
+                </span>
+                <Button
+                  onClick={commitNow}
+                  size="sm"
+                  title="Apply now (⌘⏎) — edits also apply when you leave a field"
+                  type="button"
+                  variant="primary"
+                >
+                  Apply
+                </Button>
+              </div>
+            ) : null}
+          </div>
+        </FieldLintErrorsContext.Provider>
+      </ResourceFieldContext.Provider>
+    </ComponentDocsContext.Provider>
   );
 }

--- a/frontend/src/components/pages/rp-connect/template-gallery/__tests__/template-schema.test.tsx
+++ b/frontend/src/components/pages/rp-connect/template-gallery/__tests__/template-schema.test.tsx
@@ -28,6 +28,19 @@ const components = [
         { name: 'dsn', type: 'string', kind: 'scalar', description: 'Postgres DSN', defaultValue: 'pg-default' },
         // No default → required by checkRequired.
         { name: 'snapshot', type: 'string', kind: 'scalar', description: 'Snapshot mode' },
+        {
+          name: 'multiline',
+          type: 'string',
+          kind: 'scalar',
+          description: 'A Data Source Name.\n\n==== Drivers\n:driver-support: mysql=certified\n\nSee the driver list.',
+        },
+        {
+          name: 'blankShort',
+          type: 'string',
+          kind: 'scalar',
+          description: 'The long one.',
+          shortDescription: '   ',
+        },
       ],
     },
   },
@@ -81,6 +94,24 @@ describe('applySchemaToSlots', () => {
 
     const [result] = applySchemaToSlots(template, components);
     expect(result.description).toBe('Snapshot mode');
+  });
+
+  test('flattens a multi-paragraph AsciiDoc description to plain slot help', () => {
+    const template = buildTemplate([
+      slot({ id: 'dsn', kind: 'string', section: 'source', label: 'DSN', schemaField: 'multiline' }),
+    ]);
+
+    const [result] = applySchemaToSlots(template, components);
+    expect(result.description).toBe('A Data Source Name. Drivers See the driver list.');
+  });
+
+  test('treats a blank short description as absent, as the config form does', () => {
+    const template = buildTemplate([
+      slot({ id: 'blank', kind: 'string', section: 'source', label: 'Blank', schemaField: 'blankShort' }),
+    ]);
+
+    const [result] = applySchemaToSlots(template, components);
+    expect(result.description).toBe('The long one.');
   });
 
   test('keeps an explicit slot description over the schema description', () => {

--- a/frontend/src/components/pages/rp-connect/template-gallery/template-schema.ts
+++ b/frontend/src/components/pages/rp-connect/template-gallery/template-schema.ts
@@ -11,6 +11,7 @@
 
 import type { PipelineTemplate, TemplateSlot } from './pipeline-template-types';
 import type { ConnectComponentSpec } from '../types/schema';
+import { cleanText } from '../utils/asciidoc';
 import { checkRequired, findConnectComponent, resolveFieldByPath } from '../utils/schema';
 
 // Slot-level values win; schema only fills unset `description` / `required` /
@@ -47,7 +48,8 @@ export function applySchemaToSlots(template: PipelineTemplate, components?: Conn
 
     const merged: TemplateSlot = {
       ...slot,
-      description: slot.description ?? (field.shortDescription || field.description || undefined),
+      // Slot descriptions render as plain text, so the AsciiDoc fallback has to be flattened.
+      description: slot.description ?? (field.shortDescription || cleanText(field.description ?? '') || undefined),
       required: slot.required ?? checkRequired(field),
     };
 

--- a/frontend/src/components/pages/rp-connect/template-gallery/template-schema.ts
+++ b/frontend/src/components/pages/rp-connect/template-gallery/template-schema.ts
@@ -47,7 +47,7 @@ export function applySchemaToSlots(template: PipelineTemplate, components?: Conn
 
     const merged: TemplateSlot = {
       ...slot,
-      description: slot.description ?? (field.description || undefined),
+      description: slot.description ?? (field.shortDescription || field.description || undefined),
       required: slot.required ?? checkRequired(field),
     };
 

--- a/frontend/src/components/pages/rp-connect/template-gallery/template-schema.ts
+++ b/frontend/src/components/pages/rp-connect/template-gallery/template-schema.ts
@@ -10,9 +10,13 @@
  */
 
 import type { PipelineTemplate, TemplateSlot } from './pipeline-template-types';
-import type { ConnectComponentSpec } from '../types/schema';
-import { cleanText } from '../utils/asciidoc';
+import type { ConnectComponentSpec, RawFieldSpec } from '../types/schema';
+import { asciidocToMarkdown, markdownToPlainText } from '../utils/asciidoc';
 import { checkRequired, findConnectComponent, resolveFieldByPath } from '../utils/schema';
+
+// Slot help renders as plain text, and the fallback is often multi-paragraph AsciiDoc.
+const slotDescription = (field: RawFieldSpec): string | undefined =>
+  field.shortDescription?.trim() || markdownToPlainText(asciidocToMarkdown(field.description ?? '')) || undefined;
 
 // Slot-level values win; schema only fills unset `description` / `required` /
 // `default`. Slots without `schemaField` (or with unresolvable paths) pass through.
@@ -48,8 +52,7 @@ export function applySchemaToSlots(template: PipelineTemplate, components?: Conn
 
     const merged: TemplateSlot = {
       ...slot,
-      // Slot descriptions render as plain text, so the AsciiDoc fallback has to be flattened.
-      description: slot.description ?? (field.shortDescription || cleanText(field.description ?? '') || undefined),
+      description: slot.description ?? slotDescription(field),
       required: slot.required ?? checkRequired(field),
     };
 

--- a/frontend/src/components/pages/rp-connect/utils/asciidoc.test.ts
+++ b/frontend/src/components/pages/rp-connect/utils/asciidoc.test.ts
@@ -11,162 +11,129 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { asciidocToMarkdown, cleanText, markdownToPlainText } from './asciidoc';
+import { asciidocToMarkdown, markdownToPlainText } from './asciidoc';
+
+const lines = (...rows: string[]) => rows.join('\n');
 
 describe('asciidocToMarkdown', () => {
-  it('turns AsciiDoc section titles into Markdown headings instead of leaking "=="', () => {
-    const out = asciidocToMarkdown('== Performance\nThis output benefits from batching.');
-    expect(out).toBe('#### Performance\nThis output benefits from batching.');
-    expect(out).not.toContain('== ');
-  });
-
-  it('handles multiple heading levels and keeps paragraphs separated', () => {
-    const out = asciidocToMarkdown('Intro paragraph.\n\n=== Delivery Guarantees\nAt least once.');
-    expect(out).toBe('Intro paragraph.\n\n#### Delivery Guarantees\nAt least once.');
-  });
-
-  it('converts link/xref macros to label text and bare URL macros to Markdown links', () => {
-    expect(asciidocToMarkdown('See xref:guides:about.adoc[the guide] for details.')).toBe('See the guide for details.');
-    expect(asciidocToMarkdown('Uses https://github.com/twmb/franz-go[franz-go] under the hood.')).toBe(
-      'Uses [franz-go](https://github.com/twmb/franz-go) under the hood.'
-    );
-  });
-
-  it('converts AsciiDoc bullets to Markdown list items', () => {
-    expect(asciidocToMarkdown('* first\n* second')).toBe('- first\n- second');
-  });
-
-  // Every AWS `credentials` field ends "…can be found in xref:guides:cloud/aws.adoc[].".
-  it('names a target for an empty-label xref rather than leaving dangling punctuation', () => {
-    expect(asciidocToMarkdown('More information can be found in xref:guides:cloud/aws.adoc[].')).toBe(
-      'More information can be found in the documentation.'
-    );
-  });
-
-  it('keeps a macro label that contains escaped brackets, dropping the new-window flag', () => {
-    // AsciiDoc escapes `]` inside a label, and a trailing `^` means "open in a new window".
-    const source = 'See https://example.com/dsn[`http[s\\]://user[:pass\\]`^] here.';
-    expect(asciidocToMarkdown(source)).toBe('See [`http[s]://user[:pass]`](https://example.com/dsn) here.');
-  });
-
-  it('reduces internal cross-references to their wording', () => {
-    expect(asciidocToMarkdown('Set the field <<batch_as_multipart, `batch_as_multipart`>> to `false`.')).toBe(
-      'Set the field `batch_as_multipart` to `false`.'
-    );
-    expect(asciidocToMarkdown('Brokering <<patterns>> are supported.')).toBe('Brokering patterns are supported.');
-  });
-
-  it('flattens a Markdown pipe table, dropping its header rule', () => {
-    const source = 'Placeholders:\n\n| Driver | Style |\n|---|---|\n| `mysql` | Question mark |';
-    expect(asciidocToMarkdown(source)).toBe('Placeholders:\n\n- Driver — Style\n- `mysql` — Question mark');
-  });
-
-  it('escapes angle-bracket placeholders so Markdown does not swallow them as HTML', () => {
-    const out = asciidocToMarkdown("Requests must include 'authorization: Bearer <token>' metadata.");
-    expect(out).toBe(String.raw`Requests must include 'authorization: Bearer \<token>' metadata.`);
-  });
-
-  it('leaves placeholders inside code spans untouched', () => {
-    expect(asciidocToMarkdown('Defaults to `redpanda_connect_jira_input_<resource>`.')).toBe(
-      'Defaults to `redpanda_connect_jira_input_<resource>`.'
-    );
-  });
-
-  it('flattens AsciiDoc tables to bullets and drops docs attribute lines', () => {
-    const source = [
-      'A Data Source Name.',
-      '',
-      ':driver-support: mysql=certified, postgres=certified',
-      '',
-      '|===',
-      '| Driver | Data Source Name Format',
-      '',
-      '| `mysql`',
-      '| `[username[:password]@]/dbname`',
-      '|===',
-    ].join('\n');
-    expect(asciidocToMarkdown(source)).toBe(
-      [
-        'A Data Source Name.',
+  it.each([
+    [
+      'section titles, so no "==" leaks',
+      '== Performance\nBenefits from batching.',
+      '#### Performance\nBenefits from batching.',
+    ],
+    [
+      'deeper titles, paragraphs kept apart',
+      'Intro.\n\n=== Guarantees\nAt least once.',
+      'Intro.\n\n#### Guarantees\nAt least once.',
+    ],
+    ['an over-long title, marker still stripped', `= ${'x'.repeat(70)}`, 'x'.repeat(70)],
+    ['xref macros, down to their label', 'See xref:guides:about.adoc[the guide].', 'See the guide.'],
+    [
+      'URL macros, as Markdown links',
+      'Uses https://example.com/go[franz-go].',
+      'Uses [franz-go](https://example.com/go).',
+    ],
+    // Every AWS `credentials` field ends "…can be found in xref:guides:cloud/aws.adoc[].".
+    [
+      'an empty-label xref, leaving no dangling punctuation',
+      'Found in xref:guides:cloud/aws.adoc[].',
+      'Found in the documentation.',
+    ],
+    // AsciiDoc escapes `]` inside a label; a trailing `^` means "open in a new window".
+    [
+      'bracketed labels and the new-window flag',
+      'See https://x.com/dsn[`http[s\\]://u[:p\\]`^] here.',
+      'See [`http[s]://u[:p]`](https://x.com/dsn) here.',
+    ],
+    [
+      'internal cross-references with a label',
+      'Set <<batch_as_multipart, `batch_as_multipart`>> to `false`.',
+      'Set `batch_as_multipart` to `false`.',
+    ],
+    [
+      'internal cross-references without one',
+      'Brokering <<patterns>> are supported.',
+      'Brokering patterns are supported.',
+    ],
+    ['AsciiDoc bullets', '* first\n* second', '- first\n- second'],
+    [
+      'admonitions, block titles and block delimiters',
+      lines('[CAUTION]', '.Endpoint caveats', '====', 'Order is not deterministic.', '===='),
+      lines('**CAUTION**', '#### Endpoint caveats', '', 'Order is not deterministic.'),
+    ],
+    ['the leading newline most descriptions start with', '\nA list of topics.', 'A list of topics.'],
+    [
+      'angle-bracket placeholders, escaped past remark',
+      "Send 'authorization: Bearer <token>'.",
+      String.raw`Send 'authorization: Bearer \<token>'.`,
+    ],
+    [
+      'placeholders inside a code span, untouched',
+      'Defaults to `jira_input_<resource>`.',
+      'Defaults to `jira_input_<resource>`.',
+    ],
+    [
+      'Markdown pipe tables, header rule dropped',
+      lines('Placeholders:', '', '| Driver | Style |', '|---|---|', '| `mysql` | Question mark |'),
+      lines('Placeholders:', '', '- Driver — Style', '- `mysql` — Question mark'),
+    ],
+    [
+      '`|===` tables and the `:attr:` lines around them',
+      lines(
+        'A DSN.',
         '',
-        '- Driver — Data Source Name Format',
+        ':driver-support: mysql=certified',
         '',
-        '- `mysql`',
-        '- `[username[:password]@]/dbname`',
-      ].join('\n')
-    );
-  });
-
-  // The Debezium type table writes rows as `|Type Name |Bloblang Type`, with no space after the
-  // cell marker.
-  it('splits a dsv table on colons, the separator its attribute line declares', () => {
-    const source = '[%header,format=dsv]\n|===\nSnowflake type:Connect format\nCHAR, VARCHAR:string\n|===';
-    expect(asciidocToMarkdown(source)).toBe('- Snowflake type — Connect format\n- CHAR, VARCHAR — string');
-  });
-
-  it('splits table cells that are not padded around the marker', () => {
-    const source = ['.Debezium Custom Temporal Types', '|===', '|Type Name |Bloblang Type', '|==='].join('\n');
-    expect(asciidocToMarkdown(source)).toBe(
-      ['#### Debezium Custom Temporal Types', '- Type Name — Bloblang Type'].join('\n')
-    );
-  });
-
-  it('leaves a pipe in prose alone even when the description also has a table', () => {
-    const source = ['Splits on | characters.', '', '|===', '|a |b', '|==='].join('\n');
-    expect(asciidocToMarkdown(source)).toBe(['Splits on | characters.', '', '- a — b'].join('\n'));
-  });
-
-  it('drops block delimiters that would promote the prose around them to a heading', () => {
-    const source = [
-      '[CAUTION]',
-      '.Endpoint caveats',
-      '====',
-      'Endpoints register in a non-deterministic order.',
-      '====',
-    ].join('\n');
-    expect(asciidocToMarkdown(source)).toBe(
-      ['**CAUTION**', '#### Endpoint caveats', '', 'Endpoints register in a non-deterministic order.'].join('\n')
-    );
-  });
-
-  it('trims the leading newline that many field descriptions start with', () => {
-    expect(asciidocToMarkdown('\nA list of topics to consume from.')).toBe('A list of topics to consume from.');
+        '|===',
+        '| Driver | Format',
+        '',
+        '| `mysql`',
+        '| `[user[:pass]@]/db`',
+        '|==='
+      ),
+      lines('A DSN.', '', '- Driver — Format', '', '- `mysql`', '- `[user[:pass]@]/db`'),
+    ],
+    // The Debezium type table writes rows as `|Type Name |Bloblang Type`, unpadded.
+    [
+      'cells that are not padded around the marker',
+      lines('|===', '|Type Name |Bloblang Type', '|==='),
+      '- Type Name — Bloblang Type',
+    ],
+    [
+      'dsv tables, split on the separator their attribute line declares',
+      lines('[%header,format=dsv]', '|===', 'Snowflake type:Connect format', 'CHAR, VARCHAR:string', '|==='),
+      lines('- Snowflake type — Connect format', '- CHAR, VARCHAR — string'),
+    ],
+    [
+      'a pipe in prose, even alongside a table',
+      lines('Splits on | characters.', '', '|===', '|a |b', '|==='),
+      lines('Splits on | characters.', '', '- a — b'),
+    ],
+  ])('handles %s', (_case, source, expected) => {
+    expect(asciidocToMarkdown(source)).toBe(expected);
   });
 });
 
 describe('markdownToPlainText', () => {
-  it('reduces converted Markdown to a single line without syntax', () => {
-    expect(markdownToPlainText(asciidocToMarkdown('\nUse `consumer_group` to share load.\n\n== Notes\n* first'))).toBe(
-      'Use consumer_group to share load. Notes first'
-    );
-  });
-
-  it('strips a link whose label nests brackets, as the sql DSN examples do', () => {
-    const markdown = 'A DSN: [`clickhouse://[user[:pass]@][host]`](https://example.com/dsn) applies.';
-    expect(markdownToPlainText(markdown)).toBe('A DSN: clickhouse://[user[:pass]@][host] applies.');
-  });
-
-  it('keeps link labels and unescapes placeholders', () => {
-    expect(markdownToPlainText(asciidocToMarkdown('See https://example.com[the docs] for <token> usage.'))).toBe(
-      'See the docs for <token> usage.'
-    );
-  });
-});
-
-describe('cleanText', () => {
-  it('strips code spans and macros down to one line', () => {
-    expect(cleanText('Sends to `redpanda`\nvia xref:guides:about.adoc[the guide].')).toBe(
-      'Sends to redpanda via the guide.'
-    );
-  });
-
-  it('reduces internal cross-references to their wording', () => {
-    expect(cleanText('Brokering <<patterns>> with <<codecs, structured data>>.')).toBe(
-      'Brokering patterns with structured data.'
-    );
-  });
-
-  it('substitutes a label for an empty-label xref', () => {
-    expect(cleanText('Found in xref:guides:cloud/aws.adoc[].')).toBe('Found in the documentation.');
+  it.each([
+    [
+      'converted Markdown to one line',
+      asciidocToMarkdown('\nUse `consumer_group`.\n\n== Notes\n* first'),
+      'Use consumer_group. Notes first',
+    ],
+    [
+      'link labels, unescaping placeholders',
+      asciidocToMarkdown('See https://x.com[the docs] for <token> usage.'),
+      'See the docs for <token> usage.',
+    ],
+    // The sql `dsn` fields document a bracket-heavy DSN inside the link label.
+    [
+      'a link whose label nests brackets',
+      'A DSN: [`ch://[user[:pass]@][host]`](https://x.com/dsn) applies.',
+      'A DSN: ch://[user[:pass]@][host] applies.',
+    ],
+  ])('reduces %s', (_case, markdown, expected) => {
+    expect(markdownToPlainText(markdown)).toBe(expected);
   });
 });

--- a/frontend/src/components/pages/rp-connect/utils/asciidoc.test.ts
+++ b/frontend/src/components/pages/rp-connect/utils/asciidoc.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { asciidocToMarkdown, asciidocToPlainText, cleanText } from './asciidoc';
+
+describe('asciidocToMarkdown', () => {
+  it('turns AsciiDoc section titles into Markdown headings instead of leaking "=="', () => {
+    const out = asciidocToMarkdown('== Performance\nThis output benefits from batching.');
+    expect(out).toBe('#### Performance\nThis output benefits from batching.');
+    expect(out).not.toContain('== ');
+  });
+
+  it('handles multiple heading levels and keeps paragraphs separated', () => {
+    const out = asciidocToMarkdown('Intro paragraph.\n\n=== Delivery Guarantees\nAt least once.');
+    expect(out).toBe('Intro paragraph.\n\n#### Delivery Guarantees\nAt least once.');
+  });
+
+  it('converts link/xref macros to label text and bare URL macros to Markdown links', () => {
+    expect(asciidocToMarkdown('See xref:guides:about.adoc[the guide] for details.')).toBe('See the guide for details.');
+    expect(asciidocToMarkdown('Uses https://github.com/twmb/franz-go[franz-go] under the hood.')).toBe(
+      'Uses [franz-go](https://github.com/twmb/franz-go) under the hood.'
+    );
+  });
+
+  it('converts AsciiDoc bullets to Markdown list items', () => {
+    expect(asciidocToMarkdown('* first\n* second')).toBe('- first\n- second');
+  });
+
+  // Every AWS `credentials` field ends "…can be found in xref:guides:cloud/aws.adoc[]."; dropping
+  // the macro outright left the sentence as "…can be found in .".
+  it('names a target for an empty-label xref rather than leaving dangling punctuation', () => {
+    expect(asciidocToMarkdown('More information can be found in xref:guides:cloud/aws.adoc[].')).toBe(
+      'More information can be found in the documentation.'
+    );
+  });
+
+  it('keeps a macro label that contains escaped brackets, dropping the new-window flag', () => {
+    // AsciiDoc escapes `]` inside a label, and a trailing `^` means "open in a new window".
+    const source = 'See https://example.com/dsn[`http[s\\]://user[:pass\\]`^] here.';
+    expect(asciidocToMarkdown(source)).toBe('See [`http[s]://user[:pass]`](https://example.com/dsn) here.');
+  });
+
+  it('escapes angle-bracket placeholders so Markdown does not swallow them as HTML', () => {
+    const out = asciidocToMarkdown("Requests must include 'authorization: Bearer <token>' metadata.");
+    expect(out).toBe(String.raw`Requests must include 'authorization: Bearer \<token>' metadata.`);
+  });
+
+  it('leaves placeholders inside code spans untouched', () => {
+    expect(asciidocToMarkdown('Defaults to `redpanda_connect_jira_input_<resource>`.')).toBe(
+      'Defaults to `redpanda_connect_jira_input_<resource>`.'
+    );
+  });
+
+  it('flattens AsciiDoc tables to bullets and drops docs attribute lines', () => {
+    const source = [
+      'A Data Source Name.',
+      '',
+      ':driver-support: mysql=certified, postgres=certified',
+      '',
+      '|===',
+      '| Driver | Data Source Name Format',
+      '',
+      '| `mysql`',
+      '| `[username[:password]@]/dbname`',
+      '|===',
+    ].join('\n');
+    expect(asciidocToMarkdown(source)).toBe(
+      [
+        'A Data Source Name.',
+        '',
+        '- Driver — Data Source Name Format',
+        '',
+        '- `mysql`',
+        '- `[username[:password]@]/dbname`',
+      ].join('\n')
+    );
+  });
+
+  it('trims the leading newline that many field descriptions start with', () => {
+    expect(asciidocToMarkdown('\nA list of topics to consume from.')).toBe('A list of topics to consume from.');
+  });
+});
+
+describe('asciidocToPlainText', () => {
+  it('reduces converted Markdown to a single line without syntax', () => {
+    expect(asciidocToPlainText('\nUse `consumer_group` to share load.\n\n== Notes\n* first')).toBe(
+      'Use consumer_group to share load. Notes first'
+    );
+  });
+
+  it('keeps link labels and unescapes placeholders', () => {
+    expect(asciidocToPlainText('See https://example.com[the docs] for <token> usage.')).toBe(
+      'See the docs for <token> usage.'
+    );
+  });
+});
+
+describe('cleanText', () => {
+  it('strips code spans and macros down to one line', () => {
+    expect(cleanText('Sends to `redpanda`\nvia xref:guides:about.adoc[the guide].')).toBe(
+      'Sends to redpanda via the guide.'
+    );
+  });
+
+  it('substitutes a label for an empty-label xref', () => {
+    expect(cleanText('Found in xref:guides:cloud/aws.adoc[].')).toBe('Found in the documentation.');
+  });
+});

--- a/frontend/src/components/pages/rp-connect/utils/asciidoc.test.ts
+++ b/frontend/src/components/pages/rp-connect/utils/asciidoc.test.ts
@@ -49,6 +49,18 @@ describe('asciidocToMarkdown', () => {
     expect(asciidocToMarkdown(source)).toBe('See [`http[s]://user[:pass]`](https://example.com/dsn) here.');
   });
 
+  it('reduces internal cross-references to their wording', () => {
+    expect(asciidocToMarkdown('Set the field <<batch_as_multipart, `batch_as_multipart`>> to `false`.')).toBe(
+      'Set the field `batch_as_multipart` to `false`.'
+    );
+    expect(asciidocToMarkdown('Brokering <<patterns>> are supported.')).toBe('Brokering patterns are supported.');
+  });
+
+  it('flattens a Markdown pipe table, dropping its header rule', () => {
+    const source = 'Placeholders:\n\n| Driver | Style |\n|---|---|\n| `mysql` | Question mark |';
+    expect(asciidocToMarkdown(source)).toBe('Placeholders:\n\n- Driver — Style\n- `mysql` — Question mark');
+  });
+
   it('escapes angle-bracket placeholders so Markdown does not swallow them as HTML', () => {
     const out = asciidocToMarkdown("Requests must include 'authorization: Bearer <token>' metadata.");
     expect(out).toBe(String.raw`Requests must include 'authorization: Bearer \<token>' metadata.`);
@@ -87,6 +99,11 @@ describe('asciidocToMarkdown', () => {
 
   // The Debezium type table writes rows as `|Type Name |Bloblang Type`, with no space after the
   // cell marker.
+  it('splits a dsv table on colons, the separator its attribute line declares', () => {
+    const source = '[%header,format=dsv]\n|===\nSnowflake type:Connect format\nCHAR, VARCHAR:string\n|===';
+    expect(asciidocToMarkdown(source)).toBe('- Snowflake type — Connect format\n- CHAR, VARCHAR — string');
+  });
+
   it('splits table cells that are not padded around the marker', () => {
     const source = ['.Debezium Custom Temporal Types', '|===', '|Type Name |Bloblang Type', '|==='].join('\n');
     expect(asciidocToMarkdown(source)).toBe(
@@ -124,6 +141,11 @@ describe('markdownToPlainText', () => {
     );
   });
 
+  it('strips a link whose label nests brackets, as the sql DSN examples do', () => {
+    const markdown = 'A DSN: [`clickhouse://[user[:pass]@][host]`](https://example.com/dsn) applies.';
+    expect(markdownToPlainText(markdown)).toBe('A DSN: clickhouse://[user[:pass]@][host] applies.');
+  });
+
   it('keeps link labels and unescapes placeholders', () => {
     expect(markdownToPlainText(asciidocToMarkdown('See https://example.com[the docs] for <token> usage.'))).toBe(
       'See the docs for <token> usage.'
@@ -135,6 +157,12 @@ describe('cleanText', () => {
   it('strips code spans and macros down to one line', () => {
     expect(cleanText('Sends to `redpanda`\nvia xref:guides:about.adoc[the guide].')).toBe(
       'Sends to redpanda via the guide.'
+    );
+  });
+
+  it('reduces internal cross-references to their wording', () => {
+    expect(cleanText('Brokering <<patterns>> with <<codecs, structured data>>.')).toBe(
+      'Brokering patterns with structured data.'
     );
   });
 

--- a/frontend/src/components/pages/rp-connect/utils/asciidoc.test.ts
+++ b/frontend/src/components/pages/rp-connect/utils/asciidoc.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { asciidocToMarkdown, asciidocToPlainText, cleanText } from './asciidoc';
+import { asciidocToMarkdown, cleanText, markdownToPlainText } from './asciidoc';
 
 describe('asciidocToMarkdown', () => {
   it('turns AsciiDoc section titles into Markdown headings instead of leaking "=="', () => {
@@ -36,8 +36,7 @@ describe('asciidocToMarkdown', () => {
     expect(asciidocToMarkdown('* first\n* second')).toBe('- first\n- second');
   });
 
-  // Every AWS `credentials` field ends "…can be found in xref:guides:cloud/aws.adoc[]."; dropping
-  // the macro outright left the sentence as "…can be found in .".
+  // Every AWS `credentials` field ends "…can be found in xref:guides:cloud/aws.adoc[].".
   it('names a target for an empty-label xref rather than leaving dangling punctuation', () => {
     expect(asciidocToMarkdown('More information can be found in xref:guides:cloud/aws.adoc[].')).toBe(
       'More information can be found in the documentation.'
@@ -86,20 +85,47 @@ describe('asciidocToMarkdown', () => {
     );
   });
 
+  // The Debezium type table writes rows as `|Type Name |Bloblang Type`, with no space after the
+  // cell marker.
+  it('splits table cells that are not padded around the marker', () => {
+    const source = ['.Debezium Custom Temporal Types', '|===', '|Type Name |Bloblang Type', '|==='].join('\n');
+    expect(asciidocToMarkdown(source)).toBe(
+      ['#### Debezium Custom Temporal Types', '- Type Name — Bloblang Type'].join('\n')
+    );
+  });
+
+  it('leaves a pipe in prose alone even when the description also has a table', () => {
+    const source = ['Splits on | characters.', '', '|===', '|a |b', '|==='].join('\n');
+    expect(asciidocToMarkdown(source)).toBe(['Splits on | characters.', '', '- a — b'].join('\n'));
+  });
+
+  it('drops block delimiters that would promote the prose around them to a heading', () => {
+    const source = [
+      '[CAUTION]',
+      '.Endpoint caveats',
+      '====',
+      'Endpoints register in a non-deterministic order.',
+      '====',
+    ].join('\n');
+    expect(asciidocToMarkdown(source)).toBe(
+      ['**CAUTION**', '#### Endpoint caveats', '', 'Endpoints register in a non-deterministic order.'].join('\n')
+    );
+  });
+
   it('trims the leading newline that many field descriptions start with', () => {
     expect(asciidocToMarkdown('\nA list of topics to consume from.')).toBe('A list of topics to consume from.');
   });
 });
 
-describe('asciidocToPlainText', () => {
+describe('markdownToPlainText', () => {
   it('reduces converted Markdown to a single line without syntax', () => {
-    expect(asciidocToPlainText('\nUse `consumer_group` to share load.\n\n== Notes\n* first')).toBe(
+    expect(markdownToPlainText(asciidocToMarkdown('\nUse `consumer_group` to share load.\n\n== Notes\n* first'))).toBe(
       'Use consumer_group to share load. Notes first'
     );
   });
 
   it('keeps link labels and unescapes placeholders', () => {
-    expect(asciidocToPlainText('See https://example.com[the docs] for <token> usage.')).toBe(
+    expect(markdownToPlainText(asciidocToMarkdown('See https://example.com[the docs] for <token> usage.'))).toBe(
       'See the docs for <token> usage.'
     );
   });

--- a/frontend/src/components/pages/rp-connect/utils/asciidoc.ts
+++ b/frontend/src/components/pages/rp-connect/utils/asciidoc.ts
@@ -21,13 +21,20 @@ const MACRO_LABEL = String.raw`((?:\\.|[^\]\\])*)`;
 const XREF_MACRO = new RegExp(String.raw`(?:xref|link):[^\s[\]]*\[${MACRO_LABEL}\]`, 'g');
 const URL_MACRO = new RegExp(String.raw`(https?://[^\s[\]]+)\[${MACRO_LABEL}\]`, 'g');
 
-// Every empty-label xref in the schema reads "More information can be found in xref:…[].", so a
-// generic noun keeps the sentence intact where dropping the macro would leave a dangling "in .".
+// Keeps "More information can be found in xref:…[]." from rendering as "…found in .".
 const EMPTY_XREF_LABEL = 'the documentation';
 
 const NEW_WINDOW_FLAG = /\^$/;
-const TABLE_CELL_LINE = /^\|\s*(.*)$/;
-const TABLE_CELL_SEPARATOR = /\s+\|\s+/;
+const ATTRIBUTE_LINE = /^:[a-zA-Z][\w-]*:.*$/gm;
+const TABLE_DELIMITER = /^\s*\|===\s*$/;
+const LEADING_CELL_MARKER = /^\|\s*/;
+const TABLE_CELL_SEPARATOR = /\s*\|\s*/;
+// Admonition markers keep their label; every other block attribute (`[source,yaml]`) is docs noise.
+const ADMONITION_LINE = /^\[(NOTE|TIP|WARNING|IMPORTANT|CAUTION)\]$/gm;
+const BLOCK_ATTRIBUTE_LINE = /^\[[^\]]*\]$/gm;
+// Block delimiters (`====` example, `----` listing). `-{4,}` leaves a Markdown `---` alone.
+const BLOCK_DELIMITER = /^(?:={2,}|-{4,}|\*{4,}|_{4,}|\+{4,})$/gm;
+const BLOCK_TITLE_LINE = /^\.([A-Z][^\n]*)$/gm;
 
 // `\]` escapes the bracket; a trailing `^` is AsciiDoc's "open in a new window" flag, not text.
 function macroLabel(label: string): string {
@@ -35,26 +42,29 @@ function macroLabel(label: string): string {
 }
 
 /**
- * Flattens `|===` tables to bullets. The schema's tables are one `| cell` per line with blank lines
- * between rows, so the row grouping survives; a real Markdown table isn't worth the conversion for
- * the handful of fields (sql_* DSN formats) that use one.
+ * Flattens `|===` tables to one bullet per source line, cells joined with an em dash. A Markdown
+ * table isn't worth the conversion for the handful of fields (sql DSN formats, Debezium type maps)
+ * that use one. Rows are only recognized between delimiters, so a `|` in prose is left alone.
  */
 function flattenTables(text: string): string {
   if (!text.includes('|===')) {
     return text;
   }
-  return text
-    .split('\n')
-    .filter((line) => line.trim() !== '|===')
-    .map((line) => {
-      const cells = TABLE_CELL_LINE.exec(line.trimEnd());
-      if (!cells) {
-        return line;
-      }
-      const joined = cells[1].split(TABLE_CELL_SEPARATOR).join(' — ').trim();
-      return joined ? `- ${joined}` : '';
-    })
-    .join('\n');
+  let inTable = false;
+  const lines: string[] = [];
+  for (const line of text.split('\n')) {
+    if (TABLE_DELIMITER.test(line)) {
+      inTable = !inTable;
+      continue;
+    }
+    if (!inTable) {
+      lines.push(line);
+      continue;
+    }
+    const row = line.trim().replace(LEADING_CELL_MARKER, '');
+    lines.push(row ? `- ${row.split(TABLE_CELL_SEPARATOR).join(' — ')}` : '');
+  }
+  return lines.join('\n');
 }
 
 /**
@@ -73,7 +83,7 @@ function escapePlaceholders(text: string): string {
 export function cleanText(text: string): string {
   return text
     .replace(XREF_MACRO, (_match, label: string) => macroLabel(label) || EMPTY_XREF_LABEL)
-    .replace(URL_MACRO, (_match, _url: string, label: string) => macroLabel(label))
+    .replace(URL_MACRO, (_match, url: string, label: string) => macroLabel(label) || url)
     .replace(/`([^`]+)`/g, '$1')
     .replace(/\s+/g, ' ')
     .trim();
@@ -87,7 +97,13 @@ export function asciidocToMarkdown(raw: string): string {
   return escapePlaceholders(
     flattenTables(raw.replace(/\r\n/g, '\n'))
       // Attribute definitions configure the docs build; they render as noise.
-      .replace(/^:[a-zA-Z][\w-]*:.*$/gm, '')
+      .replace(ATTRIBUTE_LINE, '')
+      .replace(ADMONITION_LINE, '**$1**')
+      .replace(BLOCK_ATTRIBUTE_LINE, '')
+      // Left in place, a delimiter turns the prose around it into a setext heading.
+      .replace(BLOCK_DELIMITER, '')
+      // Block titles (`.Endpoint caveats`) → small heading.
+      .replace(BLOCK_TITLE_LINE, '#### $1')
       // Link macros → label text.
       .replace(XREF_MACRO, (_match, label: string) => macroLabel(label) || EMPTY_XREF_LABEL)
       // Bare URL macro → Markdown link.
@@ -106,9 +122,9 @@ export function asciidocToMarkdown(raw: string): string {
   );
 }
 
-/** Single-line plain text for collapsed previews: the converted Markdown with its syntax removed. */
-export function asciidocToPlainText(raw: string): string {
-  return asciidocToMarkdown(raw)
+/** Strips Markdown syntax to a single line, for collapsed previews. */
+export function markdownToPlainText(markdown: string): string {
+  return markdown
     .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
     .replace(/^#+\s*/gm, '')
     .replace(/^[-*]\s+/gm, '')

--- a/frontend/src/components/pages/rp-connect/utils/asciidoc.ts
+++ b/frontend/src/components/pages/rp-connect/utils/asciidoc.ts
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+/**
+ * Redpanda Connect schema prose is AsciiDoc, not Markdown: `xref:`/`link:` macros, `url[label]`
+ * macros, `==` section titles, `|===` tables, `:attr:` lines, and backticks for monospace. Applies
+ * to component `summary`/`description` and per-field `description`. Field `short_description`s carry
+ * no markup by contract and must not be run through any of this.
+ */
+
+// A macro label, allowing AsciiDoc's `\]` escape: either an escaped pair or a plain char.
+const MACRO_LABEL = String.raw`((?:\\.|[^\]\\])*)`;
+const XREF_MACRO = new RegExp(String.raw`(?:xref|link):[^\s[\]]*\[${MACRO_LABEL}\]`, 'g');
+const URL_MACRO = new RegExp(String.raw`(https?://[^\s[\]]+)\[${MACRO_LABEL}\]`, 'g');
+
+// Every empty-label xref in the schema reads "More information can be found in xref:…[].", so a
+// generic noun keeps the sentence intact where dropping the macro would leave a dangling "in .".
+const EMPTY_XREF_LABEL = 'the documentation';
+
+const NEW_WINDOW_FLAG = /\^$/;
+const TABLE_CELL_LINE = /^\|\s*(.*)$/;
+const TABLE_CELL_SEPARATOR = /\s+\|\s+/;
+
+// `\]` escapes the bracket; a trailing `^` is AsciiDoc's "open in a new window" flag, not text.
+function macroLabel(label: string): string {
+  return label.replace(/\\(.)/g, '$1').replace(NEW_WINDOW_FLAG, '').trim();
+}
+
+/**
+ * Flattens `|===` tables to bullets. The schema's tables are one `| cell` per line with blank lines
+ * between rows, so the row grouping survives; a real Markdown table isn't worth the conversion for
+ * the handful of fields (sql_* DSN formats) that use one.
+ */
+function flattenTables(text: string): string {
+  if (!text.includes('|===')) {
+    return text;
+  }
+  return text
+    .split('\n')
+    .filter((line) => line.trim() !== '|===')
+    .map((line) => {
+      const cells = TABLE_CELL_LINE.exec(line.trimEnd());
+      if (!cells) {
+        return line;
+      }
+      const joined = cells[1].split(TABLE_CELL_SEPARATOR).join(' — ').trim();
+      return joined ? `- ${joined}` : '';
+    })
+    .join('\n');
+}
+
+/**
+ * Escapes `<placeholder>` spans outside code so Markdown keeps them: remark parses `<db>` as inline
+ * HTML and, with raw HTML disabled, drops it — silently corrupting the DSN and header examples that
+ * use angle-bracket placeholders. Autolinks (`<https://…>`) are left alone.
+ */
+function escapePlaceholders(text: string): string {
+  return text
+    .split(/(```[\s\S]*?```|`[^`\n]*`)/g)
+    .map((part, index) => (index % 2 === 1 ? part : part.replace(/<(?!https?:\/\/)(?=[a-zA-Z/])/g, String.raw`\<`)))
+    .join('');
+}
+
+/** Reduces one-line AsciiDoc prose (link macros, code spans) to plain label text on a single line. */
+export function cleanText(text: string): string {
+  return text
+    .replace(XREF_MACRO, (_match, label: string) => macroLabel(label) || EMPTY_XREF_LABEL)
+    .replace(URL_MACRO, (_match, _url: string, label: string) => macroLabel(label))
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Converts the AsciiDoc constructs Connect uses to Markdown for react-markdown. Unlike
+ * {@link cleanText}, newlines are preserved so titles and paragraphs stay distinct.
+ */
+export function asciidocToMarkdown(raw: string): string {
+  return escapePlaceholders(
+    flattenTables(raw.replace(/\r\n/g, '\n'))
+      // Attribute definitions configure the docs build; they render as noise.
+      .replace(/^:[a-zA-Z][\w-]*:.*$/gm, '')
+      // Link macros → label text.
+      .replace(XREF_MACRO, (_match, label: string) => macroLabel(label) || EMPTY_XREF_LABEL)
+      // Bare URL macro → Markdown link.
+      .replace(URL_MACRO, (_match, url: string, label: string) => {
+        const text = macroLabel(label);
+        return text ? `[${text}](${url})` : url;
+      })
+      // Section titles (`==`/`===`/… Title) → small heading.
+      .replace(/^=+\s+(.{1,60})$/gm, '#### $1')
+      // Strip leftover markers from over-long titles.
+      .replace(/^=+\s+/gm, '')
+      // List markers → bullets.
+      .replace(/^\*\s+/gm, '- ')
+      .replace(/\n{3,}/g, '\n\n')
+      .trim()
+  );
+}
+
+/** Single-line plain text for collapsed previews: the converted Markdown with its syntax removed. */
+export function asciidocToPlainText(raw: string): string {
+  return asciidocToMarkdown(raw)
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/^#+\s*/gm, '')
+    .replace(/^[-*]\s+/gm, '')
+    .replace(/\\([<>])/g, '$1')
+    .replace(/[`*]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}

--- a/frontend/src/components/pages/rp-connect/utils/asciidoc.ts
+++ b/frontend/src/components/pages/rp-connect/utils/asciidoc.ts
@@ -48,7 +48,6 @@ const DSV_CELL_SEPARATOR = /\s*:\s*/;
 
 const CODE_BLOCK_OR_SPAN = /(```[\s\S]*?```|`[^`\n]*`)/g;
 const PLACEHOLDER_OPENER = /<(?!https?:\/\/)(?=[a-zA-Z/])/g;
-const CODE_SPAN_TICKS = /`([^`]+)`/g;
 const MARKDOWN_MARKS = /[`*]/g;
 const MARKDOWN_HEADING = /^#+\s*/gm;
 const MARKDOWN_LIST_MARKER = /^[-*]\s+/gm;
@@ -111,15 +110,6 @@ function escapePlaceholders(text: string): string {
     .split(CODE_BLOCK_OR_SPAN)
     .map((part, index) => (index % 2 === 1 ? part : part.replace(PLACEHOLDER_OPENER, String.raw`\<`)))
     .join('');
-}
-
-/** One-line prose (component summaries) to plain text. Multi-paragraph prose needs the pair below. */
-export function cleanText(text: string): string {
-  return macrosToLabels(text)
-    .replace(URL_MACRO, (_match, url: string, label: string) => macroLabel(label) || url)
-    .replace(CODE_SPAN_TICKS, '$1')
-    .replace(WHITESPACE_RUN, ' ')
-    .trim();
 }
 
 /** AsciiDoc to Markdown for react-markdown; newlines survive, so titles and paragraphs stay distinct. */

--- a/frontend/src/components/pages/rp-connect/utils/asciidoc.ts
+++ b/frontend/src/components/pages/rp-connect/utils/asciidoc.ts
@@ -10,114 +10,135 @@
  */
 
 /**
- * Redpanda Connect schema prose is AsciiDoc, not Markdown: `xref:`/`link:` macros, `url[label]`
- * macros, `==` section titles, `|===` tables, `:attr:` lines, and backticks for monospace. Applies
- * to component `summary`/`description` and per-field `description`. Field `short_description`s carry
- * no markup by contract and must not be run through any of this.
+ * Connect schema prose is AsciiDoc, not Markdown — component `summary`/`description` and per-field
+ * `description`. `short_description` carries no markup by contract and must not come through here.
  */
 
-// A macro label, allowing AsciiDoc's `\]` escape: either an escaped pair or a plain char.
+// Macro label, allowing AsciiDoc's `\]` escape.
 const MACRO_LABEL = String.raw`((?:\\.|[^\]\\])*)`;
 const XREF_MACRO = new RegExp(String.raw`(?:xref|link):[^\s[\]]*\[${MACRO_LABEL}\]`, 'g');
 const URL_MACRO = new RegExp(String.raw`(https?://[^\s[\]]+)\[${MACRO_LABEL}\]`, 'g');
+// Lazy up to the `](`, so brackets nested in the label (code-spanned DSN examples) stay part of it.
+const MARKDOWN_LINK = /\[([^\n]*?)\]\([^)\n]*\)/g;
+const INTERNAL_XREF = /<<([^>,\n]+)(?:,\s*([^>\n]+))?>>/g;
+const NEW_WINDOW_FLAG = /\^$/;
 
-// Keeps "More information can be found in xref:…[]." from rendering as "…found in .".
+// So "found in xref:…[]." doesn't render as "found in .".
 const EMPTY_XREF_LABEL = 'the documentation';
 
-const NEW_WINDOW_FLAG = /\^$/;
 const ATTRIBUTE_LINE = /^:[a-zA-Z][\w-]*:.*$/gm;
-const TABLE_DELIMITER = /^\s*\|===\s*$/;
-const LEADING_CELL_MARKER = /^\|\s*/;
-const TABLE_CELL_SEPARATOR = /\s*\|\s*/;
-// Admonition markers keep their label; every other block attribute (`[source,yaml]`) is docs noise.
+// Admonitions keep their label; every other block attribute (`[source,yaml]`) is docs noise.
 const ADMONITION_LINE = /^\[(NOTE|TIP|WARNING|IMPORTANT|CAUTION)\]$/gm;
 const BLOCK_ATTRIBUTE_LINE = /^\[[^\]]*\]$/gm;
-// Block delimiters (`====` example, `----` listing). `-{4,}` leaves a Markdown `---` alone.
+// `-{4,}` leaves a Markdown `---` alone.
 const BLOCK_DELIMITER = /^(?:={2,}|-{4,}|\*{4,}|_{4,}|\+{4,})$/gm;
 const BLOCK_TITLE_LINE = /^\.([A-Z][^\n]*)$/gm;
+const SECTION_TITLE = /^=+\s+(.{1,60})$/gm;
+const OVERLONG_SECTION_MARKER = /^=+\s+/gm;
+const LIST_MARKER = /^\*\s+/gm;
+const BLANK_LINE_RUN = /\n{3,}/g;
 
-// `\]` escapes the bracket; a trailing `^` is AsciiDoc's "open in a new window" flag, not text.
+const TABLE_FENCE = /^\|===$/;
+const TABLE_RULE_ROW = /^\|[\s:|-]+$/;
+const TABLE_CELL_MARKERS = /^\|\s*|\s*\|$/g;
+const TABLE_CELL_SEPARATOR = /\s*\|\s*/;
+// `[%header,format=dsv]` tables separate cells with `:` instead.
+const DSV_TABLE_ATTRIBUTE = /^\[.*format=dsv.*\]$/;
+const DSV_CELL_SEPARATOR = /\s*:\s*/;
+
+const CODE_BLOCK_OR_SPAN = /(```[\s\S]*?```|`[^`\n]*`)/g;
+const PLACEHOLDER_OPENER = /<(?!https?:\/\/)(?=[a-zA-Z/])/g;
+const CODE_SPAN_TICKS = /`([^`]+)`/g;
+const MARKDOWN_MARKS = /[`*]/g;
+const MARKDOWN_HEADING = /^#+\s*/gm;
+const MARKDOWN_LIST_MARKER = /^[-*]\s+/gm;
+const BACKSLASH_ESCAPE = /\\(.)/g;
+const WHITESPACE_RUN = /\s+/g;
+const CRLF = /\r\n/g;
+
 function macroLabel(label: string): string {
-  return label.replace(/\\(.)/g, '$1').replace(NEW_WINDOW_FLAG, '').trim();
+  return label.replace(BACKSLASH_ESCAPE, '$1').replace(NEW_WINDOW_FLAG, '').trim();
 }
 
+const macrosToLabels = (text: string): string =>
+  text
+    .replace(XREF_MACRO, (_match, label: string) => macroLabel(label) || EMPTY_XREF_LABEL)
+    .replace(INTERNAL_XREF, (_match, anchor: string, label?: string) => (label ?? anchor).trim());
+
 /**
- * Flattens `|===` tables to one bullet per source line, cells joined with an em dash. A Markdown
- * table isn't worth the conversion for the handful of fields (sql DSN formats, Debezium type maps)
- * that use one. Rows are only recognized between delimiters, so a `|` in prose is left alone.
+ * Flattens `|===` and Markdown pipe tables to one bullet per row — react-markdown is mounted without
+ * remark-gfm. Outside a fence a row must be pipe-delimited at both ends, so prose keeps its `|`.
  */
 function flattenTables(text: string): string {
-  if (!text.includes('|===')) {
+  if (!text.includes('|')) {
     return text;
   }
-  let inTable = false;
+  let inFence = false;
+  let separator = TABLE_CELL_SEPARATOR;
   const lines: string[] = [];
   for (const line of text.split('\n')) {
-    if (TABLE_DELIMITER.test(line)) {
-      inTable = !inTable;
+    const trimmed = line.trim();
+    if (TABLE_FENCE.test(trimmed)) {
+      inFence = !inFence;
+      if (!inFence) {
+        separator = TABLE_CELL_SEPARATOR;
+      }
       continue;
     }
-    if (!inTable) {
+    if (!inFence && DSV_TABLE_ATTRIBUTE.test(trimmed)) {
+      separator = DSV_CELL_SEPARATOR;
       lines.push(line);
       continue;
     }
-    const row = line.trim().replace(LEADING_CELL_MARKER, '');
-    lines.push(row ? `- ${row.split(TABLE_CELL_SEPARATOR).join(' — ')}` : '');
+    const isRow = inFence || (trimmed.startsWith('|') && trimmed.endsWith('|'));
+    if (!isRow) {
+      lines.push(line);
+      continue;
+    }
+    // A Markdown header rule (`|---|---|`) carries no content; inside a fence it could be a row.
+    if (!inFence && TABLE_RULE_ROW.test(trimmed)) {
+      continue;
+    }
+    const cells = trimmed.replace(TABLE_CELL_MARKERS, '');
+    lines.push(cells ? `- ${cells.split(separator).join(' — ')}` : '');
   }
   return lines.join('\n');
 }
 
-/**
- * Escapes `<placeholder>` spans outside code so Markdown keeps them: remark parses `<db>` as inline
- * HTML and, with raw HTML disabled, drops it — silently corrupting the DSN and header examples that
- * use angle-bracket placeholders. Autolinks (`<https://…>`) are left alone.
- */
+/** Escapes `<placeholder>` outside code: remark reads it as inline HTML and, with HTML off, drops it. */
 function escapePlaceholders(text: string): string {
   return text
-    .split(/(```[\s\S]*?```|`[^`\n]*`)/g)
-    .map((part, index) => (index % 2 === 1 ? part : part.replace(/<(?!https?:\/\/)(?=[a-zA-Z/])/g, String.raw`\<`)))
+    .split(CODE_BLOCK_OR_SPAN)
+    .map((part, index) => (index % 2 === 1 ? part : part.replace(PLACEHOLDER_OPENER, String.raw`\<`)))
     .join('');
 }
 
-/** Reduces one-line AsciiDoc prose (link macros, code spans) to plain label text on a single line. */
+/** One-line prose (component summaries) to plain text. Multi-paragraph prose needs the pair below. */
 export function cleanText(text: string): string {
-  return text
-    .replace(XREF_MACRO, (_match, label: string) => macroLabel(label) || EMPTY_XREF_LABEL)
+  return macrosToLabels(text)
     .replace(URL_MACRO, (_match, url: string, label: string) => macroLabel(label) || url)
-    .replace(/`([^`]+)`/g, '$1')
-    .replace(/\s+/g, ' ')
+    .replace(CODE_SPAN_TICKS, '$1')
+    .replace(WHITESPACE_RUN, ' ')
     .trim();
 }
 
-/**
- * Converts the AsciiDoc constructs Connect uses to Markdown for react-markdown. Unlike
- * {@link cleanText}, newlines are preserved so titles and paragraphs stay distinct.
- */
+/** AsciiDoc to Markdown for react-markdown; newlines survive, so titles and paragraphs stay distinct. */
 export function asciidocToMarkdown(raw: string): string {
   return escapePlaceholders(
-    flattenTables(raw.replace(/\r\n/g, '\n'))
-      // Attribute definitions configure the docs build; they render as noise.
+    macrosToLabels(flattenTables(raw.replace(CRLF, '\n')))
       .replace(ATTRIBUTE_LINE, '')
       .replace(ADMONITION_LINE, '**$1**')
       .replace(BLOCK_ATTRIBUTE_LINE, '')
-      // Left in place, a delimiter turns the prose around it into a setext heading.
       .replace(BLOCK_DELIMITER, '')
-      // Block titles (`.Endpoint caveats`) → small heading.
       .replace(BLOCK_TITLE_LINE, '#### $1')
-      // Link macros → label text.
-      .replace(XREF_MACRO, (_match, label: string) => macroLabel(label) || EMPTY_XREF_LABEL)
-      // Bare URL macro → Markdown link.
       .replace(URL_MACRO, (_match, url: string, label: string) => {
         const text = macroLabel(label);
         return text ? `[${text}](${url})` : url;
       })
-      // Section titles (`==`/`===`/… Title) → small heading.
-      .replace(/^=+\s+(.{1,60})$/gm, '#### $1')
-      // Strip leftover markers from over-long titles.
-      .replace(/^=+\s+/gm, '')
-      // List markers → bullets.
-      .replace(/^\*\s+/gm, '- ')
-      .replace(/\n{3,}/g, '\n\n')
+      .replace(SECTION_TITLE, '#### $1')
+      .replace(OVERLONG_SECTION_MARKER, '')
+      .replace(LIST_MARKER, '- ')
+      .replace(BLANK_LINE_RUN, '\n\n')
       .trim()
   );
 }
@@ -125,11 +146,11 @@ export function asciidocToMarkdown(raw: string): string {
 /** Strips Markdown syntax to a single line, for collapsed previews. */
 export function markdownToPlainText(markdown: string): string {
   return markdown
-    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
-    .replace(/^#+\s*/gm, '')
-    .replace(/^[-*]\s+/gm, '')
-    .replace(/\\([<>])/g, '$1')
-    .replace(/[`*]/g, '')
-    .replace(/\s+/g, ' ')
+    .replace(MARKDOWN_LINK, '$1')
+    .replace(MARKDOWN_HEADING, '')
+    .replace(MARKDOWN_LIST_MARKER, '')
+    .replace(BACKSLASH_ESCAPE, '$1')
+    .replace(MARKDOWN_MARKS, '')
+    .replace(WHITESPACE_RUN, ' ')
     .trim();
 }

--- a/frontend/src/components/pages/rp-connect/utils/connector-docs.test.ts
+++ b/frontend/src/components/pages/rp-connect/utils/connector-docs.test.ts
@@ -13,6 +13,8 @@ import { describe, expect, it } from 'vitest';
 
 import { getConnectorDocsUrl, getFieldDocsUrl, getNodeDocsUrl } from './connector-docs';
 
+const DOCS = 'https://docs.redpanda.com/cloud-data-platform/develop/connect/components';
+
 describe('getConnectorDocsUrl', () => {
   it('builds correct URL for input connectors', () => {
     expect(getConnectorDocsUrl('input', 'aws_cloudwatch_logs')).toBe(
@@ -59,27 +61,19 @@ describe('getConnectorDocsUrl', () => {
 });
 
 describe('getFieldDocsUrl', () => {
-  const INPUT_REDPANDA = 'https://docs.redpanda.com/cloud-data-platform/develop/connect/components/inputs/redpanda/';
+  const REDPANDA_INPUT = `${DOCS}/inputs/redpanda/`;
 
-  it('anchors a top-level field by its name', () => {
-    expect(getFieldDocsUrl('input', 'redpanda', ['consumer_group'])).toBe(`${INPUT_REDPANDA}#consumer_group`);
-  });
-
-  it('joins a nested field path with hyphens, as the docs generator ids it', () => {
-    expect(getFieldDocsUrl('output', 'sql_insert', ['batching', 'byte_size'])).toBe(
-      'https://docs.redpanda.com/cloud-data-platform/develop/connect/components/outputs/sql_insert/#batching-byte_size'
-    );
-  });
-
-  it('ignores list nesting, which the docs anchors drop', () => {
+  it.each([
+    ['a top-level field by its name', ['consumer_group'], `${REDPANDA_INPUT}#consumer_group`],
     // Documented as `sasl[].aws.credentials.role`, anchored `#sasl-aws-credentials-role`.
-    expect(getFieldDocsUrl('input', 'redpanda', ['sasl', 'aws', 'credentials', 'role'])).toBe(
-      `${INPUT_REDPANDA}#sasl-aws-credentials-role`
-    );
-  });
-
-  it('falls back to the component page when there is no field path', () => {
-    expect(getFieldDocsUrl('input', 'redpanda', [])).toBe(INPUT_REDPANDA);
+    [
+      'a nested path with hyphens, list nesting dropped',
+      ['sasl', 'aws', 'credentials', 'role'],
+      `${REDPANDA_INPUT}#sasl-aws-credentials-role`,
+    ],
+    ['the component page when there is no field path', [], REDPANDA_INPUT],
+  ])('anchors %s', (_case, path, expected) => {
+    expect(getFieldDocsUrl('input', 'redpanda', path)).toBe(expected);
   });
 
   it('returns undefined when the component itself has no docs page', () => {

--- a/frontend/src/components/pages/rp-connect/utils/connector-docs.test.ts
+++ b/frontend/src/components/pages/rp-connect/utils/connector-docs.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { getConnectorDocsUrl, getNodeDocsUrl } from './connector-docs';
+import { getConnectorDocsUrl, getFieldDocsUrl, getNodeDocsUrl } from './connector-docs';
 
 describe('getConnectorDocsUrl', () => {
   it('builds correct URL for input connectors', () => {
@@ -55,6 +55,35 @@ describe('getConnectorDocsUrl', () => {
 
   it('returns undefined for empty section', () => {
     expect(getConnectorDocsUrl('', 'kafka')).toBeUndefined();
+  });
+});
+
+describe('getFieldDocsUrl', () => {
+  const INPUT_REDPANDA = 'https://docs.redpanda.com/cloud-data-platform/develop/connect/components/inputs/redpanda/';
+
+  it('anchors a top-level field by its name', () => {
+    expect(getFieldDocsUrl('input', 'redpanda', ['consumer_group'])).toBe(`${INPUT_REDPANDA}#consumer_group`);
+  });
+
+  it('joins a nested field path with hyphens, as the docs generator ids it', () => {
+    expect(getFieldDocsUrl('output', 'sql_insert', ['batching', 'byte_size'])).toBe(
+      'https://docs.redpanda.com/cloud-data-platform/develop/connect/components/outputs/sql_insert/#batching-byte_size'
+    );
+  });
+
+  it('ignores list nesting, which the docs anchors drop', () => {
+    // Documented as `sasl[].aws.credentials.role`, anchored `#sasl-aws-credentials-role`.
+    expect(getFieldDocsUrl('input', 'redpanda', ['sasl', 'aws', 'credentials', 'role'])).toBe(
+      `${INPUT_REDPANDA}#sasl-aws-credentials-role`
+    );
+  });
+
+  it('falls back to the component page when there is no field path', () => {
+    expect(getFieldDocsUrl('input', 'redpanda', [])).toBe(INPUT_REDPANDA);
+  });
+
+  it('returns undefined when the component itself has no docs page', () => {
+    expect(getFieldDocsUrl('metrics', 'prometheus', ['use_histogram_timing'])).toBeUndefined();
   });
 });
 

--- a/frontend/src/components/pages/rp-connect/utils/connector-docs.ts
+++ b/frontend/src/components/pages/rp-connect/utils/connector-docs.ts
@@ -28,12 +28,10 @@ export function getConnectorDocsUrl(section: string, connectorName: string): str
 }
 
 /**
- * Docs URL for one field on a connector's reference page. Each field heading on those pages is
- * anchored by its dotted path with list markers dropped (`batching.byte_size` →
- * `#batching-byte_size`), which is exactly the form's field path. A field whose name collides with
- * a prose section of the same page is anchored `-2` (~0.2% of fields, e.g. `snowflake_put`'s
- * `snowpipe`); there the plain anchor lands on that same-named section, and an anchor that misses
- * outright leaves the reader at the top of the right page.
+ * Docs URL for one field, anchored by its dotted path with list markers dropped
+ * (`batching.byte_size` → `#batching-byte_size`) — exactly the form's field path. A name that
+ * collides with a prose section on the page is anchored `-2` there instead (~0.2% of fields), and a
+ * missed anchor lands at the top of the right page.
  */
 export function getFieldDocsUrl(
   section: string,

--- a/frontend/src/components/pages/rp-connect/utils/connector-docs.ts
+++ b/frontend/src/components/pages/rp-connect/utils/connector-docs.ts
@@ -27,6 +27,26 @@ export function getConnectorDocsUrl(section: string, connectorName: string): str
   return `${DOCS_BASE}/${section}s/${connectorName}/`;
 }
 
+/**
+ * Docs URL for one field on a connector's reference page. Each field heading on those pages is
+ * anchored by its dotted path with list markers dropped (`batching.byte_size` →
+ * `#batching-byte_size`), which is exactly the form's field path. A field whose name collides with
+ * a prose section of the same page is anchored `-2` (~0.2% of fields, e.g. `snowflake_put`'s
+ * `snowpipe`); there the plain anchor lands on that same-named section, and an anchor that misses
+ * outright leaves the reader at the top of the right page.
+ */
+export function getFieldDocsUrl(
+  section: string,
+  connectorName: string,
+  fieldPath: readonly string[]
+): string | undefined {
+  const base = getConnectorDocsUrl(section, connectorName);
+  if (!base || fieldPath.length === 0) {
+    return base;
+  }
+  return `${base}#${fieldPath.join('-')}`;
+}
+
 type DocsNode = Pick<PipelineFlowNode, 'kind' | 'label' | 'section' | 'isCase' | 'resourceKey'>;
 
 /** Docs URL for a parsed pipeline node, or undefined when the node names no documented component. */


### PR DESCRIPTION
## What

Field help text in the RPCN config form now renders the schema's prose properly instead of dumping raw AsciiDoc under the control, and every field links to its own heading in the docs.

- Prefer `FieldSpec.short_description` (a markup-free one-liner) when the dataplane serves it; fall back to the AsciiDoc `description`, which is still the majority path.
- New `FieldDescription` component: converts AsciiDoc to Markdown, and collapses long or multi-paragraph prose behind "Show more" so it doesn't bury the input. A single-paragraph description renders inline, so its docs link trails the sentence instead of claiming a row.
- AsciiDoc conversion moved out of the command-palette utils into `rp-connect/utils/asciidoc.ts`, shared by the palette, the form and the template gallery.
- Template gallery slots prefer the short description too, and flatten the AsciiDoc fallback.

## Per-field docs links

`getFieldDocsUrl(section, connector, path)` deep-links a field's own heading on its connector reference page. The docs generator anchors each field heading with its dotted path, list markers dropped — `batching.byte_size` → `#batching-byte_size`, `sasl[].aws.credentials.role` → `#sasl-aws-credentials-role` — which is exactly the path the form already carries, so no new plumbing beyond a context holding the component's identity.

Checked against the live docs rather than assumed: over 90 randomly sampled cloud component pages (all HTTP 200), 1,770 leaf-field headings resolve, with **3 (0.17%)** anchored `-2` because a prose section on the same page claimed the plain id first. Those land on that same-named section, and an anchor that misses at all leaves the reader at the top of the right page — never worse than the connector-level link we'd otherwise ship. Field headings sit in a flat `Fields` section after the common/advanced tabs, so the anchor isn't buried in a collapsed panel. Verified end-to-end in localdev: all 13 links the form generated for `input: redpanda`, nested `tls.*` included, exist verbatim on the published page.

Object-group headers (`batching`, `sasl`) deliberately get no link — they carry no description, and they're where the `-2` collisions cluster (11 of 231).

## AsciiDoc rendering fixes

Found by reviewing the new converter against the bundled schema (`rp-connect-schema-full.json`: 4,650 non-deprecated field descriptions + 439 component prose blocks), and each fix re-verified over the whole corpus:

| Issue | Before | After |
| --- | --- | --- |
| `<<anchor, label>>` cross-references were never converted | 19 fields + 17 component blocks leaked `A database <\<drivers, driver>> to use.` | `A database driver to use.` — 0 left |
| Markdown pipe tables unparsed (react-markdown is mounted without remark-gfm) | `sql_raw.query` and 4 others rendered `\| Driver \| Style \| \|---\|---\|` as literal text | flattened to `- Driver — Placeholder Style`; 0 pipe rows left in 5,089 outputs |
| `format=dsv` tables split on the wrong separator | `- CHAR, VARCHAR:string` | `- CHAR, VARCHAR — string`, separator read from the table's own attribute line |
| Collapsed preview kept raw Markdown when a link label nested brackets | 8 `dsn` fields showed ``[`clickhouse://[user[:pass]@]…`](https://…)`` verbatim, URL included | 0 residual links |
| `cleanText` applied to multi-paragraph prose in template slots | 9 fields leaked `==== Drivers :driver-support: mysql=certified…` into slot help | full conversion + plain-text pass; 0 leaks |
| Slot help used `shortDescription` untrimmed | a whitespace-only value from the wire blanked the slot, while the config form treats it as absent | both consumers agree |

**Known gap, not fixed here:** the line-based block transforms aren't fence-aware, so a `----` separator or a line like `["a","b"]` inside a ``` fenced example would be dropped. Zero triggers across all 49 fenced descriptions in the current schema, so it's latent rather than live — worth a follow-up rather than a restructure in this PR.

## Notes for review

- `node-config-form.tsx` is an 18-line change: the field docs lookup rides on `ResourceFieldContext`, which already carries the edited component's identity, rather than adding a provider (a second wrapper re-indented the whole form body for no benefit).
- `cleanText` is gone. `markdownToPlainText(asciidocToMarkdown(x))` is byte-identical on all 235 component summaries — its only render site — and strictly better on descriptions, so there is now one way to flatten schema prose.
- `text-body-sm` is the `text-xs` rung and computes to 10.5px here, which is why the docs-link icon is `size-3` and positioned with `vertical-align` rather than a flex box — a flex box baselines on the icon's bottom edge and drops the word below the prose.

## Testing

`bun run type:check`, `bun run lint` (clean tree), and the full rp-connect suites: 139 unit + 772 integration passing. New coverage: internal cross-references in both conversion paths, pipe-table and dsv flattening, bracketed link labels in both the rendered link and the collapsed preview, the field-level anchor contract (including nested paths through the form), and the two template-slot fallbacks.

