### PR TITLE
[Chakra exit · Phase 2 · PR 8/14] frontend: mount the Registry ThemeProvider and take the chrome off Chakra

### DIFF
--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -57,6 +57,7 @@ import { patchedRedpandaTheme as redpandaTheme } from 'utils/redpanda-theme';
 import { applyOverrides as applyDebugFeatureFlagOverrides } from './components/debug-helper/feature-flag-overrides';
 import { NotFoundPage } from './components/misc/not-found-page';
 import { RoutePendingFallback } from './components/misc/route-pending-fallback';
+import { ThemeProvider } from './components/redpanda-ui/components/theme-provider';
 import { Toaster as BaseUiToaster } from './components/redpanda-ui/components/toast';
 import { addBearerTokenInterceptor, checkExpiredLicenseInterceptor, getGrpcBasePath, setup } from './config';
 import { routerDefaults } from './router-defaults';
@@ -132,16 +133,23 @@ const App = () => {
   return (
     <CustomFeatureFlagProvider initialFlags={window.__E2E_FEATURE_FLAGS__ ?? {}}>
       <Content apiKey={BUILDER_API_KEY} content={null} customComponents={builderCustomComponents} model={''} />
-      <ChakraProvider resetCSS={false} theme={redpandaTheme}>
-        {/* showToast viewport, above the router so the error boundary and login can toast */}
-        <BaseUiToaster testId="console-toasts" />
-        <TransportProvider transport={dataplaneTransport}>
-          <QueryClientProvider client={queryClient}>
-            <RouterProvider router={router} />
-            <ReactQueryDevtools initialIsOpen={process.env.NODE_ENV !== 'production' && developerView} />
-          </QueryClientProvider>
-        </TransportProvider>
-      </ChakraProvider>
+      {/*
+        Standalone only. `data-theme` on <html> is what theme.css keys its dark palette on, and in
+        embedded and federated mode the Cloud UI host owns that attribute — a second writer there
+        would fight it. Outside ChakraProvider so its mount effect lands last while both are up.
+      */}
+      <ThemeProvider>
+        <ChakraProvider resetCSS={false} theme={redpandaTheme}>
+          {/* showToast viewport, above the router so the error boundary and login can toast */}
+          <BaseUiToaster testId="console-toasts" />
+          <TransportProvider transport={dataplaneTransport}>
+            <QueryClientProvider client={queryClient}>
+              <RouterProvider router={router} />
+              <ReactQueryDevtools initialIsOpen={process.env.NODE_ENV !== 'production' && developerView} />
+            </QueryClientProvider>
+          </TransportProvider>
+        </ChakraProvider>
+      </ThemeProvider>
     </CustomFeatureFlagProvider>
   );
 };

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -137,8 +137,20 @@ const App = () => {
         Standalone only. `data-theme` on <html> is what theme.css keys its dark palette on, and in
         embedded and federated mode the Cloud UI host owns that attribute — a second writer there
         would fight it. Outside ChakraProvider so its mount effect lands last while both are up.
+
+        `defaultTheme="light"` deliberately, not the Registry's `system` default: Chakra pinned
+        `initialColorMode: 'light'` with `useSystemColorMode: false`, so `system` here would flip
+        every OS-dark user to the Registry's dark palette while the still-mounted Chakra half stayed
+        light — and the only toggle is dev-only, so they could not get back. Dark mode becomes an
+        opt-in default in its own project, not a side effect of this migration.
+
+        ChakraProvider's own ColorModeProvider is still a second `data-theme` writer one level down.
+        It applies once on mount and this provider's effect lands after it, so the attribute is ours;
+        but Chakra's internal colour mode no longer changes, because ColorModeSwitch was its only
+        caller. Toggling in dev therefore repaints the Registry surface and leaves Chakra components
+        light. That resolves when PR 13 removes ChakraProvider.
       */}
-      <ThemeProvider>
+      <ThemeProvider defaultTheme="light">
         <ChakraProvider resetCSS={false} theme={redpandaTheme}>
           {/* showToast viewport, above the router so the error boundary and login can toast */}
           <BaseUiToaster testId="console-toasts" />

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -64,6 +64,14 @@ import { routerDefaults } from './router-defaults';
 import { routeTree } from './routeTree.gen';
 import { installUISettingsSideEffects } from './state/ui';
 
