### PR TITLE
[Chakra exit · Phase 1 · PR 2/14] frontend: move showToast onto the Registry toast, drop Chakra's toast

### DIFF
--- a/frontend/.claude/skills/code-standards/rules/no-legacy.md
+++ b/frontend/.claude/skills/code-standards/rules/no-legacy.md
@@ -38,7 +38,7 @@ import { useDisclosure, useToast } from "@chakra-ui/react";
 import { Button } from "components/redpanda-ui/components/button";
 import { Dialog } from "components/redpanda-ui/components/dialog";
 // Use useState instead of useDisclosure
-// Use toast from sonner instead of useToast
+// Use showToast from utils/toast.utils instead of useToast
 ```
 
 **MobX:**

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -39,7 +39,7 @@ import './globals.css';
 import { Content } from '@builder.io/sdk-react';
 import { TransportProvider } from '@connectrpc/connect-query';
 import { createConnectTransport } from '@connectrpc/connect-web';
-import { ChakraProvider, redpandaToastOptions } from '@redpanda-data/ui';
+import { ChakraProvider } from '@redpanda-data/ui';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { createRouter, RouterProvider } from '@tanstack/react-router';
@@ -57,6 +57,7 @@ import { patchedRedpandaTheme as redpandaTheme } from 'utils/redpanda-theme';
 import { applyOverrides as applyDebugFeatureFlagOverrides } from './components/debug-helper/feature-flag-overrides';
 import { NotFoundPage } from './components/misc/not-found-page';
 import { RoutePendingFallback } from './components/misc/route-pending-fallback';
+import { Toaster as BaseUiToaster } from './components/redpanda-ui/components/toast';
 import { addBearerTokenInterceptor, checkExpiredLicenseInterceptor, getGrpcBasePath, setup } from './config';
 import { routeTree } from './routeTree.gen';
 import { installUISettingsSideEffects } from './state/ui';
@@ -129,7 +130,9 @@ const App = () => {
   return (
     <CustomFeatureFlagProvider initialFlags={window.__E2E_FEATURE_FLAGS__ ?? {}}>
       <Content apiKey={BUILDER_API_KEY} content={null} customComponents={builderCustomComponents} model={''} />
-      <ChakraProvider resetCSS={false} theme={redpandaTheme} toastOptions={redpandaToastOptions}>
+      <ChakraProvider resetCSS={false} theme={redpandaTheme}>
+        {/* showToast viewport, above the router so the error boundary and login can toast */}
+        <BaseUiToaster />
         <TransportProvider transport={dataplaneTransport}>
           <QueryClientProvider client={queryClient}>
             <RouterProvider router={router} />

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -132,7 +132,7 @@ const App = () => {
       <Content apiKey={BUILDER_API_KEY} content={null} customComponents={builderCustomComponents} model={''} />
       <ChakraProvider resetCSS={false} theme={redpandaTheme}>
         {/* showToast viewport, above the router so the error boundary and login can toast */}
-        <BaseUiToaster />
+        <BaseUiToaster testId="console-toasts" />
         <TransportProvider transport={dataplaneTransport}>
           <QueryClientProvider client={queryClient}>
             <RouterProvider router={router} />

--- a/frontend/src/components/misc/error-boundary.tsx
+++ b/frontend/src/components/misc/error-boundary.tsx
@@ -9,7 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
-import { Box, Button, Flex, Icon, useToast } from '@redpanda-data/ui';
+import { Box, Button, Flex, Icon } from '@redpanda-data/ui';
 import { CloseIcon, CopyAllIcon } from 'components/icons';
 import React, { type CSSProperties, type FC } from 'react';
 import StackTrace from 'stacktrace-js';
@@ -18,6 +18,7 @@ import { NoClipboardPopover } from './no-clipboard-popover';
 import { envVarDebugAr } from '../../utils/env';
 import { isClipboardAvailable } from '../../utils/feature-detection';
 import { toJson } from '../../utils/json-utils';
+import { showToast } from '../../utils/toast.utils';
 import { navigatorClipboardErrorHandler, ObjToKv } from '../../utils/tsx-utils';
 
 // background       rgb(35, 35, 35)
@@ -248,32 +249,28 @@ const CopyToClipboardButton: FC<{ message: string; disabled: boolean; isLoading:
   message,
   disabled,
   isLoading,
-}) => {
-  const toast = useToast();
-
-  return (
-    <Button
-      disabled={disabled}
-      isLoading={isLoading}
-      onClick={() => {
-        navigator.clipboard
-          .writeText(message)
-          .then(() => {
-            toast({
-              status: 'success',
-              description: 'All info copied to clipboard',
-            });
-          })
-          .catch(navigatorClipboardErrorHandler);
-      }}
-      size="large"
-      variant="ghost"
-    >
-      <Icon as={CopyAllIcon} />
-      Copy Info
-    </Button>
-  );
-};
+}) => (
+  <Button
+    disabled={disabled}
+    isLoading={isLoading}
+    onClick={() => {
+      navigator.clipboard
+        .writeText(message)
+        .then(() => {
+          showToast({
+            status: 'success',
+            description: 'All info copied to clipboard',
+          });
+        })
+        .catch(navigatorClipboardErrorHandler);
+    }}
+    size="large"
+    variant="ghost"
+  >
+    <Icon as={CopyAllIcon} />
+    Copy Info
+  </Button>
+);
 
 function InfoItemDisplay({ data }: { data: InfoItem }) {
   const title = data.name;

--- a/frontend/src/components/pages/connect/create-connector.tsx
+++ b/frontend/src/components/pages/connect/create-connector.tsx
@@ -29,10 +29,10 @@ import {
   Tabs,
   Text,
   useDisclosure,
-  useToast,
 } from '@redpanda-data/ui';
 import { useEffect, useState } from 'react';
 import { docsLinks } from 'utils/docs-links';
+import { showToast } from 'utils/toast.utils';
 
 import { ConnectorBoxCard, type ConnectorPlugin, getConnectorFriendlyName } from './connector-box-card';
 import { ConfigPage } from './dynamic-ui/components';
@@ -238,7 +238,6 @@ type ConnectorWizardProps = {
 };
 
 const ConnectorWizard = ({ connectClusters, activeCluster }: ConnectorWizardProps) => {
-  const toast = useToast();
   const [wizardState, setWizardState] = useState<{
     currentStep: number;
     selectedPlugin: ConnectorPlugin | null;
@@ -478,7 +477,7 @@ const ConnectorWizard = ({ connectClusters, activeCluster }: ConnectorWizardProp
 
             await delay(intervalSec);
           }
-          toast({
+          showToast({
             status: 'success',
             description: `Connector ${connectorName} created`,
           });

--- a/frontend/src/components/pages/connect/helper.tsx
+++ b/frontend/src/components/pages/connect/helper.tsx
@@ -29,13 +29,13 @@ import {
   ModalOverlay,
   Popover,
   Text,
-  useToast,
   VStack,
 } from '@redpanda-data/ui';
 import { AlertIcon, CheckCircleIcon, HourglassIcon, PauseCircleIcon, WarningIcon } from 'components/icons';
 import { RedpandaLogo } from 'components/redpanda-ui/components/redpanda-logo';
 import { type CSSProperties, type JSX, useRef, useState } from 'react';
 import { docsLinks } from 'utils/docs-links';
+import { showToast } from 'utils/toast.utils';
 
 import AmazonS3 from '../../../assets/connectors/amazon-s3.png';
 import ApacheLogo from '../../../assets/connectors/apache.svg';
@@ -559,8 +559,6 @@ export const ConfirmModal = <T,>(props: ConfirmModalProps<T>) => {
   const [error, setError] = useState<string | Error | null>(null);
   const cancelRef = useRef<HTMLButtonElement | null>(null);
 
-  const toast = useToast();
-
   const renderError = (): { title: string; content: string } | undefined => {
     if (!error) {
       return;
@@ -602,7 +600,7 @@ export const ConfirmModal = <T,>(props: ConfirmModalProps<T>) => {
 
   const success = (successTarget: T) => {
     const messageContent = props.successMessage(successTarget);
-    toast({
+    showToast({
       status: 'success',
       description: messageContent,
     });

--- a/frontend/src/components/pages/reassign-partitions/components/active-reassignments.tsx
+++ b/frontend/src/components/pages/reassign-partitions/components/active-reassignments.tsx
@@ -14,7 +14,6 @@ import {
   Button,
   ButtonGroup,
   Checkbox,
-  createStandaloneToast,
   DataTable,
   Flex,
   ListItem,
@@ -33,16 +32,13 @@ import {
   PopoverHeader,
   PopoverTrigger,
   Progress,
-  redpandaTheme,
-  redpandaToastOptions,
   Skeleton,
   Text,
-  type ToastId,
   UnorderedList,
   useDisclosure,
-  useToast,
 } from '@redpanda-data/ui';
 import React, { Component, type FC, type JSX, useRef, useState } from 'react';
+import { showToast, updateToast } from 'utils/toast.utils';
 
 import { BandwidthSlider } from './bandwidth-slider';
 import { api } from '../../../../state/backend-api';
@@ -52,16 +48,6 @@ import { prettyBytesOrNA, prettyMilliseconds } from '../../../../utils/utils';
 import { BrokerList } from '../../../misc/broker-list';
 import type { ReassignmentState } from '../logic/reassignment-tracker';
 import { reassignmentTracker } from '../reassign-partitions';
-
-// TODO - once ActiveReassignments is migrated to FC, we could should move this code to use useToast()
-const { ToastContainer, toast } = createStandaloneToast({
-  theme: redpandaTheme,
-  defaultOptions: {
-    ...redpandaToastOptions.defaultOptions,
-    isClosable: false,
-    duration: 2000,
-  },
-});
 
 export class ActiveReassignments extends Component<{
   throttledTopics: string[];
@@ -114,7 +100,6 @@ export class ActiveReassignments extends Component<{
 
     return (
       <>
-        <ToastContainer />
         {/* Title */}
         <div className="currentReassignments" style={{ display: 'flex', placeItems: 'center', marginBottom: '.5em' }}>
           <span className="title">Current Reassignments</span>
@@ -208,21 +193,20 @@ export const ThrottleDialog: FC<{
 }> = ({ visible, lastKnownMinThrottle, onClose }) => {
   const [newThrottleValue, setNewThrottleValue] = useState<number | null>(lastKnownMinThrottle ?? null);
 
-  const toastFn = useToast();
-  const toastRef = useRef<ToastId>(undefined);
+  const toastRef = useRef<string>(undefined);
 
   const throttleValue = newThrottleValue ?? 0;
   const noChange = newThrottleValue === lastKnownMinThrottle || newThrottleValue === null;
 
   const applyBandwidthThrottle = async () => {
-    toastRef.current = toastFn({
+    toastRef.current = showToast({
       status: 'loading',
       description: 'Setting throttle rate...',
     });
     const clusterInfo = api.clusterInfo;
     const allBrokers = clusterInfo ? clusterInfo.brokers.map((b) => b.brokerId) : null;
     if (!allBrokers) {
-      toast({
+      updateToast(toastRef.current, {
         status: 'error',
         title: 'Error',
         description: 'Cluster info not available',
@@ -243,14 +227,15 @@ export const ThrottleDialog: FC<{
         api.refreshCluster(true);
       });
 
-      toast.update(toastRef.current, {
+      updateToast(toastRef.current, {
         status: 'success',
         description: 'Setting throttle rate... done',
+        duration: 2000,
       });
     } catch (err) {
       // biome-ignore lint/suspicious/noConsole: intentional console usage
       console.error(`error in applyBandwidthThrottle: ${err}`);
-      toast.update(toastRef.current, {
+      updateToast(toastRef.current, {
         status: 'error',
         description: 'Setting throttle rate... error',
       });
@@ -590,7 +575,7 @@ export class ReassignmentDetailsDialog extends Component<{ state: ReassignmentSt
 
     const partitions = state.partitions.map((p) => p.partitionId);
 
-    const toastRef = toast({
+    const toastRef = showToast({
       status: 'loading',
       description: `Cancelling reassignment of '${state.topicName}'...`,
     });
@@ -612,7 +597,7 @@ export class ReassignmentDetailsDialog extends Component<{ state: ReassignmentSt
       // biome-ignore lint/suspicious/noConsole: intentional console usage
       console.log('cancel reassignment result', { request: cancelRequest, response });
 
-      toast.update(toastRef, {
+      updateToast(toastRef, {
         status: 'success',
         description: `Cancelling reassignment of '${state.topicName}': Done`,
         duration: 1000,
@@ -621,7 +606,7 @@ export class ReassignmentDetailsDialog extends Component<{ state: ReassignmentSt
     } catch (err) {
       // biome-ignore lint/suspicious/noConsole: intentional console usage
       console.error(`cancel reassignment: ${String(err)}`);
-      toast.update(toastRef, {
+      updateToast(toastRef, {
         status: 'error',
         description: `Cancelling reassignment of '${state.topicName}': Error`,
         duration: 1000,

--- a/frontend/src/components/pages/reassign-partitions/reassign-partitions.tsx
+++ b/frontend/src/components/pages/reassign-partitions/reassign-partitions.tsx
@@ -13,7 +13,6 @@
 import {
   Box,
   Button,
-  createStandaloneToast,
   Flex,
   Modal,
   ModalBody,
@@ -21,8 +20,6 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  redpandaTheme,
-  redpandaToastOptions,
   Step,
   StepIcon,
   StepIndicator,
@@ -33,6 +30,7 @@ import {
 } from '@redpanda-data/ui';
 import { AlertIcon, ChevronLeftIcon, ChevronRightIcon } from 'components/icons';
 import { motion } from 'motion/react';
+import { closeToast, showToast, updateToast } from 'utils/toast.utils';
 
 import { ActiveReassignments } from './components/active-reassignments';
 import { type ApiData, computeReassignments, type TopicPartitions } from './logic/reassign-logic';
@@ -75,16 +73,6 @@ export type PartitionSelection = {
 
 const reassignmentTracker = new ReassignmentTracker();
 export { reassignmentTracker };
-
-// TODO - once ReassignPartitions is migrated to FC, we could should move this code to use useToast()
-const { ToastContainer, toast } = createStandaloneToast({
-  theme: redpandaTheme,
-  defaultOptions: {
-    ...redpandaToastOptions.defaultOptions,
-    isClosable: true,
-    duration: 2000,
-  },
-});
 
 type ReassignPartitionsState = {
   removeThrottleFromTopicsContent: string[] | null;
@@ -219,233 +207,229 @@ class ReassignPartitions extends PageComponent {
     const nextButtonHelp = typeof nextButtonCheck === 'string' ? (nextButtonCheck as string) : null;
 
     return (
-      <>
-        <ToastContainer />
-        <div className="reassignPartitions" style={{ paddingBottom: '12em' }}>
-          <PageContent>
-            <NullFallbackBoundary>
-              <FeatureLicenseNotification featureName="reassignPartitions" />
-            </NullFallbackBoundary>
+      <div className="reassignPartitions" style={{ paddingBottom: '12em' }}>
+        <PageContent>
+          <NullFallbackBoundary>
+            <FeatureLicenseNotification featureName="reassignPartitions" />
+          </NullFallbackBoundary>
 
-            {/* Statistics */}
-            <Section py={4}>
-              <Flex>
-                <Statistic title="Broker Count" value={api.clusterInfo?.brokers.length} />
-                <Statistic title="Leader Partitions" value={partitionCountLeaders ?? '...'} />
-                <Statistic title="Replica Partitions" value={partitionCountOnlyReplicated ?? '...'} />
-                <Statistic
-                  title="Total Partitions"
-                  value={
-                    partitionCountLeaders !== null && partitionCountOnlyReplicated !== null
-                      ? partitionCountLeaders + partitionCountOnlyReplicated
-                      : '...'
-                  }
-                />
-              </Flex>
-            </Section>
-
-            {/* Active Reassignments */}
-            <Section id="activeReassignments">
-              <ActiveReassignments
-                onRemoveThrottleFromTopics={this.removeThrottleFromTopics}
-                throttledTopics={this.state.topicsWithThrottle}
+          {/* Statistics */}
+          <Section py={4}>
+            <Flex>
+              <Statistic title="Broker Count" value={api.clusterInfo?.brokers.length} />
+              <Statistic title="Leader Partitions" value={partitionCountLeaders ?? '...'} />
+              <Statistic title="Replica Partitions" value={partitionCountOnlyReplicated ?? '...'} />
+              <Statistic
+                title="Total Partitions"
+                value={
+                  partitionCountLeaders !== null && partitionCountOnlyReplicated !== null
+                    ? partitionCountLeaders + partitionCountOnlyReplicated
+                    : '...'
+                }
               />
-            </Section>
+            </Flex>
+          </Section>
+
+          {/* Active Reassignments */}
+          <Section id="activeReassignments">
+            <ActiveReassignments
+              onRemoveThrottleFromTopics={this.removeThrottleFromTopics}
+              throttledTopics={this.state.topicsWithThrottle}
+            />
+          </Section>
+
+          {/* Content */}
+          <Section id="wizard">
+            {/* Steps */}
+            <div style={{ margin: '.75em 1em 1em 1em' }}>
+              <Stepper colorScheme="brand" index={currentStep}>
+                {steps.map((item) => (
+                  <Step key={item.title} title={item.title}>
+                    <StepIndicator>
+                      <StepStatus active={<StepNumber />} complete={<StepIcon />} incomplete={<StepNumber />} />
+                    </StepIndicator>
+                    <Box>{item.title}</Box>
+                    <StepSeparator />
+                  </Step>
+                ))}
+              </Stepper>
+            </div>
 
             {/* Content */}
-            <Section id="wizard">
-              {/* Steps */}
-              <div style={{ margin: '.75em 1em 1em 1em' }}>
-                <Stepper colorScheme="brand" index={currentStep}>
-                  {steps.map((item) => (
-                    <Step key={item.title} title={item.title}>
-                      <StepIndicator>
-                        <StepStatus active={<StepNumber />} complete={<StepIcon />} incomplete={<StepNumber />} />
-                      </StepIndicator>
-                      <Box>{item.title}</Box>
-                      <StepSeparator />
-                    </Step>
-                  ))}
-                </Stepper>
+            <motion.div {...animProps} key={`step${currentStep}`}>
+              {' '}
+              {(() => {
+                switch (currentStep) {
+                  case 0:
+                    return (
+                      <StepSelectPartitions
+                        onPartitionSelectionChange={(newSelection) =>
+                          this.setState({ partitionSelection: newSelection })
+                        }
+                        partitionSelection={partitionSelection}
+                        throttledTopics={this.state.topicsWithThrottle}
+                      />
+                    );
+                  case 1:
+                    return (
+                      <StepSelectBrokers
+                        onSelectionChange={(newIds) => this.setState({ selectedBrokerIds: newIds })}
+                        partitionSelection={partitionSelection}
+                        selectedBrokerIds={selectedBrokerIds}
+                      />
+                    );
+                  case 2:
+                    return (
+                      <StepReview
+                        // biome-ignore lint/style/noNonNullAssertion: not touching MobX observables
+                        assignments={reassignmentRequest!}
+                        partitionSelection={partitionSelection}
+                        reassignPartitions={this}
+                        topicsWithMoves={this.topicsWithMoves}
+                      />
+                    );
+                  default:
+                    return null;
+                }
+              })()}
+            </motion.div>
+
+            {/* Navigation */}
+            <div
+              style={{
+                margin: '2.5em 0 1.5em',
+                display: 'flex',
+                alignItems: 'flex-end',
+                height: '2.5em',
+              }}
+            >
+              {/* Back */}
+              {Boolean(step.backButton) && (
+                <Button
+                  isDisabled={currentStep <= 0 || requestInProgress}
+                  onClick={this.onPreviousPage}
+                  style={{ minWidth: '14em' }}
+                >
+                  <span>
+                    <ChevronLeftIcon />
+                  </span>
+                  <span>{step.backButton}</span>
+                </Button>
+              )}
+
+              {/* Next */}
+              <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: '2em' }}>
+                <div>{nextButtonHelp}</div>
+                <Button
+                  isDisabled={!nextButtonEnabled || requestInProgress}
+                  onClick={this.onNextPage}
+                  style={{ minWidth: '14em', marginLeft: 'auto' }}
+                  variant="solid"
+                >
+                  <span>{step.nextButton.text}</span>
+                  <span>
+                    <ChevronRightIcon />
+                  </span>
+                </Button>
               </div>
-
-              {/* Content */}
-              <motion.div {...animProps} key={`step${currentStep}`}>
-                {' '}
-                {(() => {
-                  switch (currentStep) {
-                    case 0:
-                      return (
-                        <StepSelectPartitions
-                          onPartitionSelectionChange={(newSelection) =>
-                            this.setState({ partitionSelection: newSelection })
-                          }
-                          partitionSelection={partitionSelection}
-                          throttledTopics={this.state.topicsWithThrottle}
-                        />
-                      );
-                    case 1:
-                      return (
-                        <StepSelectBrokers
-                          onSelectionChange={(newIds) => this.setState({ selectedBrokerIds: newIds })}
-                          partitionSelection={partitionSelection}
-                          selectedBrokerIds={selectedBrokerIds}
-                        />
-                      );
-                    case 2:
-                      return (
-                        <StepReview
-                          // biome-ignore lint/style/noNonNullAssertion: not touching MobX observables
-                          assignments={reassignmentRequest!}
-                          partitionSelection={partitionSelection}
-                          reassignPartitions={this}
-                          topicsWithMoves={this.topicsWithMoves}
-                        />
-                      );
-                    default:
-                      return null;
+            </div>
+          </Section>
+        </PageContent>
+        <Modal
+          isOpen={this.state.removeThrottleFromTopicsContent !== null}
+          onClose={() => {
+            this.setState({ removeThrottleFromTopicsContent: null });
+          }}
+        >
+          <ModalOverlay />
+          <ModalContent minW="5xl">
+            <ModalHeader>
+              <Flex alignItems="center" gap={2}>
+                <AlertIcon size={18} />
+                Remove throttle config from topics
+              </Flex>
+            </ModalHeader>
+            <ModalBody>
+              <div>
+                <div>
+                  There are {this.state.topicsWithThrottle.length} topics with throttling applied to their replicas.
+                  <br />
+                  Kowl implements throttling of reassignments by setting{' '}
+                  <span className="tooltip" style={{ textDecoration: 'dotted underline' }}>
+                    two configuration values
+                    <span className="tooltiptext" style={{ textAlign: 'left', width: '500px' }}>
+                      Kowl sets those two configuration entries when throttling a topic reassignment:
+                      <div style={{ marginTop: '.5em' }}>
+                        <code>leader.replication.throttled.replicas</code>
+                        <br />
+                        <code>follower.replication.throttled.replicas</code>
+                      </div>
+                    </span>
+                  </span>{' '}
+                  in a topics configuration.
+                  <br />
+                  So if you previously used Kowl to reassign any of the partitions of the following topics, the
+                  throttling config might still be active.
+                </div>
+                <div style={{ margin: '1em 0' }}>
+                  <h4>Throttled Topics</h4>
+                  <ul style={{ maxHeight: '145px', overflowY: 'auto' }}>
+                    {this.state.removeThrottleFromTopicsContent?.map((t) => (
+                      <li key={t}>{t}</li>
+                    ))}
+                  </ul>
+                </div>
+                <div>Do you want to remove the throttle config from those topics?</div>
+              </div>
+            </ModalBody>
+            <ModalFooter gap={2}>
+              <Button
+                onClick={() => {
+                  this.setState({ removeThrottleFromTopicsContent: null });
+                }}
+                variant="ghost"
+              >
+                Cancel
+              </Button>
+              <Button
+                colorScheme="red"
+                onClick={async () => {
+                  if (this.state.removeThrottleFromTopicsContent === null) {
+                    return;
                   }
-                })()}
-              </motion.div>
+                  const baseText = 'Removing throttle config from topics';
 
-              {/* Navigation */}
-              <div
-                style={{
-                  margin: '2.5em 0 1.5em',
-                  display: 'flex',
-                  alignItems: 'flex-end',
-                  height: '2.5em',
+                  const toastId = showToast({
+                    status: 'loading',
+                    description: `${baseText}...`,
+                  });
+
+                  const result = await api.resetThrottledReplicas(this.state.removeThrottleFromTopicsContent);
+                  const errors = result.patchedConfigs.filter((r) => r.error);
+
+                  if (errors.length === 0) {
+                    updateToast(toastId, {
+                      status: 'success',
+                      description: `${baseText} - Done`,
+                      duration: 2500,
+                    });
+                  } else {
+                    updateToast(toastId, {
+                      status: 'error',
+                      description: `${baseText}: ${errors.length} errors`,
+                      duration: 2500,
+                    });
+                  }
+
+                  await this.refreshTopicConfigs();
                 }}
               >
-                {/* Back */}
-                {Boolean(step.backButton) && (
-                  <Button
-                    isDisabled={currentStep <= 0 || requestInProgress}
-                    onClick={this.onPreviousPage}
-                    style={{ minWidth: '14em' }}
-                  >
-                    <span>
-                      <ChevronLeftIcon />
-                    </span>
-                    <span>{step.backButton}</span>
-                  </Button>
-                )}
-
-                {/* Next */}
-                <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: '2em' }}>
-                  <div>{nextButtonHelp}</div>
-                  <Button
-                    isDisabled={!nextButtonEnabled || requestInProgress}
-                    onClick={this.onNextPage}
-                    style={{ minWidth: '14em', marginLeft: 'auto' }}
-                    variant="solid"
-                  >
-                    <span>{step.nextButton.text}</span>
-                    <span>
-                      <ChevronRightIcon />
-                    </span>
-                  </Button>
-                </div>
-              </div>
-            </Section>
-          </PageContent>
-          <Modal
-            isOpen={this.state.removeThrottleFromTopicsContent !== null}
-            onClose={() => {
-              this.setState({ removeThrottleFromTopicsContent: null });
-            }}
-          >
-            <ModalOverlay />
-            <ModalContent minW="5xl">
-              <ModalHeader>
-                <Flex alignItems="center" gap={2}>
-                  <AlertIcon size={18} />
-                  Remove throttle config from topics
-                </Flex>
-              </ModalHeader>
-              <ModalBody>
-                <div>
-                  <div>
-                    There are {this.state.topicsWithThrottle.length} topics with throttling applied to their replicas.
-                    <br />
-                    Kowl implements throttling of reassignments by setting{' '}
-                    <span className="tooltip" style={{ textDecoration: 'dotted underline' }}>
-                      two configuration values
-                      <span className="tooltiptext" style={{ textAlign: 'left', width: '500px' }}>
-                        Kowl sets those two configuration entries when throttling a topic reassignment:
-                        <div style={{ marginTop: '.5em' }}>
-                          <code>leader.replication.throttled.replicas</code>
-                          <br />
-                          <code>follower.replication.throttled.replicas</code>
-                        </div>
-                      </span>
-                    </span>{' '}
-                    in a topics configuration.
-                    <br />
-                    So if you previously used Kowl to reassign any of the partitions of the following topics, the
-                    throttling config might still be active.
-                  </div>
-                  <div style={{ margin: '1em 0' }}>
-                    <h4>Throttled Topics</h4>
-                    <ul style={{ maxHeight: '145px', overflowY: 'auto' }}>
-                      {this.state.removeThrottleFromTopicsContent?.map((t) => (
-                        <li key={t}>{t}</li>
-                      ))}
-                    </ul>
-                  </div>
-                  <div>Do you want to remove the throttle config from those topics?</div>
-                </div>
-              </ModalBody>
-              <ModalFooter gap={2}>
-                <Button
-                  onClick={() => {
-                    this.setState({ removeThrottleFromTopicsContent: null });
-                  }}
-                  variant="ghost"
-                >
-                  Cancel
-                </Button>
-                <Button
-                  colorScheme="red"
-                  onClick={async () => {
-                    if (this.state.removeThrottleFromTopicsContent === null) {
-                      return;
-                    }
-                    const baseText = 'Removing throttle config from topics';
-
-                    const toastId = toast({
-                      status: 'loading',
-                      description: `${baseText}...`,
-                      duration: null,
-                    });
-
-                    const result = await api.resetThrottledReplicas(this.state.removeThrottleFromTopicsContent);
-                    const errors = result.patchedConfigs.filter((r) => r.error);
-
-                    if (errors.length === 0) {
-                      toast.update(toastId, {
-                        status: 'success',
-                        description: `${baseText} - Done`,
-                        duration: 2500,
-                      });
-                    } else {
-                      toast.update(toastId, {
-                        status: 'error',
-                        description: `${baseText}: ${errors.length} errors`,
-                        duration: 2500,
-                      });
-                    }
-
-                    await this.refreshTopicConfigs();
-                  }}
-                >
-                  Remove throttle
-                </Button>
-              </ModalFooter>
-            </ModalContent>
-          </Modal>
-        </div>
-      </>
+                Remove throttle
+              </Button>
+            </ModalFooter>
+          </ModalContent>
+        </Modal>
+      </div>
     );
   }
 
@@ -458,12 +442,13 @@ class ReassignPartitions extends PageComponent {
     });
 
     if (showSelectionWarning) {
-      toast({
+      showToast({
         status: 'warning',
         title: 'Selection has been reset',
         description:
           'Your selection contained brokers or partitions that are not available anymore after the refresh. \n' +
           'Your selection has been reset.',
+        duration: 2000,
       });
     }
 
@@ -521,7 +506,7 @@ class ReassignPartitions extends PageComponent {
       // Review -> Start
       const request = this.state.reassignmentRequest;
       if (request === null) {
-        toast({
+        showToast({
           status: 'error',
           description: 'reassignment request was null',
           duration: 3000,
@@ -539,7 +524,7 @@ class ReassignPartitions extends PageComponent {
             this.resetSelectionAndPage(true, false);
           }
         } catch (_err) {
-          toast({
+          showToast({
             status: 'error',
             description: 'Error starting partition reassignment.\nSee console for more information.',
             duration: 3000,
@@ -567,10 +552,9 @@ class ReassignPartitions extends PageComponent {
       }
     }
 
-    const toastRef = toast({
+    const toastRef = showToast({
       status: 'loading',
       description: 'Starting reassignment',
-      duration: null,
     });
     try {
       const response = await api.startPartitionReassignment(request);
@@ -588,7 +572,7 @@ class ReassignPartitions extends PageComponent {
 
       if (errors.length === 0) {
         // No errors
-        toast.update(toastRef, {
+        updateToast(toastRef, {
           status: 'success',
           description: 'Reassignment successful',
           duration: 2500,
@@ -597,7 +581,7 @@ class ReassignPartitions extends PageComponent {
       }
       if (startedCount > 0) {
         // Some errors
-        toast.update(toastRef, {
+        updateToast(toastRef, {
           status: 'success',
           description: 'Reassignment successful',
           duration: 2500,
@@ -606,14 +590,15 @@ class ReassignPartitions extends PageComponent {
         return true;
       }
       // All errors
-      toast.update(toastRef, {
+      updateToast(toastRef, {
         status: 'error',
+        description: 'Reassignment failed',
         duration: 2500,
       });
       this.setReassignError(startedCount, errors);
       return false;
     } catch (_err) {
-      toast.close(toastRef);
+      closeToast(toastRef);
 
       return false;
     }
@@ -662,10 +647,9 @@ class ReassignPartitions extends PageComponent {
       });
     }
 
-    const toastRef = toast({
+    const toastRef = showToast({
       status: 'loading',
       description: 'Setting bandwidth throttle... 1/2',
-      duration: null,
     });
     try {
       const brokerIds = api.clusterInfo?.brokers.map((b) => b.brokerId) ?? [];
@@ -675,7 +659,7 @@ class ReassignPartitions extends PageComponent {
         throw new Error(toJson(errors));
       }
 
-      toast.update(toastRef, {
+      updateToast(toastRef, {
         description: 'Setting bandwidth throttle... 2/2',
         duration: 2500,
       });
@@ -686,14 +670,14 @@ class ReassignPartitions extends PageComponent {
         throw new Error(toJson(errors));
       }
 
-      toast.update(toastRef, {
+      updateToast(toastRef, {
         status: 'success',
         description: 'Setting bandwidth throttle... done',
         duration: 2500,
       });
       return true;
     } catch (_err) {
-      toast.close(toastRef);
+      closeToast(toastRef);
       return false;
     }
   }

--- a/frontend/src/components/pages/rp-connect/pipelines-details.tsx
+++ b/frontend/src/components/pages/rp-connect/pipelines-details.tsx
@@ -10,7 +10,7 @@
  */
 
 import { ConnectError } from '@connectrpc/connect';
-import { Alert, AlertIcon, Box, Button, createStandaloneToast, DataTable, Flex, SearchField } from '@redpanda-data/ui';
+import { Alert, AlertIcon, Box, Button, DataTable, Flex, SearchField } from '@redpanda-data/ui';
 import { Link } from '@tanstack/react-router';
 import type { SortingState } from '@tanstack/react-table';
 import { Button as RegistryButton } from 'components/redpanda-ui/components/button';
@@ -18,7 +18,7 @@ import { RefreshCcw } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast as sonnerToast } from 'sonner';
 import type { LegacyColumnDef } from 'utils/legacy-data-table';
-import { formatToastErrorMessageGRPC } from 'utils/toast.utils';
+import { formatToastErrorMessageGRPC, showToast } from 'utils/toast.utils';
 
 import { openDeleteModal } from './modals';
 import { PipelineStatus } from './pipelines-list';
@@ -51,8 +51,6 @@ import Tabs from '../../misc/tabs/tabs';
 import { PageComponent, type PageInitHelper } from '../page';
 import { ExpandedMessage } from '../topics/Tab.Messages/message-display/expanded-message';
 import { MessagePreview } from '../topics/Tab.Messages/message-display/message-preview';
-
-const { ToastContainer, toast } = createStandaloneToast();
 
 class RpConnectPipelinesDetails extends PageComponent<{ pipelineId: string }> {
   initPage(p: PageInitHelper): void {
@@ -97,8 +95,6 @@ const RpConnectPipelinesDetailsContent = ({ pipeline, pipelineId }: { pipeline: 
 
   return (
     <PageContent>
-      <ToastContainer />
-
       <Box my="4">
         {QuickTable(
           [
@@ -153,10 +149,9 @@ const RpConnectPipelinesDetailsContent = ({ pipeline, pipelineId }: { pipeline: 
 
             changePromise
               .then(() => {
-                toast({
+                showToast({
                   status: 'success',
                   duration: 4000,
-                  isClosable: false,
                   title: `Pipeline ${isStopped ? 'started' : 'stopped'}`,
                 });
 
@@ -164,10 +159,8 @@ const RpConnectPipelinesDetailsContent = ({ pipeline, pipelineId }: { pipeline: 
                 watchPipelineUpdates().catch(console.error);
               })
               .catch((err) => {
-                toast({
+                showToast({
                   status: 'error',
-                  duration: null,
-                  isClosable: true,
                   title: `Failed to ${isStopped ? 'start' : 'stop'} pipeline`,
                   description: String(err),
                 });
@@ -186,20 +179,17 @@ const RpConnectPipelinesDetailsContent = ({ pipeline, pipelineId }: { pipeline: 
               pipelinesApi
                 .deletePipeline(pipeline.id)
                 .then(() => {
-                  toast({
+                  showToast({
                     status: 'success',
                     duration: 4000,
-                    isClosable: false,
                     title: 'Pipeline deleted',
                   });
                   pipelinesApi.refreshPipelines(true);
                   appGlobal.historyPush('/connect-clusters');
                 })
                 .catch((err) => {
-                  toast({
+                  showToast({
                     status: 'error',
-                    duration: null,
-                    isClosable: true,
                     title: 'Failed to delete pipeline',
                     description: String(err),
                   });

--- a/frontend/src/components/pages/rp-connect/pipelines-edit.tsx
+++ b/frontend/src/components/pages/rp-connect/pipelines-edit.tsx
@@ -10,7 +10,7 @@
  */
 
 import { create } from '@bufbuild/protobuf';
-import { Button, Flex, FormField, Input, NumberInput, useToast } from '@redpanda-data/ui';
+import { Button, Flex, FormField, Input, NumberInput } from '@redpanda-data/ui';
 import { Link } from '@tanstack/react-router';
 import { Link as UILink } from 'components/redpanda-ui/components/typography';
 import {
@@ -20,6 +20,7 @@ import {
 } from 'protogen/redpanda/api/dataplane/v1/pipeline_pb';
 import { useState } from 'react';
 import { docsLinks } from 'utils/docs-links';
+import { showToast } from 'utils/toast.utils';
 
 import { formatPipelineError } from './errors';
 import { PipelineEditor } from './pipelines-create';
@@ -79,8 +80,6 @@ const RpConnectPipelinesEditContent = ({ pipeline, pipelineId }: { pipeline: Pip
   const tags = pipeline.tags;
   const [serviceAccount] = useState<Pipeline_ServiceAccount | undefined>(pipeline.serviceAccount);
 
-  const toast = useToast();
-
   const secrets = rpcnSecretManagerApi.secrets?.map((s) => s.id) ?? [];
   const isNameEmpty = !displayName;
 
@@ -105,19 +104,17 @@ const RpConnectPipelinesEditContent = ({ pipeline, pipelineId }: { pipeline: Pip
         })
       )
       .then(async (r) => {
-        toast({
+        showToast({
           status: 'success',
           duration: 4000,
-          isClosable: false,
           title: 'Pipeline updated',
         });
 
         const retUnits = cpuToTasks(r.response?.pipeline?.resources?.cpuShares);
         if (retUnits && tasks !== retUnits) {
-          toast({
+          showToast({
             status: 'info',
             duration: 6000,
-            isClosable: false,
             title: `Pipeline has been resized to use ${retUnits} compute units`,
           });
         }
@@ -125,10 +122,8 @@ const RpConnectPipelinesEditContent = ({ pipeline, pipelineId }: { pipeline: Pip
         appGlobal.historyPush(`/rp-connect/${pipelineId}`);
       })
       .catch((err) => {
-        toast({
+        showToast({
           status: 'error',
-          duration: null,
-          isClosable: true,
           title: 'Failed to update pipeline',
           description: formatPipelineError(err),
         });

--- a/frontend/src/components/pages/rp-connect/pipelines-list.tsx
+++ b/frontend/src/components/pages/rp-connect/pipelines-list.tsx
@@ -9,10 +9,11 @@
  * by the Apache License, Version 2.0
  */
 
-import { Box, Button, createStandaloneToast, DataTable, Flex, Image, SearchField, Text } from '@redpanda-data/ui';
+import { Box, Button, DataTable, Flex, Image, SearchField, Text } from '@redpanda-data/ui';
 import { Link } from '@tanstack/react-router';
 import { CheckIcon, CloseIcon, HelpIcon, RotateCwIcon, StopCircleIcon, TrashIcon } from 'components/icons';
 import { Button as NewButton } from 'components/redpanda-ui/components/button';
+import { showToast } from 'utils/toast.utils';
 
 import { openDeleteModal } from './modals';
 import EmptyConnectors from '../../../assets/redpanda/EmptyConnectors.svg';
@@ -25,8 +26,6 @@ import { DefaultSkeleton } from '../../../utils/tsx-utils';
 import { encodeURIComponentPercents } from '../../../utils/utils';
 import PageContent from '../../misc/page-content';
 import { PageComponent, type PageInitHelper } from '../page';
-
-const { ToastContainer, toast } = createStandaloneToast();
 
 /**
  * Navigates to /rp-connect/create (legacy flow)
@@ -139,10 +138,8 @@ class RpConnectPipelinesList extends PageComponent<{}> {
       }
 
       if (Features.pipelinesApi) {
-        toast({
+        showToast({
           status: 'error',
-          duration: null,
-          isClosable: true,
           title: 'Failed to load pipelines',
           description: String(err),
         });
@@ -178,7 +175,6 @@ class RpConnectPipelinesList extends PageComponent<{}> {
 
     return (
       <PageContent>
-        <ToastContainer />
         {/* Pipeline List */}
 
         {pipelinesApi.pipelines.length !== 0 && (
@@ -257,19 +253,16 @@ class RpConnectPipelinesList extends PageComponent<{}> {
                         pipelinesApi
                           .deletePipeline(r.id)
                           .then(async () => {
-                            toast({
+                            showToast({
                               status: 'success',
                               duration: 4000,
-                              isClosable: false,
                               title: 'Pipeline deleted',
                             });
                             await pipelinesApi.refreshPipelines(true);
                           })
                           .catch((err) => {
-                            toast({
+                            showToast({
                               status: 'error',
-                              duration: null,
-                              isClosable: true,
                               title: 'Failed to delete pipeline',
                               description: String(err),
                             });

--- a/frontend/src/components/pages/rp-connect/secrets/secrets-create.tsx
+++ b/frontend/src/components/pages/rp-connect/secrets/secrets-create.tsx
@@ -1,17 +1,16 @@
 import { create } from '@bufbuild/protobuf';
-import { Button, ButtonGroup, createStandaloneToast, Flex, FormField, Input, PasswordInput } from '@redpanda-data/ui';
+import { Button, ButtonGroup, Flex, FormField, Input, PasswordInput } from '@redpanda-data/ui';
 import { useState } from 'react';
 
 import { CreateSecretRequestSchema, Scope } from '../../../../protogen/redpanda/api/dataplane/v1/secret_pb';
 import { appGlobal } from '../../../../state/app-global';
 import { pipelinesApi, rpcnSecretManagerApi } from '../../../../state/backend-api';
+import { showToast } from '../../../../utils/toast.utils';
 import { DefaultSkeleton } from '../../../../utils/tsx-utils';
 import { base64ToUInt8Array, encodeBase64 } from '../../../../utils/utils';
 import PageContent from '../../../misc/page-content';
 import { PageComponent, type PageInitHelper } from '../../page';
 import { formatPipelineError } from '../errors';
-
-const { ToastContainer, toast } = createStandaloneToast();
 
 const returnToListTab = '/connect-clusters?defaultTab=redpanda-connect-secret';
 const SECRET_NAME_VALIDATION_REGEX = /^[A-Za-z][A-Za-z0-9_]*$/;
@@ -78,20 +77,17 @@ const RpConnectSecretCreateContent = () => {
         })
       )
       .then(() => {
-        toast({
+        showToast({
           status: 'success',
           duration: 4000,
-          isClosable: false,
           title: 'Secret created',
         });
         pipelinesApi.refreshPipelines(true);
         appGlobal.historyPush(returnToListTab);
       })
       .catch((err) => {
-        toast({
+        showToast({
           status: 'error',
-          duration: null,
-          isClosable: true,
           title: 'Failed to create secret',
           description: formatPipelineError(err),
         });
@@ -106,7 +102,6 @@ const RpConnectSecretCreateContent = () => {
 
   return (
     <PageContent>
-      <ToastContainer />
       <Flex flexDirection="column" gap={5}>
         <FormField
           description={'This secret name will be stored in upper case.'}

--- a/frontend/src/components/pages/rp-connect/secrets/secrets-quick-add.tsx
+++ b/frontend/src/components/pages/rp-connect/secrets/secrets-quick-add.tsx
@@ -1,7 +1,6 @@
 import { create } from '@bufbuild/protobuf';
 import {
   Button,
-  createStandaloneToast,
   Flex,
   FormField,
   isSingleValue,
@@ -24,10 +23,9 @@ import {
   type Secret,
 } from '../../../../protogen/redpanda/api/dataplane/v1/secret_pb';
 import { rpcnSecretManagerApi } from '../../../../state/backend-api';
+import { showToast } from '../../../../utils/toast.utils';
 import { base64ToUInt8Array, encodeBase64 } from '../../../../utils/utils';
 import { formatPipelineError } from '../errors';
-
-const { toast } = createStandaloneToast();
 
 // Regex for validating secret ID format
 const SECRET_NAME_REGEX = /^[A-Za-z][A-Za-z0-9_]*$/;
@@ -64,20 +62,17 @@ const SecretsQuickAdd = ({ isOpen, onAdd, onCloseAddSecret }: SecretsQuickAddPro
           })
         )
         .then(async () => {
-          toast({
+          showToast({
             status: 'success',
             duration: 4000,
-            isClosable: false,
             title: 'Secret created',
           });
           await rpcnSecretManagerApi.refreshSecrets(true);
           return true;
         })
         .catch((err) => {
-          toast({
+          showToast({
             status: 'error',
-            duration: null,
-            isClosable: true,
             title: 'Failed to create secret',
             description: formatPipelineError(err),
           });

--- a/frontend/src/components/pages/rp-connect/secrets/secrets-update.tsx
+++ b/frontend/src/components/pages/rp-connect/secrets/secrets-update.tsx
@@ -1,17 +1,16 @@
 import { create } from '@bufbuild/protobuf';
-import { Button, ButtonGroup, createStandaloneToast, Flex, FormField, Input, PasswordInput } from '@redpanda-data/ui';
+import { Button, ButtonGroup, Flex, FormField, Input, PasswordInput } from '@redpanda-data/ui';
 import { useState } from 'react';
 
 import { Scope, UpdateSecretRequestSchema } from '../../../../protogen/redpanda/api/dataplane/v1/secret_pb';
 import { appGlobal } from '../../../../state/app-global';
 import { pipelinesApi, rpcnSecretManagerApi } from '../../../../state/backend-api';
+import { showToast } from '../../../../utils/toast.utils';
 import { DefaultSkeleton } from '../../../../utils/tsx-utils';
 import { base64ToUInt8Array, encodeBase64 } from '../../../../utils/utils';
 import PageContent from '../../../misc/page-content';
 import { PageComponent, type PageInitHelper } from '../../page';
 import { formatPipelineError } from '../errors';
-
-const { ToastContainer, toast } = createStandaloneToast();
 
 const returnToListTab = '/connect-clusters?defaultTab=redpanda-connect-secret';
 
@@ -59,10 +58,9 @@ const RpConnectSecretUpdateContent = ({ secretId }: { secretId: string }) => {
         })
       )
       .then(() => {
-        toast({
+        showToast({
           status: 'success',
           duration: 4000,
-          isClosable: false,
           title: 'Secret updated',
           id: 'secret-update-success',
         });
@@ -70,10 +68,8 @@ const RpConnectSecretUpdateContent = ({ secretId }: { secretId: string }) => {
         appGlobal.historyPush(returnToListTab);
       })
       .catch((err) => {
-        toast({
+        showToast({
           status: 'error',
-          duration: null,
-          isClosable: true,
           title: 'Failed to update secret',
           description: formatPipelineError(err),
         });
@@ -87,7 +83,6 @@ const RpConnectSecretUpdateContent = ({ secretId }: { secretId: string }) => {
 
   return (
     <PageContent>
-      <ToastContainer />
       <Flex flexDirection="column" gap={5}>
         <FormField label="Secret name">
           <Flex alignItems="center" gap="2">

--- a/frontend/src/components/pages/transforms/transform-details.tsx
+++ b/frontend/src/components/pages/transforms/transform-details.tsx
@@ -9,10 +9,11 @@
  * by the Apache License, Version 2.0
  */
 
-import { Box, Button, createStandaloneToast, DataTable, Flex, SearchField } from '@redpanda-data/ui';
+import { Box, Button, DataTable, Flex, SearchField } from '@redpanda-data/ui';
 import type { SortingState } from '@tanstack/react-table';
 import { Fragment, useEffect, useRef, useState } from 'react';
 import type { LegacyColumnDef } from 'utils/legacy-data-table';
+import { showToast } from 'utils/toast.utils';
 
 import { openDeleteModal } from './modals';
 import { PartitionStatus } from './transforms-list';
@@ -42,8 +43,6 @@ import Tabs from '../../misc/tabs/tabs';
 import { PageComponent, type PageInitHelper } from '../page';
 import { ExpandedMessage } from '../topics/Tab.Messages/message-display/expanded-message';
 import { MessagePreview } from '../topics/Tab.Messages/message-display/message-preview';
-
-const { ToastContainer, toast } = createStandaloneToast();
 
 class TransformDetails extends PageComponent<{ transformName: string }> {
   initPage(p: PageInitHelper): void {
@@ -80,7 +79,6 @@ class TransformDetails extends PageComponent<{ transformName: string }> {
 
     return (
       <PageContent>
-        <ToastContainer />
         <Box>
           {/* <Heading as="h2">{transformName}</Heading> */}
           <Button
@@ -90,19 +88,16 @@ class TransformDetails extends PageComponent<{ transformName: string }> {
                 transformsApi
                   .deleteTransform(transformName)
                   .then(() => {
-                    toast({
+                    showToast({
                       status: 'success',
                       duration: 4000,
-                      isClosable: false,
                       title: 'Transform deleted',
                     });
                     transformsApi.refreshTransforms(true);
                   })
                   .catch((err) => {
-                    toast({
+                    showToast({
                       status: 'error',
-                      duration: null,
-                      isClosable: true,
                       title: 'Failed to delete transform',
                       description: String(err),
                     });

--- a/frontend/src/components/pages/transforms/transforms-list.tsx
+++ b/frontend/src/components/pages/transforms/transforms-list.tsx
@@ -9,21 +9,12 @@
  * by the Apache License, Version 2.0
  */
 
-import {
-  Box,
-  Button,
-  Link as ChakraLink,
-  createStandaloneToast,
-  DataTable,
-  Flex,
-  SearchField,
-  Stack,
-  Text,
-} from '@redpanda-data/ui';
+import { Box, Button, Link as ChakraLink, DataTable, Flex, SearchField, Stack, Text } from '@redpanda-data/ui';
 import { Link } from '@tanstack/react-router';
 import { CheckIcon, CloseIcon, TrashIcon } from 'components/icons';
 import type { FC } from 'react';
 import { docsLinks } from 'utils/docs-links';
+import { showToast } from 'utils/toast.utils';
 
 import { openDeleteModal } from './modals';
 import {
@@ -38,8 +29,6 @@ import { encodeURIComponentPercents } from '../../../utils/utils';
 import PageContent from '../../misc/page-content';
 import Section from '../../misc/section';
 import { PageComponent, type PageInitHelper } from '../page';
-
-const { ToastContainer, toast } = createStandaloneToast();
 
 export const PartitionStatus = (p: { status: PartitionTransformStatus_PartitionStatus }) => {
   switch (p.status) {
@@ -115,7 +104,6 @@ const TransformsListContent: FC = () => {
 
   return (
     <PageContent>
-      <ToastContainer />
       <Text maxWidth="600px">
         Data transforms let you run common data streaming tasks, like filtering, scrubbing, and transcoding, within
         Redpanda.{' '}
@@ -219,19 +207,16 @@ const TransformsListContent: FC = () => {
                       transformsApi
                         .deleteTransform(r.name)
                         .then(() => {
-                          toast({
+                          showToast({
                             status: 'success',
                             duration: 4000,
-                            isClosable: false,
                             title: 'Transform deleted',
                           });
                           transformsApi.refreshTransforms(true);
                         })
                         .catch((err) => {
-                          toast({
+                          showToast({
                             status: 'error',
-                            duration: null,
-                            isClosable: true,
                             title: 'Failed to delete transform',
                             description: String(err),
                           });

--- a/frontend/src/embedded-app.tsx
+++ b/frontend/src/embedded-app.tsx
@@ -37,7 +37,7 @@ import './globals.css';
 
 import { TransportProvider } from '@connectrpc/connect-query';
 import { createConnectTransport } from '@connectrpc/connect-web';
-import { ChakraProvider, redpandaToastOptions } from '@redpanda-data/ui';
+import { ChakraProvider } from '@redpanda-data/ui';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { createRouter, RouterProvider } from '@tanstack/react-router';
 import { CustomFeatureFlagProvider } from 'custom-feature-flag-provider';
@@ -47,6 +47,7 @@ import { patchedRedpandaTheme as redpandaTheme } from 'utils/redpanda-theme';
 
 import { NotFoundPage } from './components/misc/not-found-page';
 import { RoutePendingFallback } from './components/misc/route-pending-fallback';
+import { Toaster as BaseUiToaster } from './components/redpanda-ui/components/toast';
 import {
   addBearerTokenInterceptor,
   checkExpiredLicenseInterceptor,
@@ -151,7 +152,9 @@ function EmbeddedApp({ basePath = '', ...p }: EmbeddedProps) {
 
   return (
     <CustomFeatureFlagProvider initialFlags={p.featureFlags}>
-      <ChakraProvider resetCSS={false} theme={redpandaTheme} toastOptions={redpandaToastOptions}>
+      <ChakraProvider resetCSS={false} theme={redpandaTheme}>
+        {/* showToast viewport, above the router so the error boundary and login can toast */}
+        <BaseUiToaster />
         <TransportProvider transport={dataplaneTransport}>
           <QueryClientProvider client={queryClient}>
             <RouterProvider router={router} />

--- a/frontend/src/embedded-app.tsx
+++ b/frontend/src/embedded-app.tsx
@@ -154,7 +154,7 @@ function EmbeddedApp({ basePath = '', ...p }: EmbeddedProps) {
     <CustomFeatureFlagProvider initialFlags={p.featureFlags}>
       <ChakraProvider resetCSS={false} theme={redpandaTheme}>
         {/* showToast viewport, above the router so the error boundary and login can toast */}
-        <BaseUiToaster />
+        <BaseUiToaster testId="console-toasts" />
         <TransportProvider transport={dataplaneTransport}>
           <QueryClientProvider client={queryClient}>
             <RouterProvider router={router} />

--- a/frontend/src/federation/federated-providers.tsx
+++ b/frontend/src/federation/federated-providers.tsx
@@ -35,7 +35,7 @@ export function FederatedProviders({ children, transport, queryClient, featureFl
     <CustomFeatureFlagProvider initialFlags={featureFlags}>
       <ChakraProvider resetCSS={false} theme={redpandaTheme}>
         {/* showToast viewport; mirrors app.tsx */}
-        <BaseUiToaster />
+        <BaseUiToaster testId="console-toasts" />
         <TransportProvider transport={transport}>
           <QueryClientProvider client={queryClient}>
             <TooltipProvider>{children}</TooltipProvider>

--- a/frontend/src/federation/federated-providers.tsx
+++ b/frontend/src/federation/federated-providers.tsx
@@ -11,10 +11,11 @@
 
 import type { Transport } from '@connectrpc/connect';
 import { TransportProvider } from '@connectrpc/connect-query';
-import { ChakraProvider, redpandaTheme, redpandaToastOptions } from '@redpanda-data/ui';
+import { ChakraProvider, redpandaTheme } from '@redpanda-data/ui';
 import { type QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 
+import { Toaster as BaseUiToaster } from '../components/redpanda-ui/components/toast';
 import { TooltipProvider } from '../components/redpanda-ui/components/tooltip';
 import { CustomFeatureFlagProvider } from '../custom-feature-flag-provider';
 
@@ -32,7 +33,9 @@ type FederatedProvidersProps = {
 export function FederatedProviders({ children, transport, queryClient, featureFlags }: FederatedProvidersProps) {
   return (
     <CustomFeatureFlagProvider initialFlags={featureFlags}>
-      <ChakraProvider resetCSS={false} theme={redpandaTheme} toastOptions={redpandaToastOptions}>
+      <ChakraProvider resetCSS={false} theme={redpandaTheme}>
+        {/* showToast viewport; mirrors app.tsx */}
+        <BaseUiToaster />
         <TransportProvider transport={transport}>
           <QueryClientProvider client={queryClient}>
             <TooltipProvider>{children}</TooltipProvider>

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -2007,7 +2007,31 @@ $borderRadius: 8px;
   user-select: none;
 }
 
-// Chakra modals sit at z-index 1400; keep Registry toasts above them until Chakra leaves.
-[data-slot='toast-viewport'] {
+// Console's Registry toasts sit top-right, where Chakra's and sonner's did, and above Chakra's
+// modals (z-index 1400). The registry viewport is bottom-anchored, so the stack math below mirrors
+// toast.tsx with the vertical signs flipped; it goes once the registry has a position prop. Keyed
+// on the console test id so it cannot reach a host app's viewport.
+[data-slot='toast-viewport'][data-testid='console-toasts'] {
+  top: 1rem;
+  bottom: auto;
   z-index: 1500;
+
+  [data-slot='toast'] {
+    top: 0;
+    bottom: auto;
+    transform-origin: top;
+    --offset-y: calc(var(--toast-offset-y) + var(--toast-index) * var(--gap) + var(--toast-swipe-movement-y));
+    transform: translateX(var(--toast-swipe-movement-x))
+      translateY(calc(var(--toast-swipe-movement-y) + var(--toast-index) * var(--peek) + var(--shrink) * var(--height)))
+      scale(var(--scale));
+
+    &[data-expanded] {
+      transform: translateX(var(--toast-swipe-movement-x)) translateY(var(--offset-y));
+    }
+
+    &[data-starting-style],
+    &[data-ending-style]:not([data-limited]):not([data-swipe-direction]) {
+      transform: translateY(-150%);
+    }
+  }
 }

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -2007,3 +2007,7 @@ $borderRadius: 8px;
   user-select: none;
 }
 
+// Chakra modals sit at z-index 1400; keep Registry toasts above them until Chakra leaves.
+[data-slot='toast-viewport'] {
+  z-index: 1500;
+}

--- a/frontend/src/state/backend-api.ts
+++ b/frontend/src/state/backend-api.ts
@@ -15,7 +15,6 @@ import { create, type Registry } from '@bufbuild/protobuf';
 import type { ConnectError } from '@connectrpc/connect';
 import { Code } from '@connectrpc/connect';
 import { createLinkedAbortController } from '@connectrpc/connect/protocol';
-import { createStandaloneToast, redpandaTheme, redpandaToastOptions } from '@redpanda-data/ui';
 import {
   consoleHasEnterpriseFeature,
   getLatestExpiringLicense,
@@ -165,6 +164,7 @@ import fetchWithTimeout from '../utils/fetch-with-timeout';
 import { toJson } from '../utils/json-utils';
 import { LazyMap } from '../utils/lazy-map';
 import { convertListMessageData } from '../utils/message-converters';
+import { showToast } from '../utils/toast.utils';
 import { ObjToKv } from '../utils/tsx-utils';
 import { decodeBase64, getOidcSubject, TimeSince } from '../utils/utils';
 
@@ -177,11 +177,6 @@ export const REST_CACHE_DURATION_SEC = 20;
  * generous working set; least-recently-used URLs are evicted and simply re-fetched on next use.
  */
 const REST_CACHE_MAX_ENTRIES = 500;
-
-const { toast } = createStandaloneToast({
-  theme: redpandaTheme,
-  defaultOptions: redpandaToastOptions.defaultOptions,
-});
 
 declare const registry: Registry;
 
@@ -2637,10 +2632,11 @@ export function createMessageSearch() {
                 // error doesn't necessarily mean the whole request is done
                 // biome-ignore lint/suspicious/noConsole: intentional console usage
                 console.info(`ws backend error: ${res.controlMessage.value.message}`);
-                toast({
+                showToast({
                   title: 'Backend Error',
                   description: res.controlMessage.value.message,
                   status: 'error',
+                  duration: 5000,
                 });
 
                 break;

--- a/frontend/src/utils/toast.utils.test.ts
+++ b/frontend/src/utils/toast.utils.test.ts
@@ -1,5 +1,7 @@
 import { create } from '@bufbuild/protobuf';
 import { Code, ConnectError } from '@connectrpc/connect';
+import { rs } from '@rstest/core';
+import { toast } from 'components/redpanda-ui/components/toast';
 import {
   BadRequest_FieldViolationSchema,
   BadRequestSchema,
@@ -12,7 +14,17 @@ import {
   ResourceInfoSchema,
 } from 'protogen/google/rpc/error_details_pb';
 
-import { formatToastErrorMessageGRPC } from './toast.utils';
+import { closeToast, formatToastErrorMessageGRPC, showToast, updateToast } from './toast.utils';
+
+// Spies on the real manager: the unit project shares module caches across files, so a module mock
+// only takes effect when this file happens to load `toast.utils` first.
+const add = rs.spyOn(toast, 'add').mockImplementation(() => 'toast-1');
+const update = rs.spyOn(toast, 'update').mockImplementation(() => undefined);
+const close = rs.spyOn(toast, 'close').mockImplementation(() => undefined);
+
+afterAll(() => {
+  rs.restoreAllMocks();
+});
 
 describe('formatToastErrorMessageGRPC', () => {
   test('basic error with no details', () => {
@@ -166,5 +178,77 @@ describe('formatToastErrorMessageGRPC', () => {
     ]);
     const result = formatToastErrorMessageGRPC({ error, action: 'create', entity: 'role' });
     expect(result).toBe('Failed to create role: invalid input (reason: VALIDATION_ERROR) — name: is required');
+  });
+});
+
+describe('showToast', () => {
+  beforeEach(() => {
+    add.mockClear();
+  });
+
+  test('non-error toasts auto-dismiss after 5s', () => {
+    const id = showToast({ status: 'success', title: 'Saved' });
+    expect(id).toBe('toast-1');
+    expect(add).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', title: 'Saved', timeout: 5000 }));
+  });
+
+  test('error toasts stay until closed', () => {
+    showToast({ status: 'error', title: 'Failed' });
+    expect(add).toHaveBeenCalledWith(expect.objectContaining({ type: 'error', timeout: 0 }));
+  });
+
+  test('duration null is sticky, an explicit duration is kept', () => {
+    showToast({ status: 'info', duration: null });
+    showToast({ status: 'info', duration: 2500 });
+    expect(add.mock.calls[0][0]).toMatchObject({ timeout: 0 });
+    expect(add.mock.calls[1][0]).toMatchObject({ timeout: 2500 });
+  });
+
+  test('resourceName scopes the id, or stands in for it', () => {
+    showToast({ id: 'secret-update', resourceName: 'db-password', status: 'success' });
+    showToast({ id: 'secret-update', status: 'success' });
+    showToast({ resourceName: 'db-password', status: 'success' });
+    showToast({ status: 'success' });
+    const ids = add.mock.calls.map(([options]) => options.id);
+    expect(ids).toEqual(['secret-update_db-password', 'secret-update', 'db-password', undefined]);
+  });
+});
+
+describe('updateToast', () => {
+  beforeEach(() => {
+    update.mockClear();
+  });
+
+  test('passes only the fields given', () => {
+    updateToast('toast-1', { description: 'Setting throttle rate... done' });
+    expect(update).toHaveBeenCalledWith('toast-1', { description: 'Setting throttle rate... done' });
+  });
+
+  test('a new status re-applies its dismiss default', () => {
+    updateToast('toast-1', { status: 'error', description: 'Setting throttle rate... error' });
+    expect(update).toHaveBeenCalledWith('toast-1', {
+      type: 'error',
+      timeout: 0,
+      description: 'Setting throttle rate... error',
+    });
+    updateToast('toast-1', { status: 'success' });
+    expect(update).toHaveBeenLastCalledWith('toast-1', { type: 'success', timeout: 5000 });
+  });
+
+  test('an explicit duration wins over the status default', () => {
+    updateToast('toast-1', { status: 'error', duration: 2500 });
+    expect(update).toHaveBeenCalledWith('toast-1', { type: 'error', timeout: 2500 });
+    updateToast('toast-1', { duration: null });
+    expect(update).toHaveBeenLastCalledWith('toast-1', { timeout: 0 });
+  });
+});
+
+describe('closeToast', () => {
+  test('closes by id and ignores a missing one', () => {
+    closeToast('toast-1');
+    expect(close).toHaveBeenCalledWith('toast-1');
+    close.mockClear();
+    closeToast('');
+    expect(close).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/utils/toast.utils.tsx
+++ b/frontend/src/utils/toast.utils.tsx
@@ -1,5 +1,5 @@
 import type { ConnectError } from '@connectrpc/connect';
-import { createStandaloneToast, type ToastId, type UseToastOptions } from '@redpanda-data/ui';
+import { toast } from 'components/redpanda-ui/components/toast';
 import {
   BadRequestSchema,
   ErrorInfoSchema,
@@ -8,6 +8,7 @@ import {
   QuotaFailureSchema,
   ResourceInfoSchema,
 } from 'protogen/google/rpc/error_details_pb';
+import type { ReactNode } from 'react';
 
 export type ErrorHttpPayload = {
   internalCode: number;
@@ -16,12 +17,28 @@ export type ErrorHttpPayload = {
   description?: string;
 };
 
-interface ShowToastOptions extends Partial<UseToastOptions> {
+export type ToastStatus = 'success' | 'error' | 'warning' | 'info' | 'loading';
+
+export type ShowToastOptions = {
+  /** Showing a toast whose id is already on screen updates it in place. */
+  id?: string;
+  /** Suffixed onto `id`, so one id can be live once per resource. */
   resourceName?: string;
-}
+  status?: ToastStatus;
+  title?: ReactNode;
+  description?: ReactNode;
+  /** Milliseconds until auto-dismiss; `null` keeps the toast until closed. Errors default to `null`. */
+  duration?: number | null;
+  /** Fires when the user closes the toast or it times out. */
+  onClose?: () => void;
+};
+
+export type UpdateToastOptions = Omit<ShowToastOptions, 'id' | 'resourceName'>;
+
+const DEFAULT_TOAST_DURATION = 5000;
 
 type GetToastIdProps = {
-  initialId?: ToastId;
+  initialId?: string;
   resourceName?: string;
 };
 
@@ -30,30 +47,54 @@ const getToastId = ({ initialId, resourceName }: GetToastIdProps) => {
     return initialId;
   }
 
-  return `${initialId}_${resourceName}`;
+  return initialId ? `${initialId}_${resourceName}` : resourceName;
 };
 
-export const showToast = (options: ShowToastOptions) => {
-  const { toast } = createStandaloneToast();
+// Base UI: timeout 0 means sticky, and a `loading` toast never times out.
+const toTimeout = (status: ToastStatus | undefined, duration: number | null | undefined): number => {
+  if (duration === null) {
+    return 0;
+  }
+  if (duration !== undefined) {
+    return duration;
+  }
+  return status === 'error' ? 0 : DEFAULT_TOAST_DURATION;
+};
 
-  const defaultToastSettings: Partial<UseToastOptions> = {
-    position: 'top',
-    size: 'xs',
-    isClosable: true,
-    duration: 5000,
-  };
-
-  const toastId = getToastId({
-    initialId: options?.id,
-    resourceName: options?.resourceName,
+/** Returns the toast id, for `updateToast` / `closeToast`. */
+export const showToast = ({
+  id,
+  resourceName,
+  status,
+  title,
+  description,
+  duration,
+  onClose,
+}: ShowToastOptions): string =>
+  toast.add({
+    id: getToastId({ initialId: id, resourceName }),
+    type: status,
+    title,
+    description,
+    timeout: toTimeout(status, duration),
+    onClose,
   });
 
-  if (!(toastId && toast.isActive(toastId))) {
-    toast({
-      ...defaultToastSettings,
-      ...options,
-      duration: options.status === 'error' ? null : defaultToastSettings.duration,
-    });
+/** Only the fields given change. A new status re-applies its dismiss default unless `duration` is given. */
+export const updateToast = (id: string, { status, title, description, duration }: UpdateToastOptions) => {
+  const timeout = status !== undefined || duration !== undefined ? toTimeout(status, duration) : undefined;
+  toast.update(id, {
+    ...(status !== undefined && { type: status }),
+    ...(timeout !== undefined && { timeout }),
+    ...(title !== undefined && { title }),
+    ...(description !== undefined && { description }),
+  });
+};
+
+// Base UI closes every toast when the id is missing.
+export const closeToast = (id: string) => {
+  if (id) {
+    toast.close(id);
   }
 };
 

--- a/frontend/src/utils/tsx-utils.tsx
+++ b/frontend/src/utils/tsx-utils.tsx
@@ -9,26 +9,14 @@
  * by the Apache License, Version 2.0
  */
 
-import {
-  Box,
-  createStandaloneToast,
-  Flex,
-  type PlacementWithLogical,
-  Progress,
-  RadioGroup,
-  redpandaTheme,
-  redpandaToastOptions,
-  Skeleton,
-  Text,
-  type ToastId,
-  Tooltip,
-} from '@redpanda-data/ui';
+import { type PlacementWithLogical, RadioGroup, Skeleton, Tooltip } from '@redpanda-data/ui';
 import { CopyIcon, DownloadIcon, InfoIcon } from 'components/icons';
 import { motion } from 'motion/react';
 import React, { Component, type CSSProperties, type JSX, useEffect, useState } from 'react';
 
 import { animProps } from './animation-props';
 import { toJson } from './json-utils';
+import { closeToast, showToast, updateToast } from './toast.utils';
 import { prettyMilliseconds, simpleUniqueId } from './utils';
 import type { TimestampDisplayFormat } from '../state/ui';
 
@@ -347,17 +335,9 @@ type StatusIndicatorProps = {
   progressText: string;
 };
 
-// TODO - once StatusIndicator is migrated to FC, we could should move this code to use useToast()
-const { ToastContainer, toast } = createStandaloneToast({
-  theme: redpandaTheme,
-  defaultOptions: {
-    ...redpandaToastOptions.defaultOptions,
-    isClosable: false,
-  },
-});
-
 export class StatusIndicator extends Component<StatusIndicatorProps, { showWaitingText: boolean }> {
-  toastRef: ToastId | null = null;
+  toastRef: string | null = null;
+  dismissed = false;
 
   timerHandle: NodeJS.Timeout;
   lastUpdateTimestamp: number;
@@ -406,58 +386,75 @@ export class StatusIndicator extends Component<StatusIndicatorProps, { showWaiti
   componentWillUnmount() {
     clearInterval(this.timerHandle);
     if (this.toastRef) {
-      toast.close(this.toastRef);
+      closeToast(this.toastRef);
     }
     this.toastRef = null;
   }
 
   customRender() {
+    if (this.dismissed) {
+      return;
+    }
+    const indeterminate = this.props.statusText === 'Connecting';
+    const percent = Math.round(this.props.fillFactor * 100);
+    const showCounters = Boolean(this.props.bytesConsumed && this.props.messagesConsumed);
+
+    // The toast description is a <p>, so this stays phrasing content (spans, no Progress).
     const content = (
-      <Box mb="0.2em">
-        <Box minW={300}>
-          <Progress
-            colorScheme="blue"
-            isIndeterminate={this.props.statusText === 'Connecting'}
-            value={this.props.fillFactor * 100}
+      <span className="flex flex-col gap-1 text-body text-foreground">
+        <span
+          aria-valuemax={100}
+          aria-valuemin={0}
+          aria-valuenow={indeterminate ? undefined : percent}
+          className="block h-2 w-full overflow-hidden rounded-full bg-surface-subtle"
+          role="progressbar"
+        >
+          <span
+            className={
+              indeterminate
+                ? 'block h-full w-full animate-pulse rounded-full bg-primary'
+                : 'block h-full rounded-full bg-primary transition-[width] motion-reduce:transition-none'
+            }
+            style={indeterminate ? undefined : { width: `${percent}%` }}
           />
-        </Box>
-        <Flex fontSize="sm" fontWeight="bold">
-          <div>
+        </span>
+        <span className="flex font-semibold">
+          <span>
             {this.state.showWaitingText ? 'Redpanda Console is waiting for new messages...' : this.props.statusText}
-          </div>
-          <Text ml="auto" pl="2em">
-            {this.props.progressText}
-          </Text>
-        </Flex>
-        {Boolean(this.props.bytesConsumed && this.props.messagesConsumed) && (
-          <Flex fontSize="sm" fontWeight="bold" justifyContent="space-between">
-            <Flex alignItems="center" gap={2}>
+          </span>
+          <span className="ml-auto pl-8">{this.props.progressText}</span>
+        </span>
+        {showCounters ? (
+          <span className="flex justify-between font-semibold">
+            <span className="inline-flex items-center gap-2">
               <DownloadIcon className="text-brand" size={14} /> {this.props.bytesConsumed}
-            </Flex>
-            <Flex alignItems="center" gap={2}>
+            </span>
+            <span className="inline-flex items-center gap-2">
               <CopyIcon className="text-brand" size={14} /> {this.props.messagesConsumed} messages
-            </Flex>
-          </Flex>
-        )}
-      </Box>
+            </span>
+          </span>
+        ) : null}
+      </span>
     );
 
     if (this.toastRef === null) {
-      this.toastRef = toast({
+      this.toastRef = showToast({
         status: 'info',
         description: content,
         duration: null,
+        // A closed progress toast stays closed for this search.
+        onClose: () => {
+          this.toastRef = null;
+          this.dismissed = true;
+        },
       });
     } else {
-      toast.update(this.toastRef, {
-        description: content,
-        duration: null,
-      });
+      updateToast(this.toastRef, { description: content });
     }
   }
 
   render() {
-    return <ToastContainer />;
+    return null;
   }
 }
 
@@ -524,8 +521,9 @@ export const Code = (p: { children?: React.ReactNode; nowrap?: boolean }) => {
 };
 
 export const navigatorClipboardErrorHandler = (e: DOMException) => {
-  toast({
+  showToast({
     status: 'error',
+    duration: 5000,
     description: 'Unable to copy settings to clipboard. See console for more information.',
   });
   // biome-ignore lint/suspicious/noConsole: error logging for debugging clipboard failures

--- a/frontend/tests/mocks/redpanda-ui.ts
+++ b/frontend/tests/mocks/redpanda-ui.ts
@@ -1,13 +1,7 @@
 // Stub for @redpanda-data/ui in Node unit tests
 // The package includes CSS that can't be parsed in Node environment
 
-export const createStandaloneToast = () => ({
-  toast: () => {},
-  ToastContainer: null,
-});
-
 export const redpandaTheme = {};
-export const redpandaToastOptions = {};
 
 // Lightweight component stubs. Unit tests never render JSX, but modules
 // imported by the unit-test graph (e.g. src/utils/tsx-utils.tsx) evaluate
@@ -31,4 +25,3 @@ export const Tooltip = stubComponent;
 export type SortingState = Array<{ id: string; desc: boolean }>;
 export type PlacementWithLogical = string;
 export type ButtonProps = Record<string, unknown>;
-export type ToastId = string;


### PR DESCRIPTION
## Chakra exit · Phase 1 (wrappers) · PR 2 of 14

Part of the [Chakra exit plan and live tracker](https://claude.ai/code/artifact/1861e21c-624b-4270-98ad-9921b22c2498). Phase 1 re-implements the shared wrappers behind their existing exports, so page code does not change. Branch `chakra-exit/02-toast`, stacked on #2626; each PR on the ladder shows only its own diff and re-targets `master` as its base merges.

Chakra's toast is gone. `showToast` in `utils/toast.utils.tsx` is the one app-level entry point, re-implemented on the Registry `toast` (Base UI) that #2625 vendored; the 14 files that called Chakra's `createStandaloneToast` / `useToast` directly now go through it. Nothing else in those files changes.

### Why the Registry toast and not sonner
Revision 2 of the plan sent `showToast` to sonner first and left the Registry toast as a follow-up, because the Registry had no `toast.tsx` yet. #2625 vendors it, and its module-level manager is callable from outside React (the `backend-api.ts` stream error fires from a websocket loop, not a component), so there is no reason for a throwaway sonner stop. Sonner remains the second live toast until its 53 callers are re-pointed at `showToast` — that follow-up is mechanical and not Chakra work. Both now sit top-right.

### The façade (`utils/toast.utils.tsx`)
```ts
showToast({ id?, resourceName?, status?, title?, description?, duration? }): string
updateToast(id, { status?, title?, description?, duration? })   // only the given fields change
closeToast(id)
```
Contract carried over from the Chakra version: non-errors dismiss after 5 s, **errors stay until closed**, `duration: null` is sticky, and `id` + `resourceName` still compose the toast id. A status change on `updateToast` re-applies that status's default unless a duration is given. One thing that only works now: the id-based dedupe. The old code created a fresh standalone instance per call, so `toast.isActive` could never see an earlier toast; Base UI upserts on a duplicate id. `status: 'loading'` never auto-dismisses (Base UI), which is what every loading→update flow here already assumed.

### Where the toasts moved
| Module | Before | After |
|---|---|---|
| `state/backend-api.ts` | own standalone instance + `redpandaTheme` | `showToast` |
| `utils/tsx-utils.tsx` `StatusIndicator` | standalone instance, rendered `<ToastContainer />`, `toast.update` on every render | `showToast` once, `updateToast` after; `render()` returns null. The progress body is spans only — Base UI renders the description as a `<p>` |
| `utils/tsx-utils.tsx` `navigatorClipboardErrorHandler` | module toast | `showToast` |
| `misc/error-boundary.tsx` | `useToast` | `showToast` |
| reassign-partitions ×2 | two standalone instances with `duration: 2000` defaults, `toast.update` / `toast.close` on refs | `showToast` / `updateToast` / `closeToast`; the 2 s instance default is written onto each non-error call so nothing gets faster or slower |
| transforms ×2, rp-connect ×6, connect ×2 | standalone instances / `useToast` | `showToast`, same strings, same explicit durations |
| `app.tsx`, `embedded-app.tsx`, `federated-providers.tsx` | `toastOptions={redpandaToastOptions}` on `ChakraProvider` | prop removed (`ChakraProvider` itself stays until PR 13) |
| `app.tsx`, `embedded-app.tsx`, `federated-providers.tsx` | `ChakraProvider toastOptions` | + the Registry `<Toaster testId="console-toasts">` viewport, mounted at the provider layer (above the router and its error boundary) and placed top-right by a scoped `index.scss` block |
| `tests/mocks/redpanda-ui.ts` | stubbed `createStandaloneToast`, `redpandaToastOptions`, `ToastId` | stubs removed |

Behaviour that changed on purpose: error toasts in reassign-partitions used to vanish after 2 s (the instance default); they now stay until closed, matching every other error toast in the app.

### Reading the diff
`reassign-partitions.tsx` shows ~470 changed lines; `git diff -w` shows 48. Removing the `<><ToastContainer />…</>` wrapper de-indented the whole `render()` body.

### Gates
`bun run type:check` · `bun run lint` (no dirty tree; remaining lint findings on touched files are pre-existing on master) · unit suite (59 files / 872 tests, incl. 7 new façade tests) · integration suite (121 files / 1270 tests). E2E specs that assert toast copy use plain `getByText`, and every string is preserved verbatim; CI's Playwright run is the check for those.

### Follow-ups (not in this PR)
- Re-point the 53 sonner callers at `showToast`, then drop sonner's `<Toaster>` and the `toasterTheme` plumbing (PR 8 drops the theme plumbing anyway).
- Registry: a `position` prop on `Toaster`, so the top-right placement in `index.scss` can go.
- Registry: a rich-body slot on the toast so progress toasts don't have to stay phrasing content.

### Review pass (2026-09-03)
- **Toasts were hidden behind Chakra modals.** The Registry viewport is `z-50`; Chakra's `ModalOverlay`/`ModalContent` sit at 1300/1400, so anything toasted while a modal was open (remove-throttle, quick-add secret, throttle dialog) was unreadable. A scoped `index.scss` block lifts Console's viewport to 1500 until Chakra leaves.
- **The viewport moved above the router.** It was mounted inside `AppContent`, below the root `ErrorBoundary`, so the crash screen's own "copied" toast and anything on `/login` went nowhere. It now mounts next to `ChakraProvider` in `app.tsx`, `embedded-app.tsx` and `federated-providers.tsx`, where the removed `toastOptions` lived.
- **`updateToast` re-applies the new status's default** unless a `duration` is given. Before, a `loading → error` update inherited the loading toast's 5 s timer and the error vanished. Tests cover both directions.
- **Two toasts that changed behaviour by accident keep their old 5 s**: the per-message "Backend Error" from the websocket loop (which could otherwise pile up as sticky toasts) and the clipboard-failure toast.
- **`StatusIndicator`**: the progress body no longer overflows the description column, reads as body text rather than muted small text, carries `role="progressbar"` semantics, and if the user closes the progress toast it stays closed for that search instead of silently going stale.
- **Smaller**: `priority: 'high'` dropped (it made Base UI render error copy twice, which trips `getByText`); `closeToast` ignores a missing id (Base UI would close every toast); the all-errors reassignment update says "Reassignment failed" instead of keeping the loading text; a `closeToast` + `showToast` pair became one `updateToast`; redundant `duration: null` on error toasts and dead durations on loading toasts removed; `resourceName` without an `id` no longer yields `undefined_…`; `no-legacy.md` now points at `showToast`.
- **Position.** The registry viewport is bottom-anchored and `Toaster` has no position prop, so Console's toasts would have moved corners. The same scoped `index.scss` block anchors the viewport and the stack at the **top right**, where Chakra's and sonner's toasts are, with the registry's stacking math mirrored (vertical signs flipped). It is keyed on the viewport's `console-toasts` test id so it cannot reach a host app's toasts, and it goes once the registry grows a position prop.
- **Accepted, noted for the follow-ups**: the Registry toast is `select-none` with swipe-to-dismiss, so long error text cannot be copied out of it — a registry-level change (swipe-ignore on the description) is the right fix. A pre-existing stale-closure bug in the throttle dialog's "Remove throttle" path was spotted and left for its own change.

Plan (internal): https://claude.ai/code/artifact/1861e21c-624b-4270-98ad-9921b22c2498

🤖 Generated with [Claude Code](https://claude.com/claude-code)





