### PR TITLE
fix(frontend): disable route-level HMR when the dev server is proxied

### DIFF
--- a/frontend/src/tanstack-router-config.test.ts
+++ b/frontend/src/tanstack-router-config.test.ts
@@ -9,7 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
-import { describe, expect, it } from '@rstest/core';
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
 
 import { TANSTACK_CHUNK_PATTERN, tanstackRouterConfig } from '../tanstack-router.config';
 
@@ -31,5 +31,26 @@ describe('tanstackRouterConfig', () => {
     expect(TANSTACK_CHUNK_PATTERN.test('/app/node_modules/@tanstack/react-router/dist/index.js')).toBe(true);
     expect(TANSTACK_CHUNK_PATTERN.test(String.raw`C:\app\node_modules\@tanstack\react-query\dist\index.js`)).toBe(true);
     expect(TANSTACK_CHUNK_PATTERN.test('/app/node_modules/@redpanda-data/ui/dist/index.js')).toBe(false);
+  });
+});
+
+describe('route-level HMR', () => {
+  const loadConfig = async () => (await import('../tanstack-router.config')).tanstackRouterConfig;
+
+  afterEach(() => {
+    rs.unstubAllEnvs();
+    rs.resetModules();
+  });
+
+  it('stays on for the standalone dev server', async () => {
+    rs.stubEnv('PROXY_TARGET', undefined);
+    rs.resetModules();
+    expect((await loadConfig()).codeSplittingOptions.addHmr).toBe(true);
+  });
+
+  it('turns off when the dev server proxies to a host', async () => {
+    rs.stubEnv('PROXY_TARGET', 'http://localhost:4200');
+    rs.resetModules();
+    expect((await loadConfig()).codeSplittingOptions.addHmr).toBe(false);
   });
 });

--- a/frontend/tanstack-router.config.ts
+++ b/frontend/tanstack-router.config.ts
@@ -16,6 +16,10 @@ export const TANSTACK_CHUNK_PATTERN = /[\\/]node_modules[\\/]@tanstack[\\/]/;
 export const tanstackRouterConfig = {
   target: 'react',
   autoCodeSplitting: true,
+  // Route-level HMR finds its router through window.__TSR_ROUTER__; embedded in
+  // cloud-ui's dev server that is the host's router and Console fails to load.
+  // Component edits still hot-swap through Fast Refresh with this off.
+  codeSplittingOptions: { addHmr: !process.env.PROXY_TARGET },
   routesDirectory: './src/routes',
   generatedRouteTree: './src/routeTree.gen.ts',
   routeFileIgnorePrefix: '-',


### PR DESCRIPTION
## Problem

Console fails to load when embedded in cloud-ui's dev server through the `console-hmr` router.

`@tanstack/router-plugin` injects a route-level HMR shim into every route module in dev (`codeSplittingOptions.addHmr` defaults to `true`). That shim finds "its" router through the window global `__TSR_ROUTER__`. When Console runs inside cloud-ui's page, that global is the **host's** router. On first evaluation the shim sees a colliding `__root__`, rewrites the host route, and calls `_replaceRouteChunk` on a router-core instance that may not have it, so Console never mounts.

## Fix

Turn `addHmr` off whenever `PROXY_TARGET` is set. That env var is already the "embedded / proxied" signal: `frontend/start-cloud.sh` exports it for `start:cloud`, and cloudv2's `tools/localdev/console-hmr/main.go` sets it on the child rsbuild dev server it spawns.

The standalone dev server (no `PROXY_TARGET`) keeps route-level HMR exactly as before.

**Trade-off in the embedded case:** component edits still hot-swap through React Fast Refresh. Only edits to route *options* (loaders, `validateSearch`, etc.) need a page reload, which is what the shim was providing.

## Tests

`src/tanstack-router-config.test.ts` gains two cases that stub `PROXY_TARGET`, reset the module registry, and re-import the config: HMR stays on when the var is unset, and turns off when it is set. Verified with the var both unset and set in the shell so the "stays on" case is proven to re-evaluate rather than reuse the static import.

## Verification

- `rstest` unit: 4/4 pass in `src/tanstack-router-config.test.ts`
- `ultracite check` on both files: clean
- `bun run type:check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
