### PR TITLE
[Chakra exit · Phase 1 · PR 3/14] frontend: Registry internals for the shared display wrappers, drop Chakra type seams

### DIFF
--- a/frontend/src/components/misc/section.tsx
+++ b/frontend/src/components/misc/section.tsx
@@ -9,20 +9,21 @@
  * by the Apache License, Version 2.0
  */
 
-import { type ChakraProps, Section as ChakraSection } from '@redpanda-data/ui';
-import type { ReactNode } from 'react';
+import { Card, type CardProps } from 'components/redpanda-ui/components/card';
+import { cn } from 'components/redpanda-ui/lib/utils';
+import type { CSSProperties } from 'react';
 
-// Note: this component is intended to be temporary until all components are migrated @redpanda-data/ui
-function Section(props: { children: ReactNode; id?: string } & ChakraProps) {
+type SectionProps = Pick<CardProps, 'children' | 'id' | 'className'> & {
+  // Grid placement only; everything else is a class.
+  style?: Pick<CSSProperties, 'gridArea'>;
+};
+
+// Legacy page section: block flow and Section's padding on a Card. New pages compose Card directly.
+function Section({ children, id, className, style }: SectionProps) {
   return (
-    <ChakraSection
-      border="1px solid var(--color-border)"
-      borderRadius="8px"
-      boxShadow="var(--shadow-elevated)"
-      px={6}
-      py={6}
-      {...props}
-    />
+    <Card className={cn('block px-6', className)} id={id} size="full" style={style}>
+      {children}
+    </Card>
   );
 }
 

--- a/frontend/src/components/misc/small-stat.tsx
+++ b/frontend/src/components/misc/small-stat.tsx
@@ -1,11 +1,10 @@
-import { Flex, Text } from '@redpanda-data/ui';
 import type { JSX } from 'react';
 
 export function SmallStat(p: { title: JSX.Element | string; children: JSX.Element | number | string }) {
   return (
-    <Flex color="var(--color-foreground)" fontFamily="Inter" fontWeight="400" gap="2">
-      <Text fontWeight="500">{p.title}: </Text>
+    <div className="flex gap-2 text-foreground">
+      <span className="font-medium">{p.title}: </span>
       {p.children}
-    </Flex>
+    </div>
   );
 }

--- a/frontend/src/components/misc/statistic.tsx
+++ b/frontend/src/components/misc/statistic.tsx
@@ -1,32 +1,7 @@
-import { Box, Flex, type SpaceProps, Stat, StatLabel, StatNumber, Tooltip } from '@redpanda-data/ui';
-import { InfoIcon } from 'components/icons';
+import { Stat } from 'components/redpanda-ui/components/stat';
+import type { ReactNode } from 'react';
 
-export function Statistic(
-  p: {
-    key?: string | number;
-    title: React.ReactNode;
-    value: React.ReactNode;
-    hint?: string;
-    className?: string;
-  } & SpaceProps
-) {
-  const { key, title, value, className, hint, ...rest } = p;
-
-  return (
-    <Stat className={className} flexBasis="auto" flexGrow={0} key={key} marginRight="2rem" {...rest}>
-      <StatNumber>{value}</StatNumber>
-      <StatLabel>
-        <Flex gap={1}>
-          {title}
-          {Boolean(hint) && (
-            <Tooltip hasArrow label={hint} placement="right">
-              <Box alignSelf="start">
-                <InfoIcon size={18} />
-              </Box>
-            </Tooltip>
-          )}
-        </Flex>
-      </StatLabel>
-    </Stat>
-  );
+// Legacy stat; the row that lays these out owns the spacing.
+export function Statistic(p: { title: string; value: ReactNode; className?: string }) {
+  return <Stat className={p.className} label={p.title} value={p.value} />;
 }

--- a/frontend/src/components/misc/statistic.tsx
+++ b/frontend/src/components/misc/statistic.tsx
@@ -3,5 +3,5 @@ import type { ReactNode } from 'react';
 
 // Legacy stat; the row that lays these out owns the spacing.
 export function Statistic(p: { title: string; value: ReactNode; className?: string }) {
-  return <Stat className={p.className} label={p.title} value={p.value} />;
+  return <Stat className={p.className} label={p.title} size="lg" value={p.value} />;
 }

--- a/frontend/src/components/misc/tabs/tabs.tsx
+++ b/frontend/src/components/misc/tabs/tabs.tsx
@@ -9,13 +9,15 @@
  * by the Apache License, Version 2.0
  */
 
-import { Tabs as RpTabs } from '@redpanda-data/ui';
-import React, { useState } from 'react';
+import { Tabs as RegistryTabs, TabsContent, TabsList, TabsTrigger } from 'components/redpanda-ui/components/tabs';
+import type React from 'react';
+
+type Slot = React.ReactNode | (() => React.ReactNode);
 
 export type Tab = {
   key: string;
-  title: React.ReactNode | (() => React.ReactNode);
-  content: React.ReactNode | (() => React.ReactNode);
+  title: Slot;
+  content: Slot;
   disabled?: boolean;
 };
 
@@ -28,41 +30,30 @@ type TabsProps = {
   isFitted?: boolean; // whether or not to fit tab buttons to max width
 };
 
-export default function Tabs(props: TabsProps) {
-  const { tabs, selectedTabKey } = props;
+const renderSlot = (slot: Slot) => (typeof slot === 'function' ? slot() : slot);
 
-  const [selectedIndex, setSelectedIndex] = useState(() =>
-    selectedTabKey ? tabs.findIndex((t) => t.key === selectedTabKey) : undefined
-  );
-  const defaultIndex = props.defaultSelectedTabKey
-    ? tabs.findIndex((t) => t.key === props.defaultSelectedTabKey)
-    : undefined;
+// Only the active panel renders its children, so function content runs for one tab.
+const TabSlot = ({ slot }: { slot: Slot }) => <>{renderSlot(slot)}</>;
 
+export default function Tabs({ tabs, selectedTabKey, defaultSelectedTabKey, onChange, isFitted }: TabsProps) {
   return (
-    <RpTabs
-      defaultIndex={defaultIndex}
-      index={selectedIndex}
-      isFitted={props.isFitted}
-      items={tabs.map((t) => {
-        const titleComp = t.title;
-        const title: React.ReactNode = typeof titleComp === 'function' ? titleComp() : titleComp;
-
-        const contentComp = t.content;
-        const content = typeof contentComp === 'function' ? contentComp() : contentComp;
-
-        return {
-          key: t.key,
-          name: title,
-          component: content,
-          isDisabled: t.disabled,
-        };
-      })}
-      onChange={(index, key) => {
-        setSelectedIndex(Number(index));
-        if (props.onChange) {
-          props.onChange(String(key));
-        }
-      }}
-    />
+    <RegistryTabs
+      defaultValue={selectedTabKey || defaultSelectedTabKey || tabs[0]?.key}
+      onValueChange={(next) => onChange?.(String(next))}
+    >
+      <TabsList activateOnFocus layout={isFitted ? 'full' : 'auto'} variant="underline">
+        {tabs.map((t) => (
+          <TabsTrigger disabled={t.disabled} key={t.key} value={t.key} variant="underline">
+            {renderSlot(t.title)}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+      {tabs.map((t) => (
+        // Legacy tab bodies space themselves; keep Chakra's 1rem panel padding, drop the registry rhythm.
+        <TabsContent className="space-y-0 pt-2 pb-4" key={t.key} value={t.key}>
+          <TabSlot slot={t.content} />
+        </TabsContent>
+      ))}
+    </RegistryTabs>
   );
 }

--- a/frontend/src/components/misc/tabs/tabs.tsx
+++ b/frontend/src/components/misc/tabs/tabs.tsx
@@ -39,7 +39,12 @@ export default function Tabs({ tabs, selectedTabKey, defaultSelectedTabKey, onCh
   return (
     <RegistryTabs
       defaultValue={selectedTabKey || defaultSelectedTabKey || tabs[0]?.key}
-      onValueChange={(next) => onChange?.(String(next))}
+      onValueChange={(next, details) => {
+        // Only user activation; Base UI also reports its own initial/fallback selection.
+        if (details.reason === 'none' && next !== null) {
+          onChange?.(String(next));
+        }
+      }}
     >
       <TabsList activateOnFocus layout={isFitted ? 'full' : 'auto'} variant="underline">
         {tabs.map((t) => (

--- a/frontend/src/components/pages/connect/connector-details.tsx
+++ b/frontend/src/components/pages/connect/connector-details.tsx
@@ -403,7 +403,7 @@ const ConfigOverviewTab = (p: {
         ))}
       </Flex>
 
-      <Section gridArea="health">
+      <Section style={{ gridArea: 'health' }}>
         <Flex flexDirection="row" gap="4" m="1">
           <Box background={statusColors[connector.status]} borderRadius="3px" width="5px" />
 
@@ -416,7 +416,7 @@ const ConfigOverviewTab = (p: {
         </Flex>
       </Section>
 
-      <Section gridArea="tasks" minWidth="500px" py={4}>
+      <Section className="min-w-[500px] py-4" style={{ gridArea: 'tasks' }}>
         <Flex alignItems="center" gap="2" mb="6" mt="2">
           <Heading as="h3" color="blackAlpha.800" fontSize="1rem" fontWeight="semibold" textTransform="uppercase">
             Tasks
@@ -455,7 +455,7 @@ const ConfigOverviewTab = (p: {
         />
       </Section>
 
-      <Section gridArea="details" py={4}>
+      <Section className="py-4" style={{ gridArea: 'details' }}>
         <Heading
           as="h3"
           color="blackAlpha.800"
@@ -766,7 +766,7 @@ const LogsTab = (p: {
     <>
       <Box my="1rem">The logs below are for the last three hours.</Box>
 
-      <Section minWidth="800px">
+      <Section className="min-w-[800px]">
         <Flex mb="6">
           <SearchField searchText={logsQuickSearch} setSearchText={setLogsQuickSearch} width="230px" />
           <Button ml="auto" onClick={() => setRefreshCount((c) => c + 1)} variant="outline">

--- a/frontend/src/components/pages/connect/helper.tsx
+++ b/frontend/src/components/pages/connect/helper.tsx
@@ -471,8 +471,8 @@ export const OverviewStatisticsCard = () => {
   const totalConnectors = api.connectConnectors?.clusters?.sum((c) => c.totalConnectors) ?? '...';
 
   return (
-    <Section py={4}>
-      <div style={{ display: 'flex', gap: '1em' }}>
+    <Section className="py-4">
+      <div className="flex gap-8">
         <Statistic title="Connect Clusters" value={totalClusters} />
         <Statistic title="Total Connectors" value={totalConnectors} />
       </div>
@@ -494,8 +494,8 @@ export const ClusterStatisticsCard = (p: { clusterName: string }) => {
   const version = cluster?.clusterInfo.version ?? '...';
 
   return (
-    <Section py={4}>
-      <div style={{ display: 'flex', gap: '1em' }}>
+    <Section className="py-4">
+      <div className="flex gap-8">
         <Statistic title="Cluster" value={cluster?.clusterName} />
 
         <Statistic title="Connectors" value={`${runningConnectors} / ${totalConnectors}`} />
@@ -511,8 +511,8 @@ export const ConnectorStatisticsCard = (p: { clusterName: string; connectorName:
   const connector = cluster?.connectors.first((x) => x.name === p.connectorName);
 
   return (
-    <Section py={4}>
-      <div style={{ display: 'flex', gap: '1em' }}>
+    <Section className="py-4">
+      <div className="flex gap-8">
         <Statistic title="Cluster" value={cluster?.clusterName} />
         <Statistic title="Connector" value={connector?.name} />
 

--- a/frontend/src/components/pages/connect/overview.tsx
+++ b/frontend/src/components/pages/connect/overview.tsx
@@ -490,7 +490,6 @@ export const TabKafkaConnect = (_p: {}) => {
   );
 };
 
-export type ConnectTabKeys = 'clusters' | 'connectors' | 'tasks';
 const connectTabs: Tab[] = [
   { key: 'clusters', title: 'Clusters', content: <TabClusters /> },
   { key: 'connectors', title: 'Connectors', content: <TabConnectors /> },

--- a/frontend/src/components/pages/overview/broker-details.tsx
+++ b/frontend/src/components/pages/overview/broker-details.tsx
@@ -74,8 +74,8 @@ const BrokerDetailsContent: FC<{ brokerId: number }> = ({ brokerId }) => {
 
   return (
     <PageContent>
-      <Section py={4}>
-        <Flex>
+      <Section className="py-4">
+        <Flex gap={8}>
           <Statistic title="Broker ID" value={brokerId} />
           <Statistic title="Role" value={broker.isController ? 'Controller' : 'Follower'} />
           {/* biome-ignore lint/style/noNonNullAssertion: not touching MobX observables */}
@@ -84,7 +84,7 @@ const BrokerDetailsContent: FC<{ brokerId: number }> = ({ brokerId }) => {
           {Boolean(broker.rack) && <Statistic title="Rack" value={broker.rack} />}
         </Flex>
       </Section>
-      <Section py={4}>
+      <Section className="py-4">
         <BrokerConfigView entries={brokerConfigs} />
       </Section>
     </PageContent>

--- a/frontend/src/components/pages/overview/overview.tsx
+++ b/frontend/src/components/pages/overview/overview.tsx
@@ -139,20 +139,22 @@ class Overview extends PageComponent {
         </NullFallbackBoundary>
 
         <PageContent className="overviewGrid">
-          <Section my={4} py={5}>
-            <Flex>
-              <Statistic
-                className={`status-bar ${clusterStatus.className}`}
-                title="Cluster Status"
-                value={clusterStatus.displayText}
-              />
-              <Statistic title="Cluster Storage Size" value={brokerSize} />
-              <Statistic title="Cluster Version" value={version} />
-              <Statistic title="Brokers Online" value={brokersOnlineText} />
-              <Statistic title="Topics" value={overview.kafka?.topicsCount ?? NOT_AVAILABLE} />
-              <Statistic title="Replicas" value={overview.kafka?.replicasCount ?? NOT_AVAILABLE} />
-            </Flex>
-          </Section>
+          <div className="my-4">
+            <Section className="py-5">
+              <Flex gap={8}>
+                <Statistic
+                  className={`status-bar ${clusterStatus.className}`}
+                  title="Cluster Status"
+                  value={clusterStatus.displayText}
+                />
+                <Statistic title="Cluster Storage Size" value={brokerSize} />
+                <Statistic title="Cluster Version" value={version} />
+                <Statistic title="Brokers Online" value={brokersOnlineText} />
+                <Statistic title="Topics" value={overview.kafka?.topicsCount ?? NOT_AVAILABLE} />
+                <Statistic title="Replicas" value={overview.kafka?.replicasCount ?? NOT_AVAILABLE} />
+              </Flex>
+            </Section>
+          </div>
 
           {/* Shadow Link Overview Section */}
           <ShadowLinkSection />
@@ -160,13 +162,13 @@ class Overview extends PageComponent {
           <Grid gap={6} gridTemplateColumns={{ base: '1fr', lg: 'fit-content(60%) 1fr' }}>
             <GridItem display="flex" flexDirection="column" gap={6}>
               {api.clusterHealth?.isHealthy === false && (
-                <Section gridArea="debugInfo" py={4}>
+                <Section className="py-4" style={{ gridArea: 'debugInfo' }}>
                   <Heading as="h3">Cluster Health Debug</Heading>
                   <ClusterHealthOverview />
                 </Section>
               )}
 
-              <Section py={4}>
+              <Section className="py-4">
                 <Heading as="h3">Broker Details</Heading>
                 <DataTable<BrokerWithConfigAndStorage>
                   columns={[
@@ -237,10 +239,10 @@ class Overview extends PageComponent {
                 />
               </Section>
 
-              <Section flexDirection="column">
+              <Section>
                 <Heading as="h3">Resources and updates</Heading>
                 {Boolean(api.clusterOverview?.kafka?.distribution) && <NurturePanel />}
-                <hr />
+                <hr className="mt-4 mb-2" />
                 <div className="mt-4 flex flex-row items-center gap-2 font-sm text-subtle">
                   <a href={docsLinks.selfManaged.home}>Documentation</a>
                   <span className="mx-2 text-disabled">|</span>
@@ -250,7 +252,7 @@ class Overview extends PageComponent {
             </GridItem>
 
             <GridItem>
-              <Section py={4}>
+              <Section className="py-4">
                 <h3>Cluster Details</h3>
 
                 <ClusterDetails />

--- a/frontend/src/components/pages/overview/overview.tsx
+++ b/frontend/src/components/pages/overview/overview.tsx
@@ -162,7 +162,7 @@ class Overview extends PageComponent {
           <Grid gap={6} gridTemplateColumns={{ base: '1fr', lg: 'fit-content(60%) 1fr' }}>
             <GridItem display="flex" flexDirection="column" gap={6}>
               {api.clusterHealth?.isHealthy === false && (
-                <Section className="py-4" style={{ gridArea: 'debugInfo' }}>
+                <Section className="py-4">
                   <Heading as="h3">Cluster Health Debug</Heading>
                   <ClusterHealthOverview />
                 </Section>

--- a/frontend/src/components/pages/reassign-partitions/reassign-partitions.tsx
+++ b/frontend/src/components/pages/reassign-partitions/reassign-partitions.tsx
@@ -214,8 +214,8 @@ class ReassignPartitions extends PageComponent {
           </NullFallbackBoundary>
 
           {/* Statistics */}
-          <Section py={4}>
-            <Flex>
+          <Section className="py-4">
+            <Flex gap={8}>
               <Statistic title="Broker Count" value={api.clusterInfo?.brokers.length} />
               <Statistic title="Leader Partitions" value={partitionCountLeaders ?? '...'} />
               <Statistic title="Replica Partitions" value={partitionCountOnlyReplicated ?? '...'} />

--- a/frontend/src/components/pages/rp-connect/pipelines-details.tsx
+++ b/frontend/src/components/pages/rp-connect/pipelines-details.tsx
@@ -247,7 +247,7 @@ const PipelineEditor = (p: { pipeline: Pipeline }) => {
   );
 };
 
-export const LogsTab = ({ pipeline, variant = 'card' }: { pipeline: Pipeline; variant?: 'ghost' | 'card' }) => {
+export const LogsTab = ({ pipeline }: { pipeline: Pipeline }) => {
   const topicName = '__redpanda.connect.logs';
   const topic = api.topics?.first((x) => x.topicName === topicName);
 
@@ -374,7 +374,7 @@ export const LogsTab = ({ pipeline, variant = 'card' }: { pipeline: Pipeline; va
     <>
       <Box my="1rem">The logs below are for the last five hours.</Box>
 
-      <Section borderColor={variant === 'ghost' ? 'transparent' : undefined} minWidth="800px" overflowY="auto">
+      <Section className="min-w-[800px] overflow-y-auto">
         <div className="mb-6 flex items-center justify-between gap-2">
           <SearchField searchText={logsQuickSearch} setSearchText={setLogsQuickSearch} width="230px" />
           <RegistryButton onClick={() => setRefreshCount((c) => c + 1)} size="icon" variant="ghost">

--- a/frontend/src/components/pages/transforms/transform-details.tsx
+++ b/frontend/src/components/pages/transforms/transform-details.tsx
@@ -286,7 +286,7 @@ const LogsTab = (p: { transform: TransformMetadata }) => {
     <>
       <Box my="1rem">The logs below are for the last five hours.</Box>
 
-      <Section minWidth="800px">
+      <Section className="min-w-[800px]">
         <Flex mb="6">
           <SearchField searchText={logsQuickSearch} setSearchText={setLogsQuickSearch} width="230px" />
           <Button ml="auto" onClick={() => setRefreshCount((c) => c + 1)} variant="outline">

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -315,8 +315,8 @@
   font-size: 85%;
   font-family: monospace;
 
-  background: var(--color-surface-subtle);
-  border: 1px solid var(--color-border);
+  background: var(--color-surface-recess);
+  border: 1px solid var(--color-border-subtle);
   border-radius: 3px;
 }
 
@@ -671,10 +671,6 @@ tr.consumerGroupNoMemberAssigned {
 
   div.brokerConfigView {
     padding: 16px 16px 8px 16px;
-  }
-
-  .codeBox {
-    background: hsl(0, 45%, 80%);
   }
 }
 

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -315,8 +315,8 @@
   font-size: 85%;
   font-family: monospace;
 
-  background: rgb(241, 241, 241);
-  border: 1px solid rgba(0, 0, 0, 0.06);
+  background: var(--color-surface-subtle);
+  border: 1px solid var(--color-border);
   border-radius: 3px;
 }
 

--- a/frontend/src/state/ui.ts
+++ b/frontend/src/state/ui.ts
@@ -9,13 +9,12 @@
  * by the Apache License, Version 2.0
  */
 
-import type { SortingState } from '@redpanda-data/ui';
+import type { SortingState } from '@tanstack/react-table';
 import { create } from 'zustand';
 import { persist, subscribeWithSelector } from 'zustand/middleware';
 
 import { AclRequestDefault, type GetAclsRequest } from './rest-interfaces';
 import { DEFAULT_TABLE_PAGE_SIZE } from '../components/constants';
-import type { ConnectTabKeys } from '../components/pages/connect/overview';
 import type { TopicTabId } from '../components/pages/topics/topic-details';
 import { CompressionType, PayloadEncoding } from '../protogen/redpanda/api/console/v1alpha1/common_pb';
 import { clone } from '../utils/json-utils';
@@ -110,6 +109,8 @@ export const PartitionOffsetOrigin = {
 } as const;
 
 export type PartitionOffsetOriginType = (typeof PartitionOffsetOrigin)[keyof typeof PartitionOffsetOrigin];
+
+export type ConnectTabKeys = 'clusters' | 'connectors' | 'tasks';
 
 export const DEFAULT_SEARCH_PARAMS = {
   offsetOrigin: -1 as PartitionOffsetOriginType, // start, end, custom

--- a/frontend/src/utils/tsx-utils.tsx
+++ b/frontend/src/utils/tsx-utils.tsx
@@ -10,9 +10,8 @@
  */
 
 import { CopyIcon, DownloadIcon, InfoIcon } from 'components/icons';
-import { Label as RegistryLabel } from 'components/redpanda-ui/components/label';
-import { RadioGroup, RadioGroupItem } from 'components/redpanda-ui/components/radio-group';
 import { SkeletonText } from 'components/redpanda-ui/components/skeleton';
+import { ToggleGroup, ToggleGroupItem } from 'components/redpanda-ui/components/toggle-group';
 import { Tooltip, TooltipContent, TooltipTrigger } from 'components/redpanda-ui/components/tooltip';
 import { motion } from 'motion/react';
 import React, { Component, type CSSProperties, type JSX, useEffect, useState } from 'react';
@@ -313,21 +312,22 @@ export class OptionGroup<T extends string> extends Component<{
 
     return (
       <Label text={p.label}>
-        <RadioGroup
-          name={p.label}
-          onValueChange={(val) => {
-            p.onChange(val as T);
+        <ToggleGroup
+          aria-label={p.label}
+          onValueChange={([next]) => {
+            // Single-select: ignore the deselect that toggling the active segment reports.
+            if (next !== undefined && next !== p.value) {
+              p.onChange(next as T);
+            }
           }}
-          orientation="horizontal"
-          value={p.value}
+          value={[p.value]}
         >
           {ObjToKv(p.options).map((kv) => (
-            <RegistryLabel className="cursor-pointer" key={kv.key}>
-              <RadioGroupItem value={String(kv.value)} />
+            <ToggleGroupItem key={kv.key} value={String(kv.value)}>
               {kv.key}
-            </RegistryLabel>
+            </ToggleGroupItem>
           ))}
-        </RadioGroup>
+        </ToggleGroup>
       </Label>
     );
   }

--- a/frontend/src/utils/tsx-utils.tsx
+++ b/frontend/src/utils/tsx-utils.tsx
@@ -9,8 +9,11 @@
  * by the Apache License, Version 2.0
  */
 
-import { type PlacementWithLogical, RadioGroup, Skeleton, Tooltip } from '@redpanda-data/ui';
 import { CopyIcon, DownloadIcon, InfoIcon } from 'components/icons';
+import { Label as RegistryLabel } from 'components/redpanda-ui/components/label';
+import { RadioGroup, RadioGroupItem } from 'components/redpanda-ui/components/radio-group';
+import { SkeletonText } from 'components/redpanda-ui/components/skeleton';
+import { Tooltip, TooltipContent, TooltipTrigger } from 'components/redpanda-ui/components/tooltip';
 import { motion } from 'motion/react';
 import React, { Component, type CSSProperties, type JSX, useEffect, useState } from 'react';
 
@@ -244,7 +247,7 @@ export const InfoText = (p: {
 
   maxWidth?: string;
   align?: 'center' | 'left';
-  placement?: PlacementWithLogical;
+  placement?: 'top' | 'bottom' | 'left' | 'right';
 
   gap?: string;
   transform?: string;
@@ -256,7 +259,6 @@ export const InfoText = (p: {
   const gap = p.gap ?? '4px';
 
   const gray = 'var(--color-subtle)';
-  // const blue = 'hsl(209deg, 100%, 55%)';
   const color = p.iconColor ?? gray;
   const placement = p.placement ?? 'top';
 
@@ -276,23 +278,24 @@ export const InfoText = (p: {
     </span>
   );
 
+  const tooltip = (
+    <Tooltip>
+      <TooltipTrigger render={<span style={{ display: 'inline-flex', alignItems: 'center' }} />}>
+        {p.tooltipOverText === true ? p.children : null}
+        {icon}
+      </TooltipTrigger>
+      <TooltipContent side={placement}>{overlay}</TooltipContent>
+    </Tooltip>
+  );
+
   if (p.tooltipOverText === true) {
-    return (
-      <Tooltip hasArrow label={overlay} placement={placement}>
-        <span style={{ display: 'inline-flex', alignItems: 'center' }}>
-          {p.children}
-          {icon}
-        </span>
-      </Tooltip>
-    );
+    return tooltip;
   }
 
   return (
     <span style={{ display: 'inline-flex', alignItems: 'center' }}>
       {p.children}
-      <Tooltip hasArrow label={overlay} placement={placement}>
-        {icon}
-      </Tooltip>
+      {tooltip}
     </span>
   );
 };
@@ -312,15 +315,19 @@ export class OptionGroup<T extends string> extends Component<{
       <Label text={p.label}>
         <RadioGroup
           name={p.label}
-          onChange={(val) => {
-            p.onChange(val);
+          onValueChange={(val) => {
+            p.onChange(val as T);
           }}
-          options={ObjToKv(p.options).map((kv) => ({
-            value: String(kv.value),
-            label: kv.key,
-          }))}
+          orientation="horizontal"
           value={p.value}
-        />
+        >
+          {ObjToKv(p.options).map((kv) => (
+            <RegistryLabel className="cursor-pointer" key={kv.key}>
+              <RadioGroupItem value={String(kv.value)} />
+              {kv.key}
+            </RegistryLabel>
+          ))}
+        </RadioGroup>
       </Label>
     );
   }
@@ -494,10 +501,9 @@ export class ZeroSizeWrapper extends Component<{
 }
 
 const defaultSkeletonStyle = { margin: '2rem' };
-const innerSkeleton = <Skeleton height={4} noOfLines={8} />;
 export const DefaultSkeleton = (
   <motion.div {...animProps} key={'defaultSkeleton'} style={defaultSkeletonStyle}>
-    {innerSkeleton}
+    <SkeletonText lines={8} width="full" />
   </motion.div>
 );
 

--- a/frontend/tests/mocks/redpanda-ui.ts
+++ b/frontend/tests/mocks/redpanda-ui.ts
@@ -3,25 +3,5 @@
 
 export const redpandaTheme = {};
 
-// Lightweight component stubs. Unit tests never render JSX, but modules
-// imported by the unit-test graph (e.g. src/utils/tsx-utils.tsx) evaluate
-// React.createElement at import time for const expressions like
-// `const innerSkeleton = <Skeleton ... />`. Without these stubs, React
-// emits "type is invalid -- expected a string ... but got: undefined"
-// warnings. Return a minimal function component (null output) so the
-// createElement call is valid.
-const stubComponent = () => null;
-
-export const Box = stubComponent;
-export const Flex = stubComponent;
-export const Progress = stubComponent;
-export const RadioGroup = stubComponent;
-export const Button = stubComponent;
-export const Skeleton = stubComponent;
-export const Text = stubComponent;
-export const Tooltip = stubComponent;
-
 // Type exports don't need runtime values
-export type SortingState = Array<{ id: string; desc: boolean }>;
-export type PlacementWithLogical = string;
 export type ButtonProps = Record<string, unknown>;


### PR DESCRIPTION
## Chakra exit · Phase 1 (wrappers) · PR 3 of 14

Part of the [Chakra exit plan and live tracker](https://claude.ai/code/artifact/1861e21c-624b-4270-98ad-9921b22c2498). Phase 1 re-implements the shared wrappers behind their existing exports, so page code does not change. Branch `chakra-exit/03-display-primitives`, stacked on #2627; each PR on the ladder shows only its own diff and re-targets `master` as its base merges.

Five shared wrappers keep their exports and get Registry internals, so their importers do not change. `utils/tsx-utils.tsx` no longer imports `@redpanda-data/ui` at all. The one type seam in `state/ui.ts` moves to TanStack v9, and the `state/ui.ts → pages/connect/overview` import is gone.

### Wrappers (same export, new internals)
| Module | Was | Now | Importers touched |
|---|---|---|---|
| `tsx-utils` `DefaultSkeleton` | Chakra `Skeleton height={4} noOfLines={8}` | Registry `SkeletonText lines={8} width="full"`, same `motion.div` + 2 rem margin | 0 (27 importers) |
| `tsx-utils` `InfoText` | Chakra `Tooltip hasArrow label placement` | Registry `Tooltip` / `TooltipTrigger render` / `TooltipContent side`; `placement` narrows to `top\|bottom\|left\|right` (no caller passed one) | 0 |
| `tsx-utils` `OptionGroup` | Chakra `RadioGroup options=` (an attached `RadioCard` segment group) | Registry `ToggleGroup` single-select, segmented like the original | 0 |
| `misc/section` `Section` | Chakra `Section` (block `<section>`, white, border, `rounded-lg`, shadow, `p-6`) forwarding all `ChakraProps` | Registry `Card size="full" variant="elevated"` with `gap-0 px-6`; props are now `id`, `className`, `style` | **7 files, 17 call sites** — every `py=`, `my=`, `minWidth=`, `gridArea=`, `overflowY=`, `borderColor=` became a class or an inline `gridArea`; `flexDirection="column"` on a block Box was a no-op and is dropped |
| `misc/tabs` `Tabs` | Chakra `Tabs items=` (index-based) | Registry `Tabs` / `TabsList variant="underline"` / `TabsTrigger` / `TabsContent`, value-based; `isFitted` → `layout="full"`; inactive panels stay unmounted as before | 0 (5 importers); its 6 tests pass unchanged |
| `misc/statistic` `Statistic` | Chakra `Stat` + `StatNumber`/`StatLabel`, `SpaceProps` passthrough | Registry `Stat size="lg" label value`; props are `title`, `value`, `className`. No caller used `hint` or a space prop | 0 (4 importers, 24 sites) |
| `misc/small-stat` `SmallStat` | Chakra `Flex` + `Text` | a flex `div` + `span`; nothing here is a Stat | 0 |
| `.codeBox` (what `tsx-utils` `Code` and nine raw call sites render) | hardcoded light grey background, no text colour — unreadable in the dark theme | `--color-surface-subtle` / `--color-border` tokens, so it reads in both themes | 0 |

### Type seams
- `state/ui.ts`: `SortingState` now comes from `@tanstack/react-table` (v9). The shape is identical to the v8 one Chakra re-exported (`{ id: string; desc: boolean }[]`), and it was the last file importing it from `@redpanda-data/ui`.
- `ConnectTabKeys` is defined in `state/ui.ts` and no longer imported from a page component. `TopicTabId` still comes from `topics/topic-details` as an `import type` — erased at build, and that file belongs to the #2588 stream, so it moves when that lands.
- `utils/legacy-data-table.ts` is deliberately untouched: it derives column/row types from the legacy `DataTable` *because* the app's v9 `ColumnDef` is the wrong shape for that component. It deletes with the last legacy table (its own comment says so).

### What a reviewer should look at
The two hunks with judgement in them are `misc/section.tsx` (a `<section>` became a `Card` kept in block flow with a grid-area-only `style`) and `misc/tabs/tabs.tsx` (uncontrolled Registry Tabs seeded from `selectedTabKey`, which the old wrapper also read only once). Visually: `Statistic` now renders the Registry `Stat`, so the stat strips on Overview, Broker details, Kafka Connect cards and Reassign partitions switch from value-above-label to label-above-value — the same `Stat` the consumer-group page already uses. The old `status-bar` colour class on Overview's cluster-status stat is passed through, but its CSS was scoped under a dead `.ant-statistic` selector and has not painted for some time.

### Effect
Files importing `@redpanda-data/ui`: **95 → 89**.

### Gates
`bun run type:check` · `bun run lint` (no dirty tree; every remaining lint finding on touched files is pre-existing on master) · unit suite · integration suite (121 files / 1270 tests), including `misc/tabs/tabs.test.tsx`.

### Review pass (2026-09-03)
- **`Section` keeps block flow.** Card is a flex column, which stretched the "Create …" buttons in the security tabs to full width and stopped margins collapsing; `block` restores the old layout. Its `style` prop is typed to `gridArea` only, and Overview's `<hr>` keeps the margins the Chakra Section used to inject. The Card is a `div`, not a `<section>` — the registry Card has no `render` prop; nothing selects on the element.
- **`Tabs` is uncontrolled** (`defaultValue`), forwards `onValueChange`, and passes `activateOnFocus` so arrow keys still select a tab as Chakra's did. Function-valued content is rendered through a child component, so it runs only for the active panel. Panels keep Chakra's 1rem padding.
- **`Statistic` is a plain `Stat`**; spacing moved to the rows that lay stats out (`Flex gap={8}` / `flex gap-8`) instead of a margin baked into each stat.
- **`OptionGroup`** nests each radio in the registry `Label` (implicit association), replacing hand-built ids that could collide.
- `InfoText` builds one tooltip tree; `LogsTab` loses a `variant` no caller passed; the unit stub drops two dead type exports.

### Review pass 2 (2026-09-04, pre-merge)
Parity checks against the Chakra versions, applied where the old behaviour was silently lost:
- **`OptionGroup` is a segmented control again** (registry `ToggleGroup`), which is what Chakra's attached `RadioCard` group looked like on Broker details and the message preview settings; the radio-circle rendering was an undisclosed change.
- **`Statistic` renders `Stat size="lg"`**, so headline numbers keep their size and weight instead of dropping to body text.
- **`Tabs` forwards `onChange` only for user activation.** Base UI also reports its own initial or fallback selection, which the Chakra wrapper never surfaced.
- `.codeBox` paints with `surface-recess` and `border-subtle`, the tokens the theme documents for a code block; its dead `.noPadding` tint is gone. Overview drops a `gridArea` whose parent was a flex column.

Looked at and left alone: the legacy `Tabs`/`InfoText` prop surface (unused props are harmless on wrappers slated for removal), `ui.ts`'s dead `connectorsDetails`/`pipelinesDetails` settings (pre-existing, not Chakra), Overview's inert `status-bar` colour class (a `tone` on the cluster-status stat would be a feature for the Overview PR), and `tsx-utils` pulling `ToggleGroup` into the startup chunk (about 3 KB gzipped; splitting `OptionGroup` out is a follow-up).

Plan (internal): https://claude.ai/code/artifact/1861e21c-624b-4270-98ad-9921b22c2498

🤖 Generated with [Claude Code](https://claude.com/claude-code)





