### PR TITLE
Fix timestamp message search hanging on empty partitions and 'topic undefined' 404 on navigation

### DIFF
--- a/backend/pkg/console/list_messages.go
+++ b/backend/pkg/console/list_messages.go
@@ -335,6 +335,7 @@ func (s *Service) calculateConsumeRequests(
 	startOffsets, endOffsets kadm.ListedOffsets,
 ) (map[int32]*PartitionConsumeRequest, error) {
 	requests := make(map[int32]*PartitionConsumeRequest)
+	failedPartitions := 0
 
 	predictableResults := listReq.StartOffset != StartOffsetNewest && listReq.FilterInterpreterCode == ""
 
@@ -366,6 +367,7 @@ func (s *Service) calculateConsumeRequests(
 				slog.String("topic", listReq.TopicName),
 				slog.Int("partition", int(partitionID)),
 			)
+			failedPartitions++
 			continue
 		}
 		if !endExists {
@@ -374,6 +376,7 @@ func (s *Service) calculateConsumeRequests(
 				slog.String("topic", listReq.TopicName),
 				slog.Int("partition", int(partitionID)),
 			)
+			failedPartitions++
 			continue
 		}
 
@@ -385,6 +388,7 @@ func (s *Service) calculateConsumeRequests(
 				slog.Int("partition", int(partitionID)),
 				slog.Any("error", startOffset.Err),
 			)
+			failedPartitions++
 			continue
 		}
 		if endOffset.Err != nil {
@@ -394,6 +398,16 @@ func (s *Service) calculateConsumeRequests(
 				slog.Int("partition", int(partitionID)),
 				slog.Any("error", endOffset.Err),
 			)
+			failedPartitions++
+			continue
+		}
+
+		// Skip partitions that have no consumable messages (low watermark == high watermark),
+		// unless we live tail (StartOffsetNewest), which deliberately waits for new messages.
+		// Including an empty partition makes the whole request wait for messages that never
+		// arrive: e.g. a start offset resolved by timestamp is -1 on an empty partition, which
+		// kgo interprets as "start at the end", i.e. an indefinite live tail.
+		if listReq.StartOffset != StartOffsetNewest && endOffset.Offset <= startOffset.Offset {
 			continue
 		}
 
