### PR TITLE
[Chakra exit · Phase 2 · PR 5/14] frontend: transforms pages on Registry components

### DIFF
--- a/frontend/src/components/misc/search-input.test.tsx
+++ b/frontend/src/components/misc/search-input.test.tsx
@@ -1,0 +1,59 @@
+import { expect, test } from '@rstest/core';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+
+import { SearchInput } from './search-input';
+
+function Example({ slashToFocus }: { slashToFocus?: boolean }) {
+  const [query, setQuery] = useState('');
+  return (
+    <>
+      <input aria-label="Other field" />
+      <SearchInput onChange={setQuery} slashToFocus={slashToFocus} value={query} />
+      <output>{query}</output>
+    </>
+  );
+}
+
+test('slash focuses the field; Escape clears it, then blurs', async () => {
+  const user = userEvent.setup();
+  render(<Example />);
+  const search = screen.getByTestId('search-field-input');
+  await user.keyboard('/');
+  expect(search).toHaveFocus();
+  await user.type(search, 'alpha');
+  expect(screen.getByRole('status')).toHaveTextContent('alpha');
+  await user.keyboard('{Escape}');
+  expect(search).toHaveValue('');
+  expect(search).toHaveFocus();
+  await user.keyboard('{Escape}');
+  expect(search).not.toHaveFocus();
+});
+
+test('slash typed into another field is left alone', async () => {
+  const user = userEvent.setup();
+  render(<Example />);
+  const other = screen.getByLabelText('Other field');
+  await user.click(other);
+  await user.keyboard('/');
+  expect(other).toHaveValue('/');
+  expect(screen.getByTestId('search-field-input')).not.toHaveFocus();
+});
+
+test('clearing with the button keeps focus in the field', async () => {
+  const user = userEvent.setup();
+  render(<Example />);
+  const search = screen.getByTestId('search-field-input');
+  await user.type(search, 'beta');
+  await user.click(screen.getByTestId('search-field-reset-icon'));
+  expect(search).toHaveValue('');
+  expect(search).toHaveFocus();
+});
+
+test('the clear button is hidden and unfocusable while empty', () => {
+  render(<Example slashToFocus={false} />);
+  const clear = screen.getByTestId('search-field-reset-icon');
+  expect(clear).toBeDisabled();
+  expect(clear).toHaveClass('invisible');
+});

