### PR TITLE
fix(frontend): allow DROP, CREATE, and GRANT in SQL editor

### DIFF
--- a/frontend/src/components/pages/sql/sql-workspace.tsx
+++ b/frontend/src/components/pages/sql/sql-workspace.tsx
@@ -280,18 +280,11 @@ export function SqlWorkspace({ sqlRole: sqlRoleProp }: SqlWorkspaceProps) {
       if (blocked) {
         let title = 'Statement not allowed';
         let message = `Only read queries are supported in this release. Found "${kw || 'empty statement'}".`;
-        let hint: string | undefined;
-        let hintAction = false;
-        if (kw === 'CREATE') {
-          title = 'Use the wizard to create tables';
-          message = "CREATE TABLE isn't run from the editor in this release.";
-          hint = 'Creating a table from a topic?';
-          hintAction = true;
-        } else if (kw === 'GRANT' || kw === 'REVOKE') {
+        if (kw === 'REVOKE') {
           title = 'Manage access in Security';
           message = 'Grants are managed in Security in this release.';
         }
-        setRun({ state: 'error', token, title, message, hint, hintAction });
+        setRun({ state: 'error', token, title, message });
         return;
       }
 

--- a/frontend/src/components/pages/sql/sql.test.tsx
+++ b/frontend/src/components/pages/sql/sql.test.tsx
@@ -59,12 +59,13 @@ describe('sql helpers', () => {
     expect(isWriteKeyword('EXPLAIN SELECT 1')).toBe(false);
     expect(isWriteKeyword('(SELECT 1)')).toBe(false);
     expect(isWriteKeyword('SHOW TABLES')).toBe(false);
-    // Writes / DDL / DCL — blocked.
+    // No longer blocked in the editor.
+    expect(isWriteKeyword('CREATE TABLE t (a int)')).toBe(false);
+    expect(isWriteKeyword('DROP TABLE t')).toBe(false);
+    expect(isWriteKeyword('GRANT ALL ON t TO u')).toBe(false);
+    // Writes / DDL / DCL — still blocked.
     expect(isWriteKeyword('INSERT INTO t VALUES (1)')).toBe(true);
     expect(isWriteKeyword('DELETE FROM t')).toBe(true);
-    expect(isWriteKeyword('CREATE TABLE t (a int)')).toBe(true);
-    expect(isWriteKeyword('DROP TABLE t')).toBe(true);
-    expect(isWriteKeyword('GRANT ALL ON t TO u')).toBe(true);
   });
 
   test('bridgeTopicForQuery resolves a single Redpanda SQL table to its backing topic', () => {

--- a/frontend/src/components/pages/sql/sql.tsx
+++ b/frontend/src/components/pages/sql/sql.tsx
@@ -38,13 +38,10 @@ const WRITE_KEYWORDS = new Set([
   'MERGE',
   'UPSERT',
   'REPLACE',
-  'CREATE',
-  'DROP',
   'ALTER',
   'TRUNCATE',
   'RENAME',
   'COMMENT',
-  'GRANT',
   'REVOKE',
 ]);
 


### PR DESCRIPTION
DROP, CREATE, and GRANT are removed from the SQL editor's client-side write/DDL/DCL block list, so they now run like any other statement instead of being rejected before reaching the server. The workspace's CREATE- and GRANT-specific error messaging (wizard hint, "manage in Security") is dropped along with them; REVOKE keeps its dedicated message.

Refs UX-1486