### PR TITLE
Polish SQL studio toolbar and panel padding

### DIFF
--- a/frontend/src/components/pages/sql/sql-editor.tsx
+++ b/frontend/src/components/pages/sql/sql-editor.tsx
@@ -22,7 +22,6 @@ import { EditorView, keymap } from '@codemirror/view';
 import { tags } from '@lezer/highlight';
 import CodeMirror, { type ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import { Button } from 'components/redpanda-ui/components/button';
-import { Kbd, KbdGroup } from 'components/redpanda-ui/components/kbd';
 import { Popover, PopoverContent, PopoverTrigger } from 'components/redpanda-ui/components/popover';
 import { Tabs, TabsList, TabsTrigger } from 'components/redpanda-ui/components/tabs';
 import { useThemeAppearance } from 'hooks/use-theme-appearance';
@@ -525,10 +524,8 @@ export const SqlEditor = forwardRef<SqlEditorHandle, SqlEditorProps>(
             </Button>
             <Button onClick={doRun} size="sm" variant="primary">
               <Play /> Run
-              <KbdGroup>
-                <Kbd size="xs">{isMacOS() ? '⌘' : 'Ctrl'}</Kbd>
-                <Kbd size="xs">↵</Kbd>
-              </KbdGroup>
+              {/* Inline hint, not boxed keys: the registry chip's chrome is for on-surface use. */}
+              <span className="-ml-1 font-mono text-body-sm opacity-70">{isMacOS() ? '⌘↵' : 'Ctrl+↵'}</span>
             </Button>
           </div>
         </div>

--- a/frontend/src/components/pages/sql/sql-workspace.tsx
+++ b/frontend/src/components/pages/sql/sql-workspace.tsx
@@ -435,7 +435,7 @@ export function SqlWorkspace({ sqlRole: sqlRoleProp }: SqlWorkspaceProps) {
           'flex min-h-0 flex-1 overflow-hidden bg-background transition-[margin,border-radius,border-color,box-shadow] duration-300 ease-in-out',
           // Boxed: rounded card below the studio header. Full: flush sides; top/bottom
           // borders stay so clipped scrollable content keeps a visible edge.
-          expanded ? 'rounded-none border border-x-transparent shadow-none' : 'mt-3 rounded-xl border pt-3 shadow-sm'
+          expanded ? 'rounded-none border border-x-transparent shadow-none' : 'mt-3 rounded-xl border shadow-sm'
         )}
       >
         <div className="flex min-h-0 w-[320px] shrink-0 flex-col border-r bg-background">


### PR DESCRIPTION
Two small visual fixes on the SQL studio page.

- **Run button shortcut hint** — the two boxed `Kbd` chips read as hollow boxes on the primary fill (that chrome is meant for on-surface use). Now a single quiet inline `⌘↵` / `Ctrl+↵`, still real text so the button's accessible name is unchanged.
- **Panel top padding** — the boxed card's `pt-3` pushed the catalog sidebar and query tab strip down off the card's top border. Removed, matching expanded mode, which never had it.

### screenshots
<img width="33%" alt="Screenshot 2026-08-28 at 3 57 07 PM" src="https://github.com/user-attachments/assets/2296231f-02a2-4404-a143-7b9794e49d3b" />
<img width="33%" alt="Screenshot 2026-08-28 at 3 57 20 PM" src="https://github.com/user-attachments/assets/5c6d062c-02af-4973-b9a9-429591824f91" />
