### PR TITLE
[Chakra exit · Phase 2 · PR 10/14] frontend: the Kafka Connect dynamic-ui engine on Registry components

### DIFF
--- a/frontend/src/components/pages/connect/dynamic-ui/components.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/components.tsx
@@ -81,7 +81,7 @@ export const ConfigPage: React.FC<ConfigPageProps> = ({ connectorStore, context 
         >
           {(['form', 'json'] as const).map((mode) => (
             <div className="flex items-center gap-2" key={mode}>
-              <RadioGroupItem id={`settings-mode-${mode}`} value={mode} />
+              <RadioGroupItem id={`settings-mode-${mode}`} testId={`${mode}_field`} value={mode} />
               <Label className="cursor-pointer" htmlFor={`settings-mode-${mode}`}>
                 {mode === 'form' ? 'Form' : 'JSON'}
               </Label>

--- a/frontend/src/components/pages/connect/dynamic-ui/components.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/components.tsx
@@ -9,7 +9,10 @@
  * by the Apache License, Version 2.0
  */
 
-import { Box, RadioGroup, Skeleton, Switch } from '@redpanda-data/ui';
+import { Label } from 'components/redpanda-ui/components/label';
+import { RadioGroup, RadioGroupItem } from 'components/redpanda-ui/components/radio-group';
+import { SkeletonText } from 'components/redpanda-ui/components/skeleton';
+import { Switch } from 'components/redpanda-ui/components/switch';
 import { useCallback, useState, useSyncExternalStore } from 'react';
 
 import { ConnectorStepComponent } from './connector-step';
@@ -41,7 +44,7 @@ export const ConfigPage: React.FC<ConfigPageProps> = ({ connectorStore, context 
   }
 
   if (connectorStore.initPending) {
-    return <Skeleton height={4} mt={5} noOfLines={20} />;
+    return <SkeletonText className="mt-5" lines={20} width="full" />;
   }
 
   if (connectorStore.allGroups.length === 0) {
@@ -61,32 +64,43 @@ export const ConfigPage: React.FC<ConfigPageProps> = ({ connectorStore, context 
 
   return (
     <>
-      <Box mb="8">
+      <div className="mb-8">
         <RadioGroup
+          className="flex gap-4"
           name="settingsMode"
-          onChange={(x) => {
-            connectorStore.viewMode = x;
-            setViewMode(x as 'form' | 'json');
+          onValueChange={(next) => {
+            connectorStore.viewMode = next as 'form' | 'json';
+            setViewMode(next as 'form' | 'json');
           }}
-          options={[
-            { value: 'form', label: <Box mx="4">Form</Box> },
-            { value: 'json', label: <Box mx="4">JSON</Box> },
-          ]}
+          orientation="horizontal"
           value={viewMode}
-        />
-      </Box>
+        >
+          {(['form', 'json'] as const).map((mode) => (
+            <div className="flex items-center gap-2" key={mode}>
+              <RadioGroupItem id={`settings-mode-${mode}`} value={mode} />
+              <Label className="mx-4 cursor-pointer" htmlFor={`settings-mode-${mode}`}>
+                {mode === 'form' ? 'Form' : 'JSON'}
+              </Label>
+            </div>
+          ))}
+        </RadioGroup>
+      </div>
 
       {viewMode === 'form' ? (
         <>
-          <Switch
-            isChecked={showAdvancedOptions}
-            onChange={(s) => {
-              connectorStore.showAdvancedOptions = s.target.checked;
-              setShowAdvancedOptions(s.target.checked);
-            }}
-          >
-            Show advanced options
-          </Switch>
+          <div className="flex items-center gap-2">
+            <Switch
+              checked={showAdvancedOptions}
+              id="show-advanced-options"
+              onCheckedChange={(checked) => {
+                connectorStore.showAdvancedOptions = checked;
+                setShowAdvancedOptions(checked);
+              }}
+            />
+            <Label className="cursor-pointer" htmlFor="show-advanced-options">
+              Show advanced options
+            </Label>
+          </div>
 
           {steps.map(({ step, groups }) => (
             <ConnectorStepComponent

--- a/frontend/src/components/pages/connect/dynamic-ui/components.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/components.tsx
@@ -44,7 +44,11 @@ export const ConfigPage: React.FC<ConfigPageProps> = ({ connectorStore, context 
   }
 
   if (connectorStore.initPending) {
-    return <SkeletonText className="mt-5" lines={20} width="full" />;
+    return (
+      <div className="mt-5">
+        <SkeletonText lines={20} width="full" />
+      </div>
+    );
   }
 
   if (connectorStore.allGroups.length === 0) {
@@ -78,7 +82,7 @@ export const ConfigPage: React.FC<ConfigPageProps> = ({ connectorStore, context 
           {(['form', 'json'] as const).map((mode) => (
             <div className="flex items-center gap-2" key={mode}>
               <RadioGroupItem id={`settings-mode-${mode}`} value={mode} />
-              <Label className="mx-4 cursor-pointer" htmlFor={`settings-mode-${mode}`}>
+              <Label className="cursor-pointer" htmlFor={`settings-mode-${mode}`}>
                 {mode === 'form' ? 'Form' : 'JSON'}
               </Label>
             </div>

--- a/frontend/src/components/pages/connect/dynamic-ui/connector-step.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/connector-step.tsx
@@ -9,8 +9,6 @@
  * by the Apache License, Version 2.0
  */
 
-import { Box, Heading, Text } from '@redpanda-data/ui';
-
 import type { ConfigPageProps } from './components';
 import { PropertyGroupComponent } from './property-group';
 import type { PropertyGroup } from '../../../../state/connect/state';
@@ -33,16 +31,10 @@ export const ConnectorStepComponent = (props: {
   }
 
   return (
-    <Box>
-      <Heading as="h3" mb="4" mt="8" size="md">
-        {step.name}
-      </Heading>
+    <div>
+      <h3 className="mt-8 mb-4 text-heading-md">{step.name}</h3>
 
-      {Boolean(step.description) && (
-        <Text mb="4" size="sm">
-          {step.description}
-        </Text>
-      )}
+      {Boolean(step.description) && <p className="mb-4 text-body-sm">{step.description}</p>}
 
       {groups.map((g) => (
         <PropertyGroupComponent
@@ -54,6 +46,6 @@ export const ConnectorStepComponent = (props: {
           showAdvancedOptions={props.showAdvancedOptions}
         />
       ))}
-    </Box>
+    </div>
   );
 };

--- a/frontend/src/components/pages/connect/dynamic-ui/connector-step.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/connector-step.tsx
@@ -32,9 +32,9 @@ export const ConnectorStepComponent = (props: {
 
   return (
     <div>
-      <h3 className="mt-8 mb-4 text-heading-md">{step.name}</h3>
+      <h3 className="mt-8 text-heading-md">{step.name}</h3>
 
-      {Boolean(step.description) && <p className="mb-4 text-body-sm">{step.description}</p>}
+      {Boolean(step.description) && <p className="mt-4 text-body-sm">{step.description}</p>}
 
       {groups.map((g) => (
         <PropertyGroupComponent

--- a/frontend/src/components/pages/connect/dynamic-ui/forms/error-wrapper.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/forms/error-wrapper.tsx
@@ -8,8 +8,17 @@ import { ExpandableText } from '../../../../misc/expandable-text';
 const isRequiredError = (name: string) => `Required configuration "${name}" must be provided`;
 const isEmpty = (property: Property) => property.value === '' || property.value === null;
 
-export const ErrorWrapper = (props: PropsWithoutRef<{ property: Property; input: JSX.Element }>) => {
-  const { property, input } = props;
+export const ErrorWrapper = (
+  props: PropsWithoutRef<{
+    property: Property;
+    input: JSX.Element;
+    /** id of the control `input` renders, so the label can point at it as Chakra's FormControl did. */
+    inputId?: string;
+    /** BOOLEAN/RADIO_GROUP properties sat inline with their label under Chakra's FormField. */
+    orientation?: 'vertical' | 'horizontal';
+  }>
+) => {
+  const { property, input, inputId, orientation = 'vertical' } = props;
   const [currentErrorIndex, setCurrentErrorIndex] = useState(0);
   const isRequired = property.entry.definition.required;
   const showErrors = property.errors.length > 0;
@@ -29,12 +38,16 @@ export const ErrorWrapper = (props: PropsWithoutRef<{ property: Property; input:
         `onClick` on the field, as before: a property can carry several validation errors and the
         only way to see the rest is to click the field, which advances `currentErrorIndex`.
       */}
-      <Field data-invalid={isInvalid || undefined} onClick={cycleError}>
-        <FieldLabel required={isRequired}>{property.entry.definition.display_name}</FieldLabel>
-        {input}
+      <Field data-invalid={isInvalid || undefined} onClick={cycleError} orientation={orientation}>
+        <FieldLabel htmlFor={inputId} required={isRequired}>
+          {property.entry.definition.display_name}
+        </FieldLabel>
+        {/* Documentation between label and control, where Chakra's FormField put it. */}
         <FieldDescription>
           <ExpandableText maxChars={60}>{property.entry.definition.documentation}</ExpandableText>
         </FieldDescription>
+        {/* Wrapped so `Field`'s vertical `[&>*]:w-full` lands here and not on a Switch. */}
+        <div>{input}</div>
         {errorText ? <FieldError>{errorText}</FieldError> : null}
       </Field>
     </div>

--- a/frontend/src/components/pages/connect/dynamic-ui/forms/error-wrapper.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/forms/error-wrapper.tsx
@@ -1,4 +1,4 @@
-import { FormField } from '@redpanda-data/ui';
+import { Field, FieldDescription, FieldError, FieldLabel } from 'components/redpanda-ui/components/field';
 import type { JSX, PropsWithoutRef } from 'react';
 import { useState } from 'react';
 
@@ -20,18 +20,24 @@ export const ErrorWrapper = (props: PropsWithoutRef<{ property: Property; input:
 
   const cycleError = showErrors ? () => setCurrentErrorIndex((i) => i + 1) : undefined;
 
+  const errorText = isEmpty(property) && isRequired ? errorToShow || isRequiredError(property.name) : errorToShow;
+  const isInvalid = Boolean(errorToShow) || (isEmpty(property) && isRequired);
+
   return (
     <div>
-      <FormField
-        description={<ExpandableText maxChars={60}>{property.entry.definition.documentation}</ExpandableText>}
-        errorText={isEmpty(property) && isRequired ? errorToShow || isRequiredError(property.name) : errorToShow}
-        isInvalid={!!errorToShow || (isEmpty(property) && isRequired)}
-        isRequired={isRequired}
-        label={property.entry.definition.display_name}
-        onClick={cycleError}
-      >
+      {/*
+        `onClick` on the field, as before: a property can carry several validation errors and the
+        only way to see the rest is to click the field, which advances `currentErrorIndex`.
+      */}
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: cycling errors is a shortcut, not the only path — every error is reachable by fixing the field */}
+      <Field data-invalid={isInvalid || undefined} onClick={cycleError}>
+        <FieldLabel required={isRequired}>{property.entry.definition.display_name}</FieldLabel>
         {input}
-      </FormField>
+        <FieldDescription>
+          <ExpandableText maxChars={60}>{property.entry.definition.documentation}</ExpandableText>
+        </FieldDescription>
+        {errorText ? <FieldError>{errorText}</FieldError> : null}
+      </Field>
     </div>
   );
 };

--- a/frontend/src/components/pages/connect/dynamic-ui/forms/error-wrapper.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/forms/error-wrapper.tsx
@@ -29,7 +29,6 @@ export const ErrorWrapper = (props: PropsWithoutRef<{ property: Property; input:
         `onClick` on the field, as before: a property can carry several validation errors and the
         only way to see the rest is to click the field, which advances `currentErrorIndex`.
       */}
-      {/* biome-ignore lint/a11y/useKeyWithClickEvents: cycling errors is a shortcut, not the only path — every error is reachable by fixing the field */}
       <Field data-invalid={isInvalid || undefined} onClick={cycleError}>
         <FieldLabel required={isRequired}>{property.entry.definition.display_name}</FieldLabel>
         {input}

--- a/frontend/src/components/pages/connect/dynamic-ui/forms/error-wrapper.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/forms/error-wrapper.tsx
@@ -12,13 +12,11 @@ export const ErrorWrapper = (
   props: PropsWithoutRef<{
     property: Property;
     input: JSX.Element;
-    /** id of the control `input` renders, so the label can point at it as Chakra's FormControl did. */
+    /** id of the control `input` renders; the label points at it and is `${inputId}-label` for aria-labelledby. */
     inputId?: string;
-    /** BOOLEAN/RADIO_GROUP properties sat inline with their label under Chakra's FormField. */
-    orientation?: 'vertical' | 'horizontal';
   }>
 ) => {
-  const { property, input, inputId, orientation = 'vertical' } = props;
+  const { property, input, inputId } = props;
   const [currentErrorIndex, setCurrentErrorIndex] = useState(0);
   const isRequired = property.entry.definition.required;
   const showErrors = property.errors.length > 0;
@@ -38,11 +36,11 @@ export const ErrorWrapper = (
         `onClick` on the field, as before: a property can carry several validation errors and the
         only way to see the rest is to click the field, which advances `currentErrorIndex`.
       */}
-      <Field data-invalid={isInvalid || undefined} onClick={cycleError} orientation={orientation}>
-        <FieldLabel htmlFor={inputId} required={isRequired}>
+      <Field data-invalid={isInvalid || undefined} onClick={cycleError}>
+        <FieldLabel htmlFor={inputId} id={inputId ? `${inputId}-label` : undefined} required={isRequired}>
           {property.entry.definition.display_name}
         </FieldLabel>
-        {/* Documentation between label and control, where Chakra's FormField put it. */}
+        {/* Documentation sits between label and control. */}
         <FieldDescription>
           <ExpandableText maxChars={60}>{property.entry.definition.documentation}</ExpandableText>
         </FieldDescription>

--- a/frontend/src/components/pages/connect/dynamic-ui/forms/secret-input.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/forms/secret-input.tsx
@@ -1,15 +1,6 @@
-import {
-  Button,
-  type ButtonProps,
-  Flex,
-  Icon,
-  Input,
-  InputGroup,
-  InputRightElement,
-  Tooltip,
-  useBoolean,
-} from '@redpanda-data/ui';
-import { EyeIcon, EyeOffIcon } from 'components/icons';
+import { Button } from 'components/redpanda-ui/components/button';
+import { Input } from 'components/redpanda-ui/components/input';
+import { Tooltip, TooltipContent, TooltipTrigger } from 'components/redpanda-ui/components/tooltip';
 import { useRef, useState } from 'react';
 
 export type SecretInputProps = {
@@ -18,22 +9,26 @@ export type SecretInputProps = {
   updating: boolean;
 };
 
-const EditButton = ({ onClick }: Pick<ButtonProps, 'onClick'>) => (
-  <Tooltip hasArrow={true} label="Edit secret value" placement="top">
-    <Button onClick={onClick} variant="link">
-      Edit
-    </Button>
+const EditButton = ({ onClick }: { onClick: () => void }) => (
+  <Tooltip>
+    <TooltipTrigger
+      render={
+        <Button onClick={onClick} variant="link">
+          Edit
+        </Button>
+      }
+    />
+    <TooltipContent side="top">Edit secret value</TooltipContent>
   </Tooltip>
 );
 
-const ClearButton = ({ onClick }: Pick<ButtonProps, 'onClick'>) => (
+const ClearButton = ({ onClick }: { onClick: () => void }) => (
   <Button onClick={onClick} variant="link">
     Undo
   </Button>
 );
 
 export const SecretInput = ({ value, onChange, updating = false }: SecretInputProps) => {
-  const [visible, setVisible] = useBoolean();
   const initialValueRef = useRef(value);
   const [canEdit, setCanEdit] = useState(!updating);
   // Intentionally seeded from prop: localValue is edited independently during user interaction
@@ -54,35 +49,32 @@ export const SecretInput = ({ value, onChange, updating = false }: SecretInputPr
         setCanEdit(false);
         setLocalValue(initialValueRef.current);
         onChange(initialValueRef.current);
-        setVisible.off();
       }}
     />
   );
 
   return (
-    <Flex flexDirection="row" gap={2}>
-      <InputGroup>
-        <Input
-          onChange={(e) => {
-            setLocalValue(e.target.value);
-            if (onChange) {
-              onChange(e.target.value);
-            }
-          }}
-          readOnly={!canEdit}
-          type={visible ? 'text' : 'password'}
-          value={localValue}
-        />
-        {Boolean(canEdit) && (
-          <InputRightElement>
-            <Button onClick={() => setVisible.toggle()} variant="ghost">
-              <Icon as={visible ? EyeIcon : EyeOffIcon} color="gray.500" />
-            </Button>
-          </InputRightElement>
-        )}
-      </InputGroup>
+    <div className="flex flex-row gap-2">
+      {/*
+        The Registry Input owns the reveal toggle for `type="password"`, and disables it while the
+        field is read-only — which is the state an existing secret sits in before Edit. `key` is
+        what re-masks on Undo: the toggle's state lives inside the Input, so the transition out of
+        editing has to remount it or Undo would leave the restored secret in plain text.
+      */}
+      <Input
+        key={canEdit ? 'editing' : 'masked'}
+        onChange={(e) => {
+          setLocalValue(e.target.value);
+          if (onChange) {
+            onChange(e.target.value);
+          }
+        }}
+        readOnly={!canEdit}
+        type="password"
+        value={localValue}
+      />
       {Boolean(updating) && (canEdit ? clearButton : editButton)}
-    </Flex>
+    </div>
   );
 };
 

--- a/frontend/src/components/pages/connect/dynamic-ui/forms/secret-input.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/forms/secret-input.tsx
@@ -1,6 +1,6 @@
 import { Button } from 'components/redpanda-ui/components/button';
 import { Input } from 'components/redpanda-ui/components/input';
-import { Tooltip, TooltipContent, TooltipTrigger } from 'components/redpanda-ui/components/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from 'components/redpanda-ui/components/tooltip';
 import { useRef, useState } from 'react';
 
 export type SecretInputProps = {
@@ -10,16 +10,19 @@ export type SecretInputProps = {
 };
 
 const EditButton = ({ onClick }: { onClick: () => void }) => (
-  <Tooltip>
-    <TooltipTrigger
-      render={
-        <Button onClick={onClick} variant="link">
-          Edit
-        </Button>
-      }
-    />
-    <TooltipContent side="top">Edit secret value</TooltipContent>
-  </Tooltip>
+  // Without a provider the trigger falls back to Base UI's 600ms open delay; the app's is 150ms.
+  <TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button onClick={onClick} variant="link">
+            Edit
+          </Button>
+        }
+      />
+      <TooltipContent side="top">Edit secret value</TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
 );
 
 const ClearButton = ({ onClick }: { onClick: () => void }) => (

--- a/frontend/src/components/pages/connect/dynamic-ui/forms/secret-input.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/forms/secret-input.tsx
@@ -7,6 +7,7 @@ export type SecretInputProps = {
   id: string;
   value: string;
   onChange: (v: string) => void;
+  required?: boolean;
   updating: boolean;
 };
 
@@ -32,7 +33,7 @@ const ClearButton = ({ onClick }: { onClick: () => void }) => (
   </Button>
 );
 
-export const SecretInput = ({ id, value, onChange, updating = false }: SecretInputProps) => {
+export const SecretInput = ({ id, value, onChange, required, updating = false }: SecretInputProps) => {
   const initialValueRef = useRef(value);
   const [canEdit, setCanEdit] = useState(!updating);
   // Intentionally seeded from prop: localValue is edited independently during user interaction
@@ -75,6 +76,7 @@ export const SecretInput = ({ id, value, onChange, updating = false }: SecretInp
           }
         }}
         readOnly={!canEdit}
+        required={required}
         type="password"
         value={localValue}
       />

--- a/frontend/src/components/pages/connect/dynamic-ui/forms/secret-input.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/forms/secret-input.tsx
@@ -4,6 +4,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from 'compon
 import { useRef, useState } from 'react';
 
 export type SecretInputProps = {
+  id: string;
   value: string;
   onChange: (v: string) => void;
   updating: boolean;
@@ -31,7 +32,7 @@ const ClearButton = ({ onClick }: { onClick: () => void }) => (
   </Button>
 );
 
-export const SecretInput = ({ value, onChange, updating = false }: SecretInputProps) => {
+export const SecretInput = ({ id, value, onChange, updating = false }: SecretInputProps) => {
   const initialValueRef = useRef(value);
   const [canEdit, setCanEdit] = useState(!updating);
   // Intentionally seeded from prop: localValue is edited independently during user interaction
@@ -65,6 +66,7 @@ export const SecretInput = ({ value, onChange, updating = false }: SecretInputPr
         editing has to remount it or Undo would leave the restored secret in plain text.
       */}
       <Input
+        id={id}
         key={canEdit ? 'editing' : 'masked'}
         onChange={(e) => {
           setLocalValue(e.target.value);

--- a/frontend/src/components/pages/connect/dynamic-ui/forms/topic-input.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/forms/topic-input.tsx
@@ -101,7 +101,6 @@ export const TopicInput = (p: { properties: Property[]; connectorType: 'sink' | 
           />
         )}
 
-        {/* biome-ignore lint/a11y/useKeyWithClickEvents: cycling errors is a shortcut, not the only path */}
         {Boolean(showErrors) && <FieldError onClick={cycleError}>{errorToShow}</FieldError>}
       </Field>
     </div>

--- a/frontend/src/components/pages/connect/dynamic-ui/forms/topic-input.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/forms/topic-input.tsx
@@ -9,16 +9,11 @@
  * by the Apache License, Version 2.0
  */
 
-import {
-  Checkbox,
-  FormControl,
-  FormErrorMessage,
-  FormHelperText,
-  Grid,
-  Input,
-  isMultiValue,
-  Select,
-} from '@redpanda-data/ui';
+import { Checkbox } from 'components/redpanda-ui/components/checkbox';
+import { Field, FieldDescription, FieldError } from 'components/redpanda-ui/components/field';
+import { Input } from 'components/redpanda-ui/components/input';
+import { Label } from 'components/redpanda-ui/components/label';
+import { SimpleMultiSelect } from 'components/redpanda-ui/components/multi-select';
 import { useEffect, useMemo, useState } from 'react';
 
 import { api } from '../../../../../state/backend-api';
@@ -60,24 +55,30 @@ export const TopicInput = (p: { properties: Property[]; connectorType: 'sink' | 
       }
     : undefined;
 
+  const selectedTopics = property.value ? property.value.toString().split(',').filter(Boolean) : [];
+
   return (
-    <Grid gap="10" templateColumns="1fr">
-      <FormControl position="relative">
+    <div className="grid grid-cols-1 gap-10">
+      <Field className="relative">
         {propsMap.has('topics.regex') && (
-          <Checkbox
-            isChecked={isRegex}
-            onChange={(e) => {
-              setPropertyValue(property, '');
-              setSelected(e.target.checked ? 'topics.regex' : 'topics');
-            }}
-          >
-            Use regular expressions
-          </Checkbox>
+          <div className="flex items-center gap-2">
+            <Checkbox
+              checked={isRegex}
+              id="topics-use-regex"
+              onCheckedChange={(checked) => {
+                setPropertyValue(property, '');
+                setSelected(checked === true ? 'topics.regex' : 'topics');
+              }}
+            />
+            <Label className="cursor-pointer" htmlFor="topics-use-regex">
+              Use regular expressions
+            </Label>
+          </div>
         )}
 
-        <FormHelperText mb={15}>
+        <FieldDescription className="mb-4">
           <ExpandableText maxChars={60}>{property.entry.definition.documentation}</ExpandableText>
-        </FormHelperText>
+        </FieldDescription>
 
         {/* A 'source' connector imports data into the cluster. So we let the user choose the name of the topic directly  */}
         {isRegex || p.connectorType === 'source' ? (
@@ -90,35 +91,19 @@ export const TopicInput = (p: { properties: Property[]; connectorType: 'sink' | 
             value={String(property.value)}
           />
         ) : (
-          <Select
-            isMulti
-            onChange={(v) => {
-              if (isMultiValue(v)) {
-                setPropertyValue(property, v.map(({ value }) => value)?.join(',') ?? []);
-              }
+          <SimpleMultiSelect
+            onValueChange={(values) => {
+              setPropertyValue(property, values.join(','));
             }}
-            options={api.topics?.map((x) => ({ value: x.topicName, label: x.topicName })) ?? []}
-            value={
-              property.value
-                ? property.value
-                    ?.toString()
-                    .split(',')
-                    .map((val) => ({
-                      value: val,
-                      label: val,
-                    }))
-                : []
-            }
+            options={api.topics?.map((x) => x.topicName) ?? []}
+            value={selectedTopics}
+            width="full"
           />
         )}
 
-        {Boolean(showErrors) && <FormErrorMessage onClick={cycleError}>{errorToShow}</FormErrorMessage>}
-      </FormControl>
-
-      {/* <Box p="4" >
-                <h2>Matching Topics</h2>
-
-            </Box> */}
-    </Grid>
+        {/* biome-ignore lint/a11y/useKeyWithClickEvents: cycling errors is a shortcut, not the only path */}
+        {Boolean(showErrors) && <FieldError onClick={cycleError}>{errorToShow}</FieldError>}
+      </Field>
+    </div>
   );
 };

--- a/frontend/src/components/pages/connect/dynamic-ui/forms/topic-input.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/forms/topic-input.tsx
@@ -14,7 +14,7 @@ import { Field, FieldDescription, FieldError } from 'components/redpanda-ui/comp
 import { Input } from 'components/redpanda-ui/components/input';
 import { Label } from 'components/redpanda-ui/components/label';
 import { SimpleMultiSelect } from 'components/redpanda-ui/components/multi-select';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useId, useMemo, useState } from 'react';
 
 import { api } from '../../../../../state/backend-api';
 import type { Property } from '../../../../../state/connect/state';
@@ -29,6 +29,8 @@ const incrementErrorIndex = (property: Property) => {
 };
 
 export const TopicInput = (p: { properties: Property[]; connectorType: 'sink' | 'source' }) => {
+  // A TopicInput is rendered per property group, so a fixed id would collide.
+  const regexCheckboxId = useId();
   const propsMap = useMemo(() => new Map(p.properties.map((prop) => [prop.name, prop])), [p.properties]);
   const topicsRegex = p.properties.find((x) => x.name === 'topics.regex');
   const initialSelection = topicsRegex?.value ? 'topics.regex' : 'topics';
@@ -56,6 +58,9 @@ export const TopicInput = (p: { properties: Property[]; connectorType: 'sink' | 
     : undefined;
 
   const selectedTopics = property.value ? property.value.toString().split(',').filter(Boolean) : [];
+  // Union, not just `api.topics`: a chip for a topic that has since been deleted (or one rendered
+  // before the topic list resolves) is only removable if its value is among the options.
+  const topicOptions = [...new Set([...(api.topics?.map((x) => x.topicName) ?? []), ...selectedTopics])];
 
   return (
     <div className="grid grid-cols-1 gap-10">
@@ -64,19 +69,19 @@ export const TopicInput = (p: { properties: Property[]; connectorType: 'sink' | 
           <div className="flex items-center gap-2">
             <Checkbox
               checked={isRegex}
-              id="topics-use-regex"
+              id={regexCheckboxId}
               onCheckedChange={(checked) => {
                 setPropertyValue(property, '');
                 setSelected(checked === true ? 'topics.regex' : 'topics');
               }}
             />
-            <Label className="cursor-pointer" htmlFor="topics-use-regex">
+            <Label className="cursor-pointer" htmlFor={regexCheckboxId}>
               Use regular expressions
             </Label>
           </div>
         )}
 
-        <FieldDescription className="mb-4">
+        <FieldDescription>
           <ExpandableText maxChars={60}>{property.entry.definition.documentation}</ExpandableText>
         </FieldDescription>
 
@@ -95,7 +100,7 @@ export const TopicInput = (p: { properties: Property[]; connectorType: 'sink' | 
             onValueChange={(values) => {
               setPropertyValue(property, values.join(','));
             }}
-            options={api.topics?.map((x) => x.topicName) ?? []}
+            options={topicOptions}
             value={selectedTopics}
             width="full"
           />

--- a/frontend/src/components/pages/connect/dynamic-ui/list.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/list.tsx
@@ -10,9 +10,11 @@
  */
 
 import { DragDropContext, Draggable, Droppable, type DropResult, type ResponderProvided } from '@hello-pangea/dnd';
-import { Button, Input, Tooltip } from '@redpanda-data/ui';
 import { arrayMoveMutable } from 'array-move';
 import { CloseIcon, MenuIcon } from 'components/icons';
+import { Button } from 'components/redpanda-ui/components/button';
+import { Input } from 'components/redpanda-ui/components/input';
+import { Tooltip, TooltipContent, TooltipTrigger } from 'components/redpanda-ui/components/tooltip';
 import { type JSX, useEffect, useRef, useState } from 'react';
 
 const VALID_NAME_REGEX = /^[a-z][a-z_\d]*$/i;
@@ -41,44 +43,49 @@ const Item = ({ item, allItems, onUpdate, onDelete }: ItemProps): JSX.Element =>
 
   return (
     <>
-      {/* Input */}
-      <Tooltip hasArrow={true} isOpen={hasFocus} label="[Enter] confirm, [ESC] cancel" placement="top">
-        <Input
-          className="ghostInput"
-          onBlur={() => {
-            setHasFocus(false);
-          }}
-          onChange={(e) => setValuePending(e.target.value)}
-          onFocus={() => {
-            setValuePending(item.id);
-            setHasFocus(true);
-          }}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              // can we rename that entry?
-              if (allItems.some((x) => x.id === valuePending)) {
-                // no, already exists
-                e.stopPropagation();
-                return;
-              }
+      {/* Input. The hint is shown while the field has focus, not on hover, so the Tooltip is controlled. */}
+      <Tooltip open={hasFocus}>
+        <TooltipTrigger
+          render={
+            <Input
+              className="ghostInput"
+              onBlur={() => {
+                setHasFocus(false);
+              }}
+              onChange={(e) => setValuePending(e.target.value)}
+              onFocus={() => {
+                setValuePending(item.id);
+                setHasFocus(true);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  // can we rename that entry?
+                  if (allItems.some((x) => x.id === valuePending)) {
+                    // no, already exists
+                    e.stopPropagation();
+                    return;
+                  }
 
-              if (VALID_NAME_REGEX.test(valuePending) === false) {
-                // no, invalid characters
-                e.stopPropagation();
-                return;
-              }
+                  if (VALID_NAME_REGEX.test(valuePending) === false) {
+                    // no, invalid characters
+                    e.stopPropagation();
+                    return;
+                  }
 
-              onUpdate(valuePending);
-              (e.target as HTMLElement).blur();
-            } else if (e.key === 'Escape') {
-              (e.target as HTMLElement).blur();
-            }
-          }}
-          size="sm"
-          spellCheck={false}
-          style={{ flexGrow: 1, flexBasis: '400px' }}
-          value={hasFocus ? valuePending : item.id}
+                  onUpdate(valuePending);
+                  (e.target as HTMLElement).blur();
+                } else if (e.key === 'Escape') {
+                  (e.target as HTMLElement).blur();
+                }
+              }}
+              size="sm"
+              spellCheck={false}
+              style={{ flexGrow: 1, flexBasis: '400px' }}
+              value={hasFocus ? valuePending : item.id}
+            />
+          }
         />
+        <TooltipContent side="top">[Enter] confirm, [ESC] cancel</TooltipContent>
       </Tooltip>
 
       {/* Delete */}
@@ -161,7 +168,7 @@ export function CommaSeparatedStringList(props: {
             setNewEntry(null);
           }}
           style={{ padding: '0px 16px', height: '100%', minWidth: '120px' }}
-          variant="solid"
+          variant="primary"
         >
           Add
         </Button>

--- a/frontend/src/components/pages/connect/dynamic-ui/list.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/list.tsx
@@ -49,6 +49,7 @@ const Item = ({ item, allItems, onUpdate, onDelete }: ItemProps): JSX.Element =>
           render={
             <Input
               className="ghostInput"
+              containerClassName="grow basis-[400px]"
               onBlur={() => {
                 setHasFocus(false);
               }}
@@ -80,7 +81,6 @@ const Item = ({ item, allItems, onUpdate, onDelete }: ItemProps): JSX.Element =>
               }}
               size="sm"
               spellCheck={false}
-              style={{ flexGrow: 1, flexBasis: '400px' }}
               value={hasFocus ? valuePending : item.id}
             />
           }
@@ -136,6 +136,7 @@ export function CommaSeparatedStringList(props: {
       <div className="createEntryRow">
         <div className={`inputWrapper${newEntryError ? 'hasError' : ''}`} style={{ height: '100%' }}>
           <Input
+            containerClassName="h-full grow basis-[260px]"
             onChange={(e) => {
               const value = e.target.value;
               setNewEntry(value);
@@ -153,7 +154,6 @@ export function CommaSeparatedStringList(props: {
             }}
             placeholder={props.locale?.addInputPlaceholder ?? 'Enter a name...'}
             spellCheck={false}
-            style={{ flexGrow: 1, height: '100%', flexBasis: '260px' }}
             value={newEntry ?? ''}
           />
 
@@ -161,13 +161,13 @@ export function CommaSeparatedStringList(props: {
         </div>
 
         <Button
+          className="h-full min-w-[120px] px-4"
           disabled={newEntryError !== null || !newEntry || newEntry.trim().length === 0}
           onClick={() => {
             if (!newEntry) return;
             setData((prev) => [...prev, { id: newEntry }]);
             setNewEntry(null);
           }}
-          style={{ padding: '0px 16px', height: '100%', minWidth: '120px' }}
           variant="primary"
         >
           Add

--- a/frontend/src/components/pages/connect/dynamic-ui/list.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/list.tsx
@@ -99,6 +99,7 @@ const Item = ({ item, allItems, onUpdate, onDelete }: ItemProps): JSX.Element =>
 
 export function CommaSeparatedStringList(props: {
   defaultValue: string;
+  id?: string;
   onChange: (list: string) => void;
   locale?: {
     addInputPlaceholder?: string;
@@ -139,6 +140,7 @@ export function CommaSeparatedStringList(props: {
           <Input
             className="h-full"
             containerClassName="h-full grow basis-[260px]"
+            id={props.id}
             onChange={(e) => {
               const value = e.target.value;
               setNewEntry(value);

--- a/frontend/src/components/pages/connect/dynamic-ui/list.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/list.tsx
@@ -48,7 +48,8 @@ const Item = ({ item, allItems, onUpdate, onDelete }: ItemProps): JSX.Element =>
         <TooltipTrigger
           render={
             <Input
-              className="ghostInput"
+              // Border colour on the element: a layered !important beats the unlayered scss one.
+              className="ghostInput !border-transparent focus:!border-input"
               containerClassName="grow basis-[400px]"
               onBlur={() => {
                 setHasFocus(false);
@@ -136,6 +137,7 @@ export function CommaSeparatedStringList(props: {
       <div className="createEntryRow">
         <div className={`inputWrapper${newEntryError ? 'hasError' : ''}`} style={{ height: '100%' }}>
           <Input
+            className="h-full"
             containerClassName="h-full grow basis-[260px]"
             onChange={(e) => {
               const value = e.target.value;

--- a/frontend/src/components/pages/connect/dynamic-ui/property-component.test.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/property-component.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, test } from '@rstest/core';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useReducer } from 'react';
+
+import { PropertyComponent } from './property-component';
+import type { Property } from '../../../../state/connect/state';
+
+const makeProperty = (type: 'DOUBLE' | 'FLOAT' | 'PASSWORD', crud: 'create' | 'update' = 'create'): Property => ({
+  name: 'example',
+  entry: {
+    definition: {
+      name: 'example',
+      type,
+      required: false,
+      default_value: null,
+      importance: 'HIGH',
+      documentation: 'Example configuration',
+      width: 'MEDIUM',
+      display_name: 'Example',
+      dependents: [],
+      order: 0,
+    },
+    value: { name: 'example', value: null, recommended_values: [], errors: [], visible: true },
+    metadata: {},
+  },
+  value: type === 'PASSWORD' ? 'secret' : '1.5',
+  isHidden: false,
+  errors: [],
+  showErrors: false,
+  lastErrors: [],
+  currentErrorIndex: 0,
+  lastErrorValue: null,
+  propertyGroup: {
+    step: { name: 'General', groups: [], stepIndex: 0 },
+    group: { config_keys: [] },
+    properties: [],
+    filteredProperties: [],
+    propertiesWithErrors: [],
+  },
+  crud,
+  isDisabled: false,
+  notifyChange: () => undefined,
+});
+
+const Form = ({ property }: { property: Property }) => {
+  const [, refresh] = useReducer((value: number) => value + 1, 0);
+  property.notifyChange = refresh;
+  return <PropertyComponent property={property} />;
+};
+
+describe('connector property controls', () => {
+  test.each(['DOUBLE', 'FLOAT'] as const)('%s steppers preserve fractional configuration values', async (type) => {
+    const user = userEvent.setup();
+    const property = makeProperty(type);
+    render(<Form property={property} />);
+    await user.click(screen.getByRole('button', { name: 'Increment value' }));
+    expect(screen.getByRole('spinbutton', { name: 'Example' })).toHaveValue(2.5);
+    expect(property.value).toBe('2.5');
+    await user.click(screen.getByRole('button', { name: 'Decrement value' }));
+    expect(screen.getByRole('spinbutton', { name: 'Example' })).toHaveValue(1.5);
+    expect(property.value).toBe('1.5');
+  });
+
+  test('password label stays associated after edit and undo', async () => {
+    const user = userEvent.setup();
+    render(<Form property={makeProperty('PASSWORD', 'update')} />);
+    expect(screen.getByLabelText('Example')).toHaveValue('secret');
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
+    await user.click(screen.getByText('Example', { selector: 'label' }));
+    expect(screen.getByLabelText('Example')).toHaveFocus();
+    await user.type(screen.getByLabelText('Example'), 'replacement');
+    await user.click(screen.getByRole('button', { name: 'Undo' }));
+    expect(screen.getByLabelText('Example')).toHaveValue('secret');
+    expect(screen.getByLabelText('Example')).toHaveAttribute('type', 'password');
+  });
+});

--- a/frontend/src/components/pages/connect/dynamic-ui/property-component.test.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/property-component.test.tsx
@@ -67,6 +67,8 @@ describe('connector property controls', () => {
     render(<Form property={makeProperty('PASSWORD', 'update')} />);
     expect(screen.getByLabelText('Example')).toHaveValue('secret');
     await user.click(screen.getByRole('button', { name: 'Edit' }));
+    await user.click(screen.getByRole('button', { name: 'Show password' }));
+    expect(screen.getByLabelText('Example')).toHaveAttribute('type', 'text');
     await user.click(screen.getByText('Example', { selector: 'label' }));
     expect(screen.getByLabelText('Example')).toHaveFocus();
     await user.type(screen.getByLabelText('Example'), 'replacement');

--- a/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
@@ -50,6 +50,10 @@ export const PropertyComponent = (props: { property: Property }) => {
   );
 
   const v = p.value;
+  // Chakra's FormControl generated an id and wired the label to it; the Registry Field does not,
+  // so the id is derived here and handed to both the control and the label.
+  const fieldId = `property-${p.name}`;
+  const isInlineControl = def.type === 'BOOLEAN' || metadata?.component_type === 'RADIO_GROUP';
 
   switch (def.type) {
     case 'STRING':
@@ -63,6 +67,7 @@ export const PropertyComponent = (props: { property: Property }) => {
         inputComp = (
           <RadioGroup
             className="flex flex-wrap gap-4"
+            id={fieldId}
             name={p.name}
             onValueChange={(next) => {
               updatePropertyValue(p, next as Property['value']);
@@ -92,6 +97,7 @@ export const PropertyComponent = (props: { property: Property }) => {
         inputComp = (
           <div className="max-w-[260px]">
             <SingleSelect
+              id={fieldId}
               onChange={(e) => {
                 updatePropertyValue(p, e);
               }}
@@ -106,6 +112,7 @@ export const PropertyComponent = (props: { property: Property }) => {
           <Input
             defaultValue={def.default_value ?? undefined}
             disabled={props.property.isDisabled}
+            id={fieldId}
             onChange={(e) => {
               updatePropertyValue(p, e.target.value);
             }}
@@ -134,13 +141,23 @@ export const PropertyComponent = (props: { property: Property }) => {
     case 'DOUBLE':
     case 'FLOAT':
       inputComp = (
-        // Chakra's NumberInput emitted a number; a native number input emits a string, so coerce
-        // here or the config would carry `"3"` where the connector expects `3`.
         <Input
+          id={fieldId}
           onChange={(e) => {
-            updatePropertyValue(p, e.target.valueAsNumber);
+            // The *string*, not `valueAsNumber`: Chakra's NumberInput handed `onChange` its
+            // `valueAsString`, and `getConfigObject` both sends `p.value` as-is and compares it
+            // `===` against `default_value` to suppress untouched defaults. Storing a number here
+            // would change which properties get sent — and `sanitizeDefaultValue` only numbers the
+            // INT/LONG/SHORT defaults, so it would not even be consistent across the numeric types.
+            updatePropertyValue(p, e.target.value);
           }}
+          // Chakra's NumberInput shipped its steppers by default and the Registry Input needs
+          // asking. `step="any"` for the float types, which the Registry otherwise pins to 1 and
+          // the browser then marks non-integer values invalid.
+          showStepControls
+          step={def.type === 'DOUBLE' || def.type === 'FLOAT' ? 'any' : 1}
           type="number"
+          // Guarded only so a mid-edit empty field does not render the string "NaN".
           value={Number.isNaN(Number(v)) ? '' : Number(v)}
         />
       );
@@ -150,6 +167,7 @@ export const PropertyComponent = (props: { property: Property }) => {
       inputComp = (
         <Switch
           checked={Boolean(v)}
+          id={fieldId}
           onCheckedChange={(checked) => {
             updatePropertyValue(p, checked);
           }}
@@ -171,6 +189,7 @@ export const PropertyComponent = (props: { property: Property }) => {
         inputComp = (
           <Input
             defaultValue={def.default_value ?? undefined}
+            id={fieldId}
             onChange={(e) => {
               updatePropertyValue(p, e.target.value);
             }}
@@ -184,6 +203,7 @@ export const PropertyComponent = (props: { property: Property }) => {
       inputComp = (
         <Input
           defaultValue={def.default_value ?? undefined}
+          id={fieldId}
           onChange={(e) => {
             updatePropertyValue(p, e.target.value);
           }}
@@ -193,7 +213,16 @@ export const PropertyComponent = (props: { property: Property }) => {
       break;
   }
 
-  inputComp = <ErrorWrapper input={inputComp} property={p} />;
+  inputComp = (
+    <ErrorWrapper
+      input={inputComp}
+      inputId={fieldId}
+      // BOOLEAN and RADIO_GROUP sat inline with their label under Chakra's FormField, which
+      // special-cased a Switch child.
+      orientation={isInlineControl ? 'horizontal' : 'vertical'}
+      property={p}
+    />
+  );
   // Wrap name and input element
   return (
     <div className={`mt-6 ${inputSizeToClass[def.width]}`} data-testid={`property-${p.name}`}>

--- a/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
@@ -9,7 +9,10 @@
  * by the Apache License, Version 2.0
  */
 
-import { Box, Input, NumberInput, RadioGroup, Switch } from '@redpanda-data/ui';
+import { Input } from 'components/redpanda-ui/components/input';
+import { Label } from 'components/redpanda-ui/components/label';
+import { RadioGroup, RadioGroupItem } from 'components/redpanda-ui/components/radio-group';
+import { Switch } from 'components/redpanda-ui/components/switch';
 
 import { ErrorWrapper } from './forms/error-wrapper';
 import { SecretInput } from './forms/secret-input';
@@ -59,13 +62,26 @@ export const PropertyComponent = (props: { property: Property }) => {
             : recValues.map((recValue) => ({ value: recValue, label: String(recValue).toUpperCase() }));
         inputComp = (
           <RadioGroup
+            className="flex flex-wrap gap-4"
             name={p.name}
-            onChange={(e) => {
-              updatePropertyValue(p, e);
+            onValueChange={(next) => {
+              updatePropertyValue(p, next as Property['value']);
             }}
-            options={options}
+            orientation="horizontal"
             value={String(v || def.default_value)}
-          />
+          >
+            {options.map((option) => {
+              const id = `${p.name}-${option.value}`;
+              return (
+                <div className="flex items-center gap-2" key={String(option.value)}>
+                  <RadioGroupItem id={id} value={String(option.value)} />
+                  <Label className="cursor-pointer" htmlFor={id}>
+                    {option.label}
+                  </Label>
+                </div>
+              );
+            })}
+          </RadioGroup>
         );
         break;
       }
@@ -74,7 +90,7 @@ export const PropertyComponent = (props: { property: Property }) => {
         // Enum (recommended_values)
         const options = recValues.map((x: string) => ({ label: x, value: x }));
         inputComp = (
-          <Box maxWidth={260}>
+          <div className="max-w-[260px]">
             <SingleSelect
               onChange={(e) => {
                 updatePropertyValue(p, e);
@@ -82,14 +98,14 @@ export const PropertyComponent = (props: { property: Property }) => {
               options={options}
               value={v}
             />
-          </Box>
+          </div>
         );
       } else {
         // Input
         inputComp = (
           <Input
             defaultValue={def.default_value ?? undefined}
-            isDisabled={props.property.isDisabled}
+            disabled={props.property.isDisabled}
             onChange={(e) => {
               updatePropertyValue(p, e.target.value);
             }}
@@ -118,11 +134,14 @@ export const PropertyComponent = (props: { property: Property }) => {
     case 'DOUBLE':
     case 'FLOAT':
       inputComp = (
-        <NumberInput
+        // Chakra's NumberInput emitted a number; a native number input emits a string, so coerce
+        // here or the config would carry `"3"` where the connector expects `3`.
+        <Input
           onChange={(e) => {
-            updatePropertyValue(p, e);
+            updatePropertyValue(p, e.target.valueAsNumber);
           }}
-          value={Number(v)}
+          type="number"
+          value={Number.isNaN(Number(v)) ? '' : Number(v)}
         />
       );
       break;
@@ -130,9 +149,9 @@ export const PropertyComponent = (props: { property: Property }) => {
     case 'BOOLEAN':
       inputComp = (
         <Switch
-          isChecked={Boolean(v)}
-          onChange={(e) => {
-            updatePropertyValue(p, e.target.checked);
+          checked={Boolean(v)}
+          onCheckedChange={(checked) => {
+            updatePropertyValue(p, checked);
           }}
         />
       );
@@ -177,9 +196,9 @@ export const PropertyComponent = (props: { property: Property }) => {
   inputComp = <ErrorWrapper input={inputComp} property={p} />;
   // Wrap name and input element
   return (
-    <Box className={inputSizeToClass[def.width]} data-testid={`property-${p.name}`} mt="6">
+    <div className={`mt-6 ${inputSizeToClass[def.width]}`} data-testid={`property-${p.name}`}>
       {inputComp}
-    </Box>
+    </div>
   );
 };
 

--- a/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
@@ -79,7 +79,7 @@ export const PropertyComponent = (props: { property: Property }) => {
               const id = `${p.name}-${option.value}`;
               return (
                 <div className="flex items-center gap-2" key={String(option.value)}>
-                  <RadioGroupItem id={id} value={String(option.value)} />
+                  <RadioGroupItem id={id} testId={`${option.value}_field`} value={String(option.value)} />
                   <Label className="cursor-pointer" htmlFor={id}>
                     {option.label}
                   </Label>

--- a/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
@@ -50,10 +50,8 @@ export const PropertyComponent = (props: { property: Property }) => {
   );
 
   const v = p.value;
-  // Chakra's FormControl generated an id and wired the label to it; the Registry Field does not,
-  // so the id is derived here and handed to both the control and the label.
+  // Field generates no ids; the label and the control share this one.
   const fieldId = `property-${p.name}`;
-  const isInlineControl = def.type === 'BOOLEAN' || metadata?.component_type === 'RADIO_GROUP';
 
   switch (def.type) {
     case 'STRING':
@@ -66,8 +64,9 @@ export const PropertyComponent = (props: { property: Property }) => {
             : recValues.map((recValue) => ({ value: recValue, label: String(recValue).toUpperCase() }));
         inputComp = (
           <RadioGroup
+            aria-labelledby={`${fieldId}-label`}
+            // A radiogroup div is not labelable; it takes its name from the label instead of htmlFor.
             className="flex flex-wrap gap-4"
-            id={fieldId}
             name={p.name}
             onValueChange={(next) => {
               updatePropertyValue(p, next as Property['value']);
@@ -145,19 +144,14 @@ export const PropertyComponent = (props: { property: Property }) => {
         <Input
           id={fieldId}
           onChange={(e) => {
-            // The *string*, not `valueAsNumber`: Chakra's NumberInput handed `onChange` its
-            // `valueAsString`, and `getConfigObject` both sends `p.value` as-is and compares it
-            // `===` against `default_value` to suppress untouched defaults. Storing a number here
-            // would change which properties get sent — and `sanitizeDefaultValue` only numbers the
-            // INT/LONG/SHORT defaults, so it would not even be consistent across the numeric types.
+            // Store the string: getConfigObject sends p.value as-is and ===-compares it to default_value.
             updatePropertyValue(p, e.target.value);
           }}
-          // Match Chakra's default increment, including fractional starting values. Registry Input
-          // requires a finite numeric step: it coerces "any" to NaN before stepping.
+          // Registry Input coerces step with Number(); "any" would become NaN.
           showStepControls
           step={1}
           type="number"
-          // Guarded only so a mid-edit empty field does not render the string "NaN".
+          // Keep the input controlled with '' when the stored value is not numeric.
           value={Number.isNaN(Number(v)) ? '' : Number(v)}
         />
       );
@@ -213,16 +207,7 @@ export const PropertyComponent = (props: { property: Property }) => {
       break;
   }
 
-  inputComp = (
-    <ErrorWrapper
-      input={inputComp}
-      inputId={fieldId}
-      // BOOLEAN and RADIO_GROUP sat inline with their label under Chakra's FormField, which
-      // special-cased a Switch child.
-      orientation={isInlineControl ? 'horizontal' : 'vertical'}
-      property={p}
-    />
-  );
+  inputComp = <ErrorWrapper input={inputComp} inputId={fieldId} property={p} />;
   // Wrap name and input element
   return (
     <div className={`mt-6 ${inputSizeToClass[def.width]}`} data-testid={`property-${p.name}`}>

--- a/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
@@ -127,6 +127,7 @@ export const PropertyComponent = (props: { property: Property }) => {
     case 'PASSWORD':
       inputComp = (
         <SecretInput
+          id={fieldId}
           onChange={(e) => {
             updatePropertyValue(p, e);
           }}
@@ -151,11 +152,10 @@ export const PropertyComponent = (props: { property: Property }) => {
             // INT/LONG/SHORT defaults, so it would not even be consistent across the numeric types.
             updatePropertyValue(p, e.target.value);
           }}
-          // Chakra's NumberInput shipped its steppers by default and the Registry Input needs
-          // asking. `step="any"` for the float types, which the Registry otherwise pins to 1 and
-          // the browser then marks non-integer values invalid.
+          // Match Chakra's default increment, including fractional starting values. Registry Input
+          // requires a finite numeric step: it coerces "any" to NaN before stepping.
           showStepControls
-          step={def.type === 'DOUBLE' || def.type === 'FLOAT' ? 'any' : 1}
+          step={1}
           type="number"
           // Guarded only so a mid-edit empty field does not render the string "NaN".
           value={Number.isNaN(Number(v)) ? '' : Number(v)}

--- a/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
@@ -52,6 +52,7 @@ export const PropertyComponent = (props: { property: Property }) => {
   const v = p.value;
   // Field generates no ids; the label and the control share this one.
   const fieldId = `property-${p.name}`;
+  const isRequired = def.required;
 
   switch (def.type) {
     case 'STRING':
@@ -65,6 +66,7 @@ export const PropertyComponent = (props: { property: Property }) => {
         inputComp = (
           <RadioGroup
             aria-labelledby={`${fieldId}-label`}
+            aria-required={isRequired || undefined}
             // A radiogroup div is not labelable; it takes its name from the label instead of htmlFor.
             className="flex flex-wrap gap-4"
             name={p.name}
@@ -115,6 +117,7 @@ export const PropertyComponent = (props: { property: Property }) => {
             onChange={(e) => {
               updatePropertyValue(p, e.target.value);
             }}
+            required={isRequired}
             spellCheck={false}
             value={String(v)}
           />
@@ -130,6 +133,7 @@ export const PropertyComponent = (props: { property: Property }) => {
           onChange={(e) => {
             updatePropertyValue(p, e);
           }}
+          required={isRequired}
           updating={p.crud === 'update'}
           value={String(v ?? '')}
         />
@@ -147,6 +151,7 @@ export const PropertyComponent = (props: { property: Property }) => {
             // Store the string: getConfigObject sends p.value as-is and ===-compares it to default_value.
             updatePropertyValue(p, e.target.value);
           }}
+          required={isRequired}
           // Registry Input coerces step with Number(); "any" would become NaN.
           showStepControls
           step={1}
@@ -160,6 +165,7 @@ export const PropertyComponent = (props: { property: Property }) => {
     case 'BOOLEAN':
       inputComp = (
         <Switch
+          aria-required={isRequired || undefined}
           checked={Boolean(v)}
           id={fieldId}
           onCheckedChange={(checked) => {
@@ -174,6 +180,7 @@ export const PropertyComponent = (props: { property: Property }) => {
         inputComp = (
           <CommaSeparatedStringList
             defaultValue={String(v)}
+            id={fieldId}
             onChange={(x) => {
               updatePropertyValue(p, x);
             }}
@@ -187,6 +194,7 @@ export const PropertyComponent = (props: { property: Property }) => {
             onChange={(e) => {
               updatePropertyValue(p, e.target.value);
             }}
+            required={isRequired}
             value={String(v)}
           />
         );
@@ -201,6 +209,7 @@ export const PropertyComponent = (props: { property: Property }) => {
           onChange={(e) => {
             updatePropertyValue(p, e.target.value);
           }}
+          required={isRequired}
           value={String(v)}
         />
       );

--- a/frontend/src/components/pages/connect/dynamic-ui/property-group.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/property-group.tsx
@@ -9,7 +9,13 @@
  * by the Apache License, Version 2.0
  */
 
-import { Accordion, Box, Divider, Flex, Heading, Text } from '@redpanda-data/ui';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from 'components/redpanda-ui/components/accordion';
+import { Separator } from 'components/redpanda-ui/components/separator';
 import { Link } from 'components/redpanda-ui/components/typography';
 
 import type { ConfigPageProps } from './components';
@@ -46,46 +52,40 @@ export const PropertyGroupComponent = (props: {
           <PropertyComponent key={p.name} property={p} />
         ))}
 
-        <div style={{ gridColumn: 'span 4', paddingLeft: '8px' }}>
-          <Accordion
-            items={subGroups.map((subGroup) => ({
-              heading: (
-                <Flex alignItems="center" gap={4}>
-                  <span style={{ fontSize: '1.1em', fontWeight: 600, fontFamily: 'Open Sans' }}>
-                    {subGroup.group.name}
-                  </span>
-                  <span style={{ fontSize: '1.1em', fontWeight: 600, fontFamily: 'Open Sans' }}>
-                    {subGroup.group.name}
-                  </span>
-                  <span className="issuesTag">{subGroup.propertiesWithErrors.length} issues</span>
-                </Flex>
-              ),
-              description: (
-                <PropertyGroupComponent
-                  allGroups={props.allGroups}
-                  connectorType={props.connectorType}
-                  context={props.context}
-                  group={subGroup}
-                  showAdvancedOptions={props.showAdvancedOptions}
-                />
-              ),
-            }))}
-          />
+        <div className="col-span-4 pl-2">
+          <Accordion variant="contained">
+            {subGroups.map((subGroup) => (
+              <AccordionItem key={subGroup.group.name} value={subGroup.group.name ?? ''}>
+                <AccordionTrigger>
+                  <div className="flex items-center gap-4">
+                    {/* The group name was rendered twice here before the migration. */}
+                    <span className="font-semibold text-heading-sm">{subGroup.group.name}</span>
+                    <span className="issuesTag">{subGroup.propertiesWithErrors.length} issues</span>
+                  </div>
+                </AccordionTrigger>
+                <AccordionContent>
+                  <PropertyGroupComponent
+                    allGroups={props.allGroups}
+                    connectorType={props.connectorType}
+                    context={props.context}
+                    group={subGroup}
+                    showAdvancedOptions={props.showAdvancedOptions}
+                  />
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
         </div>
       </div>
     );
   }
   // Normal group
   return (
-    <Box>
-      {Boolean(g.group.name) && (
-        <Heading as="h3" mb="4" mt="8" size="md">
-          {g.group.name}
-        </Heading>
-      )}
+    <div>
+      {Boolean(g.group.name) && <h3 className="mt-8 mb-4 text-heading-md">{g.group.name}</h3>}
 
       {Boolean(g.group.description) && (
-        <Text>
+        <p className="text-body">
           {g.group.description}
           {g.group.documentation_link ? (
             <>
@@ -93,7 +93,7 @@ export const PropertyGroupComponent = (props: {
               <Link href={g.group.documentation_link}>Documentation</Link>
             </>
           ) : null}
-        </Text>
+        </p>
       )}
 
       <div>
@@ -112,7 +112,7 @@ export const PropertyGroupComponent = (props: {
             return <PropertyComponent key={p.name} property={p} />;
           })}
       </div>
-      <Divider my={10} />
-    </Box>
+      <Separator className="my-10" />
+    </div>
   );
 };

--- a/frontend/src/components/pages/connect/dynamic-ui/property-group.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/property-group.tsx
@@ -112,7 +112,9 @@ export const PropertyGroupComponent = (props: {
             return <PropertyComponent key={p.name} property={p} />;
           })}
       </div>
-      <Separator className="my-10" />
+      <div className="my-10">
+        <Separator />
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/pages/connect/dynamic-ui/property-group.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/property-group.tsx
@@ -82,10 +82,10 @@ export const PropertyGroupComponent = (props: {
   // Normal group
   return (
     <div>
-      {Boolean(g.group.name) && <h3 className="mt-8 mb-4 text-heading-md">{g.group.name}</h3>}
+      {Boolean(g.group.name) && <h3 className="mt-8 text-heading-md">{g.group.name}</h3>}
 
       {Boolean(g.group.description) && (
-        <p className="text-body">
+        <p className="mt-4 text-body">
           {g.group.description}
           {g.group.documentation_link ? (
             <>

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -1776,7 +1776,9 @@ $easeInOutCirc: cubic-bezier(0.785, 0.135, 0.15, 0.86);
 
       // Normal
       .ghostInput:not(:focus-within) {
-        border-color: transparent;
+        // `!important` to match: the Registry Input sets `!border-input`, so a plain declaration
+        // here loses and the "ghost" input renders permanently bordered.
+        border-color: transparent !important;
         background-color: transparent;
 
         transition: border-color 350ms ease-out, background-color 100ms ease-out;

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -1747,7 +1747,7 @@ $easeInOutCirc: cubic-bezier(0.785, 0.135, 0.15, 0.86);
       align-items: center;
       gap: 4px;
 
-      background: hsl(0deg, 0%, 97%);
+      background: var(--color-surface-recess);
 
       height: 32px;
       // padding: 0px 4px;
@@ -1764,7 +1764,7 @@ $easeInOutCirc: cubic-bezier(0.785, 0.135, 0.15, 0.86);
         width: 28px;
         margin-left: 2px;
         padding-top: 1px;
-        color: hsl(0deg, 0%, 70%);
+        color: var(--color-subtle);
 
         transform: scale(0.8);
       }
@@ -1801,7 +1801,7 @@ $easeInOutCirc: cubic-bezier(0.785, 0.135, 0.15, 0.86);
         // margin-right: 4px;
         padding-right: 2px;
 
-        color: hsl(0deg, 0%, 70%);
+        color: var(--color-subtle);
         cursor: pointer;
 
         opacity: 0; // only visible on hover
@@ -1812,8 +1812,8 @@ $easeInOutCirc: cubic-bezier(0.785, 0.135, 0.15, 0.86);
         }
 
         &:hover {
-          color: hsl(0, 0%, 45%);
-          background: hsl(0, 0%, 95%);
+          color: var(--color-foreground);
+          background: var(--color-surface-subtle);
         }
       }
 

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -1776,9 +1776,7 @@ $easeInOutCirc: cubic-bezier(0.785, 0.135, 0.15, 0.86);
 
       // Normal
       .ghostInput:not(:focus-within) {
-        // `!important` to match: the Registry Input sets `!border-input`, so a plain declaration
-        // here loses and the "ghost" input renders permanently bordered.
-        border-color: transparent !important;
+        // The border colour is a Tailwind class on the element; unlayered !important would lose to it.
         background-color: transparent;
 
         transition: border-color 350ms ease-out, background-color 100ms ease-out;


### PR DESCRIPTION
## Chakra exit · Phase 2 (route by route) · PR 10 of 14

Part of the [Chakra exit plan and live tracker](https://claude.ai/code/artifact/1861e21c-624b-4270-98ad-9921b22c2498). Branch `chakra-exit/10-connect-dynamic-ui`, based on `master` (rebased onto it 2026-09-09, 0 commits behind). **PR 11 (#2638) is stacked on this one.**

The schema-driven form renderer: a connector's config schema arrives from the backend and `PropertyComponent` picks an input per `definition.type`. **The schema contract does not change and neither does the value written back** — `updatePropertyValue` still writes `property.value` and calls `notifyChange()`.

### Old → new, by file
| File | Change |
|---|---|
| `forms/error-wrapper` | Chakra `FormField` → `Field` + `FieldLabel` + `FieldDescription` + `FieldError`. This is the shell **every** property renders through, so it is the widest hunk by reach. Its `onClick` stays on the field: a property can carry several errors and clicking is what advances `currentErrorIndex`. |
| `property-component` | `NumberInput` → `Input type="number"`; `RadioGroup options={…}` → composed `RadioGroupItem` + `Label` (Base UI has no options prop); `Switch isChecked/onChange` → `checked/onCheckedChange`. |
| `forms/secret-input` | The Registry `Input` already owns the reveal toggle for `type="password"` and disables it while read-only — which is the state an existing secret sits in before Edit — so the hand-rolled `InputGroup` + `InputRightElement` + `useBoolean` all go. |
| `forms/topic-input` | `Select isMulti` → `SimpleMultiSelect` (string-valued, and the property is a comma-joined string either way); FormControl/FormHelperText/FormErrorMessage → Field/FieldDescription/FieldError. |
| `list` | The rename hint Tooltip was `isOpen={hasFocus}` — focus-controlled, not hover — so it stays controlled via `open`. |
| `property-group` | Chakra `Accordion items={…}` → composed AccordionItem/Trigger/Content. **The sub-group heading rendered its name twice**; fixed rather than carried across. |
| `components`, `connector-step` | Layout props, and `Skeleton noOfLines` → `SkeletonText lines`. |

### The two hunks that carry real judgement
Both were caught in review and fixed in a follow-up commit; they are the reason this PR is worth reading closely.

1. **Numeric properties must stay strings.** Chakra's `NumberInput.onChange` is `(valueAsString, valueAsNumber)` and the old code took the *first* argument. `getConfigObject` sends `p.value` as-is **and** `===`-compares it against `default_value` to suppress untouched defaults — and `sanitizeDefaultValue` numbers only the INT/LONG/SHORT defaults. Storing a number changed which properties get sent, inconsistently across the numeric types; clearing a field stored `NaN`, which `JSON.stringify` turns into `null` in the validate and create requests.
2. **Chakra's `FormControl` generated an id and wired `FormLabel htmlFor`; the Registry `Field` does not.** Without it every property on the create/edit connector form was an unlabeled control. A derived `property-<name>` id now goes to both the control and the label. `FormField` also special-cased a `Switch` child into an inline row, and `Field`'s vertical variant carries `[&>*]:w-full`, which stretched the Switch pill across the row — BOOLEAN and RADIO_GROUP are `orientation="horizontal"` and the control is wrapped.

Also from review: the Registry `Input` **discards a caller's `style`** (it applies its own after the prop spread), so both list inputs had silently lost their flex sizing; the numeric steppers are back (`showStepControls`). A second review then caught `step="any"`: the Registry `Input` coerces `step` with `Number()`, so it became `NaN` and one stepper click wrote an empty value — `step={1}` now — and forwarded the property id into `SecretInput` so the password label associates.

### Effect
Files importing `@redpanda-data/ui`: **50 → 42**. (Earlier revisions of this body quoted 81 → 73, against the pre-Phase-2 master.)

### Gates
Re-run on the rebased branch (2026-09-09): `type:check` clean · unit **62 files / 882 tests** · integration **132 files / 1316 tests**, all passing · `lint:check` on the 10 changed files reports **1 error**, pre-existing (`useBlockStatements` in `dynamic-ui/list.tsx`, present on master). `connector.spec.ts` exercises this end to end.

### Final review (2026-09-08)
- Radio-group properties are named: a radiogroup div is not labelable, so the label carries an id and the group points at it with `aria-labelledby`.
- BOOLEAN and RADIO_GROUP fields are vertical again — Chakra's FormField never inlined them (its Switch check never matched at runtime), so the horizontal Field row was a layout change, not parity.
- The list ghost input's transparent border is a Tailwind class on the element: the unlayered `!important` in index.scss lost to the Registry's layered `!border-input`, so the field rendered bordered. The new-entry input fits its 29px row.
- Known: the Registry number stepper does not round, so stepping a DOUBLE like 2.3 can store 1.2999999999999998 (Chakra rounded to the value's precision).

### Fourth review round (2026-09-08)
- Required properties carry `required`/`aria-required` again — Chakra's `FormControl` stamped them and the Registry `Field` does not. Applied across STRING/PASSWORD/INT/BOOLEAN/RADIO_GROUP and the two remaining text branches.
- The comma-separated-list control takes the property id, so its new-entry input's label resolves.
- Heading/description gaps moved to `mt-*` on the following element. The `mb-*` they replaced was inert while the `index.scss` margin reset sat unlayered; **#2636 has since moved that reset into `@layer base`**, so either would work now — `mt-*` is kept because it is what was tested.
- The password test reveals the value before Undo, so it fails without the remount `key`.
- `.stringList` rows and buttons use theme tokens (`--color-surface-recess`) instead of literal greys, so they follow dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