@@ -458,7 +472,12 @@ func (s *Service) calculateConsumeRequests(
 
 	// Validate that at least one partition was successfully processed
 	if len(requests) == 0 {
-		return nil, fmt.Errorf("no partitions available for consumption: all partitions failed offset retrieval. Check topic availability and permissions for %q", listReq.TopicName)
+		if failedPartitions > 0 {
+			return nil, fmt.Errorf("no partitions available for consumption: all partitions failed offset retrieval. Check topic availability and permissions for %q", listReq.TopicName)
+		}
+		// All requested partitions are empty — there is nothing to consume and the caller
+		// completes the request early.
+		return requests, nil
 	}
 
 	if !predictableResults {

--- a/backend/pkg/console/list_messages_test.go
+++ b/backend/pkg/console/list_messages_test.go
@@ -173,6 +173,85 @@ func TestCalculateConsumeRequests_SinglePartition(t *testing.T) {
 	}
 }
 
+func TestCalculateConsumeRequests_EmptyPartitions(t *testing.T) {
+	svc := Service{}
+
+	// Partition 0 has messages, partitions 1 and 2 are empty (never produced to, and
+	// emptied by retention respectively). Empty partitions must not be part of the
+	// consume request, otherwise the consumer waits indefinitely for messages that
+	// never arrive (until the request is cancelled).
+	startOffsets := make(kadm.ListedOffsets)
+	startOffsets["test"] = map[int32]kadm.ListedOffset{
+		0: {Topic: "test", Partition: 0, Offset: 0},
+		1: {Topic: "test", Partition: 1, Offset: 0},
+		2: {Topic: "test", Partition: 2, Offset: 25},
+	}
+
+	endOffsets := make(kadm.ListedOffsets)
+	endOffsets["test"] = map[int32]kadm.ListedOffset{
+		0: {Topic: "test", Partition: 0, Offset: 10},
+		1: {Topic: "test", Partition: 1, Offset: 0},
+		2: {Topic: "test", Partition: 2, Offset: 25},
+	}
+
+	req := &ListMessageRequest{
+		TopicName:    "test",
+		PartitionID:  partitionsAll,
+		StartOffset:  StartOffsetOldest,
+		MessageCount: 100,
+	}
+
+	expected := map[int32]*PartitionConsumeRequest{
+		0: {PartitionID: 0, IsDrained: true, LowWaterMark: 0, HighWaterMark: 10, StartOffset: 0, EndOffset: 10 - 1, MaxMessageCount: 10},
+	}
+	actual, err := svc.calculateConsumeRequests(t.Context(), nil, req, []int32{0, 1, 2}, startOffsets, endOffsets)
+	require.NoError(t, err)
+	assert.Equal(t, expected, actual, "empty partitions must be excluded from the consume request")
+}
+
+func TestCalculateConsumeRequests_AllPartitionsEmpty(t *testing.T) {
+	svc := Service{}
+
+	// A topic whose partitions are all empty must yield an empty consume request
+	// (and no error) so that the request completes immediately instead of waiting
+	// for messages until it is cancelled.
+	startOffsets := make(kadm.ListedOffsets)
+	startOffsets["test"] = map[int32]kadm.ListedOffset{
+		0: {Topic: "test", Partition: 0, Offset: 0},
+		1: {Topic: "test", Partition: 1, Offset: 30},
+	}
+
+	endOffsets := make(kadm.ListedOffsets)
+	endOffsets["test"] = map[int32]kadm.ListedOffset{
+		0: {Topic: "test", Partition: 0, Offset: 0},
+		1: {Topic: "test", Partition: 1, Offset: 30},
+	}
+
+	for _, startOffset := range []int64{StartOffsetOldest, StartOffsetRecent, 5} {
+		req := &ListMessageRequest{
+			TopicName:    "test",
+			PartitionID:  partitionsAll,
+			StartOffset:  startOffset,
+			MessageCount: 50,
+		}
+		actual, err := svc.calculateConsumeRequests(t.Context(), nil, req, []int32{0, 1}, startOffsets, endOffsets)
+		require.NoError(t, err)
+		assert.Empty(t, actual, "expected no consume requests for an empty topic (startOffset=%d)", startOffset)
+	}
+
+	// Live tail must still include empty partitions, as it deliberately waits for
+	// new messages to arrive.
+	req := &ListMessageRequest{
+		TopicName:    "test",
+		PartitionID:  partitionsAll,
+		StartOffset:  StartOffsetNewest,
+		MessageCount: 50,
+	}
+	actual, err := svc.calculateConsumeRequests(t.Context(), nil, req, []int32{0, 1}, startOffsets, endOffsets)
+	require.NoError(t, err)
+	assert.Len(t, actual, 2, "live tail must keep consuming from empty partitions")
+}
+
 func TestCalculateConsumeRequests_AllPartitions_WithFilter(t *testing.T) {
 	svc := Service{}
 	// Request less messages than we have partitions, if filter code is set we handle consume requests different than

--- a/frontend/src/federation/federated-routes.tsx
+++ b/frontend/src/federation/federated-routes.tsx
@@ -12,7 +12,6 @@
 import type { Transport } from '@connectrpc/connect';
 import type { QueryClient } from '@tanstack/react-query';
 import { createRootRouteWithContext, Outlet } from '@tanstack/react-router';
-import { NuqsAdapter } from 'nuqs/adapters/tanstack-router';
 import { useLayoutEffect, useRef } from 'react';
 
 import { DebugHelper } from '../components/debug-helper/debug-helper';
@@ -30,6 +29,7 @@ import RequireAuth from '../components/require-auth';
 import { useThemeAppearance } from '../hooks/use-theme-appearance';
 import { chainToBody, documentTop } from '../utils/dom-position';
 import { ModalContainer } from '../utils/modal-container';
+import { NuqsAdapter } from '../utils/nuqs-tanstack-adapter';
 
 /**
  * Builder.io components are excluded from federated routes.

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -17,7 +17,7 @@ import AnnouncementBar from 'components/builder-io/announcement-bar';
 import { Toaster } from 'components/redpanda-ui/components/sonner';
 import { TooltipProvider } from 'components/redpanda-ui/components/tooltip';
 import { isEmbedded } from 'config';
-import { NuqsAdapter } from 'nuqs/adapters/tanstack-router';
+import { NuqsAdapter } from 'utils/nuqs-tanstack-adapter';
 
 import { DebugHelper } from '../components/debug-helper/debug-helper';
 import AppFooter from '../components/layout/footer';

--- a/frontend/src/utils/nuqs-tanstack-adapter.tsx
+++ b/frontend/src/utils/nuqs-tanstack-adapter.tsx
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { useLocation, useMatches, useNavigate, useRouter } from '@tanstack/react-router';
+import {
+  type unstable_AdapterInterface as AdapterInterface,
+  type unstable_AdapterOptions as AdapterOptions,
+  unstable_createAdapterProvider as createAdapterProvider,
+  renderQueryString,
+} from 'nuqs/adapters/custom';
+import { startTransition, useCallback, useMemo } from 'react';
+
+/**
+ * Drop-in replacement for `NuqsAdapter` from 'nuqs/adapters/tanstack-router' that drops
+ * stale URL updates.
+ *
+ * nuqs queues URL updates and flushes them inside `startTransition(() => navigate({ to, from }))`.
+ * That transition is low-priority: frequent synchronous re-renders (e.g. message-search progress
+ * updates) can keep preempting it, and a user navigation commits first. The deferred flush then
+ * runs `navigate` with a `from` route that is no longer matched, so its path params are
+ * unresolvable and TanStack Router interpolates them as the literal string "undefined"
+ * (e.g. /topics/$topicName -> /topics/undefined). We drop such updates instead: the component
+ * that requested them is gone, so the update is meaningless.
+ */
+function useNuqsTanstackRouterAdapter(watchKeys: string[]): AdapterInterface {
+  const search = useLocation({
+    select: (state) => Object.fromEntries(Object.entries(state.search).filter(([key]) => watchKeys.includes(key))),
+  });
+  const navigate = useNavigate();
+  const router = useRouter();
+  const from = useMatches({
+    select: (matches) => (matches.length > 0 ? matches.at(-1)?.fullPath : undefined),
+  });
+
+  const watchKeysStr = watchKeys.join(',');
+  const searchParams = useMemo(
+    () =>
+      new URLSearchParams(
+        Object.entries(search).flatMap(([key, value]): [string, string][] => {
+          if (Array.isArray(value)) {
+            return value.map((v) => [key, String(v)]);
+          }
+          if (typeof value === 'object' && value !== null) {
+            return [[key, JSON.stringify(value)]];
+          }
+          return [[key, String(value)]];
+        })
+      ),
+    // watchKeysStr mirrors the upstream nuqs adapter's dependency on the watched keys.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: intentional, mirrors upstream
+    [search, watchKeysStr]
+  );
+
+  const updateUrl = useCallback(
+    (newSearch: URLSearchParams, options: Required<AdapterOptions>) => {
+      startTransition(() => {
+        // Checked at flush time, not render time: the router may have navigated away (or
+        // have a navigation in flight) between this update being queued and the transition
+        // running. While a navigation is pending, `state.matches` still holds the previous
+        // route, so the pending matches are the ones `from` must be resolved against.
+        const pendingMatches = router.stores.pendingMatches.get();
+        const activeMatches = pendingMatches.length > 0 ? pendingMatches : router.state.matches;
+        if (from && !activeMatches.some((m) => m.fullPath === from)) {
+          return;
+        }
+        navigate({
+          to: renderQueryString(newSearch) || '.',
+          ...(from ? { from } : {}),
+          replace: options.history === 'replace',
+          resetScroll: options.scroll,
+          hash: (prevHash?: string) => prevHash ?? '',
+        });
+      });
+    },
+    [navigate, from, router]
+  );
+
+  return {
+    searchParams,
+    updateUrl,
+    rateLimitFactor: 1,
+  };
+}
+
+export const NuqsAdapter = createAdapterProvider(useNuqsTanstackRouterAdapter);


### PR DESCRIPTION
Fixes two customer-reported issues (Zendesk ticket 7199).

## 1. Backend: \`[unknown] request was cancelled while waiting for messages\` with Timestamp start offset

A start offset resolved by timestamp is \`-1\` on an empty partition. \`calculateConsumeRequests\` clamped it to \`highWaterMark - 1\`, which is \`-1\` again for an empty partition — and kgo interprets \`At(-1)\` as "start at the end", i.e. an indefinite live tail. The round-robin allocator also assigned a message to such partitions, so the request could never be satisfied and only ended via cancellation after the server deadline (~35s). One empty partition in an otherwise populated topic was enough to make every timestamp search fail this way.

**Fix:** exclude partitions with nothing to consume (\`high <= low\`) from the consume request (except deliberate live tail), and complete immediately — instead of returning an error — when all partitions are empty.

Verified live via \`buf curl\` against the streaming RPC:
- empty 3-partition topic + timestamp offset: before → hang + cancellation error after 35s; after → \`done\` in 2ms
- topic with data in one of three partitions: before → messages returned but request still dies after 35s; after → messages returned, \`done\` in 7ms

New unit tests: \`TestCalculateConsumeRequests_EmptyPartitions\`, \`TestCalculateConsumeRequests_AllPartitionsEmpty\` (live tail still includes empty partitions).

## 2. Frontend: 404 "The topic 'undefined' does not exist" when navigating away mid-fetch

nuqs flushes queued URL updates inside \`startTransition(() => navigate({ to, from }))\`. Frequent synchronous re-renders during an in-flight message search ("Fetching data...") keep preempting that transition; when the user clicks away, their navigation commits first and the deferred flush then runs \`navigate\` with a \`from\` route that is no longer matched. TanStack Router interpolates the missing \`$topicName\` param as the literal string \`undefined\`, navigating to \`/topics/undefined\` — a persistent 404 (console warning: \`Could not find match for from: /topics/$topicName/\`).

**Fix:** wrap the tanstack-router nuqs adapter (\`utils/nuqs-tanstack-adapter.tsx\`) so a flush is dropped when its originating route is no longer in the router's pending/current matches, checked at flush time.

Verified with a headless-browser repro (empty topic, start a hanging search, click "Topics" while "Fetching data..." shows): before → \`/topics/undefined\` + persistent 404, 3/3 runs; after → lands on \`/topics/\` normally.

## Repro (for QA)

1. \`rpk topic create repro-empty -p 3\`
2. Topic → Messages tab → Start Offset → **Timestamp** (any time) → search errors after ~35s (issue 1)
3. While "Fetching data..." shows (use **Latest / Live** on the empty topic for a stable window), click **Topics** in the sidebar → URL becomes \`/topics/undefined\` (issue 2)

## Testing

- \`go test ./pkg/console/\`, \`go vet\`, \`gofmt\` clean
- frontend \`type:check\`, \`lint\`, full \`bun run test\` (1259 tests) pass