+// Chakra must not resurrect a stored colour mode: the Registry ThemeProvider owns the theme now.
+const LIGHT_ONLY_COLOR_MODE = {
+  type: 'localStorage',
+  ssr: false,
+  get: (): 'light' => 'light',
+  set: () => undefined,
+} as const;
+
 // Create transport before router so loaders can use it
 const dataplaneTransport = createConnectTransport({
   baseUrl: getGrpcBasePath(''), // Embedded mode handles the path separately.
@@ -133,25 +141,11 @@ const App = () => {
   return (
     <CustomFeatureFlagProvider initialFlags={window.__E2E_FEATURE_FLAGS__ ?? {}}>
       <Content apiKey={BUILDER_API_KEY} content={null} customComponents={builderCustomComponents} model={''} />
-      {/*
-        Standalone only. `data-theme` on <html> is what theme.css keys its dark palette on, and in
-        embedded and federated mode the Cloud UI host owns that attribute — a second writer there
-        would fight it. Outside ChakraProvider so its mount effect lands last while both are up.
-
-        `defaultTheme="light"` deliberately, not the Registry's `system` default: Chakra pinned
-        `initialColorMode: 'light'` with `useSystemColorMode: false`, so `system` here would flip
-        every OS-dark user to the Registry's dark palette while the still-mounted Chakra half stayed
-        light — and the only toggle is dev-only, so they could not get back. Dark mode becomes an
-        opt-in default in its own project, not a side effect of this migration.
-
-        ChakraProvider's own ColorModeProvider is still a second `data-theme` writer one level down.
-        It applies once on mount and this provider's effect lands after it, so the attribute is ours;
-        but Chakra's internal colour mode no longer changes, because ColorModeSwitch was its only
-        caller. Toggling in dev therefore repaints the Registry surface and leaves Chakra components
-        light. That resolves when PR 13 removes ChakraProvider.
-      */}
+      {/* Standalone only: embedded and federated mode leave data-theme to the Cloud UI host. Outside
+          ChakraProvider so its mount effect lands last. defaultTheme="light" matches Chakra's pinned
+          light mode until PR 13 removes ChakraProvider. */}
       <ThemeProvider defaultTheme="light">
-        <ChakraProvider resetCSS={false} theme={redpandaTheme}>
+        <ChakraProvider colorModeManager={LIGHT_ONLY_COLOR_MODE} resetCSS={false} theme={redpandaTheme}>
           {/* showToast viewport, above the router so the error boundary and login can toast */}
           <BaseUiToaster testId="console-toasts" />
           <TransportProvider transport={dataplaneTransport}>

--- a/frontend/src/bootstrap.tsx
+++ b/frontend/src/bootstrap.tsx
@@ -8,9 +8,13 @@
  * the Business Source License, use of this software will be governed
  * by the Apache License, Version 2.0
  */
+import { initTheme } from 'components/redpanda-ui/components/theme-provider';
 import { createRoot } from 'react-dom/client';
 
 import App from './app';
+
+// Pre-paint theme stamp; ThemeProvider in app.tsx re-applies the same values, so keep the two in step.
+initTheme({ defaultTheme: 'light' });
 
 const rootElement = document.getElementById('root');
 // biome-ignore lint/style/noNonNullAssertion: bootstrapping the app

--- a/frontend/src/components/layout/header.test.tsx
+++ b/frontend/src/components/layout/header.test.tsx
@@ -24,10 +24,8 @@ rs.mock('@tanstack/react-router', () => ({
   useRouter: () => ({ getMatchedRoutes }),
 }));
 
-rs.mock('@redpanda-data/ui', () => ({
-  Button: () => null,
-  ColorModeSwitch: () => null,
-  CopyButton: () => null,
+rs.mock('./theme-mode-switch', () => ({
+  ThemeModeSwitch: () => null,
 }));
 
 rs.mock('components/redpanda-ui/lib/utils', () => ({

--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -9,12 +9,12 @@
  * by the Apache License, Version 2.0
  */
 
-import { ColorModeSwitch } from '@redpanda-data/ui';
 import { Link, useLocation, useMatchRoute, useRouter } from '@tanstack/react-router';
 import { cn } from 'components/redpanda-ui/lib/utils';
 import { ChevronLeft } from 'lucide-react';
 import { Fragment, useMemo } from 'react';
 
+import { ThemeModeSwitch } from './theme-mode-switch';
 import { isEmbedded, isFeatureFlagEnabled } from '../../config';
 import { api, useApiStoreHook } from '../../state/backend-api';
 import { type BreadcrumbEntry, useUIStateStore } from '../../state/ui-state';
@@ -165,7 +165,7 @@ function AppPageHeader() {
                   </Tooltip>
                 </TooltipProvider>
               ))}
-            {IsDev && !isEmbedded() && <ColorModeSwitch m={0} p={0} variant="ghost" />}
+            {IsDev && !isEmbedded() && <ThemeModeSwitch />}
           </div>
         </div>
       )}

--- a/frontend/src/components/layout/theme-mode-switch.tsx
+++ b/frontend/src/components/layout/theme-mode-switch.tsx
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { Button } from 'components/redpanda-ui/components/button';
+import { useTheme } from 'components/redpanda-ui/components/theme-provider';
+import { Moon, Sun } from 'lucide-react';
+
+/**
+ * Dev-only theme toggle, replacing Chakra's `ColorModeSwitch`.
+ *
+ * It drives the Registry `ThemeProvider`, which is what stamps `data-theme` on `<html>` — the
+ * selector `theme.css` keys its dark palette on, and the attribute `use-theme-appearance` watches
+ * to tell Monaco, CodeMirror, react-flow and sonner which ground they are painting on. Same
+ * `data-testid` as the Chakra control it replaces.
+ *
+ * `resolvedTheme`, not `theme`: the stored preference can be `system`, and the label has to name
+ * the theme the click will produce.
+ */
+export const ThemeModeSwitch = () => {
+  const { resolvedTheme, setTheme } = useTheme();
+  const next = resolvedTheme === 'dark' ? 'light' : 'dark';
+
+  return (
+    <Button
+      aria-label={`Switch to ${next} mode`}
+      data-testid="ColorModeSwitch"
+      onClick={() => setTheme(next)}
+      size="icon-sm"
+      variant="ghost"
+    >
+      {resolvedTheme === 'dark' ? <Sun /> : <Moon />}
+    </Button>
+  );
+};

--- a/frontend/src/components/layout/theme-mode-switch.tsx
+++ b/frontend/src/components/layout/theme-mode-switch.tsx
@@ -13,17 +13,8 @@ import { Button } from 'components/redpanda-ui/components/button';
 import { useTheme } from 'components/redpanda-ui/components/theme-provider';
 import { Moon, Sun } from 'lucide-react';
 
-/**
- * Dev-only theme toggle, replacing Chakra's `ColorModeSwitch`.
- *
- * It drives the Registry `ThemeProvider`, which is what stamps `data-theme` on `<html>` — the
- * selector `theme.css` keys its dark palette on, and the attribute `use-theme-appearance` watches
- * to tell Monaco, CodeMirror, react-flow and sonner which ground they are painting on. Same
- * `data-testid` as the Chakra control it replaces.
- *
- * `resolvedTheme`, not `theme`: the stored preference can be `system`, and the label has to name
- * the theme the click will produce.
- */
+/** Dev-only theme toggle on the Registry ThemeProvider. `resolvedTheme`, not `theme`: the stored
+ * preference can be `system`, and the label names the theme the click produces. */
 export const ThemeModeSwitch = () => {
   const { resolvedTheme, setTheme } = useTheme();
   const next = resolvedTheme === 'dark' ? 'light' : 'dark';

--- a/frontend/src/components/misc/Wizard.module.scss
+++ b/frontend/src/components/misc/Wizard.module.scss
@@ -41,15 +41,3 @@
     gap: 1rem;
 }
 
-.nextButton {
-
-}
-
-.prevButton {
-}
-
-.nextButton,
-.prevButton {
-    display: inline-flex;
-    align-items: center;
-}

--- a/frontend/src/components/misc/common.tsx
+++ b/frontend/src/components/misc/common.tsx
@@ -9,8 +9,16 @@
  * by the Apache License, Version 2.0
  */
 
-import { Button, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, ModalOverlay } from '@redpanda-data/ui';
 import { AlertIcon } from 'components/icons';
+import { Button } from 'components/redpanda-ui/components/button';
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from 'components/redpanda-ui/components/dialog';
 import React, { type JSX, type PropsWithChildren, useState } from 'react';
 
 import type { TopicLogDirSummary } from '../../state/rest-interfaces';
@@ -92,18 +100,25 @@ export const UpdatePopup = () => {
   }
 
   return (
-    <Modal isOpen={isUpdateDialogOpen} onClose={() => setUpdateDialogOpen(false)}>
-      <ModalOverlay />
-      <ModalContent minW="xl">
-        <ModalHeader>Redpanda Console has been updated</ModalHeader>
-        <ModalBody>The page must be reloaded to apply the newest version of the frontend.</ModalBody>
-        <ModalFooter gap={2}>
+    <Dialog
+      onOpenChange={(open) => {
+        if (!open) {
+          setUpdateDialogOpen(false);
+        }
+      }}
+      open={isUpdateDialogOpen}
+    >
+      <DialogContent size="xl">
+        <DialogHeader>
+          <DialogTitle>Redpanda Console has been updated</DialogTitle>
+        </DialogHeader>
+        <DialogBody>The page must be reloaded to apply the newest version of the frontend.</DialogBody>
+        <DialogFooter>
           <Button
-            colorScheme="red"
             onClick={() => {
               setUpdateDialogOpen(false);
             }}
-            variant="outline"
+            variant="destructive-outline"
           >
             Cancel
           </Button>
@@ -112,13 +127,13 @@ export const UpdatePopup = () => {
               setUpdateDialogOpen(false);
               window.location.reload();
             }}
-            variant="solid"
+            variant="primary"
           >
             Reload
           </Button>
-        </ModalFooter>
-      </ModalContent>
-    </Modal>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/frontend/src/components/misc/common.tsx
+++ b/frontend/src/components/misc/common.tsx
@@ -100,15 +100,9 @@ export const UpdatePopup = () => {
   }
 
   return (
-    <Dialog
-      onOpenChange={(open) => {
-        if (!open) {
-          setUpdateDialogOpen(false);
-        }
-      }}
-      open={isUpdateDialogOpen}
-    >
-      <DialogContent size="xl">
+    <Dialog onOpenChange={setUpdateDialogOpen} open={isUpdateDialogOpen}>
+      {/* Chakra's `minW="xl"` was 36rem; `size="lg"` (max-w-2xl, 42rem) is the nearest rung. */}
+      <DialogContent size="lg">
         <DialogHeader>
           <DialogTitle>Redpanda Console has been updated</DialogTitle>
         </DialogHeader>

--- a/frontend/src/components/misc/common.tsx
+++ b/frontend/src/components/misc/common.tsx
@@ -101,7 +101,7 @@ export const UpdatePopup = () => {
 
   return (
     <Dialog onOpenChange={setUpdateDialogOpen} open={isUpdateDialogOpen}>
-      {/* Chakra's `minW="xl"` was 36rem; `size="lg"` (max-w-2xl, 42rem) is the nearest rung. */}
+      {/* Nearest rung above the old 36rem minimum. */}
       <DialogContent size="lg">
         <DialogHeader>
           <DialogTitle>Redpanda Console has been updated</DialogTitle>

--- a/frontend/src/components/misc/common.tsx
+++ b/frontend/src/components/misc/common.tsx
@@ -112,7 +112,7 @@ export const UpdatePopup = () => {
             onClick={() => {
               setUpdateDialogOpen(false);
             }}
-            variant="destructive-outline"
+            variant="outline"
           >
             Cancel
           </Button>

--- a/frontend/src/components/misc/error-boundary.tsx
+++ b/frontend/src/components/misc/error-boundary.tsx
@@ -199,7 +199,7 @@ export class ErrorBoundary extends React.Component<{ children?: React.ReactNode 
     }
 
     return (
-      <div className="min-h-screen overflow-visible px-16 py-8">
+      <div className="min-h-screen px-16 py-8">
         <div>
           <h1>Rendering Error!</h1>
           <p>

--- a/frontend/src/components/misc/error-boundary.tsx
+++ b/frontend/src/components/misc/error-boundary.tsx
@@ -11,7 +11,7 @@
 
 import { CloseIcon, CopyAllIcon } from 'components/icons';
 import { Button } from 'components/redpanda-ui/components/button';
-import React, { type CSSProperties, type FC } from 'react';
+import React, { type FC } from 'react';
 import StackTrace from 'stacktrace-js';
 
 import { NoClipboardPopover } from './no-clipboard-popover';
@@ -28,16 +28,6 @@ import { navigatorClipboardErrorHandler, ObjToKv } from '../../utils/tsx-utils';
 //    - main        rgb(252, 207, 207)
 //    - highligh    rgb(204, 102, 102)
 //    - secondary   rgb(135, 142, 145)
-
-const valueStyle: CSSProperties = {
-  whiteSpace: 'pre-wrap',
-  lineBreak: 'anywhere',
-
-  fontSize: '12px',
-  background: 'var(--color-surface-recess)',
-  borderRadius: '2px',
-  padding: '1rem',
-};
 
 type InfoItem = {
   name: string;
@@ -209,20 +199,17 @@ export class ErrorBoundary extends React.Component<{ children?: React.ReactNode 
     }
 
     return (
-      <div style={{ minHeight: '100vh', overflow: 'visible', padding: '2rem 4rem' }}>
+      <div className="min-h-screen overflow-visible px-16 py-8">
         <div>
           <h1>Rendering Error!</h1>
           <p>
             Please report this at{' '}
-            <a
-              href="https://github.com/redpanda-data/console/issues"
-              style={{ textDecoration: 'underline', fontWeight: 'bold' }}
-            >
+            <a className="font-bold underline" href="https://github.com/redpanda-data/console/issues">
               our GitHub Repo
             </a>
           </p>
           <div className="mb-2">
-            <Button onClick={this.dismiss} size="lg" style={{ width: '16rem' }} variant="primary">
+            <Button className="w-64" onClick={this.dismiss} size="lg" variant="primary">
               <CloseIcon />
               Dismiss
             </Button>
@@ -283,7 +270,7 @@ function InfoItemDisplay({ data }: { data: InfoItem }) {
   return (
     <div>
       <h2>{title}</h2>
-      <pre style={valueStyle}>{content}</pre>
+      <pre className="wrap-anywhere whitespace-pre-wrap rounded-xs bg-surface-recess p-4 text-body-sm">{content}</pre>
     </div>
   );
 }

--- a/frontend/src/components/misc/expandable-text.tsx
+++ b/frontend/src/components/misc/expandable-text.tsx
@@ -9,7 +9,6 @@
  * by the Apache License, Version 2.0
  */
 
-import { Box, Icon, Text } from '@redpanda-data/ui';
 import { ChevronDownIcon, ChevronUpIcon } from 'components/icons';
 import { useState } from 'react';
 
@@ -22,32 +21,29 @@ export function ExpandableText(p: { children: string; maxChars: number }) {
   const text = isTruncated ? p.children.slice(0, p.maxChars) : p.children;
 
   return (
-    <Text>
+    <div>
       {text}
 
       {Boolean(isTruncated) && '...'}
 
       {Boolean(showExpander) && (
-        <Box
-          cursor="pointer"
-          display="inline"
-          fontWeight="semibold"
-          mt="1px"
+        // A real button: it was a clickable Box with no role, name or keyboard path.
+        <button
+          className="mt-px inline cursor-pointer select-none border-none bg-transparent px-2 font-semibold"
           onClick={() => setExpanded(!expanded)}
-          px="2"
-          userSelect="none"
+          type="button"
         >
           {expanded ? (
-            <span style={{ whiteSpace: 'nowrap' }}>
-              less <Icon as={ChevronUpIcon} />
+            <span className="whitespace-nowrap">
+              less <ChevronUpIcon className="inline size-4" />
             </span>
           ) : (
-            <span style={{ whiteSpace: 'nowrap' }}>
-              more <Icon as={ChevronDownIcon} />
+            <span className="whitespace-nowrap">
+              more <ChevronDownIcon className="inline size-4" />
             </span>
           )}
-        </Box>
+        </button>
       )}
-    </Text>
+    </div>
   );
 }

--- a/frontend/src/components/misc/expandable-text.tsx
+++ b/frontend/src/components/misc/expandable-text.tsx
@@ -29,7 +29,8 @@ export function ExpandableText(p: { children: string; maxChars: number }) {
       {Boolean(showExpander) && (
         // A real button: it was a clickable Box with no role, name or keyboard path.
         <button
-          className="mt-px inline cursor-pointer select-none border-none bg-transparent px-2 font-semibold"
+          aria-expanded={expanded}
+          className="mt-px inline cursor-pointer select-none px-2 font-semibold"
           onClick={() => setExpanded(!expanded)}
           type="button"
         >

--- a/frontend/src/components/misc/expandable-text.tsx
+++ b/frontend/src/components/misc/expandable-text.tsx
@@ -21,7 +21,7 @@ export function ExpandableText(p: { children: string; maxChars: number }) {
   const isTruncated = showExpander && !expanded;
   const text = isTruncated ? p.children.slice(0, p.maxChars) : p.children;
 
-  // A span: callers render this inside <p> description slots.
+  // A span: valid in inline and <p> slots alike.
   return (
     <span>
       {text}
@@ -29,7 +29,6 @@ export function ExpandableText(p: { children: string; maxChars: number }) {
       {Boolean(isTruncated) && '...'}
 
       {Boolean(showExpander) && (
-        // A real button: it was a clickable Box with no role, name or keyboard path.
         <Button
           aria-expanded={expanded}
           className="h-auto px-2 align-baseline"

--- a/frontend/src/components/misc/expandable-text.tsx
+++ b/frontend/src/components/misc/expandable-text.tsx
@@ -10,6 +10,7 @@
  */
 
 import { ChevronDownIcon, ChevronUpIcon } from 'components/icons';
+import { Button } from 'components/redpanda-ui/components/button';
 import { useState } from 'react';
 
 export function ExpandableText(p: { children: string; maxChars: number }) {
@@ -20,19 +21,20 @@ export function ExpandableText(p: { children: string; maxChars: number }) {
   const isTruncated = showExpander && !expanded;
   const text = isTruncated ? p.children.slice(0, p.maxChars) : p.children;
 
+  // A span: callers render this inside <p> description slots.
   return (
-    <div>
+    <span>
       {text}
 
       {Boolean(isTruncated) && '...'}
 
       {Boolean(showExpander) && (
         // A real button: it was a clickable Box with no role, name or keyboard path.
-        <button
+        <Button
           aria-expanded={expanded}
-          className="mt-px inline cursor-pointer select-none px-2 font-semibold"
+          className="h-auto px-2 align-baseline"
           onClick={() => setExpanded(!expanded)}
-          type="button"
+          variant="link"
         >
           {expanded ? (
             <span className="whitespace-nowrap">
@@ -43,8 +45,8 @@ export function ExpandableText(p: { children: string; maxChars: number }) {
               more <ChevronDownIcon className="inline size-4" />
             </span>
           )}
-        </button>
+        </Button>
       )}
-    </div>
+    </span>
   );
 }

--- a/frontend/src/components/misc/kowl-json-view.tsx
+++ b/frontend/src/components/misc/kowl-json-view.tsx
@@ -9,7 +9,6 @@
  * by the Apache License, Version 2.0
  */
 
-import { Box } from '@redpanda-data/ui';
 import { type CSSProperties, useCallback, useEffect, useMemo, useRef } from 'react';
 
 import KowlEditor, { type IStandaloneCodeEditor } from './kowl-editor';
@@ -143,15 +142,10 @@ export const KowlJsonView = (props: {
   }, [scheduleLayout]);
 
   return (
-    <Box
-      display="block"
-      height="96"
-      position="relative"
-      style={{ minHeight: '10rem', maxHeight: '45rem', ...props.style }}
-    >
-      <Box h="full" position="absolute" ref={containerRef} w="full">
+    <div className="relative block h-96" style={{ minHeight: '10rem', maxHeight: '45rem', ...props.style }}>
+      <div className="absolute h-full w-full" ref={containerRef}>
         <KowlEditor language="json" onMount={handleMount} options={READ_ONLY_EDITOR_OPTIONS} value={str} />
-      </Box>
-    </Box>
+      </div>
+    </div>
   );
 };

--- a/frontend/src/components/misc/kowl-json-view.tsx
+++ b/frontend/src/components/misc/kowl-json-view.tsx
@@ -142,8 +142,8 @@ export const KowlJsonView = (props: {
   }, [scheduleLayout]);
 
   return (
-    <div className="relative block h-96" style={{ minHeight: '10rem', maxHeight: '45rem', ...props.style }}>
-      <div className="absolute h-full w-full" ref={containerRef}>
+    <div className="relative h-96 max-h-180 min-h-40" style={props.style}>
+      <div className="absolute inset-0" ref={containerRef}>
         <KowlEditor language="json" onMount={handleMount} options={READ_ONLY_EDITOR_OPTIONS} value={str} />
       </div>
     </div>

--- a/frontend/src/components/misc/kowl-time-picker.tsx
+++ b/frontend/src/components/misc/kowl-time-picker.tsx
@@ -9,7 +9,6 @@
  * by the Apache License, Version 2.0
  */
 
-import { Box } from '@redpanda-data/ui';
 import { DateTimeInput } from 'components/ui/date-time-input';
 import { useState } from 'react';
 
@@ -17,7 +16,7 @@ export function KowlTimePicker(props: { valueUtcMs: number; onChange: (utcMs: nu
   const [timestampUtcMs, setTimestampUtcMs] = useState(props.valueUtcMs);
 
   return (
-    <Box maxW={300}>
+    <div className="max-w-[300px]">
       <DateTimeInput
         disabled={props.disabled}
         onChange={(value) => {
@@ -26,6 +25,6 @@ export function KowlTimePicker(props: { valueUtcMs: number; onChange: (utcMs: nu
         }}
         value={timestampUtcMs}
       />
-    </Box>
+    </div>
   );
 }

--- a/frontend/src/components/misc/no-clipboard-popover.tsx
+++ b/frontend/src/components/misc/no-clipboard-popover.tsx
@@ -31,7 +31,13 @@ export const NoClipboardPopover: FunctionComponent<{
   ) : (
     // Hover-triggered and informational, so a Tooltip rather than a Popover.
     <Tooltip>
-      <TooltipTrigger render={children} />
+      {/*
+        The trigger is a wrapper span, not the child itself: the child here is a component that
+        forwards no rest props (so ref and pointer handlers would be dropped) and renders a
+        *disabled* button, which dispatches no pointer events at all. Same shape as the disabled
+        buttons in layout/header.tsx.
+      */}
+      <TooltipTrigger render={<span className="inline-flex">{children}</span>} />
       <TooltipContent side={placement}>{popoverContent}</TooltipContent>
     </Tooltip>
   );

--- a/frontend/src/components/misc/no-clipboard-popover.tsx
+++ b/frontend/src/components/misc/no-clipboard-popover.tsx
@@ -9,13 +9,14 @@
  * by the Apache License, Version 2.0
  */
 
-import { Popover } from '@redpanda-data/ui';
+import { Tooltip, TooltipContent, TooltipTrigger } from 'components/redpanda-ui/components/tooltip';
 import type { FunctionComponent, ReactElement } from 'react';
 
 import { isClipboardAvailable } from '../../utils/feature-detection';
 
 const popoverContent = (
   <>
+    <p className="font-semibold">Clipboard unavailable</p>
     <p>Due to browser restrictions, the clipboard is not accessible on unsecure connections.</p>
     <p>Run Redpanda Console with SSL enabled to use this feature.</p>
   </>
@@ -28,7 +29,9 @@ export const NoClipboardPopover: FunctionComponent<{
   isClipboardAvailable ? (
     children
   ) : (
-    <Popover content={popoverContent} placement={placement} title="Clipboard unavailable" trigger="hover">
-      {children}
-    </Popover>
+    // Hover-triggered and informational, so a Tooltip rather than a Popover.
+    <Tooltip>
+      <TooltipTrigger render={children} />
+      <TooltipContent side={placement}>{popoverContent}</TooltipContent>
+    </Tooltip>
   );

--- a/frontend/src/components/misc/no-clipboard-popover.tsx
+++ b/frontend/src/components/misc/no-clipboard-popover.tsx
@@ -14,30 +14,22 @@ import type { FunctionComponent, ReactElement } from 'react';
 
 import { isClipboardAvailable } from '../../utils/feature-detection';
 
-const popoverContent = (
-  <>
+const tooltipContent = (
+  <div className="space-y-1">
     <p className="font-semibold">Clipboard unavailable</p>
     <p>Due to browser restrictions, the clipboard is not accessible on unsecure connections.</p>
     <p>Run Redpanda Console with SSL enabled to use this feature.</p>
-  </>
+  </div>
 );
 
-export const NoClipboardPopover: FunctionComponent<{
-  children: ReactElement;
-  placement?: 'left' | 'top';
-}> = ({ children, placement = 'top' }) =>
+export const NoClipboardPopover: FunctionComponent<{ children: ReactElement }> = ({ children }) =>
   isClipboardAvailable ? (
     children
   ) : (
     // Hover-triggered and informational, so a Tooltip rather than a Popover.
     <Tooltip>
-      {/*
-        The trigger is a wrapper span, not the child itself: the child here is a component that
-        forwards no rest props (so ref and pointer handlers would be dropped) and renders a
-        *disabled* button, which dispatches no pointer events at all. Same shape as the disabled
-        buttons in layout/header.tsx.
-      */}
+      {/* Wrapper span: the child forwards no props and renders a disabled button, which emits no pointer events. */}
       <TooltipTrigger render={<span className="inline-flex">{children}</span>} />
-      <TooltipContent side={placement}>{popoverContent}</TooltipContent>
+      <TooltipContent>{tooltipContent}</TooltipContent>
     </Tooltip>
   );

--- a/frontend/src/components/misc/not-found-page.tsx
+++ b/frontend/src/components/misc/not-found-page.tsx
@@ -5,6 +5,7 @@ import errorBananaSlip from '../../assets/redpanda/ErrorBananaSlip.svg';
 import rocketPanda from '../../assets/redpanda/RocketPanda.svg';
 import { config } from '../../config';
 import { Button, buttonVariants } from '../redpanda-ui/components/button';
+import { cn } from '../redpanda-ui/lib/utils';
 
 export const NotFoundPage = () => {
   const router = useRouter();
@@ -20,7 +21,7 @@ export const NotFoundPage = () => {
           <p className="max-w-xl text-muted-foreground">
             AI agents, MCP servers, knowledge bases, and transcripts are now available in Redpanda AI.
           </p>
-          <a className={buttonVariants()} href={legacyAiDestination}>
+          <a className={cn(buttonVariants(), 'rounded-md')} href={legacyAiDestination}>
             Open Redpanda AI
           </a>
           <Button

--- a/frontend/src/components/misc/removable-filter.tsx
+++ b/frontend/src/components/misc/removable-filter.tsx
@@ -3,7 +3,7 @@ import { Button } from 'components/redpanda-ui/components/button';
 import type { FC, ReactElement } from 'react';
 
 const RemovableFilter: FC<{ children: ReactElement; onRemove: () => void }> = ({ children, onRemove }) => (
-  <div className="!border-border flex items-center rounded-md border">
+  <div className="flex items-center rounded-md border border-border">
     {children}
     <Button aria-label="Remove filter" onClick={() => onRemove()} size="icon-sm" variant="ghost">
       <CloseIcon size={18} />

--- a/frontend/src/components/misc/removable-filter.tsx
+++ b/frontend/src/components/misc/removable-filter.tsx
@@ -1,17 +1,14 @@
-import { Flex, IconButton } from '@redpanda-data/ui';
 import { CloseIcon } from 'components/icons';
+import { Button } from 'components/redpanda-ui/components/button';
 import type { FC, ReactElement } from 'react';
 
 const RemovableFilter: FC<{ children: ReactElement; onRemove: () => void }> = ({ children, onRemove }) => (
-  <Flex alignItems="center" border="1px solid" borderColor="gray.200" borderRadius="md">
+  <div className="!border-border flex items-center rounded-md border">
     {children}
-    <IconButton
-      aria-label="Remove filter"
-      icon={<CloseIcon size={18} />}
-      onClick={() => onRemove()}
-      variant="unstyled"
-    />
-  </Flex>
+    <Button aria-label="Remove filter" onClick={() => onRemove()} size="icon-sm" variant="ghost">
+      <CloseIcon size={18} />
+    </Button>
+  </div>
 );
 
 export default RemovableFilter;

--- a/frontend/src/components/misc/removable-filter.tsx
+++ b/frontend/src/components/misc/removable-filter.tsx
@@ -6,7 +6,7 @@ const RemovableFilter: FC<{ children: ReactElement; onRemove: () => void }> = ({
   <div className="flex items-center rounded-md border border-border">
     {children}
     <Button aria-label="Remove filter" onClick={() => onRemove()} size="icon-sm" variant="ghost">
-      <CloseIcon size={18} />
+      <CloseIcon />
     </Button>
   </div>
 );

--- a/frontend/src/components/misc/search-bar.test.tsx
+++ b/frontend/src/components/misc/search-bar.test.tsx
@@ -1,0 +1,72 @@
+import { expect, test } from '@rstest/core';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+
+import SearchBar from './search-bar';
+
+const data = ['alpha', 'beta'];
+const dataSource = () => data;
+const matches = (query: string, item: string) => item.includes(query);
+const onFilteredDataChanged = () => undefined;
+function SearchExample() {
+  const [query, setQuery] = useState('');
+  return (
+    <SearchBar
+      dataSource={dataSource}
+      filterText={query}
+      isFilterMatch={matches}
+      onFilteredDataChanged={onFilteredDataChanged}
+      onQueryChanged={setQuery}
+    />
+  );
+}
+
+test('slash focuses search; Escape clears the filter then blurs', async () => {
+  const user = userEvent.setup();
+  render(<SearchExample />);
+  const search = screen.getByRole('textbox');
+  await user.keyboard('/');
+  expect(search).toHaveFocus();
+  expect(search).toHaveValue('');
+  await user.type(search, 'alpha');
+  await user.keyboard('{Escape}');
+  expect(search).toHaveValue('');
+  expect(search).toHaveFocus();
+  await user.keyboard('{Escape}');
+  expect(search).not.toHaveFocus();
+});
+
+test('typing in other controls and modified shortcuts do not steal focus', async () => {
+  const user = userEvent.setup();
+  render(
+    <>
+      <SearchExample />
+      <input aria-label="Other input" />
+      <textarea aria-label="Other text" />
+      {/* biome-ignore lint/a11y/useSemanticElements: exercises rich-text contenteditable shortcut isolation */}
+      <div aria-label="Editor" contentEditable role="textbox" tabIndex={0} />
+    </>
+  );
+  for (const name of ['Other input', 'Other text', 'Editor']) {
+    const control = screen.getByRole('textbox', { name });
+    await user.click(control);
+    await user.keyboard('/{Escape}');
+    expect(control).toHaveFocus();
+  }
+  await user.click(document.body);
+  await user.keyboard('{Control>}/{/Control}');
+  expect(screen.getByRole('textbox', { name: '' })).not.toHaveFocus();
+});
+
+test('unmount removes the global shortcut listener', async () => {
+  const user = userEvent.setup();
+  const { unmount } = render(<SearchExample />);
+  unmount();
+  const event = new KeyboardEvent('keydown', { key: '/', bubbles: true, cancelable: true });
+  document.body.dispatchEvent(event);
+  expect(event.defaultPrevented).toBe(false);
+  render(<SearchExample />);
+  await user.keyboard('/');
+  expect(screen.getByRole('textbox')).toHaveFocus();
+});

--- a/frontend/src/components/misc/search-bar.tsx
+++ b/frontend/src/components/misc/search-bar.tsx
@@ -9,7 +9,9 @@
  * by the Apache License, Version 2.0
  */
 
-import { SearchField } from '@redpanda-data/ui';
+import { Button } from 'components/redpanda-ui/components/button';
+import { Input, InputEnd, InputStart } from 'components/redpanda-ui/components/input';
+import { SearchIcon, XIcon } from 'lucide-react';
 import { type ReactNode, useEffect, useMemo } from 'react';
 
 import { AnimatePresence, animProps_span_searchResult, MotionSpan } from '../../utils/animation-props';
@@ -72,12 +74,30 @@ function SearchBar<TItem>(props: SearchBarProps<TItem>) {
         alignItems: 'center',
       }}
     >
-      <SearchField
-        placeholderText={placeholderText}
-        searchText={filterText}
-        setSearchText={onQueryChanged}
-        width="350px"
-      />
+      <Input
+        containerClassName="max-w-[350px]"
+        onChange={(e) => onQueryChanged(e.target.value)}
+        placeholder={placeholderText ?? 'Search...'}
+        testId="search-field-input"
+        value={filterText}
+      >
+        <InputStart>
+          <SearchIcon className="size-4 text-muted-foreground" data-testid="search-field-search-icon" />
+        </InputStart>
+        {filterText !== '' && (
+          <InputEnd className="pointer-events-auto">
+            <Button
+              aria-label="Clear search"
+              data-testid="search-field-reset-icon"
+              onClick={() => onQueryChanged('')}
+              size="icon-xs"
+              variant="ghost"
+            >
+              <XIcon />
+            </Button>
+          </InputEnd>
+        )}
+      </Input>
 
       <AnimatePresence>
         {Boolean(filterSummary) && (

--- a/frontend/src/components/misc/search-bar.tsx
+++ b/frontend/src/components/misc/search-bar.tsx
@@ -9,9 +9,10 @@
  * by the Apache License, Version 2.0
  */
 
+import { CloseIcon } from 'components/icons';
 import { Button } from 'components/redpanda-ui/components/button';
 import { Input, InputEnd, InputStart } from 'components/redpanda-ui/components/input';
-import { SearchIcon, XIcon } from 'lucide-react';
+import { SearchIcon } from 'lucide-react';
 import { type ReactNode, useEffect, useMemo } from 'react';
 
 import { AnimatePresence, animProps_span_searchResult, MotionSpan } from '../../utils/animation-props';
@@ -75,7 +76,7 @@ function SearchBar<TItem>(props: SearchBarProps<TItem>) {
       }}
     >
       <Input
-        containerClassName="max-w-[350px]"
+        containerClassName="w-full max-w-[350px]"
         onChange={(e) => onQueryChanged(e.target.value)}
         placeholder={placeholderText ?? 'Search...'}
         testId="search-field-input"
@@ -84,19 +85,21 @@ function SearchBar<TItem>(props: SearchBarProps<TItem>) {
         <InputStart>
           <SearchIcon className="size-4 text-muted-foreground" data-testid="search-field-search-icon" />
         </InputStart>
-        {filterText !== '' && (
-          <InputEnd className="pointer-events-auto">
-            <Button
-              aria-label="Clear search"
-              data-testid="search-field-reset-icon"
-              onClick={() => onQueryChanged('')}
-              size="icon-xs"
-              variant="ghost"
-            >
-              <XIcon />
-            </Button>
-          </InputEnd>
-        )}
+        {/* Always mounted: InputEnd never resets the padding it measured, and unmounting the
+            button under the click would drop focus to <body>. */}
+        <InputEnd className="pointer-events-auto">
+          <Button
+            aria-label="Clear search"
+            className={filterText === '' ? 'invisible' : undefined}
+            data-testid="search-field-reset-icon"
+            disabled={filterText === ''}
+            onClick={() => onQueryChanged('')}
+            size="icon-xs"
+            variant="ghost"
+          >
+            <CloseIcon />
+          </Button>
+        </InputEnd>
       </Input>
 
       <AnimatePresence>

--- a/frontend/src/components/misc/search-bar.tsx
+++ b/frontend/src/components/misc/search-bar.tsx
@@ -9,12 +9,9 @@
  * by the Apache License, Version 2.0
  */
 
-import { CloseIcon } from 'components/icons';
-import { Button } from 'components/redpanda-ui/components/button';
-import { Input, InputEnd, InputStart } from 'components/redpanda-ui/components/input';
-import { SearchIcon } from 'lucide-react';
-import { type ReactNode, useEffect, useMemo, useRef } from 'react';
+import { type ReactNode, useEffect, useMemo } from 'react';
 
+import { SearchInput } from './search-input';
 import { AnimatePresence, animProps_span_searchResult, MotionSpan } from '../../utils/animation-props';
 
 type SearchBarProps<TItem> = {
@@ -28,29 +25,6 @@ type SearchBarProps<TItem> = {
 
 function SearchBar<TItem>(props: SearchBarProps<TItem>) {
   const { dataSource, isFilterMatch, filterText, onQueryChanged, onFilteredDataChanged, placeholderText } = props;
-
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(function subscribeToSearchShortcut() {
-    function focusSearch(event: KeyboardEvent) {
-      if (
-        event.key !== '/' ||
-        event.defaultPrevented ||
-        event.isComposing ||
-        event.ctrlKey ||
-        event.metaKey ||
-        event.altKey ||
-        (event.target instanceof HTMLElement &&
-          (event.target.isContentEditable || event.target.closest('input, textarea, select, [role="textbox"]')))
-      ) {
-        return;
-      }
-      event.preventDefault();
-      inputRef.current?.focus();
-    }
-    document.addEventListener('keydown', focusSearch);
-    return () => document.removeEventListener('keydown', focusSearch);
-  }, []);
 
   const source = dataSource();
   const filteredData = useMemo(() => {
@@ -84,66 +58,25 @@ function SearchBar<TItem>(props: SearchBarProps<TItem>) {
       identity: 'r',
       node: (
         <span>
-          <span style={{ fontWeight: 600 }}>{filteredData.length}</span> results
+          <span className="font-semibold">{filteredData.length}</span> results
         </span>
       ),
     };
   }, [source, filterText, filteredData]);
 
   return (
-    <div
-      style={{
-        marginBottom: '.5rem',
-        padding: '0',
-        whiteSpace: 'nowrap',
-        display: 'flex',
-        alignItems: 'center',
-      }}
-    >
-      <Input
+    <div className="mb-2 flex items-center whitespace-nowrap">
+      <SearchInput
         containerClassName="w-full max-w-[350px]"
-        onChange={(e) => onQueryChanged(e.target.value)}
-        onKeyDown={(event) => {
-          if (event.key !== 'Escape' || event.nativeEvent.isComposing) {
-            return;
-          }
-          event.preventDefault();
-          event.stopPropagation();
-          if (filterText) {
-            onQueryChanged('');
-          } else {
-            event.currentTarget.blur();
-          }
-        }}
+        onChange={onQueryChanged}
         placeholder={placeholderText ?? 'Search...'}
-        ref={inputRef}
-        testId="search-field-input"
         value={filterText}
-      >
-        <InputStart>
-          <SearchIcon className="size-4 text-muted-foreground" data-testid="search-field-search-icon" />
-        </InputStart>
-        {/* Always mounted: InputEnd never resets the padding it measured, and unmounting the
-            button under the click would drop focus to <body>. */}
-        <InputEnd className="pointer-events-auto">
-          <Button
-            aria-label="Clear search"
-            className={filterText === '' ? 'invisible' : undefined}
-            data-testid="search-field-reset-icon"
-            disabled={filterText === ''}
-            onClick={() => onQueryChanged('')}
-            size="icon-xs"
-            variant="ghost"
-          >
-            <CloseIcon />
-          </Button>
-        </InputEnd>
-      </Input>
+      />
 
       <AnimatePresence>
         {Boolean(filterSummary) && (
           <MotionSpan identityKey={filterSummary?.identity ?? 'null'} overrideAnimProps={animProps_span_searchResult}>
-            <span style={{ opacity: 0.8, paddingLeft: '1em' }}>{filterSummary?.node}</span>
+            <span className="pl-4 opacity-80">{filterSummary?.node}</span>
           </MotionSpan>
         )}
       </AnimatePresence>

--- a/frontend/src/components/misc/search-bar.tsx
+++ b/frontend/src/components/misc/search-bar.tsx
@@ -13,25 +13,50 @@ import { CloseIcon } from 'components/icons';
 import { Button } from 'components/redpanda-ui/components/button';
 import { Input, InputEnd, InputStart } from 'components/redpanda-ui/components/input';
 import { SearchIcon } from 'lucide-react';
-import { type ReactNode, useEffect, useMemo } from 'react';
+import { type ReactNode, useEffect, useMemo, useRef } from 'react';
 
 import { AnimatePresence, animProps_span_searchResult, MotionSpan } from '../../utils/animation-props';
 
-interface SearchBarProps<TItem> {
+type SearchBarProps<TItem> = {
   dataSource: () => TItem[];
   isFilterMatch: (filter: string, item: TItem) => boolean;
   filterText: string;
   onQueryChanged: (value: string) => void;
   onFilteredDataChanged: (data: TItem[]) => void;
   placeholderText?: string;
-}
+};
 
 function SearchBar<TItem>(props: SearchBarProps<TItem>) {
   const { dataSource, isFilterMatch, filterText, onQueryChanged, onFilteredDataChanged, placeholderText } = props;
 
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(function subscribeToSearchShortcut() {
+    function focusSearch(event: KeyboardEvent) {
+      if (
+        event.key !== '/' ||
+        event.defaultPrevented ||
+        event.isComposing ||
+        event.ctrlKey ||
+        event.metaKey ||
+        event.altKey ||
+        (event.target instanceof HTMLElement &&
+          (event.target.isContentEditable || event.target.closest('input, textarea, select, [role="textbox"]')))
+      ) {
+        return;
+      }
+      event.preventDefault();
+      inputRef.current?.focus();
+    }
+    document.addEventListener('keydown', focusSearch);
+    return () => document.removeEventListener('keydown', focusSearch);
+  }, []);
+
   const source = dataSource();
   const filteredData = useMemo(() => {
-    if (!source) return [];
+    if (!source) {
+      return [];
+    }
     return source.filter((item) => isFilterMatch(filterText, item));
   }, [source, filterText, isFilterMatch]);
 
@@ -78,7 +103,20 @@ function SearchBar<TItem>(props: SearchBarProps<TItem>) {
       <Input
         containerClassName="w-full max-w-[350px]"
         onChange={(e) => onQueryChanged(e.target.value)}
+        onKeyDown={(event) => {
+          if (event.key !== 'Escape' || event.nativeEvent.isComposing) {
+            return;
+          }
+          event.preventDefault();
+          event.stopPropagation();
+          if (filterText) {
+            onQueryChanged('');
+          } else {
+            event.currentTarget.blur();
+          }
+        }}
         placeholder={placeholderText ?? 'Search...'}
+        ref={inputRef}
         testId="search-field-input"
         value={filterText}
       >

--- a/frontend/src/components/misc/search-input.test.tsx
+++ b/frontend/src/components/misc/search-input.test.tsx
@@ -1,0 +1,59 @@
+import { expect, test } from '@rstest/core';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+
+import { SearchInput } from './search-input';
+
+function Example({ slashToFocus }: { slashToFocus?: boolean }) {
+  const [query, setQuery] = useState('');
+  return (
+    <>
+      <input aria-label="Other field" />
+      <SearchInput onChange={setQuery} slashToFocus={slashToFocus} value={query} />
+      <output>{query}</output>
+    </>
+  );
+}
+
+test('slash focuses the field; Escape clears it, then blurs', async () => {
+  const user = userEvent.setup();
+  render(<Example />);
+  const search = screen.getByTestId('search-field-input');
+  await user.keyboard('/');
+  expect(search).toHaveFocus();
+  await user.type(search, 'alpha');
+  expect(screen.getByRole('status')).toHaveTextContent('alpha');
+  await user.keyboard('{Escape}');
+  expect(search).toHaveValue('');
+  expect(search).toHaveFocus();
+  await user.keyboard('{Escape}');
+  expect(search).not.toHaveFocus();
+});
+
+test('slash typed into another field is left alone', async () => {
+  const user = userEvent.setup();
+  render(<Example />);
+  const other = screen.getByLabelText('Other field');
+  await user.click(other);
+  await user.keyboard('/');
+  expect(other).toHaveValue('/');
+  expect(screen.getByTestId('search-field-input')).not.toHaveFocus();
+});
+
+test('clearing with the button keeps focus in the field', async () => {
+  const user = userEvent.setup();
+  render(<Example />);
+  const search = screen.getByTestId('search-field-input');
+  await user.type(search, 'beta');
+  await user.click(screen.getByTestId('search-field-reset-icon'));
+  expect(search).toHaveValue('');
+  expect(search).toHaveFocus();
+});
+
+test('the clear button is hidden and unfocusable while empty', () => {
+  render(<Example slashToFocus={false} />);
+  const clear = screen.getByTestId('search-field-reset-icon');
+  expect(clear).toBeDisabled();
+  expect(clear).toHaveClass('invisible');
+});

--- a/frontend/src/components/misc/search-input.tsx
+++ b/frontend/src/components/misc/search-input.tsx
@@ -88,6 +88,7 @@ export function SearchInput({
 
   return (
     <Input
+      aria-keyshortcuts="/"
       aria-label={ariaLabel}
       className={className}
       containerClassName={containerClassName}
@@ -123,6 +124,7 @@ export function SearchInput({
           disabled={isEmpty}
           onClick={clear}
           size="icon-xs"
+          title="Clear (Esc)"
           variant="ghost"
         >
           <CloseIcon />

--- a/frontend/src/components/misc/search-input.tsx
+++ b/frontend/src/components/misc/search-input.tsx
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { CloseIcon } from 'components/icons';
+import { Button } from 'components/redpanda-ui/components/button';
+import { Input, InputEnd, InputStart } from 'components/redpanda-ui/components/input';
+import { cn } from 'components/redpanda-ui/lib/utils';
+import { SearchIcon } from 'lucide-react';
+import { type ReactNode, useEffect, useRef } from 'react';
+
+type SearchInputProps = {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  /** Leading icon; a magnifier unless given. */
+  icon?: ReactNode;
+  /** `/` anywhere on the page focuses the field. */
+  slashToFocus?: boolean;
+  className?: string;
+  containerClassName?: string;
+  testId?: string;
+  'aria-label'?: string;
+};
+
+// Where `/` is a character the user is typing, not a shortcut.
+const TYPING_TARGET = 'input, textarea, select, [contenteditable], [role="textbox"], [role="combobox"]';
+const DIALOG = '[role="dialog"], [role="alertdialog"]';
+
+/** Search field: leading icon, clear button, `/` to focus, Escape to clear (or blur when empty). */
+export function SearchInput({
+  value,
+  onChange,
+  placeholder = 'Search...',
+  icon,
+  slashToFocus = true,
+  className,
+  containerClassName,
+  testId = 'search-field-input',
+  'aria-label': ariaLabel,
+}: SearchInputProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const isEmpty = value === '';
+
+  useEffect(() => {
+    if (!slashToFocus) {
+      return;
+    }
+    const focusOnSlash = (event: KeyboardEvent) => {
+      if (
+        event.key !== '/' ||
+        event.defaultPrevented ||
+        event.isComposing ||
+        event.ctrlKey ||
+        event.metaKey ||
+        event.altKey
+      ) {
+        return;
+      }
+      const target = event.target instanceof HTMLElement ? event.target : null;
+      if (target?.isContentEditable || target?.closest(TYPING_TARGET)) {
+        return;
+      }
+      // Focus inside an open dialog stays there unless the field is in the same dialog.
+      const dialog = target?.closest(DIALOG);
+      if (dialog && !dialog.contains(inputRef.current)) {
+        return;
+      }
+      event.preventDefault();
+      inputRef.current?.focus();
+    };
+    document.addEventListener('keydown', focusOnSlash);
+    return () => document.removeEventListener('keydown', focusOnSlash);
+  }, [slashToFocus]);
+
+  // Refocus before the re-render disables the button, or focus lands on <body>.
+  const clear = () => {
+    onChange('');
+    inputRef.current?.focus();
+  };
+
+  return (
+    <Input
+      aria-label={ariaLabel}
+      className={className}
+      containerClassName={containerClassName}
+      onChange={(event) => onChange(event.target.value)}
+      onKeyDown={(event) => {
+        if (event.key !== 'Escape' || event.nativeEvent.isComposing) {
+          return;
+        }
+        if (isEmpty) {
+          event.currentTarget.blur();
+          return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        onChange('');
+      }}
+      placeholder={placeholder}
+      ref={inputRef}
+      testId={testId}
+      value={value}
+    >
+      <InputStart>
+        <span className="flex text-muted-foreground" data-testid="search-field-search-icon">
+          {icon ?? <SearchIcon className="size-4" />}
+        </span>
+      </InputStart>
+      {/* Always mounted: InputEnd never resets the padding it measured. Click-through while empty. */}
+      <InputEnd className={cn(!isEmpty && 'pointer-events-auto')}>
+        <Button
+          aria-label="Clear search"
+          className={cn(isEmpty && 'invisible')}
+          data-testid="search-field-reset-icon"
+          disabled={isEmpty}
+          onClick={clear}
+          size="icon-xs"
+          variant="ghost"
+        >
+          <CloseIcon />
+        </Button>
+      </InputEnd>
+    </Input>
+  );
+}

--- a/frontend/src/components/misc/wizard.tsx
+++ b/frontend/src/components/misc/wizard.tsx
@@ -9,7 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
-import { Button } from '@redpanda-data/ui';
+import { Button } from 'components/redpanda-ui/components/button';
 import React from 'react';
 
 import styles from './Wizard.module.scss';
@@ -21,13 +21,13 @@ export function Wizard<State extends WizardState>({ state }: { state: State }) {
       <div className={styles.content}>{currentStep.content}</div>
       <div className={styles.footer}>
         {currentStep.nextButtonLabel !== null && (
-          <Button disabled={!state.canContinue()} onClick={state.next} px="8" variant="solid">
+          <Button className="px-8" disabled={!state.canContinue()} onClick={state.next} variant="primary">
             {currentStep.nextButtonLabel ?? 'Next'}
           </Button>
         )}
 
         {state.isFirst() ? null : (
-          <Button className={styles.prevButton} onClick={state.previous} px="8" variant="link">
+          <Button className={`px-8 ${styles.prevButton}`} onClick={state.previous} variant="link">
             {currentStep.prevButtonLabel ?? 'Back'}
           </Button>
         )}

--- a/frontend/src/components/misc/wizard.tsx
+++ b/frontend/src/components/misc/wizard.tsx
@@ -10,6 +10,7 @@
  */
 
 import { Button } from 'components/redpanda-ui/components/button';
+import { cn } from 'components/redpanda-ui/lib/utils';
 import React from 'react';
 
 import styles from './Wizard.module.scss';
@@ -27,7 +28,7 @@ export function Wizard<State extends WizardState>({ state }: { state: State }) {
         )}
 
         {state.isFirst() ? null : (
-          <Button className={`px-8 ${styles.prevButton}`} onClick={state.previous} variant="link">
+          <Button className={cn('px-8', styles.prevButton)} onClick={state.previous} variant="link">
             {currentStep.prevButtonLabel ?? 'Back'}
           </Button>
         )}

--- a/frontend/src/components/misc/wizard.tsx
+++ b/frontend/src/components/misc/wizard.tsx
@@ -10,7 +10,6 @@
  */
 
 import { Button } from 'components/redpanda-ui/components/button';
-import { cn } from 'components/redpanda-ui/lib/utils';
 import React from 'react';
 
 import styles from './Wizard.module.scss';
@@ -28,7 +27,7 @@ export function Wizard<State extends WizardState>({ state }: { state: State }) {
         )}
 
         {state.isFirst() ? null : (
-          <Button className={cn('px-8', styles.prevButton)} onClick={state.previous} variant="link">
+          <Button className="px-8" onClick={state.previous} variant="link">
             {currentStep.prevButtonLabel ?? 'Back'}
           </Button>
         )}

--- a/frontend/src/components/pages/consumers/group-details.tsx
+++ b/frontend/src/components/pages/consumers/group-details.tsx
@@ -454,6 +454,8 @@ const PartitionTable = ({
   const table = useDataTable({
     data: partitions,
     columns,
+    enableHiding: false,
+    enableRowSelection: false,
     state: { sorting, pagination },
     onSortingChange: setSorting,
     onPaginationChange: setPagination,

--- a/frontend/src/components/pages/consumers/group-list.tsx
+++ b/frontend/src/components/pages/consumers/group-list.tsx
@@ -197,6 +197,8 @@ const GroupList: FC = () => {
   const table = useDataTable({
     data: consumerGroups,
     columns,
+    enableHiding: false,
+    enableRowSelection: false,
     state: { sorting, pagination, columnFilters },
     onSortingChange: handleSortingChange,
     onPaginationChange: handlePaginationChange,

--- a/frontend/src/components/pages/consumers/modals.tsx
+++ b/frontend/src/components/pages/consumers/modals.tsx
@@ -813,6 +813,8 @@ const OffsetPreviewTable = ({ items, selectedTime }: { items: GroupOffset[]; sel
   const table = useDataTable({
     data: items,
     columns,
+    enableHiding: false,
+    enableRowSelection: false,
     state: { sorting },
     onSortingChange: setSorting,
   });

--- a/frontend/src/components/pages/quotas/quotas-list.tsx
+++ b/frontend/src/components/pages/quotas/quotas-list.tsx
@@ -218,6 +218,8 @@ const QuotasList = () => {
   const table = useDataTable({
     data: quotasData,
     columns,
+    enableHiding: false,
+    enableRowSelection: false,
     state: { pagination, sorting },
     onPaginationChange: handlePaginationChange,
     onSortingChange: handleSortingChange,

--- a/frontend/src/components/pages/schemas/schema-list.tsx
+++ b/frontend/src/components/pages/schemas/schema-list.tsx
@@ -470,6 +470,8 @@ const SchemaList: FC = () => {
   const table = useDataTable({
     data: enrichedSubjects,
     columns,
+    enableHiding: false,
+    enableRowSelection: false,
     state: { sorting, pagination, columnFilters },
     onSortingChange: setSorting,
     onPaginationChange: handlePaginationChange,

--- a/frontend/src/components/pages/security/tabs/roles-tab-new.tsx
+++ b/frontend/src/components/pages/security/tabs/roles-tab-new.tsx
@@ -169,6 +169,8 @@ export const RolesTabNew: FC = () => {
   const table = useDataTable({
     data: rolesWithMembers,
     columns,
+    enableHiding: false,
+    enableRowSelection: false,
     state: { sorting, pagination, columnFilters },
     onSortingChange: setSorting,
     onPaginationChange: handlePaginationChange,

--- a/frontend/src/components/pages/security/tabs/users-tab-new.tsx
+++ b/frontend/src/components/pages/security/tabs/users-tab-new.tsx
@@ -231,6 +231,8 @@ export const UsersTabNew: FC = () => {
   const table = useDataTable({
     data: users,
     columns,
+    enableHiding: false,
+    enableRowSelection: false,
     state: { sorting, pagination, columnFilters },
     onSortingChange: setSorting,
     onPaginationChange: handlePaginationChange,

--- a/frontend/src/components/pages/topics/Tab.Acl/acl-list.tsx
+++ b/frontend/src/components/pages/topics/Tab.Acl/acl-list.tsx
@@ -95,6 +95,8 @@ const AclList = ({ acl }: { acl: Acls }) => {
   const table = useDataTable({
     data: resources,
     columns,
+    enableHiding: false,
+    enableRowSelection: false,
     state: { sorting, pagination },
     onSortingChange,
     onPaginationChange,

--- a/frontend/src/components/pages/topics/Tab.Messages/index.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/index.tsx
@@ -1243,6 +1243,7 @@ export const TopicMessageView: FC<TopicMessageViewProps> = (props) => {
   const table = useDataTable({
     data: filteredMessages,
     columns: [expanderColumn, ...columns],
+    enableRowSelection: false,
     state: {
       pagination: paginationParams,
       sorting,

--- a/frontend/src/components/pages/topics/tab-consumers.tsx
+++ b/frontend/src/components/pages/topics/tab-consumers.tsx
@@ -67,6 +67,8 @@ export const TopicConsumers: FC<TopicConsumersProps> = ({ topic }) => {
   const table = useDataTable({
     data: consumers,
     columns,
+    enableHiding: false,
+    enableRowSelection: false,
     state: { sorting, pagination },
     onSortingChange,
     onPaginationChange,

--- a/frontend/src/components/pages/topics/tab-partitions.tsx
+++ b/frontend/src/components/pages/topics/tab-partitions.tsx
@@ -110,6 +110,8 @@ export const TopicPartitions: FC<TopicPartitionsProps> = ({ topic }) => {
   const table = useDataTable({
     data: partitions,
     columns,
+    enableHiding: false,
+    enableRowSelection: false,
     state: { sorting, pagination },
     onSortingChange,
     onPaginationChange,

--- a/frontend/src/components/pages/topics/topic-list-new.tsx
+++ b/frontend/src/components/pages/topics/topic-list-new.tsx
@@ -290,6 +290,8 @@ const TopicList: FC = () => {
   const table = useDataTable({
     data: allTopics,
     columns,
+    enableHiding: false,
+    enableRowSelection: false,
     state: { sorting, pagination, columnFilters },
     onSortingChange: handleSortingChange,
     onPaginationChange: handlePaginationChange,

--- a/frontend/src/components/ui/connect/log-explorer.tsx
+++ b/frontend/src/components/ui/connect/log-explorer.tsx
@@ -331,6 +331,7 @@ export function LogExplorer({ pipeline, serverless, enableLiveView = false, titl
   const table = useDataTable({
     data: messages,
     columns: messageTableColumns,
+    enableRowSelection: false,
     state: {
       pagination: paginationParams,
       sorting,
@@ -539,12 +540,7 @@ export function LogExplorer({ pipeline, serverless, enableLiveView = false, titl
           </TableBody>
         </Table>
       </div>
-      {/* Hide DataTablePagination's "X of N row(s) selected." (no row selection) while keeping its layout slot. */}
-      {filteredRowCount > 0 && (
-        <div className="[&>div>div:first-child]:invisible">
-          <DataTablePagination table={table} />
-        </div>
-      )}
+      {filteredRowCount > 0 && <DataTablePagination table={table} />}
       <LogDetailSheet message={selectedMessage} onClose={() => setSelectedMessage(null)} />
     </div>
   );

--- a/frontend/src/hooks/use-developer-view.test.tsx
+++ b/frontend/src/hooks/use-developer-view.test.tsx
@@ -48,30 +48,28 @@ describe('useDeveloperView', () => {
     expect(result.current).toBe(true);
   });
 
-  it('does not crash when pressing ? key', async () => {
+  it('toggles on ? and persists the choice', async () => {
     const user = userEvent.setup();
     const { result } = renderHook(() => useDeveloperView());
 
-    // Simulate pressing '?' — this previously caused React error #301 in production
-    // when connected to vanilla Kafka (issue #2262).
-    // userEvent.keyboard wraps the state update triggered by useKey in act()
-    // automatically, eliminating the "not wrapped in act" warning.
+    expect(result.current).toBe(false);
+
+    // Pressing '?' previously caused React error #301 in production when connected to
+    // vanilla Kafka (issue #2262). userEvent.keyboard wraps the state update in act().
     await user.keyboard('?');
 
-    // Hook should still return a valid boolean
-    expect(typeof result.current).toBe('boolean');
+    expect(result.current).toBe(true);
+    expect(store.dv).toBe(JSON.stringify(true));
+
+    await user.keyboard('?');
+
+    expect(result.current).toBe(false);
+    expect(store.dv).toBe(JSON.stringify(false));
   });
 
   it('returns false when localStorage contains invalid JSON', () => {
-    // The tested fallback path intentionally catches + logs a SyntaxError via
-    // @redpanda-data/ui's useLocalStorage (which uses console.log). Scope the
-    // mute to this single test so the expected error doesn't pollute CI output.
-    const logSpy = rs.spyOn(console, 'log').mockImplementation(() => {
-      // intentionally empty — scoped mute for expected fallback log
-    });
     store.dv = 'not-json';
     const { result } = renderHook(() => useDeveloperView());
-    expect(typeof result.current).toBe('boolean');
-    logSpy.mockRestore();
+    expect(result.current).toBe(false);
   });
 });

--- a/frontend/src/hooks/use-developer-view.ts
+++ b/frontend/src/hooks/use-developer-view.ts
@@ -42,7 +42,8 @@ const useDeveloperViewDev = (): boolean => {
   return developerView;
 };
 
-const useDeveloperViewProd = (): boolean => readStored();
+// Read once at mount, not on every render of the app root — the value cannot change in prod.
+const useDeveloperViewProd = (): boolean => useState(readStored)[0];
 
 const useDeveloperView = IS_DEV ? useDeveloperViewDev : useDeveloperViewProd;
 

--- a/frontend/src/hooks/use-developer-view.ts
+++ b/frontend/src/hooks/use-developer-view.ts
@@ -1,23 +1,48 @@
-import { useKey, useLocalStorage } from '@redpanda-data/ui';
+import { useEffect, useState } from 'react';
 
 const IS_DEV = process.env.NODE_ENV !== 'production';
+const STORAGE_KEY = 'dv';
 
-const useDeveloperViewDev = (): boolean => {
-  const [developerView, setDeveloperView] = useLocalStorage('dv', false);
-  useKey('?', () => {
-    setDeveloperView(!developerView);
-  });
-  return developerView;
-};
-
-const useDeveloperViewProd = (): boolean => {
+const readStored = (): boolean => {
   try {
-    const stored = window.localStorage.getItem('dv');
+    const stored = window.localStorage.getItem(STORAGE_KEY);
     return stored ? JSON.parse(stored) : false;
   } catch {
     return false;
   }
 };
+
+/** `?` toggles the developer view; the choice persists so a reload keeps it. */
+const useDeveloperViewDev = (): boolean => {
+  const [developerView, setDeveloperView] = useState(readStored);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      // Not while typing, and not as part of a shortcut.
+      const target = event.target as HTMLElement | null;
+      const isEditable = target?.isContentEditable || ['INPUT', 'TEXTAREA', 'SELECT'].includes(target?.tagName ?? '');
+      if (event.key !== '?' || isEditable || event.ctrlKey || event.metaKey || event.altKey) {
+        return;
+      }
+      setDeveloperView((previous) => {
+        const next = !previous;
+        try {
+          window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+        } catch {
+          // Persisting is an optimisation; the toggle still applies for this session.
+        }
+        return next;
+      });
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
+
+  return developerView;
+};
+
+const useDeveloperViewProd = (): boolean => readStored();
 
 const useDeveloperView = IS_DEV ? useDeveloperViewDev : useDeveloperViewProd;
 

--- a/frontend/src/hooks/use-developer-view.ts
+++ b/frontend/src/hooks/use-developer-view.ts
@@ -2,11 +2,13 @@ import { useEffect, useState } from 'react';
 
 const IS_DEV = process.env.NODE_ENV !== 'production';
 const STORAGE_KEY = 'dv';
+// Where `?` is a character being typed, not a shortcut.
+const TYPING_TARGET = 'input, textarea, select, [contenteditable], [role="textbox"], [role="combobox"]';
 
 const readStored = (): boolean => {
   try {
     const stored = window.localStorage.getItem(STORAGE_KEY);
-    return stored ? JSON.parse(stored) : false;
+    return stored === 'true';
   } catch {
     return false;
   }
@@ -18,10 +20,19 @@ const useDeveloperViewDev = (): boolean => {
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      // Not while typing, and not as part of a shortcut.
-      const target = event.target as HTMLElement | null;
-      const isEditable = target?.isContentEditable || ['INPUT', 'TEXTAREA', 'SELECT'].includes(target?.tagName ?? '');
-      if (event.key !== '?' || isEditable || event.ctrlKey || event.metaKey || event.altKey) {
+      // Not while typing, not on key repeat, and not as part of a shortcut.
+      const target = event.target instanceof HTMLElement ? event.target : null;
+      const isEditable = Boolean(target?.isContentEditable || target?.closest(TYPING_TARGET));
+      if (
+        event.key !== '?' ||
+        event.repeat ||
+        event.defaultPrevented ||
+        event.isComposing ||
+        isEditable ||
+        event.ctrlKey ||
+        event.metaKey ||
+        event.altKey
+      ) {
         return;
       }
       setDeveloperView((previous) => {

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -1965,17 +1965,20 @@ nav.chakra-breadcrumb {
   }
 }
 
-p,
-dl,
-dd,
-ol,
-ul,
-h1,
-h2,
-h3,
-h4,
-h5 {
-  margin-bottom: 0;
+// In @layer base so spacing utilities on these elements still apply.
+@layer base {
+  p,
+  dl,
+  dd,
+  ol,
+  ul,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5 {
+    margin-bottom: 0;
+  }
 }
 
 .BreadcrumbHeading,


### PR DESCRIPTION
## Chakra exit · Phase 2 (route by route) · PR 8 of 14

Part of the [Chakra exit plan and live tracker](https://claude.ai/code/artifact/1861e21c-624b-4270-98ad-9921b22c2498). Branch `chakra-exit/08-chrome-shell`, directly on `master`.

**Hard prerequisite for PR 13** — the cut cannot happen until the theme provider is mounted here.

### The load-bearing half
`data-theme` on `<html>` is what `theme.css` keys its dark palette on, and what `use-theme-appearance` watches to tell Monaco, CodeMirror, react-flow and sonner which ground they are painting on. Chakra's `ColorModeSwitch` was the only thing setting it.

- `components/layout/theme-mode-switch.tsx` replaces it on the Registry `ThemeProvider`'s `useTheme()`, keeping the `ColorModeSwitch` test id and the "Switch to *next* mode" label. It reads `resolvedTheme`, not `theme`, because the stored preference can be `system`.
- **The provider is mounted in `app.tsx` only**, not in embedded-app or federated-providers as the plan said. In those modes the Cloud UI host owns `data-theme`; a second writer inside Console would fight it.
- **`defaultTheme="light"`, deliberately.** Chakra pinned `initialColorMode: 'light'` with `useSystemColorMode: false`. The Registry default is `system`, which would flip every OS-dark user to the Registry's dark palette while the still-mounted Chakra half stayed light — and the toggle is dev-only, so no way back. Dark mode stays its own project.
- **The `theme={toasterTheme}` plumbing stays**, contrary to the plan. `sonner.tsx` reads `useTheme().theme`, which can be `system` and then resolves off `prefers-color-scheme` — disagreeing with an explicit toggle. `useThemeAppearance()` reads the ground actually painted, which is the answer sonner needs.

ChakraProvider's own ColorModeProvider is still a second `data-theme` writer one level down. It applies once on mount and this provider's effect lands after it, so the attribute is ours — but Chakra's internal colour mode no longer changes, so toggling in dev repaints the Registry surface and leaves Chakra components light. That resolves when PR 13 removes ChakraProvider; it is written down at the mount point.

### The misc leftovers
Each behind its existing export: `no-clipboard-popover` (hover Popover → Tooltip), `kowl-time-picker`, `removable-filter`, `search-bar` (`SearchField` → the shared `misc/search-input`, keeping the `search-field-*` test ids and the `/`/Escape shortcuts), `kowl-json-view`, `expandable-text`, `common` (update Modal → Dialog) and `wizard`.

`hooks/use-developer-view` loses Chakra's `useKey` + `useLocalStorage` for a keydown listener and localStorage directly — these non-visual hooks keep the dependency alive on their own. The replacement ignores `?` typed into a field or held with a modifier, which Chakra's `useKey` did not, and its test now asserts the toggle flips and persists rather than only that it does not crash.

### Worth a look
**The clipboard-unavailable tooltip could never open.** `render={children}` handed the trigger props to a component that forwards no rest props, and the child in that branch is a *disabled* button, which dispatches no pointer events. It wraps in a span now — the same shape the header's disabled buttons use. This is the only explanation users get for a copy button that silently fails over plain HTTP.

### Folded in: single-select tables (2026-09-08)
Thirteen Registry tables already on `master` (consumer groups list and details, the edit-offsets modal, quotas, schema registry, the new security tabs, the topic list and its partitions, consumers, ACL and messages tabs, the Connect log explorer) now pass `enableHiding: false` and `enableRowSelection: false`. The first removes the "Hide" item from the column header menus — none of these pages has a column-visibility control to bring a column back. The second removes the pager's "X of N row(s) selected." text, which the Registry gates on that option — none of them selects rows. The log explorer had blanked that text with a CSS hack; it uses the option now. The secrets store keeps both (it has row checkboxes and view options). Folded in here rather than opened as a fifteenth PR.

### Effect
Files importing `@redpanda-data/ui`: **81 → 71** — the largest single drop in Phase 2.

### Gates
`type:check` · `lint` · `lint:check` per changed file · unit (882) · integration (1311), including `header.test.tsx` and `use-developer-view.test.tsx`. By hand: the header on both embedded and self-hosted layouts, and that `data-theme` still lands on `<html>` with Monaco, CodeMirror, react-flow and sonner following the dev toggle.

### Second review round (2026-09-08)
- `index.scss`: the `p, dl, dd, ol, ul, h1–h5 { margin-bottom: 0 }` reset is in `@layer base` now — unlayered it beat every `mb-*` utility the migration put on a heading.
- Chakra's colour-mode manager is pinned to light so a stored `chakra-ui-color-mode=dark` cannot resurrect a dark Chakra half; `bootstrap.tsx` calls `initTheme` so the first paint already carries the theme.
- The `?` developer-view toggle ignores key repeat, IME composition, handled events and typing targets, and reads its stored flag as a boolean.
- Misc: clipboard notice spacing and dead `placement` prop; `ExpandableText` renders a span (it sits inside `<p>`) with a Registry link Button; UpdatePopup Cancel is plain outline; dead Wizard scss classes and an inert icon size removed; JSON view sizing on utilities; the error boundary is on Tailwind classes (asked on #2629 after it merged); the not-found anchor gets the radius `buttonVariants` alone does not give.

### Final review (2026-09-08)
- Escape in the search field is field-scoped (the Chakra SearchField cleared the filter from anywhere on the page) — deliberate, so Escape-to-close-a-dialog no longer wipes a filter. Comments trimmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