--- a/frontend/src/components/misc/search-input.tsx
+++ b/frontend/src/components/misc/search-input.tsx
@@ -88,6 +88,7 @@ export function SearchInput({
 
   return (
     <Input
+      aria-keyshortcuts="/"
       aria-label={ariaLabel}
       className={className}
       containerClassName={containerClassName}
@@ -123,6 +124,7 @@ export function SearchInput({
           disabled={isEmpty}
           onClick={clear}
           size="icon-xs"
+          title="Clear (Esc)"
           variant="ghost"
         >
           <CloseIcon />

--- a/frontend/src/components/misc/search-input.tsx
+++ b/frontend/src/components/misc/search-input.tsx
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { CloseIcon } from 'components/icons';
+import { Button } from 'components/redpanda-ui/components/button';
+import { Input, InputEnd, InputStart } from 'components/redpanda-ui/components/input';
+import { cn } from 'components/redpanda-ui/lib/utils';
+import { SearchIcon } from 'lucide-react';
+import { type ReactNode, useEffect, useRef } from 'react';
+
+type SearchInputProps = {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  /** Leading icon; a magnifier unless given. */
+  icon?: ReactNode;
+  /** `/` anywhere on the page focuses the field. */
+  slashToFocus?: boolean;
+  className?: string;
+  containerClassName?: string;
+  testId?: string;
+  'aria-label'?: string;
+};
+
+// Where `/` is a character the user is typing, not a shortcut.
+const TYPING_TARGET = 'input, textarea, select, [contenteditable], [role="textbox"], [role="combobox"]';
+const DIALOG = '[role="dialog"], [role="alertdialog"]';
+
+/** Search field: leading icon, clear button, `/` to focus, Escape to clear (or blur when empty). */
+export function SearchInput({
+  value,
+  onChange,
+  placeholder = 'Search...',
+  icon,
+  slashToFocus = true,
+  className,
+  containerClassName,
+  testId = 'search-field-input',
+  'aria-label': ariaLabel,
+}: SearchInputProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const isEmpty = value === '';
+
+  useEffect(() => {
+    if (!slashToFocus) {
+      return;
+    }
+    const focusOnSlash = (event: KeyboardEvent) => {
+      if (
+        event.key !== '/' ||
+        event.defaultPrevented ||
+        event.isComposing ||
+        event.ctrlKey ||
+        event.metaKey ||
+        event.altKey
+      ) {
+        return;
+      }
+      const target = event.target instanceof HTMLElement ? event.target : null;
+      if (target?.isContentEditable || target?.closest(TYPING_TARGET)) {
+        return;
+      }
+      // Focus inside an open dialog stays there unless the field is in the same dialog.
+      const dialog = target?.closest(DIALOG);
+      if (dialog && !dialog.contains(inputRef.current)) {
+        return;
+      }
+      event.preventDefault();
+      inputRef.current?.focus();
+    };
+    document.addEventListener('keydown', focusOnSlash);
+    return () => document.removeEventListener('keydown', focusOnSlash);
+  }, [slashToFocus]);
+
+  // Refocus before the re-render disables the button, or focus lands on <body>.
+  const clear = () => {
+    onChange('');
+    inputRef.current?.focus();
+  };
+
+  return (
+    <Input
+      aria-label={ariaLabel}
+      className={className}
+      containerClassName={containerClassName}
+      onChange={(event) => onChange(event.target.value)}
+      onKeyDown={(event) => {
+        if (event.key !== 'Escape' || event.nativeEvent.isComposing) {
+          return;
+        }
+        if (isEmpty) {
+          event.currentTarget.blur();
+          return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        onChange('');
+      }}
+      placeholder={placeholder}
+      ref={inputRef}
+      testId={testId}
+      value={value}
+    >
+      <InputStart>
+        <span className="flex text-muted-foreground" data-testid="search-field-search-icon">
+          {icon ?? <SearchIcon className="size-4" />}
+        </span>
+      </InputStart>
+      {/* Always mounted: InputEnd never resets the padding it measured. Click-through while empty. */}
+      <InputEnd className={cn(!isEmpty && 'pointer-events-auto')}>
+        <Button
+          aria-label="Clear search"
+          className={cn(isEmpty && 'invisible')}
+          data-testid="search-field-reset-icon"
+          disabled={isEmpty}
+          onClick={clear}
+          size="icon-xs"
+          variant="ghost"
+        >
+          <CloseIcon />
+        </Button>
+      </InputEnd>
+    </Input>
+  );
+}

--- a/frontend/src/components/pages/transforms/modals.tsx
+++ b/frontend/src/components/pages/transforms/modals.tsx
@@ -1,15 +1,13 @@
+import { Button } from 'components/redpanda-ui/components/button';
 import {
-  Box,
-  Button,
-  Input,
-  Modal,
-  ModalBody,
-  ModalCloseButton,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalOverlay,
-} from '@redpanda-data/ui';
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from 'components/redpanda-ui/components/dialog';
+import { Input } from 'components/redpanda-ui/components/input';
 import { type JSX, useState } from 'react';
 
 import { openModal } from '../../../utils/modal-container';
@@ -33,35 +31,37 @@ const ExplicitConfirmModal = (p: {
   const isConfirmEnabled = confirmBoxText === requiredText;
 
   return (
-    <Modal isCentered isOpen onClose={p.closeModal} size="2xl">
-      <ModalOverlay />
-      <ModalContent>
-        <ModalHeader mr="4">{p.title}</ModalHeader>
-        <ModalCloseButton />
-        <ModalBody>
+    <Dialog
+      onOpenChange={(open) => {
+        if (!open) {
+          p.closeModal();
+        }
+      }}
+      open
+    >
+      <DialogContent size="lg">
+        <DialogHeader>
+          <DialogTitle>{p.title}</DialogTitle>
+        </DialogHeader>
+        <DialogBody>
           {p.body}
 
-          <Box mt="4">
+          <div className="mt-4">
             To confirm, enter "{requiredText}":
-            <Input onChange={(e) => setConfirmBoxText(e.target.value)} />
-          </Box>
-        </ModalBody>
+            <Input onChange={(e) => setConfirmBoxText(e.target.value)} value={confirmBoxText} />
+          </div>
+        </DialogBody>
 
-        <ModalFooter>
+        <DialogFooter>
           <Button onClick={() => p.onSecondaryButton(p.closeModal)} variant="ghost">
             {p.secondaryButtonContent}
           </Button>
-          <Button
-            colorScheme="red"
-            isDisabled={!isConfirmEnabled}
-            ml={3}
-            onClick={() => p.onPrimaryButton(p.closeModal)}
-          >
+          <Button disabled={!isConfirmEnabled} onClick={() => p.onPrimaryButton(p.closeModal)} variant="destructive">
             {p.primaryButtonContent}
           </Button>
-        </ModalFooter>
-      </ModalContent>
-    </Modal>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/frontend/src/components/pages/transforms/modals.tsx
+++ b/frontend/src/components/pages/transforms/modals.tsx
@@ -40,7 +40,8 @@ const ExplicitConfirmModal = (p: {
       open
     >
       <DialogContent size="lg">
-        <DialogHeader>
+        {/* Room for DialogContent's absolute close button. */}
+        <DialogHeader className="pr-10">
           <DialogTitle>{p.title}</DialogTitle>
         </DialogHeader>
         <DialogBody>

--- a/frontend/src/components/pages/transforms/transform-details.test.tsx
+++ b/frontend/src/components/pages/transforms/transform-details.test.tsx
@@ -1,6 +1,6 @@
 import { create } from '@bufbuild/protobuf';
 import { afterEach, expect, rs, test } from '@rstest/core';
-import { render, screen, within } from '@testing-library/react';
+import { act, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import TransformDetails from './transform-details';
@@ -14,7 +14,10 @@ import { useTransformsStore } from '../../../state/backend-api';
 const initialState = useTransformsStore.getState();
 const initialRefresh = appGlobal.onRefresh;
 afterEach(() => {
-  useTransformsStore.setState(initialState, true);
+  // The page is still mounted and subscribed when this runs.
+  act(() => {
+    useTransformsStore.setState(initialState, true);
+  });
   appGlobal.onRefresh = initialRefresh;
 });
 

--- a/frontend/src/components/pages/transforms/transform-details.test.tsx
+++ b/frontend/src/components/pages/transforms/transform-details.test.tsx
@@ -1,0 +1,48 @@
+import { create } from '@bufbuild/protobuf';
+import { afterEach, expect, rs, test } from '@rstest/core';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import TransformDetails from './transform-details';
+import {
+  PartitionTransformStatus_PartitionStatus,
+  TransformMetadataSchema,
+} from '../../../protogen/redpanda/api/dataplane/v1/transform_pb';
+import { appGlobal } from '../../../state/app-global';
+import { useTransformsStore } from '../../../state/backend-api';
+
+const initialState = useTransformsStore.getState();
+const initialRefresh = appGlobal.onRefresh;
+afterEach(() => {
+  useTransformsStore.setState(initialState, true);
+  appGlobal.onRefresh = initialRefresh;
+});
+
+test('sorts transform partitions by lag in both directions', async () => {
+  const user = userEvent.setup();
+  const transform = create(TransformMetadataSchema, {
+    name: 'example',
+    inputTopicName: 'input',
+    outputTopicNames: ['output'],
+    statuses: [
+      { partitionId: 1, brokerId: 1, lag: 100, status: PartitionTransformStatus_PartitionStatus.RUNNING },
+      { partitionId: 2, brokerId: 2, lag: 10, status: PartitionTransformStatus_PartitionStatus.RUNNING },
+    ],
+  });
+  useTransformsStore.setState({
+    refreshTransforms: rs.fn(),
+    transforms: [transform],
+    transformDetails: new Map([['example', transform]]),
+  });
+  render(<TransformDetails matchedPath="/transforms/example" transformName="example" />);
+  const table = screen.getByRole('columnheader', { name: 'Lag' }).closest('table');
+  if (!table) {
+    throw new Error('Missing partition table');
+  }
+  await user.click(screen.getByRole('button', { name: 'Lag' }));
+  await user.click(screen.getByRole('menuitem', { name: 'Asc' }));
+  expect(within(within(table).getAllByRole('row')[1]).getAllByRole('cell')[0]).toHaveTextContent('2');
+  await user.click(screen.getByRole('button', { name: 'Lag' }));
+  await user.click(screen.getByRole('menuitem', { name: 'Desc' }));
+  expect(within(within(table).getAllByRole('row')[1]).getAllByRole('cell')[0]).toHaveTextContent('1');
+});

--- a/frontend/src/components/pages/transforms/transform-details.tsx
+++ b/frontend/src/components/pages/transforms/transform-details.tsx
@@ -9,11 +9,16 @@
  * by the Apache License, Version 2.0
  */
 
+import { ChevronDownIcon, ChevronRightIcon, CloseIcon } from 'components/icons';
 import { Button } from 'components/redpanda-ui/components/button';
-import { DataTable, type DataTableColumnDef } from 'components/redpanda-ui/components/data-table';
+import {
+  DataTable,
+  type DataTableColumnDef,
+  DataTableColumnHeader,
+} from 'components/redpanda-ui/components/data-table';
 import { Input, InputEnd, InputStart } from 'components/redpanda-ui/components/input';
-import { ChevronDown, ChevronRight, SearchIcon, XIcon } from 'lucide-react';
-import { Fragment, useEffect, useRef, useState } from 'react';
+import { SearchIcon } from 'lucide-react';
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import { showToast } from 'utils/toast.utils';
 
 import { openDeleteModal } from './modals';
@@ -254,47 +259,58 @@ const LogsTab = (p: { transform: TransformMetadata }) => {
   };
 
   const paginationParams = usePaginationParams(messages.length, 10);
-  const messageTableColumns: DataTableColumnDef<TopicMessage>[] = [
-    // Chakra's DataTable injected this column whenever `subComponent` was set; the Registry one does not.
-    {
-      id: 'expander',
-      size: 40,
-      enableSorting: false,
-      cell: ({ row }) =>
-        row.getCanExpand() ? (
-          <Button
-            aria-label={row.getIsExpanded() ? 'Collapse row' : 'Expand row'}
-            onClick={row.getToggleExpandedHandler()}
-            size="icon-xs"
-            variant="ghost"
-          >
-            {row.getIsExpanded() ? <ChevronDown className="size-4" /> : <ChevronRight className="size-4" />}
-          </Button>
-        ) : null,
-    },
-    {
-      header: 'Timestamp',
-      accessorKey: 'timestamp',
-      cell: ({
-        row: {
-          original: { timestamp },
-        },
-      }) => <TimestampDisplay format="default" unixEpochMillisecond={timestamp} />,
-      size: 30,
-    },
-    {
-      header: 'Value',
-      accessorKey: 'value',
-      cell: ({ row: { original } }) => (
-        <MessagePreview
-          isCompactTopic={topic ? topic.cleanupPolicy.includes('compact') : false}
-          msg={original}
-          previewFields={() => []}
-        />
-      ),
-      size: Number.MAX_SAFE_INTEGER,
-    },
-  ];
+  const logsTableOptions = useMemo(() => ({ initialState: { pagination: paginationParams } }), [paginationParams]);
+  const messageTableColumns: DataTableColumnDef<TopicMessage>[] = useMemo(
+    () => [
+      // Chakra's DataTable injected this column whenever `subComponent` was set; the Registry one does not.
+      // The Registry only sets aria-expanded on the row, and only for `expandRowByClick`, so it goes here.
+      {
+        id: 'expander',
+        enableHiding: false,
+        enableSorting: false,
+        cell: ({ row }) =>
+          row.getCanExpand() ? (
+            <Button
+              aria-expanded={row.getIsExpanded()}
+              aria-label={row.getIsExpanded() ? 'Collapse row' : 'Expand row'}
+              onClick={row.getToggleExpandedHandler()}
+              size="icon-xs"
+              variant="ghost"
+            >
+              {row.getIsExpanded() ? <ChevronDownIcon className="size-4" /> : <ChevronRightIcon className="size-4" />}
+            </Button>
+          ) : null,
+      },
+      {
+        id: 'timestamp',
+        enableHiding: false,
+        header: ({ column }) => <DataTableColumnHeader column={column} title="Timestamp" />,
+        accessorKey: 'timestamp',
+        cell: ({
+          row: {
+            original: { timestamp },
+          },
+        }) => <TimestampDisplay format="default" unixEpochMillisecond={timestamp} />,
+        size: 30,
+      },
+      {
+        header: 'Value',
+        // The cell renders a decoded preview; sorting the raw value was never meaningful.
+        enableSorting: false,
+        enableHiding: false,
+        accessorKey: 'value',
+        cell: ({ row: { original } }) => (
+          <MessagePreview
+            isCompactTopic={topic ? topic.cleanupPolicy.includes('compact') : false}
+            msg={original}
+            previewFields={() => []}
+          />
+        ),
+        size: Number.MAX_SAFE_INTEGER,
+      },
+    ],
+    [topic]
+  );
 
   const filteredMessages = messages.filter((x) => {
     if (!logsQuickSearch) {
@@ -319,19 +335,21 @@ const LogsTab = (p: { transform: TransformMetadata }) => {
             <InputStart>
               <SearchIcon className="size-4 text-muted-foreground" data-testid="search-field-search-icon" />
             </InputStart>
-            {logsQuickSearch !== '' && (
-              <InputEnd className="pointer-events-auto">
-                <Button
-                  aria-label="Clear search"
-                  data-testid="search-field-reset-icon"
-                  onClick={() => setLogsQuickSearch('')}
-                  size="icon-xs"
-                  variant="ghost"
-                >
-                  <XIcon />
-                </Button>
-              </InputEnd>
-            )}
+            {/* Always mounted: InputEnd never resets the padding it measured, and unmounting the
+                button under the click would drop focus to <body>. */}
+            <InputEnd className="pointer-events-auto">
+              <Button
+                aria-label="Clear search"
+                className={logsQuickSearch === '' ? 'invisible' : undefined}
+                data-testid="search-field-reset-icon"
+                disabled={logsQuickSearch === ''}
+                onClick={() => setLogsQuickSearch('')}
+                size="icon-xs"
+                variant="ghost"
+              >
+                <CloseIcon />
+              </Button>
+            </InputEnd>
           </Input>
           <Button className="ml-auto" onClick={() => setRefreshCount((c) => c + 1)} variant="outline">
             Refresh logs
@@ -343,6 +361,9 @@ const LogsTab = (p: { transform: TransformMetadata }) => {
           data={filteredMessages}
           emptyText="No messages"
           isLoading={!isComplete && messages.length === 0}
+          sorting
+          // todo: message rendering should be extracted from TopicMessagesTab into a standalone component, in its own folder,
+          //       to make it clear that it does not depend on other functinoality from TopicMessagesTab
           subComponent={({ row: { original } }) => (
             <ExpandedMessage
               loadLargeMessage={() =>
@@ -355,9 +376,7 @@ const LogsTab = (p: { transform: TransformMetadata }) => {
               msg={original}
             />
           )}
-          // todo: message rendering should be extracted from TopicMessagesTab into a standalone component, in its own folder,
-          //       to make it clear that it does not depend on other functinoality from TopicMessagesTab
-          tableOptions={{ initialState: { pagination: paginationParams } }}
+          tableOptions={logsTableOptions}
         />
       </Section>
     </>

--- a/frontend/src/components/pages/transforms/transform-details.tsx
+++ b/frontend/src/components/pages/transforms/transform-details.tsx
@@ -9,10 +9,11 @@
  * by the Apache License, Version 2.0
  */
 
-import { Box, Button, DataTable, Flex, SearchField } from '@redpanda-data/ui';
-import type { SortingState } from '@tanstack/react-table';
+import { Button } from 'components/redpanda-ui/components/button';
+import { DataTable, type DataTableColumnDef } from 'components/redpanda-ui/components/data-table';
+import { Input, InputEnd, InputStart } from 'components/redpanda-ui/components/input';
+import { SearchIcon, XIcon } from 'lucide-react';
 import { Fragment, useEffect, useRef, useState } from 'react';
-import type { LegacyColumnDef } from 'utils/legacy-data-table';
 import { showToast } from 'utils/toast.utils';
 
 import { openDeleteModal } from './modals';
@@ -79,10 +80,9 @@ class TransformDetails extends PageComponent<{ transformName: string }> {
 
     return (
       <PageContent>
-        <Box>
-          {/* <Heading as="h2">{transformName}</Heading> */}
+        <div>
           <Button
-            mt="2"
+            className="mt-2"
             onClick={() =>
               openDeleteModal(transformName, () => {
                 transformsApi
@@ -104,11 +104,11 @@ class TransformDetails extends PageComponent<{ transformName: string }> {
                   });
               })
             }
-            variant="outline-delete"
+            variant="destructive-outline"
           >
             Delete
           </Button>
-        </Box>
+        </div>
 
         <Tabs
           tabs={[
@@ -121,6 +121,17 @@ class TransformDetails extends PageComponent<{ transformName: string }> {
   }
 }
 export default TransformDetails;
+
+const partitionStatusColumns: DataTableColumnDef<PartitionTransformStatus>[] = [
+  { header: 'Partition', accessorKey: 'partitionId' },
+  { header: 'Node', accessorKey: 'brokerId' },
+  {
+    id: 'status',
+    header: 'Status',
+    cell: ({ row: { original: r } }) => <PartitionStatus status={r.status} />,
+  },
+  { header: 'Lag', accessorKey: 'lag' },
+];
 
 const OverviewTab = (p: { transform: TransformMetadata }) => {
   let overallStatus = <></>;
@@ -136,7 +147,7 @@ const OverviewTab = (p: { transform: TransformMetadata }) => {
 
   return (
     <>
-      <Box my="6">
+      <div className="my-6">
         {QuickTable(
           [
             { key: 'Status', value: overallStatus },
@@ -162,21 +173,15 @@ const OverviewTab = (p: { transform: TransformMetadata }) => {
             gapWidth: '4rem',
           }
         )}
-      </Box>
-      <Box maxWidth="35rem">
+      </div>
+      <div className="max-w-[35rem]">
         <DataTable<PartitionTransformStatus>
-          columns={[
-            { header: 'Partition', accessorKey: 'partitionId' },
-            { header: 'Node', accessorKey: 'brokerId' },
-            {
-              header: 'Status',
-              cell: ({ row: { original: r } }) => <PartitionStatus status={r.status} />,
-            },
-            { header: 'Lag', accessorKey: 'lag' },
-          ]}
+          columns={partitionStatusColumns}
           data={p.transform.statuses}
+          pagination={false}
+          sorting={false}
         />
-      </Box>
+      </div>
     </>
   );
 };
@@ -191,7 +196,6 @@ const LogsTab = (p: { transform: TransformMetadata }) => {
   });
   const { messages, isComplete } = logState;
   const [logsQuickSearch, setLogsQuickSearch] = useState('');
-  const [sorting, setSorting] = useState<SortingState>([]);
   const searchRef = useRef<MessageSearch | null>(null);
   const [refreshCount, setRefreshCount] = useState(0);
 
@@ -250,7 +254,7 @@ const LogsTab = (p: { transform: TransformMetadata }) => {
   };
 
   const paginationParams = usePaginationParams(messages.length, 10);
-  const messageTableColumns: LegacyColumnDef<TopicMessage>[] = [
+  const messageTableColumns: DataTableColumnDef<TopicMessage>[] = [
     {
       header: 'Timestamp',
       accessorKey: 'timestamp',
@@ -284,26 +288,44 @@ const LogsTab = (p: { transform: TransformMetadata }) => {
 
   return (
     <>
-      <Box my="1rem">The logs below are for the last five hours.</Box>
+      <div className="my-4">The logs below are for the last five hours.</div>
 
       <Section className="min-w-[800px]">
-        <Flex mb="6">
-          <SearchField searchText={logsQuickSearch} setSearchText={setLogsQuickSearch} width="230px" />
-          <Button ml="auto" onClick={() => setRefreshCount((c) => c + 1)} variant="outline">
+        <div className="mb-6 flex">
+          <Input
+            containerClassName="max-w-[230px]"
+            onChange={(e) => setLogsQuickSearch(e.target.value)}
+            placeholder="Search..."
+            testId="search-field-input"
+            value={logsQuickSearch}
+          >
+            <InputStart>
+              <SearchIcon className="size-4 text-muted-foreground" data-testid="search-field-search-icon" />
+            </InputStart>
+            {logsQuickSearch !== '' && (
+              <InputEnd className="pointer-events-auto">
+                <Button
+                  aria-label="Clear search"
+                  data-testid="search-field-reset-icon"
+                  onClick={() => setLogsQuickSearch('')}
+                  size="icon-xs"
+                  variant="ghost"
+                >
+                  <XIcon />
+                </Button>
+              </InputEnd>
+            )}
+          </Input>
+          <Button className="ml-auto" onClick={() => setRefreshCount((c) => c + 1)} variant="outline">
             Refresh logs
           </Button>
-        </Flex>
+        </div>
 
         <DataTable<TopicMessage>
           columns={messageTableColumns}
           data={filteredMessages}
           emptyText="No messages"
           isLoading={!isComplete && messages.length === 0}
-          onSortingChange={setSorting}
-          pagination={paginationParams}
-          sorting={sorting}
-          // todo: message rendering should be extracted from TopicMessagesTab into a standalone component, in its own folder,
-          //       to make it clear that it does not depend on other functinoality from TopicMessagesTab
           subComponent={({ row: { original } }) => (
             <ExpandedMessage
               loadLargeMessage={() =>
@@ -316,6 +338,9 @@ const LogsTab = (p: { transform: TransformMetadata }) => {
               msg={original}
             />
           )}
+          // todo: message rendering should be extracted from TopicMessagesTab into a standalone component, in its own folder,
+          //       to make it clear that it does not depend on other functinoality from TopicMessagesTab
+          tableOptions={{ initialState: { pagination: paginationParams } }}
         />
       </Section>
     </>

--- a/frontend/src/components/pages/transforms/transform-details.tsx
+++ b/frontend/src/components/pages/transforms/transform-details.tsx
@@ -12,7 +12,7 @@
 import { Button } from 'components/redpanda-ui/components/button';
 import { DataTable, type DataTableColumnDef } from 'components/redpanda-ui/components/data-table';
 import { Input, InputEnd, InputStart } from 'components/redpanda-ui/components/input';
-import { SearchIcon, XIcon } from 'lucide-react';
+import { ChevronDown, ChevronRight, SearchIcon, XIcon } from 'lucide-react';
 import { Fragment, useEffect, useRef, useState } from 'react';
 import { showToast } from 'utils/toast.utils';
 
@@ -255,6 +255,23 @@ const LogsTab = (p: { transform: TransformMetadata }) => {
 
   const paginationParams = usePaginationParams(messages.length, 10);
   const messageTableColumns: DataTableColumnDef<TopicMessage>[] = [
+    // Chakra's DataTable injected this column whenever `subComponent` was set; the Registry one does not.
+    {
+      id: 'expander',
+      size: 40,
+      enableSorting: false,
+      cell: ({ row }) =>
+        row.getCanExpand() ? (
+          <Button
+            aria-label={row.getIsExpanded() ? 'Collapse row' : 'Expand row'}
+            onClick={row.getToggleExpandedHandler()}
+            size="icon-xs"
+            variant="ghost"
+          >
+            {row.getIsExpanded() ? <ChevronDown className="size-4" /> : <ChevronRight className="size-4" />}
+          </Button>
+        ) : null,
+    },
     {
       header: 'Timestamp',
       accessorKey: 'timestamp',

--- a/frontend/src/components/pages/transforms/transform-details.tsx
+++ b/frontend/src/components/pages/transforms/transform-details.tsx
@@ -361,6 +361,8 @@ const LogsTab = (p: { transform: TransformMetadata }) => {
 
         <DataTable<TopicMessage>
           columns={messageTableColumns}
+          // No pager under the loading or empty row, as the legacy table.
+          pagination={filteredMessages.length > 0}
           data={filteredMessages}
           emptyText="No messages"
           isLoading={!isComplete && messages.length === 0}

--- a/frontend/src/components/pages/transforms/transform-details.tsx
+++ b/frontend/src/components/pages/transforms/transform-details.tsx
@@ -362,10 +362,10 @@ const LogsTab = (p: { transform: TransformMetadata }) => {
         <DataTable<TopicMessage>
           columns={messageTableColumns}
           // No pager under the loading or empty row, as the legacy table.
-          pagination={filteredMessages.length > 0}
           data={filteredMessages}
           emptyText="No messages"
           isLoading={!isComplete && messages.length === 0}
+          pagination={filteredMessages.length > 0}
           sorting
           // todo: message rendering should be extracted from TopicMessagesTab into a standalone component, in its own folder,
           //       to make it clear that it does not depend on other functinoality from TopicMessagesTab

--- a/frontend/src/components/pages/transforms/transform-details.tsx
+++ b/frontend/src/components/pages/transforms/transform-details.tsx
@@ -128,14 +128,26 @@ class TransformDetails extends PageComponent<{ transformName: string }> {
 export default TransformDetails;
 
 const partitionStatusColumns: DataTableColumnDef<PartitionTransformStatus>[] = [
-  { header: 'Partition', accessorKey: 'partitionId' },
-  { header: 'Node', accessorKey: 'brokerId' },
+  {
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Partition" />,
+    accessorKey: 'partitionId',
+    enableHiding: false,
+  },
+  {
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Node" />,
+    accessorKey: 'brokerId',
+    enableHiding: false,
+  },
   {
     id: 'status',
     header: 'Status',
     cell: ({ row: { original: r } }) => <PartitionStatus status={r.status} />,
   },
-  { header: 'Lag', accessorKey: 'lag' },
+  {
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Lag" />,
+    accessorKey: 'lag',
+    enableHiding: false,
+  },
 ];
 
 const OverviewTab = (p: { transform: TransformMetadata }) => {
@@ -184,7 +196,7 @@ const OverviewTab = (p: { transform: TransformMetadata }) => {
           columns={partitionStatusColumns}
           data={p.transform.statuses}
           pagination={false}
-          sorting={false}
+          sorting
         />
       </div>
     </>

--- a/frontend/src/components/pages/transforms/transform-details.tsx
+++ b/frontend/src/components/pages/transforms/transform-details.tsx
@@ -9,21 +9,18 @@
  * by the Apache License, Version 2.0
  */
 
-import { ChevronDownIcon, ChevronRightIcon, CloseIcon } from 'components/icons';
+import { ChevronDownIcon, ChevronRightIcon } from 'components/icons';
 import { Button } from 'components/redpanda-ui/components/button';
 import {
   DataTable,
   type DataTableColumnDef,
   DataTableColumnHeader,
 } from 'components/redpanda-ui/components/data-table';
-import { Input, InputEnd, InputStart } from 'components/redpanda-ui/components/input';
-import { SearchIcon } from 'lucide-react';
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import { showToast } from 'utils/toast.utils';
 
 import { openDeleteModal } from './modals';
 import { PartitionStatus } from './transforms-list';
-import usePaginationParams from '../../../hooks/use-pagination-params';
 import { PayloadEncoding } from '../../../protogen/redpanda/api/console/v1alpha1/common_pb';
 import {
   type PartitionTransformStatus,
@@ -43,7 +40,9 @@ import { PartitionOffsetOrigin } from '../../../state/ui';
 import { sanitizeString } from '../../../utils/filter-helper';
 import { DefaultSkeleton, QuickTable, TimestampDisplay } from '../../../utils/tsx-utils';
 import { decodeURIComponentPercents, encodeBase64 } from '../../../utils/utils';
+import { DEFAULT_TABLE_PAGE_SIZE } from '../../constants';
 import PageContent from '../../misc/page-content';
+import { SearchInput } from '../../misc/search-input';
 import Section from '../../misc/section';
 import Tabs from '../../misc/tabs/tabs';
 import { PageComponent, type PageInitHelper } from '../page';
@@ -127,6 +126,14 @@ class TransformDetails extends PageComponent<{ transformName: string }> {
 }
 export default TransformDetails;
 
+// Legacy table parity: 50 rows a page, pager only past that.
+const TABLE_OPTIONS = { initialState: { pagination: { pageIndex: 0, pageSize: DEFAULT_TABLE_PAGE_SIZE } } };
+// Stable identity keeps an expanded row on its message when the list is filtered or refreshed.
+const LOGS_TABLE_OPTIONS = {
+  initialState: { pagination: { pageIndex: 0, pageSize: 10 } },
+  getRowId: (message: TopicMessage) => `${message.partitionID}-${message.offset}`,
+};
+
 const partitionStatusColumns: DataTableColumnDef<PartitionTransformStatus>[] = [
   {
     header: ({ column }) => <DataTableColumnHeader column={column} title="Partition" />,
@@ -195,8 +202,9 @@ const OverviewTab = (p: { transform: TransformMetadata }) => {
         <DataTable<PartitionTransformStatus>
           columns={partitionStatusColumns}
           data={p.transform.statuses}
-          pagination={false}
+          pagination={p.transform.statuses.length > DEFAULT_TABLE_PAGE_SIZE}
           sorting
+          tableOptions={TABLE_OPTIONS}
         />
       </div>
     </>
@@ -270,8 +278,6 @@ const LogsTab = (p: { transform: TransformMetadata }) => {
     }
   };
 
-  const paginationParams = usePaginationParams(messages.length, 10);
-  const logsTableOptions = useMemo(() => ({ initialState: { pagination: paginationParams } }), [paginationParams]);
   const messageTableColumns: DataTableColumnDef<TopicMessage>[] = useMemo(
     () => [
       // Chakra's DataTable injected this column whenever `subComponent` was set; the Registry one does not.
@@ -302,8 +308,11 @@ const LogsTab = (p: { transform: TransformMetadata }) => {
           row: {
             original: { timestamp },
           },
-        }) => <TimestampDisplay format="default" unixEpochMillisecond={timestamp} />,
-        size: 30,
+        }) => (
+          <span className="whitespace-nowrap">
+            <TimestampDisplay format="default" unixEpochMillisecond={timestamp} />
+          </span>
+        ),
       },
       {
         header: 'Value',
@@ -311,14 +320,16 @@ const LogsTab = (p: { transform: TransformMetadata }) => {
         enableSorting: false,
         enableHiding: false,
         accessorKey: 'value',
+        // The Registry DataTable ignores column sizes; a viewport-wide max-content hands this column the slack.
         cell: ({ row: { original } }) => (
-          <MessagePreview
-            isCompactTopic={topic ? topic.cleanupPolicy.includes('compact') : false}
-            msg={original}
-            previewFields={() => []}
-          />
+          <div className="w-screen max-w-full">
+            <MessagePreview
+              isCompactTopic={topic ? topic.cleanupPolicy.includes('compact') : false}
+              msg={original}
+              previewFields={() => []}
+            />
+          </div>
         ),
-        size: Number.MAX_SAFE_INTEGER,
       },
     ],
     [topic]
@@ -337,32 +348,12 @@ const LogsTab = (p: { transform: TransformMetadata }) => {
 
       <Section className="min-w-[800px]">
         <div className="mb-6 flex">
-          <Input
-            containerClassName="max-w-[230px]"
-            onChange={(e) => setLogsQuickSearch(e.target.value)}
+          <SearchInput
+            containerClassName="w-[230px]"
+            onChange={setLogsQuickSearch}
             placeholder="Search..."
-            testId="search-field-input"
             value={logsQuickSearch}
-          >
-            <InputStart>
-              <SearchIcon className="size-4 text-muted-foreground" data-testid="search-field-search-icon" />
-            </InputStart>
-            {/* Always mounted: InputEnd never resets the padding it measured, and unmounting the
-                button under the click would drop focus to <body>. */}
-            <InputEnd className="pointer-events-auto">
-              <Button
-                aria-label="Clear search"
-                className={logsQuickSearch === '' ? 'invisible' : undefined}
-                data-testid="search-field-reset-icon"
-                disabled={logsQuickSearch === ''}
-                onClick={() => setLogsQuickSearch('')}
-                size="icon-xs"
-                variant="ghost"
-              >
-                <CloseIcon />
-              </Button>
-            </InputEnd>
-          </Input>
+          />
           <Button className="ml-auto" onClick={() => setRefreshCount((c) => c + 1)} variant="outline">
             Refresh logs
           </Button>
@@ -388,7 +379,7 @@ const LogsTab = (p: { transform: TransformMetadata }) => {
               msg={original}
             />
           )}
-          tableOptions={logsTableOptions}
+          tableOptions={LOGS_TABLE_OPTIONS}
         />
       </Section>
     </>

--- a/frontend/src/components/pages/transforms/transform-details.tsx
+++ b/frontend/src/components/pages/transforms/transform-details.tsx
@@ -126,10 +126,14 @@ class TransformDetails extends PageComponent<{ transformName: string }> {
 }
 export default TransformDetails;
 
-// Legacy table parity: 50 rows a page, pager only past that.
-const TABLE_OPTIONS = { initialState: { pagination: { pageIndex: 0, pageSize: DEFAULT_TABLE_PAGE_SIZE } } };
+// Legacy table parity: 50 rows a page, pager only past that. No column-visibility UI, so hiding is off.
+const TABLE_OPTIONS = {
+  enableHiding: false,
+  initialState: { pagination: { pageIndex: 0, pageSize: DEFAULT_TABLE_PAGE_SIZE } },
+};
 // Stable identity keeps an expanded row on its message when the list is filtered or refreshed.
 const LOGS_TABLE_OPTIONS = {
+  enableHiding: false,
   initialState: { pagination: { pageIndex: 0, pageSize: 10 } },
   getRowId: (message: TopicMessage) => `${message.partitionID}-${message.offset}`,
 };
@@ -138,12 +142,10 @@ const partitionStatusColumns: DataTableColumnDef<PartitionTransformStatus>[] = [
   {
     header: ({ column }) => <DataTableColumnHeader column={column} title="Partition" />,
     accessorKey: 'partitionId',
-    enableHiding: false,
   },
   {
     header: ({ column }) => <DataTableColumnHeader column={column} title="Node" />,
     accessorKey: 'brokerId',
-    enableHiding: false,
   },
   {
     id: 'status',
@@ -153,7 +155,6 @@ const partitionStatusColumns: DataTableColumnDef<PartitionTransformStatus>[] = [
   {
     header: ({ column }) => <DataTableColumnHeader column={column} title="Lag" />,
     accessorKey: 'lag',
-    enableHiding: false,
   },
 ];
 
@@ -284,7 +285,6 @@ const LogsTab = (p: { transform: TransformMetadata }) => {
       // The Registry only sets aria-expanded on the row, and only for `expandRowByClick`, so it goes here.
       {
         id: 'expander',
-        enableHiding: false,
         enableSorting: false,
         cell: ({ row }) =>
           row.getCanExpand() ? (
@@ -301,7 +301,6 @@ const LogsTab = (p: { transform: TransformMetadata }) => {
       },
       {
         id: 'timestamp',
-        enableHiding: false,
         header: ({ column }) => <DataTableColumnHeader column={column} title="Timestamp" />,
         accessorKey: 'timestamp',
         cell: ({
@@ -318,7 +317,6 @@ const LogsTab = (p: { transform: TransformMetadata }) => {
         header: 'Value',
         // The cell renders a decoded preview; sorting the raw value was never meaningful.
         enableSorting: false,
-        enableHiding: false,
         accessorKey: 'value',
         // The Registry DataTable ignores column sizes; a viewport-wide max-content hands this column the slack.
         cell: ({ row: { original } }) => (

--- a/frontend/src/components/pages/transforms/transforms-list.tsx
+++ b/frontend/src/components/pages/transforms/transforms-list.tsx
@@ -9,9 +9,17 @@
  * by the Apache License, Version 2.0
  */
 
-import { Box, Button, Link as ChakraLink, DataTable, Flex, SearchField, Stack, Text } from '@redpanda-data/ui';
 import { Link } from '@tanstack/react-router';
 import { CheckIcon, CloseIcon, TrashIcon } from 'components/icons';
+import { Button } from 'components/redpanda-ui/components/button';
+import {
+  DataTable,
+  type DataTableColumnDef,
+  DataTableColumnHeader,
+} from 'components/redpanda-ui/components/data-table';
+import { Input, InputEnd, InputStart } from 'components/redpanda-ui/components/input';
+import { Link as ExternalLink } from 'components/redpanda-ui/components/typography';
+import { SearchIcon, XIcon } from 'lucide-react';
 import type { FC } from 'react';
 import { docsLinks } from 'utils/docs-links';
 import { showToast } from 'utils/toast.utils';
@@ -34,27 +42,27 @@ export const PartitionStatus = (p: { status: PartitionTransformStatus_PartitionS
   switch (p.status) {
     case PartitionTransformStatus_PartitionStatus.UNSPECIFIED:
       return (
-        <Flex alignItems="center" gap="2">
-          <CloseIcon color="orange" height="14px" /> Unspecified
-        </Flex>
+        <div className="flex items-center gap-2">
+          <CloseIcon className="size-3.5 text-warning" /> Unspecified
+        </div>
       );
     case PartitionTransformStatus_PartitionStatus.RUNNING:
       return (
-        <Flex alignItems="center" gap="2">
-          <CheckIcon color="green" height="14px" /> Running
-        </Flex>
+        <div className="flex items-center gap-2">
+          <CheckIcon className="size-3.5 text-success" /> Running
+        </div>
       );
     case PartitionTransformStatus_PartitionStatus.INACTIVE:
       return (
-        <Flex alignItems="center" gap="2">
-          <CloseIcon color="red" height="14px" /> Inactive
-        </Flex>
+        <div className="flex items-center gap-2">
+          <CloseIcon className="size-3.5 text-destructive" /> Inactive
+        </div>
       );
     case PartitionTransformStatus_PartitionStatus.ERRORED:
       return (
-        <Flex alignItems="center" gap="2">
-          <CloseIcon color="red" height="14px" /> Errored
-        </Flex>
+        <div className="flex items-center gap-2">
+          <CloseIcon className="size-3.5 text-destructive" /> Errored
+        </div>
       );
     default:
       return 'Unknown';
@@ -78,6 +86,98 @@ class TransformsList extends PageComponent {
   }
 }
 
+const columns: DataTableColumnDef<TransformMetadata>[] = [
+  {
+    id: 'name',
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Name" />,
+    accessorKey: 'name',
+    size: 300,
+    cell: ({ row: { original: r } }) => (
+      <div className="whitespace-break-spaces break-words">
+        <Link
+          params={{ transformName: encodeURIComponentPercents(r.name) }}
+          search={{} as never}
+          to="/transforms/$transformName"
+        >
+          {r.name}
+        </Link>
+      </div>
+    ),
+  },
+  {
+    id: 'status',
+    header: 'Status',
+    enableSorting: false,
+    cell: ({ row: { original: r } }) => {
+      if (r.statuses.all((x) => x.status === PartitionTransformStatus_PartitionStatus.RUNNING)) {
+        return <PartitionStatus status={PartitionTransformStatus_PartitionStatus.RUNNING} />;
+      }
+      // biome-ignore lint/style/noNonNullAssertion: not touching to avoid breaking code during migration
+      const partitionTransformStatus = r.statuses.first(
+        (x) => x.status !== PartitionTransformStatus_PartitionStatus.RUNNING
+      )!;
+
+      return <PartitionStatus status={partitionTransformStatus.status} />;
+    },
+  },
+  {
+    id: 'inputTopicName',
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Input topic" />,
+    accessorKey: 'inputTopicName',
+  },
+  {
+    id: 'outputTopicNames',
+    header: 'Output topics',
+    enableSorting: false,
+    cell: ({ row: { original: r } }) => (
+      <div className="flex flex-col">
+        {r.outputTopicNames.map((n) => (
+          <div key={n}>{n}</div>
+        ))}
+      </div>
+    ),
+  },
+  {
+    header: '',
+    id: 'actions',
+    enableSorting: false,
+    cell: ({ row: { original: r } }) => (
+      <Button
+        aria-label={`Delete transform ${r.name}`}
+        onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+          e.stopPropagation();
+          e.preventDefault();
+
+          openDeleteModal(r.name, () => {
+            transformsApi
+              .deleteTransform(r.name)
+              .then(() => {
+                showToast({
+                  status: 'success',
+                  duration: 4000,
+                  title: 'Transform deleted',
+                });
+                transformsApi.refreshTransforms(true);
+              })
+              .catch((err) => {
+                showToast({
+                  status: 'error',
+                  title: 'Failed to delete transform',
+                  description: String(err),
+                });
+              });
+          });
+        }}
+        size="icon-xs"
+        variant="ghost"
+      >
+        <TrashIcon />
+      </Button>
+    ),
+    size: 1,
+  },
+];
+
 const TransformsListContent: FC = () => {
   const { transformsList, updateSettings } = useUISettingsStore();
 
@@ -89,13 +189,13 @@ const TransformsListContent: FC = () => {
     return null;
   }
 
+  const quickSearch = transformsList.quickSearch;
   const filteredTransforms = (transformsApi.transforms ?? []).filter((u) => {
-    const filter = transformsList.quickSearch;
-    if (!filter) {
+    if (!quickSearch) {
       return true;
     }
     try {
-      const quickSearchRegExp = new RegExp(filter, 'i');
+      const quickSearchRegExp = new RegExp(quickSearch, 'i');
       return u.name.match(quickSearchRegExp);
     } catch {
       return false;
@@ -104,137 +204,53 @@ const TransformsListContent: FC = () => {
 
   return (
     <PageContent>
-      <Text maxWidth="600px">
+      <p className="max-w-[600px] text-body">
         Data transforms let you run common data streaming tasks, like filtering, scrubbing, and transcoding, within
         Redpanda.{' '}
-        <ChakraLink
-          href={docsLinks.selfManaged.dataTransforms}
-          isExternal
-          style={{ textDecoration: 'underline solid 1px' }}
-        >
+        <ExternalLink href={docsLinks.selfManaged.dataTransforms} rel="noopener noreferrer" target="_blank">
           Learn more
-        </ChakraLink>
-      </Text>
+        </ExternalLink>
+      </p>
 
-      <Stack direction="row" mb="6">
+      <div className="mb-6 flex flex-row gap-2">
         <Link to="/transforms-setup">
           <Button variant="outline">Create transform</Button>
         </Link>
 
-        <Button isDisabled variant="outline">
+        <Button disabled variant="outline">
           Export metrics
         </Button>
-      </Stack>
+      </div>
 
       <Section>
-        <Box mb="5">
-          <SearchField
-            placeholderText="Enter search term / regex..."
-            searchText={transformsList.quickSearch}
-            setSearchText={(x) => {
-              updateSettings({ transformsList: { quickSearch: x } });
-            }}
-            width="350px"
-          />
-        </Box>
-
-        <DataTable<TransformMetadata>
-          columns={[
-            {
-              header: 'Name',
-              accessorKey: 'name',
-              size: 300,
-              cell: ({ row: { original: r } }) => (
-                <Box whiteSpace="break-spaces" wordBreak="break-word">
-                  <Link
-                    params={{ transformName: encodeURIComponentPercents(r.name) }}
-                    search={{} as never}
-                    to="/transforms/$transformName"
-                  >
-                    {r.name}
-                  </Link>
-                </Box>
-              ),
-            },
-            {
-              header: 'Status',
-              cell: ({ row: { original: r } }) => {
-                if (r.statuses.all((x) => x.status === PartitionTransformStatus_PartitionStatus.RUNNING)) {
-                  return (
-                    <Flex alignItems="center">
-                      <PartitionStatus status={PartitionTransformStatus_PartitionStatus.RUNNING} />
-                    </Flex>
-                  );
-                }
-                // biome-ignore lint/style/noNonNullAssertion: not touching to avoid breaking code during migration
-                const partitionTransformStatus = r.statuses.first(
-                  (x) => x.status !== PartitionTransformStatus_PartitionStatus.RUNNING
-                )!;
-
-                return (
-                  <Flex alignItems="center">
-                    <PartitionStatus status={partitionTransformStatus.status} />
-                  </Flex>
-                );
-              },
-            },
-            {
-              header: 'Input topic',
-              accessorKey: 'inputTopicName',
-            },
-            {
-              header: 'Output topics',
-              cell: ({ row: { original: r } }) => (
-                <Stack>
-                  {r.outputTopicNames.map((n) => (
-                    <Box key={n}>{n}</Box>
-                  ))}
-                </Stack>
-              ),
-            },
-            {
-              header: '',
-              id: 'actions',
-              cell: ({ row: { original: r } }) => (
+        <div className="mb-5">
+          <Input
+            containerClassName="max-w-[350px]"
+            onChange={(e) => updateSettings({ transformsList: { quickSearch: e.target.value } })}
+            placeholder="Enter search term / regex..."
+            testId="search-field-input"
+            value={quickSearch}
+          >
+            <InputStart>
+              <SearchIcon className="size-4 text-muted-foreground" data-testid="search-field-search-icon" />
+            </InputStart>
+            {quickSearch !== '' && (
+              <InputEnd className="pointer-events-auto">
                 <Button
-                  color="gray.500"
-                  height="16px"
-                  onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-                    e.stopPropagation();
-                    e.preventDefault();
-
-                    openDeleteModal(r.name, () => {
-                      transformsApi
-                        .deleteTransform(r.name)
-                        .then(() => {
-                          showToast({
-                            status: 'success',
-                            duration: 4000,
-                            title: 'Transform deleted',
-                          });
-                          transformsApi.refreshTransforms(true);
-                        })
-                        .catch((err) => {
-                          showToast({
-                            status: 'error',
-                            title: 'Failed to delete transform',
-                            description: String(err),
-                          });
-                        });
-                    });
-                  }}
-                  variant="icon"
+                  aria-label="Clear search"
+                  data-testid="search-field-reset-icon"
+                  onClick={() => updateSettings({ transformsList: { quickSearch: '' } })}
+                  size="icon-xs"
+                  variant="ghost"
                 >
-                  <TrashIcon />
+                  <XIcon />
                 </Button>
-              ),
-              size: 1,
-            },
-          ]}
-          data={filteredTransforms}
-          pagination
-          sorting
-        />
+              </InputEnd>
+            )}
+          </Input>
+        </div>
+
+        <DataTable<TransformMetadata> columns={columns} data={filteredTransforms} pagination sorting />
       </Section>
     </PageContent>
   );

--- a/frontend/src/components/pages/transforms/transforms-list.tsx
+++ b/frontend/src/components/pages/transforms/transforms-list.tsx
@@ -19,7 +19,7 @@ import {
 } from 'components/redpanda-ui/components/data-table';
 import { Input, InputEnd, InputStart } from 'components/redpanda-ui/components/input';
 import { Link as ExternalLink } from 'components/redpanda-ui/components/typography';
-import { SearchIcon, XIcon } from 'lucide-react';
+import { SearchIcon } from 'lucide-react';
 import type { FC } from 'react';
 import { docsLinks } from 'utils/docs-links';
 import { showToast } from 'utils/toast.utils';
@@ -89,6 +89,8 @@ class TransformsList extends PageComponent {
 const columns: DataTableColumnDef<TransformMetadata>[] = [
   {
     id: 'name',
+    // No DataTableViewOptions on this page, so a hidden column could not be brought back.
+    enableHiding: false,
     header: ({ column }) => <DataTableColumnHeader column={column} title="Name" />,
     accessorKey: 'name',
     size: 300,
@@ -122,6 +124,7 @@ const columns: DataTableColumnDef<TransformMetadata>[] = [
   },
   {
     id: 'inputTopicName',
+    enableHiding: false,
     header: ({ column }) => <DataTableColumnHeader column={column} title="Input topic" />,
     accessorKey: 'inputTopicName',
   },
@@ -190,16 +193,20 @@ const TransformsListContent: FC = () => {
   }
 
   const quickSearch = transformsList.quickSearch;
+  // Compiled once, not once per row. An invalid pattern matches nothing, as before.
+  let quickSearchRegExp: RegExp | null = null;
+  if (quickSearch) {
+    try {
+      quickSearchRegExp = new RegExp(quickSearch, 'i');
+    } catch {
+      quickSearchRegExp = null;
+    }
+  }
   const filteredTransforms = (transformsApi.transforms ?? []).filter((u) => {
     if (!quickSearch) {
       return true;
     }
-    try {
-      const quickSearchRegExp = new RegExp(quickSearch, 'i');
-      return u.name.match(quickSearchRegExp);
-    } catch {
-      return false;
-    }
+    return quickSearchRegExp ? quickSearchRegExp.test(u.name) : false;
   });
 
   return (
@@ -234,19 +241,21 @@ const TransformsListContent: FC = () => {
             <InputStart>
               <SearchIcon className="size-4 text-muted-foreground" data-testid="search-field-search-icon" />
             </InputStart>
-            {quickSearch !== '' && (
-              <InputEnd className="pointer-events-auto">
-                <Button
-                  aria-label="Clear search"
-                  data-testid="search-field-reset-icon"
-                  onClick={() => updateSettings({ transformsList: { quickSearch: '' } })}
-                  size="icon-xs"
-                  variant="ghost"
-                >
-                  <XIcon />
-                </Button>
-              </InputEnd>
-            )}
+            {/* Always mounted: InputEnd never resets the padding it measured, and unmounting the
+                button under the click would drop focus to <body>. */}
+            <InputEnd className="pointer-events-auto">
+              <Button
+                aria-label="Clear search"
+                className={quickSearch === '' ? 'invisible' : undefined}
+                data-testid="search-field-reset-icon"
+                disabled={quickSearch === ''}
+                onClick={() => updateSettings({ transformsList: { quickSearch: '' } })}
+                size="icon-xs"
+                variant="ghost"
+              >
+                <CloseIcon />
+              </Button>
+            </InputEnd>
           </Input>
         </div>
 

--- a/frontend/src/components/pages/transforms/transforms-list.tsx
+++ b/frontend/src/components/pages/transforms/transforms-list.tsx
@@ -17,9 +17,7 @@ import {
   type DataTableColumnDef,
   DataTableColumnHeader,
 } from 'components/redpanda-ui/components/data-table';
-import { Input, InputEnd, InputStart } from 'components/redpanda-ui/components/input';
 import { Link as ExternalLink } from 'components/redpanda-ui/components/typography';
-import { SearchIcon } from 'lucide-react';
 import type { FC } from 'react';
 import { docsLinks } from 'utils/docs-links';
 import { showToast } from 'utils/toast.utils';
@@ -34,7 +32,9 @@ import { transformsApi } from '../../../state/backend-api';
 import { useUISettingsStore } from '../../../state/ui';
 import { DefaultSkeleton } from '../../../utils/tsx-utils';
 import { encodeURIComponentPercents } from '../../../utils/utils';
+import { DEFAULT_TABLE_PAGE_SIZE } from '../../constants';
 import PageContent from '../../misc/page-content';
+import { SearchInput } from '../../misc/search-input';
 import Section from '../../misc/section';
 import { PageComponent, type PageInitHelper } from '../page';
 
@@ -86,6 +86,9 @@ class TransformsList extends PageComponent {
   }
 }
 
+// Legacy table parity: 50 rows a page, pager only past that.
+const TABLE_OPTIONS = { initialState: { pagination: { pageIndex: 0, pageSize: DEFAULT_TABLE_PAGE_SIZE } } };
+
 const columns: DataTableColumnDef<TransformMetadata>[] = [
   {
     id: 'name',
@@ -93,7 +96,6 @@ const columns: DataTableColumnDef<TransformMetadata>[] = [
     enableHiding: false,
     header: ({ column }) => <DataTableColumnHeader column={column} title="Name" />,
     accessorKey: 'name',
-    size: 300,
     cell: ({ row: { original: r } }) => (
       <div className="whitespace-break-spaces break-words">
         <Link
@@ -177,7 +179,6 @@ const columns: DataTableColumnDef<TransformMetadata>[] = [
         <TrashIcon />
       </Button>
     ),
-    size: 1,
   },
 ];
 
@@ -231,35 +232,21 @@ const TransformsListContent: FC = () => {
 
       <Section>
         <div className="mb-5">
-          <Input
+          <SearchInput
             containerClassName="max-w-[350px]"
-            onChange={(e) => updateSettings({ transformsList: { quickSearch: e.target.value } })}
+            onChange={(value) => updateSettings({ transformsList: { quickSearch: value } })}
             placeholder="Enter search term / regex..."
-            testId="search-field-input"
             value={quickSearch}
-          >
-            <InputStart>
-              <SearchIcon className="size-4 text-muted-foreground" data-testid="search-field-search-icon" />
-            </InputStart>
-            {/* Always mounted: InputEnd never resets the padding it measured, and unmounting the
-                button under the click would drop focus to <body>. */}
-            <InputEnd className="pointer-events-auto">
-              <Button
-                aria-label="Clear search"
-                className={quickSearch === '' ? 'invisible' : undefined}
-                data-testid="search-field-reset-icon"
-                disabled={quickSearch === ''}
-                onClick={() => updateSettings({ transformsList: { quickSearch: '' } })}
-                size="icon-xs"
-                variant="ghost"
-              >
-                <CloseIcon />
-              </Button>
-            </InputEnd>
-          </Input>
+          />
         </div>
 
-        <DataTable<TransformMetadata> columns={columns} data={filteredTransforms} pagination sorting />
+        <DataTable<TransformMetadata>
+          columns={columns}
+          data={filteredTransforms}
+          pagination={filteredTransforms.length > DEFAULT_TABLE_PAGE_SIZE}
+          sorting
+          tableOptions={TABLE_OPTIONS}
+        />
       </Section>
     </PageContent>
   );

--- a/frontend/src/components/pages/transforms/transforms-list.tsx
+++ b/frontend/src/components/pages/transforms/transforms-list.tsx
@@ -86,14 +86,15 @@ class TransformsList extends PageComponent {
   }
 }
 
-// Legacy table parity: 50 rows a page, pager only past that.
-const TABLE_OPTIONS = { initialState: { pagination: { pageIndex: 0, pageSize: DEFAULT_TABLE_PAGE_SIZE } } };
+// Legacy table parity: 50 rows a page, pager only past that. No column-visibility UI, so hiding is off.
+const TABLE_OPTIONS = {
+  enableHiding: false,
+  initialState: { pagination: { pageIndex: 0, pageSize: DEFAULT_TABLE_PAGE_SIZE } },
+};
 
 const columns: DataTableColumnDef<TransformMetadata>[] = [
   {
     id: 'name',
-    // No DataTableViewOptions on this page, so a hidden column could not be brought back.
-    enableHiding: false,
     header: ({ column }) => <DataTableColumnHeader column={column} title="Name" />,
     accessorKey: 'name',
     cell: ({ row: { original: r } }) => (
@@ -126,7 +127,6 @@ const columns: DataTableColumnDef<TransformMetadata>[] = [
   },
   {
     id: 'inputTopicName',
-    enableHiding: false,
     header: ({ column }) => <DataTableColumnHeader column={column} title="Input topic" />,
     accessorKey: 'inputTopicName',
   },

--- a/frontend/src/components/pages/transforms/transforms-setup.tsx
+++ b/frontend/src/components/pages/transforms/transforms-setup.tsx
@@ -1,18 +1,6 @@
-import {
-  Alert,
-  AlertDescription,
-  AlertIcon,
-  AlertTitle,
-  Box,
-  Link as ChakraLink,
-  CodeBlock,
-  Grid,
-  Heading,
-  ListItem,
-  OrderedList,
-  Stack,
-  Text,
-} from '@redpanda-data/ui';
+import { Alert, AlertDescription, AlertTitle } from 'components/redpanda-ui/components/alert';
+import { CodeBlock, Pre } from 'components/redpanda-ui/components/code-block';
+import { InlineCode, Link, List, ListItem } from 'components/redpanda-ui/components/typography';
 import { docsLinks } from 'utils/docs-links';
 
 import Tabs from '../../misc/tabs/tabs';
@@ -29,22 +17,18 @@ export class TransformsSetup extends PageComponent {
 
   render() {
     return (
-      <Grid gap={10} templateColumns="1fr 320px">
-        <Stack spacing={3}>
-          <Heading as="h2">Data transforms</Heading>
-          <Text>
+      <div className="grid gap-10 lg:grid-cols-[1fr_320px]">
+        <div className="flex flex-col gap-3">
+          <h2 className="text-heading-lg">Data transforms</h2>
+          <p className="text-body">
             Data transforms let you run common data streaming tasks, like filtering, scrubbing, and transcoding, within
             Redpanda.{' '}
-            <ChakraLink
-              href={docsLinks.selfManaged.dataTransformsBuild}
-              isExternal
-              style={{ textDecoration: 'underline solid 1px' }}
-            >
+            <Link href={docsLinks.selfManaged.dataTransformsBuild} rel="noopener noreferrer" target="_blank">
               Learn more
-            </ChakraLink>
-          </Text>
+            </Link>
+          </p>
 
-          <Heading as="h3">Getting started</Heading>
+          <h3 className="text-heading-md">Getting started</h3>
 
           <Tabs
             tabs={[
@@ -52,8 +36,8 @@ export class TransformsSetup extends PageComponent {
               { key: 'rust', title: 'Rust', content: <TabRust />, disabled: true },
             ]}
           />
-        </Stack>
-      </Grid>
+        </div>
+      </div>
     );
   }
 }
@@ -69,38 +53,39 @@ const exampleDir = `${`
 
 function TabGo(_p: Record<string, never>) {
   return (
-    <OrderedList display="flex" flexDirection="column" gap="0.5rem">
+    <List className="flex flex-col gap-2" ordered>
       <ListItem>
-        <Text mt={3}>Create and initialize a data transforms project:</Text>
-        <CodeBlock codeString={rpkInitTransform} language="bash" />
+        <p className="mt-3 text-body">Create and initialize a data transforms project:</p>
+        <CodeBlock width="full">
+          <Pre>{rpkInitTransform}</Pre>
+        </CodeBlock>
 
-        <Text mt={3}>
-          If you do not include the <code>--language</code> flag, the <code>transform init</code> command will prompt
-          you for the language.
-        </Text>
+        <p className="mt-3 text-body">
+          If you do not include the <InlineCode>--language</InlineCode> flag, the{' '}
+          <InlineCode>transform init</InlineCode> command will prompt you for the language.
+        </p>
 
-        <Text mt={3}>A successful command generates project files in your current directory:</Text>
-        <CodeBlock codeString={exampleDir} language="text" />
+        <p className="mt-3 text-body">A successful command generates project files in your current directory:</p>
+        <CodeBlock width="full">
+          <Pre>{exampleDir}</Pre>
+        </CodeBlock>
 
-        <Text mt={3}>
-          The <code>transform.go</code> file contains the transform logic, and the <code>transform.yaml</code> file
-          specifies the transform's configuration.
-        </Text>
+        <p className="mt-3 text-body">
+          The <InlineCode>transform.go</InlineCode> file contains the transform logic, and the{' '}
+          <InlineCode>transform.yaml</InlineCode> file specifies the transform's configuration.
+        </p>
 
-        <Alert status="info">
-          <AlertIcon />
-          <Box>
-            <AlertTitle>Hint</AlertTitle>
-            <AlertDescription>
-              When creating a custom data transform, initialization steps can be done either in <code>main</code>{' '}
-              (because it's only run once at the start of the package) or in Go's standard predefined{' '}
-              <code>init()</code> function. Although state can be cached in global variables, Redpanda may restart a
-              WASM module at any point, which causes the state to be lost.
-            </AlertDescription>
-          </Box>
+        <Alert variant="informative">
+          <AlertTitle>Hint</AlertTitle>
+          <AlertDescription>
+            When creating a custom data transform, initialization steps can be done either in{' '}
+            <InlineCode>main</InlineCode> (because it's only run once at the start of the package) or in Go's standard
+            predefined <InlineCode>init()</InlineCode> function. Although state can be cached in global variables,
+            Redpanda may restart a WASM module at any point, which causes the state to be lost.
+          </AlertDescription>
         </Alert>
       </ListItem>
-    </OrderedList>
+    </List>
   );
 }
 

--- a/frontend/src/components/pages/transforms/transforms-setup.tsx
+++ b/frontend/src/components/pages/transforms/transforms-setup.tsx
@@ -1,5 +1,5 @@
 import { Alert, AlertDescription, AlertTitle } from 'components/redpanda-ui/components/alert';
-import { CodeBlock, Pre } from 'components/redpanda-ui/components/code-block';
+import { DynamicCodeBlock } from 'components/redpanda-ui/components/code-block-dynamic';
 import { InlineCode, Link, List, ListItem } from 'components/redpanda-ui/components/typography';
 import { docsLinks } from 'utils/docs-links';
 
@@ -56,9 +56,7 @@ function TabGo(_p: Record<string, never>) {
     <List className="flex flex-col gap-2" ordered>
       <ListItem>
         <p className="mt-3 text-body">Create and initialize a data transforms project:</p>
-        <CodeBlock width="full">
-          <Pre>{rpkInitTransform}</Pre>
-        </CodeBlock>
+        <DynamicCodeBlock code={rpkInitTransform} lang="bash" />
 
         <p className="mt-3 text-body">
           If you do not include the <InlineCode>--language</InlineCode> flag, the{' '}
@@ -66,9 +64,7 @@ function TabGo(_p: Record<string, never>) {
         </p>
 
         <p className="mt-3 text-body">A successful command generates project files in your current directory:</p>
-        <CodeBlock width="full">
-          <Pre>{exampleDir}</Pre>
-        </CodeBlock>
+        <DynamicCodeBlock code={exampleDir} lang="text" />
 
         <p className="mt-3 text-body">
           The <InlineCode>transform.go</InlineCode> file contains the transform logic, and the{' '}
@@ -78,10 +74,13 @@ function TabGo(_p: Record<string, never>) {
         <Alert variant="informative">
           <AlertTitle>Hint</AlertTitle>
           <AlertDescription>
-            When creating a custom data transform, initialization steps can be done either in{' '}
-            <InlineCode>main</InlineCode> (because it's only run once at the start of the package) or in Go's standard
-            predefined <InlineCode>init()</InlineCode> function. Although state can be cached in global variables,
-            Redpanda may restart a WASM module at any point, which causes the state to be lost.
+            {/* One block child: AlertDescription is a grid, so loose text runs each become a row. */}
+            <p>
+              When creating a custom data transform, initialization steps can be done either in{' '}
+              <InlineCode>main</InlineCode> (because it's only run once at the start of the package) or in Go's standard
+              predefined <InlineCode>init()</InlineCode> function. Although state can be cached in global variables,
+              Redpanda may restart a WASM module at any point, which causes the state to be lost.
+            </p>
           </AlertDescription>
         </Alert>
       </ListItem>

--- a/frontend/src/components/pages/transforms/transforms-setup.tsx
+++ b/frontend/src/components/pages/transforms/transforms-setup.tsx
@@ -1,5 +1,5 @@
 import { Alert, AlertDescription, AlertTitle } from 'components/redpanda-ui/components/alert';
-import { SimpleCodeBlock } from 'components/redpanda-ui/components/code-block';
+import { DynamicCodeBlock, SyncCodeBlock } from 'components/redpanda-ui/components/code-block-dynamic';
 import { InlineCode, Link, List, ListItem } from 'components/redpanda-ui/components/typography';
 import { docsLinks } from 'utils/docs-links';
 
@@ -56,7 +56,7 @@ function TabGo(_p: Record<string, never>) {
     <List className="flex flex-col gap-2" ordered>
       <ListItem>
         <p className="mt-3 text-body">Create and initialize a data transforms project:</p>
-        <SimpleCodeBlock code={rpkInitTransform} language="bash" width="full" />
+        <SyncCodeBlock code={rpkInitTransform} keepBackground lang="bash" />
 
         <p className="mt-3 text-body">
           If you do not include the <InlineCode>--language</InlineCode> flag, the{' '}
@@ -64,7 +64,7 @@ function TabGo(_p: Record<string, never>) {
         </p>
 
         <p className="mt-3 text-body">A successful command generates project files in your current directory:</p>
-        <SimpleCodeBlock code={exampleDir} language="text" width="full" />
+        <DynamicCodeBlock code={exampleDir} keepBackground lang="text" />
 
         <p className="mt-3 text-body">
           The <InlineCode>transform.go</InlineCode> file contains the transform logic, and the{' '}

--- a/frontend/src/components/pages/transforms/transforms-setup.tsx
+++ b/frontend/src/components/pages/transforms/transforms-setup.tsx
@@ -1,5 +1,5 @@
 import { Alert, AlertDescription, AlertTitle } from 'components/redpanda-ui/components/alert';
-import { DynamicCodeBlock } from 'components/redpanda-ui/components/code-block-dynamic';
+import { SimpleCodeBlock } from 'components/redpanda-ui/components/code-block';
 import { InlineCode, Link, List, ListItem } from 'components/redpanda-ui/components/typography';
 import { docsLinks } from 'utils/docs-links';
 
@@ -56,7 +56,7 @@ function TabGo(_p: Record<string, never>) {
     <List className="flex flex-col gap-2" ordered>
       <ListItem>
         <p className="mt-3 text-body">Create and initialize a data transforms project:</p>
-        <DynamicCodeBlock code={rpkInitTransform} lang="bash" />
+        <SimpleCodeBlock code={rpkInitTransform} language="bash" width="full" />
 
         <p className="mt-3 text-body">
           If you do not include the <InlineCode>--language</InlineCode> flag, the{' '}
@@ -64,7 +64,7 @@ function TabGo(_p: Record<string, never>) {
         </p>
 
         <p className="mt-3 text-body">A successful command generates project files in your current directory:</p>
-        <DynamicCodeBlock code={exampleDir} lang="text" />
+        <SimpleCodeBlock code={exampleDir} language="text" width="full" />
 
         <p className="mt-3 text-body">
           The <InlineCode>transform.go</InlineCode> file contains the transform logic, and the{' '}

--- a/frontend/tests/test-variant-console/transforms/transforms-setup.spec.ts
+++ b/frontend/tests/test-variant-console/transforms/transforms-setup.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Smoke coverage for the transforms setup page.
+ *
+ * `transforms.spec.ts` is commented out because it needs transforms seeded through the
+ * backend API, which the UI cannot do yet. This page has no such dependency: it renders
+ * static getting-started content, so it is reachable in every variant and guards the
+ * pieces a re-skin can break — the tab strip, the code blocks, and the hint callout.
+ */
+test.describe('Transforms setup', () => {
+  test('renders the getting-started content', async ({ page }) => {
+    await page.goto('/transforms-setup');
+
+    await expect(page.getByRole('heading', { name: 'Data transforms' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Getting started' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Learn more' })).toBeVisible();
+
+    await expect(page.getByText('Create and initialize a data transforms project')).toBeVisible();
+    await expect(page.getByText('rpk transform init --language=tinygo')).toBeVisible();
+    await expect(page.getByText('transform.yaml').first()).toBeVisible();
+
+    // The hint is a registry Alert, which paints its own icon.
+    await expect(page.getByRole('alert').filter({ hasText: 'Hint' })).toBeVisible();
+  });
+
+  test('offers Go and a disabled Rust tab', async ({ page }) => {
+    await page.goto('/transforms-setup');
+
+    const goTab = page.getByRole('tab', { name: 'Go' });
+    const rustTab = page.getByRole('tab', { name: 'Rust' });
+
+    await expect(goTab).toBeVisible();
+    await expect(rustTab).toBeDisabled();
+
+    // Go is the default tab, so its panel is the one on screen.
+    await expect(page.getByText('Create and initialize a data transforms project')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Chakra exit · Phase 2 (route by route) · PR 5 of 14

Part of the [Chakra exit plan and live tracker](https://claude.ai/code/artifact/1861e21c-624b-4270-98ad-9921b22c2498). Phase 2 walks the routes one directory at a time. Branch `chakra-exit/05-transforms`, cut from #2629; re-targets `master` once that merges. Every Phase 2 branch is cut from the same base and touches a disjoint file set, so they merge in any order.

Four transforms files off Chakra, plus the shared search input, its test, a partition-sort test and a smoke spec. No API changes; behaviour follows the Chakra table contract (see the second round below).

### What moved
- **transforms-list** — Chakra `DataTable` → Registry `DataTable`, with `DataTableColumnHeader` on the two sortable columns; `SearchField` → the shared `misc/search-input` (`/` to focus, Escape to clear, same `search-field-*` test ids).
- **transform-details** — same table swap; drops the `LegacyColumnDef` import and the controlled `SortingState` (nothing else read it). The URL-derived pagination hook only fed an `initialState` TanStack reads once, so it is gone; log rows are keyed by partition+offset instead.
- **transforms-setup** — the Registry `Alert` paints its own icon, so `AlertIcon` goes; code blocks keep the terminal look: `SyncCodeBlock` for the `bash` command (highlighted synchronously, no skeleton flash) and `DynamicCodeBlock` for the plain directory listing.
- **modals** — Chakra `Modal` → Registry `Dialog`, opened through `utils/modal-container`.

### Coverage
`transforms.spec.ts` turned out to be **commented out end to end** — it needs transforms seeded through the backend API, which the UI cannot do. So transforms was an eighth uncovered route, not a covered one. The new spec covers what needs no seeding: the setup page, which is static and reachable in every variant.

### Worth a look
Two traps that recur across Phase 2, both fixed here in a follow-up commit after review:
- **Chakra's `DataTable` injected an expander column for `subComponent`; the Registry's renders no affordance at all** — the expanded log messages were unreachable.
- **Chakra painted the sort affordance on every header itself.** The Registry sorts only through `DataTableColumnHeader`, so `sorting` stayed enabled with no UI. `DataTableColumnHeader` also offers a "Hide" item, and these pages have no `DataTableViewOptions` to bring a column back — hence `enableHiding: false`.

### Effect
Files importing `@redpanda-data/ui`: **81 → 77**.

### Gates
`type:check` · `lint` · `lint:check` per changed file · unit (880) · integration (1304). Note `bun run lint` is `ultracite fix` and exits 0 with errors still present — `lint:check` is the gate.

### Second review round (2026-09-08)
- Tables paginate like the legacy DataTable again: 50 a page, pager only past that (the Registry defaults to 10 with a permanent pager; the partition table had lost paging entirely).
- Logs table: the Registry ignores column `size`, so the Value column had collapsed; it takes the slack again and timestamps stay on one line.
- Both search boxes are the shared `misc/search-input` (identical copy on #2636 and #2638): clear refocuses the field, the empty right edge is click-through, `/` focuses, Escape clears then blurs.
- Dialog title clears the absolute close button; the logs table shows no pager under its loading or empty row; the partition-sort test resets its store inside `act()`. The `?page`/`?pageSize` deep-link initial value was dropped deliberately (TanStack read it once at mount, with an empty list).

### Final review (2026-09-08)
- The bash snippet is back on `SyncCodeBlock` (terminal look, synchronous highlighting); the logs table shows no pager under its loading or empty row; `SearchInput` advertises its shortcuts (`aria-keyshortcuts`, a title on the clear button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

