### PR TITLE
[Chakra exit · Phase 2 · PR 11/14] frontend: the Kafka Connect pages on Registry components

### DIFF
--- a/frontend/src/components/pages/connect/cluster-details.tsx
+++ b/frontend/src/components/pages/connect/cluster-details.tsx
@@ -9,8 +9,9 @@
  * by the Apache License, Version 2.0
  */
 
-import { Box, Button, DataTable, Text } from '@redpanda-data/ui';
 import { Link } from '@tanstack/react-router';
+import { buttonVariants } from 'components/redpanda-ui/components/button';
+import { DataTable, type DataTableColumnDef } from 'components/redpanda-ui/components/data-table';
 import { useCallback, useState } from 'react';
 
 import { ClusterStatisticsCard, ConnectorClass, NotConfigured, TaskState, TasksColumn } from './helper';
@@ -78,23 +79,7 @@ class KafkaClusterDetails extends PageComponent<{ clusterName: string }> {
             <h3 style={{ marginLeft: '0.25em', marginBottom: '0.6em' }}>Connector Types</h3>
 
             <DataTable<ClusterAdditionalInfo['plugins'][0]>
-              columns={[
-                {
-                  header: 'Class',
-                  accessorKey: 'class',
-                  cell: ({ row: { original } }) => <ConnectorClass observable={original} />,
-                  size: 500,
-                },
-                {
-                  header: 'Version',
-                  accessorKey: 'version',
-                  size: 300,
-                },
-                {
-                  header: 'Type',
-                  accessorKey: 'type',
-                },
-              ]}
+              columns={pluginColumns}
               data={additionalInfo?.plugins ?? []}
               pagination
               sorting
@@ -105,6 +90,24 @@ class KafkaClusterDetails extends PageComponent<{ clusterName: string }> {
     );
   }
 }
+
+const pluginColumns: DataTableColumnDef<ClusterAdditionalInfo['plugins'][0]>[] = [
+  {
+    header: 'Class',
+    accessorKey: 'class',
+    cell: ({ row: { original } }) => <ConnectorClass observable={original} />,
+    size: 500,
+  },
+  {
+    header: 'Version',
+    accessorKey: 'version',
+    size: 300,
+  },
+  {
+    header: 'Type',
+    accessorKey: 'type',
+  },
+];
 
 const ConnectorsList = ({ clusterName, connectors }: { clusterName: string; connectors: ClusterConnectorInfo[] }) => {
   const [filteredResults, setFilteredResults] = useState<ClusterConnectorInfo[]>([]);
@@ -133,13 +136,17 @@ const ConnectorsList = ({ clusterName, connectors }: { clusterName: string; conn
 
   return (
     <div>
-      <div style={{ display: 'flex', marginBottom: '.5em' }}>
-        <Link params={{ clusterName }} to="/connect-clusters/$clusterName/create-connector">
-          <Button variant="solid">Create connector</Button>
+      <div className="mb-2 flex">
+        <Link
+          className={buttonVariants({ variant: 'primary' })}
+          params={{ clusterName }}
+          to="/connect-clusters/$clusterName/create-connector"
+        >
+          Create connector
         </Link>
       </div>
 
-      <Box my={5}>
+      <div className="my-5">
         <SearchBar<ClusterConnectorInfo>
           dataSource={dataSource}
           filterText={searchText}
@@ -148,7 +155,7 @@ const ConnectorsList = ({ clusterName, connectors }: { clusterName: string; conn
           onQueryChanged={onQueryChanged}
           placeholderText="Enter search term/regex"
         />
-      </Box>
+      </div>
 
       <DataTable<ClusterConnectorInfo>
         columns={[
@@ -164,9 +171,7 @@ const ConnectorsList = ({ clusterName, connectors }: { clusterName: string; conn
                 search={{} as never}
                 to="/connect-clusters/$clusterName/$connector"
               >
-                <Text whiteSpace="break-spaces" wordBreak="break-word">
-                  {original.name}
-                </Text>
+                <span className="whitespace-break-spaces break-words">{original.name}</span>
               </Link>
             ),
             size: Number.POSITIVE_INFINITY,
@@ -194,9 +199,9 @@ const ConnectorsList = ({ clusterName, connectors }: { clusterName: string; conn
           },
         ]}
         data={filteredResults}
-        defaultPageSize={10}
         pagination
         sorting
+        tableOptions={{ initialState: { pagination: { pageIndex: 0, pageSize: 10 } } }}
       />
     </div>
   );

--- a/frontend/src/components/pages/connect/cluster-details.tsx
+++ b/frontend/src/components/pages/connect/cluster-details.tsx
@@ -10,9 +10,13 @@
  */
 
 import { Link } from '@tanstack/react-router';
-import { buttonVariants } from 'components/redpanda-ui/components/button';
-import { DataTable, type DataTableColumnDef } from 'components/redpanda-ui/components/data-table';
-import { useCallback, useState } from 'react';
+import { Button } from 'components/redpanda-ui/components/button';
+import {
+  DataTable,
+  type DataTableColumnDef,
+  DataTableColumnHeader,
+} from 'components/redpanda-ui/components/data-table';
+import { useCallback, useMemo, useState } from 'react';
 
 import { ClusterStatisticsCard, ConnectorClass, NotConfigured, TaskState, TasksColumn } from './helper';
 import { isEmbedded } from '../../../config';
@@ -93,18 +97,22 @@ class KafkaClusterDetails extends PageComponent<{ clusterName: string }> {
 
 const pluginColumns: DataTableColumnDef<ClusterAdditionalInfo['plugins'][0]>[] = [
   {
-    header: 'Class',
+    id: 'class',
+    enableHiding: false,
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Class" />,
     accessorKey: 'class',
     cell: ({ row: { original } }) => <ConnectorClass observable={original} />,
-    size: 500,
   },
   {
-    header: 'Version',
+    id: 'version',
+    enableHiding: false,
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Version" />,
     accessorKey: 'version',
-    size: 300,
   },
   {
-    header: 'Type',
+    id: 'type',
+    enableHiding: false,
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Type" />,
     accessorKey: 'type',
   },
 ];
@@ -134,15 +142,67 @@ const ConnectorsList = ({ clusterName, connectors }: { clusterName: string; conn
     uiSettings.connectorsList.quickSearch = filterText;
   }, []);
 
+  // Memoised on clusterName: DataTable memoises its column model on `columns` identity, and this
+  // component re-renders on every keystroke in the SearchBar.
+  const connectorColumns = useMemo<DataTableColumnDef<ClusterConnectorInfo>[]>(
+    () => [
+      {
+        id: 'name',
+        enableHiding: false,
+        header: ({ column }) => <DataTableColumnHeader column={column} title="Connector" />,
+        accessorKey: 'name',
+        cell: ({ row: { original } }) => (
+          <Link
+            params={{
+              clusterName,
+              connector: original.name,
+            }}
+            search={{} as never}
+            to="/connect-clusters/$clusterName/$connector"
+          >
+            <span className="whitespace-break-spaces break-words">{original.name}</span>
+          </Link>
+        ),
+      },
+      {
+        id: 'class',
+        enableHiding: false,
+        header: ({ column }) => <DataTableColumnHeader column={column} title="Class" />,
+        accessorKey: 'class',
+        cell: ({ row: { original } }) => <ConnectorClass observable={original} />,
+      },
+      {
+        id: 'type',
+        enableHiding: false,
+        header: ({ column }) => <DataTableColumnHeader column={column} title="Type" />,
+        accessorKey: 'type',
+      },
+      {
+        id: 'state',
+        enableHiding: false,
+        header: ({ column }) => <DataTableColumnHeader column={column} title="State" />,
+        accessorKey: 'state',
+        cell: ({ row: { original } }) => <TaskState observable={original} />,
+      },
+      {
+        id: 'tasks',
+        // Derived from the task list, so there is nothing to sort on.
+        enableSorting: false,
+        enableHiding: false,
+        header: 'Tasks',
+        cell: ({ row: { original } }) => <TasksColumn observable={original} />,
+      },
+    ],
+    [clusterName]
+  );
+
   return (
     <div>
       <div className="mb-2 flex">
-        <Link
-          className={buttonVariants({ variant: 'primary' })}
-          params={{ clusterName }}
-          to="/connect-clusters/$clusterName/create-connector"
-        >
-          Create connector
+        {/* tests/shared/connector.utils.ts clicks this with getByRole('button'), which this
+            nesting produces — and the Registry Button takes no route `params`. */}
+        <Link params={{ clusterName }} to="/connect-clusters/$clusterName/create-connector">
+          <Button variant="primary">Create connector</Button>
         </Link>
       </div>
 
@@ -157,52 +217,7 @@ const ConnectorsList = ({ clusterName, connectors }: { clusterName: string; conn
         />
       </div>
 
-      <DataTable<ClusterConnectorInfo>
-        columns={[
-          {
-            header: 'Connector',
-            accessorKey: 'name',
-            cell: ({ row: { original } }) => (
-              <Link
-                params={{
-                  clusterName,
-                  connector: original.name,
-                }}
-                search={{} as never}
-                to="/connect-clusters/$clusterName/$connector"
-              >
-                <span className="whitespace-break-spaces break-words">{original.name}</span>
-              </Link>
-            ),
-            size: Number.POSITIVE_INFINITY,
-          },
-          {
-            header: 'Class',
-            accessorKey: 'class',
-            cell: ({ row: { original } }) => <ConnectorClass observable={original} />,
-          },
-          {
-            header: 'Type',
-            accessorKey: 'type',
-            size: 100,
-          },
-          {
-            header: 'State',
-            accessorKey: 'state',
-            size: 120,
-            cell: ({ row: { original } }) => <TaskState observable={original} />,
-          },
-          {
-            header: 'Tasks',
-            size: 120,
-            cell: ({ row: { original } }) => <TasksColumn observable={original} />,
-          },
-        ]}
-        data={filteredResults}
-        pagination
-        sorting
-        tableOptions={{ initialState: { pagination: { pageIndex: 0, pageSize: 10 } } }}
-      />
+      <DataTable<ClusterConnectorInfo> columns={connectorColumns} data={filteredResults} pagination sorting />
     </div>
   );
 };

--- a/frontend/src/components/pages/connect/cluster-details.tsx
+++ b/frontend/src/components/pages/connect/cluster-details.tsx
@@ -31,8 +31,13 @@ import SearchBar from '../../misc/search-bar';
 import Section from '../../misc/section';
 import { PageComponent, type PageInitHelper, type PageProps } from '../page';
 
-// Legacy table parity: 50 rows a page, pager only past that.
-const TABLE_OPTIONS = { initialState: { pagination: { pageIndex: 0, pageSize: DEFAULT_TABLE_PAGE_SIZE } } };
+// Legacy table parity: 50 rows a page, pager only past that. No column-visibility UI, so hiding is off.
+const TABLE_OPTIONS = {
+  enableHiding: false,
+  initialState: { pagination: { pageIndex: 0, pageSize: DEFAULT_TABLE_PAGE_SIZE } },
+};
+// Ten a page (the Registry default) is the legacy page size for this table.
+const CONNECTORS_TABLE_OPTIONS = { enableHiding: false };
 
 class KafkaClusterDetails extends PageComponent<{ clusterName: string }> {
   placeholder = 5;
@@ -103,20 +108,17 @@ class KafkaClusterDetails extends PageComponent<{ clusterName: string }> {
 const pluginColumns: DataTableColumnDef<ClusterAdditionalInfo['plugins'][0]>[] = [
   {
     id: 'class',
-    enableHiding: false,
     header: ({ column }) => <DataTableColumnHeader column={column} title="Class" />,
     accessorKey: 'class',
     cell: ({ row: { original } }) => <ConnectorClass observable={original} />,
   },
   {
     id: 'version',
-    enableHiding: false,
     header: ({ column }) => <DataTableColumnHeader column={column} title="Version" />,
     accessorKey: 'version',
   },
   {
     id: 'type',
-    enableHiding: false,
     header: ({ column }) => <DataTableColumnHeader column={column} title="Type" />,
     accessorKey: 'type',
   },
@@ -153,7 +155,6 @@ const ConnectorsList = ({ clusterName, connectors }: { clusterName: string; conn
     () => [
       {
         id: 'name',
-        enableHiding: false,
         header: ({ column }) => <DataTableColumnHeader column={column} title="Connector" />,
         accessorKey: 'name',
         cell: ({ row: { original } }) => (
@@ -171,20 +172,17 @@ const ConnectorsList = ({ clusterName, connectors }: { clusterName: string; conn
       },
       {
         id: 'class',
-        enableHiding: false,
         header: ({ column }) => <DataTableColumnHeader column={column} title="Class" />,
         accessorKey: 'class',
         cell: ({ row: { original } }) => <ConnectorClass observable={original} />,
       },
       {
         id: 'type',
-        enableHiding: false,
         header: ({ column }) => <DataTableColumnHeader column={column} title="Type" />,
         accessorKey: 'type',
       },
       {
         id: 'state',
-        enableHiding: false,
         header: ({ column }) => <DataTableColumnHeader column={column} title="State" />,
         accessorKey: 'state',
         cell: ({ row: { original } }) => <TaskState observable={original} />,
@@ -193,7 +191,6 @@ const ConnectorsList = ({ clusterName, connectors }: { clusterName: string; conn
         id: 'tasks',
         // Derived from the task list, so there is nothing to sort on.
         enableSorting: false,
-        enableHiding: false,
         header: 'Tasks',
         cell: ({ row: { original } }) => <TasksColumn observable={original} />,
       },
@@ -228,6 +225,7 @@ const ConnectorsList = ({ clusterName, connectors }: { clusterName: string; conn
         // Legacy parity: ten a page, pager only past that.
         pagination={filteredResults.length > 10}
         sorting
+        tableOptions={CONNECTORS_TABLE_OPTIONS}
       />
     </div>
   );

--- a/frontend/src/components/pages/connect/cluster-details.tsx
+++ b/frontend/src/components/pages/connect/cluster-details.tsx
@@ -84,7 +84,7 @@ class KafkaClusterDetails extends PageComponent<{ clusterName: string }> {
 
           {/* Plugin List */}
           <div style={{ marginTop: '2em', display: isEmbedded() ? 'none' : 'block' }}>
-            <h3 className="mb-2.5 ml-1">Connector Types</h3>
+            <h3 className="ml-1 pb-2.5">Connector Types</h3>
 
             <DataTable<ClusterAdditionalInfo['plugins'][0]>
               columns={pluginColumns}
@@ -222,7 +222,13 @@ const ConnectorsList = ({ clusterName, connectors }: { clusterName: string; conn
         />
       </div>
 
-      <DataTable<ClusterConnectorInfo> columns={connectorColumns} data={filteredResults} pagination sorting />
+      <DataTable<ClusterConnectorInfo>
+        columns={connectorColumns}
+        data={filteredResults}
+        // Legacy parity: ten a page, pager only past that.
+        pagination={filteredResults.length > 10}
+        sorting
+      />
     </div>
   );
 };

--- a/frontend/src/components/pages/connect/cluster-details.tsx
+++ b/frontend/src/components/pages/connect/cluster-details.tsx
@@ -25,10 +25,14 @@ import { api } from '../../../state/backend-api';
 import type { ClusterAdditionalInfo, ClusterConnectorInfo } from '../../../state/rest-interfaces';
 import { uiSettings } from '../../../state/ui';
 import { DefaultSkeleton } from '../../../utils/tsx-utils';
+import { DEFAULT_TABLE_PAGE_SIZE } from '../../constants';
 import PageContent from '../../misc/page-content';
 import SearchBar from '../../misc/search-bar';
 import Section from '../../misc/section';
 import { PageComponent, type PageInitHelper, type PageProps } from '../page';
+
+// Legacy table parity: 50 rows a page, pager only past that.
+const TABLE_OPTIONS = { initialState: { pagination: { pageIndex: 0, pageSize: DEFAULT_TABLE_PAGE_SIZE } } };
 
 class KafkaClusterDetails extends PageComponent<{ clusterName: string }> {
   placeholder = 5;
@@ -80,13 +84,14 @@ class KafkaClusterDetails extends PageComponent<{ clusterName: string }> {
 
           {/* Plugin List */}
           <div style={{ marginTop: '2em', display: isEmbedded() ? 'none' : 'block' }}>
-            <h3 style={{ marginLeft: '0.25em', marginBottom: '0.6em' }}>Connector Types</h3>
+            <h3 className="mb-2.5 ml-1">Connector Types</h3>
 
             <DataTable<ClusterAdditionalInfo['plugins'][0]>
               columns={pluginColumns}
               data={additionalInfo?.plugins ?? []}
-              pagination
+              pagination={(additionalInfo?.plugins?.length ?? 0) > DEFAULT_TABLE_PAGE_SIZE}
               sorting
+              tableOptions={TABLE_OPTIONS}
             />
           </div>
         </Section>

--- a/frontend/src/components/pages/connect/connector-box-card.tsx
+++ b/frontend/src/components/pages/connect/connector-box-card.tsx
@@ -49,11 +49,11 @@ function ConnectorRadioCardContent({ connectorPlugin }: { connectorPlugin: Conne
     <div className="flex flex-col">
       <div className="mb-2 size-8">{logo}</div>
 
-      <div className="font-semibold text-[0.85em]">{type === 'source' ? 'Import from' : 'Export to'}</div>
+      <div className="text-label">{type === 'source' ? 'Import from' : 'Export to'}</div>
 
-      <div className="mb-2 font-semibold text-[1.1em]">{displayName}</div>
+      <div className="mb-2 font-semibold text-body-lg">{displayName}</div>
 
-      <p className="line-clamp-3 text-[0.85em] text-subtle">{description}</p>
+      <p className="line-clamp-3 text-body-sm text-subtle">{description}</p>
       {learnMoreLink ? (
         <div className="mt-2">
           <Badge tone="default" variant="subtle">

--- a/frontend/src/components/pages/connect/connector-box-card.tsx
+++ b/frontend/src/components/pages/connect/connector-box-card.tsx
@@ -9,7 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
-import { Box, Flex, Tag, TagLabel, Text } from '@redpanda-data/ui';
+import { Badge } from 'components/redpanda-ui/components/badge';
 import { Link } from 'components/redpanda-ui/components/typography';
 
 import { findConnectorMetadata, removeNamespace } from './helper';
@@ -46,32 +46,24 @@ function ConnectorRadioCardContent({ connectorPlugin }: { connectorPlugin: Conne
   const type = connectorPlugin.type ?? 'unknown';
 
   return (
-    <Flex direction="column">
-      <Box height="32px" mb="2" width="32px">
-        {logo}
-      </Box>
+    <div className="flex flex-col">
+      <div className="mb-2 size-8">{logo}</div>
 
-      <Box fontSize=".85em" fontWeight="600">
-        {type === 'source' ? 'Import from' : 'Export to'}
-      </Box>
+      <div className="font-semibold text-[0.85em]">{type === 'source' ? 'Import from' : 'Export to'}</div>
 
-      <Box fontSize="1.1em" fontWeight="600" mb="2">
-        {displayName}
-      </Box>
+      <div className="mb-2 font-semibold text-[1.1em]">{displayName}</div>
 
-      <Text color="gray.500" fontSize=".85em" noOfLines={3}>
-        {description}
-      </Text>
+      <p className="line-clamp-3 text-[0.85em] text-subtle">{description}</p>
       {learnMoreLink ? (
-        <Box mt="2">
-          <Tag mt="auto">
+        <div className="mt-2">
+          <Badge tone="default" variant="subtle">
             <Link className="opacity-80" href={learnMoreLink} rel="noopener noreferrer" target="_blank">
-              <TagLabel>Documentation</TagLabel>
+              Documentation
             </Link>
-          </Tag>
-        </Box>
+          </Badge>
+        </div>
       ) : null}
-    </Flex>
+    </div>
   );
 }
 

--- a/frontend/src/components/pages/connect/connector-details.tsx
+++ b/frontend/src/components/pages/connect/connector-details.tsx
@@ -26,10 +26,15 @@ import {
 import { Code, TimestampDisplay } from '../../../utils/tsx-utils';
 import { PageComponent, type PageInitHelper } from '../page';
 import './helper';
+import { AlertIcon, ChevronDownIcon, ChevronRightIcon, CloseIcon, WarningIcon } from 'components/icons';
 import { Alert, AlertDescription } from 'components/redpanda-ui/components/alert';
 import { Button } from 'components/redpanda-ui/components/button';
-import { CodeBlock, Pre } from 'components/redpanda-ui/components/code-block';
-import { DataTable, type DataTableColumnDef } from 'components/redpanda-ui/components/data-table';
+import { SimpleCodeBlock } from 'components/redpanda-ui/components/code-block';
+import {
+  DataTable,
+  type DataTableColumnDef,
+  DataTableColumnHeader,
+} from 'components/redpanda-ui/components/data-table';
 import {
   Dialog,
   DialogBody,
@@ -41,7 +46,8 @@ import {
 import { Input, InputEnd, InputStart } from 'components/redpanda-ui/components/input';
 import { SkeletonText } from 'components/redpanda-ui/components/skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from 'components/redpanda-ui/components/tooltip';
-import { ChevronDown, ChevronRight, CircleAlertIcon, SearchIcon, TriangleAlertIcon, XIcon } from 'lucide-react';
+import { cn } from 'components/redpanda-ui/lib/utils';
+import { SearchIcon } from 'lucide-react';
 
 import { getConnectorFriendlyName } from './connector-box-card';
 import { ConfirmModal, NotConfigured, statusColors, TaskState } from './helper';
@@ -99,7 +105,11 @@ const KafkaConnectorMain = ({
   const setS = (patch: Partial<LocalConnectorState>) => setStateInternal((prev) => ({ ...prev, ...patch }));
 
   if (!connectClusterStore.isInitialized) {
-    return <SkeletonText className="mt-5" lines={20} width="full" />;
+    return (
+      <div className="mt-5">
+        <SkeletonText lines={20} width="full" />
+      </div>
+    );
   }
 
   const connectorStore = connectClusterStore.getConnectorStore(connectorName);
@@ -214,7 +224,9 @@ const KafkaConnectorMain = ({
               'Logs'
             ) : (
               <Tooltip>
-                <TooltipTrigger render={<span>Logs</span>} />
+                {/* The disabled trigger sets `aria-disabled:pointer-events-none`, which cascades —
+                    without re-enabling them here the tooltip could never open. */}
+                <TooltipTrigger render={<span className="pointer-events-auto">Logs</span>} />
                 <TooltipContent side="top">{`Logs topic '${LOGS_TOPIC_NAME}' does not exist.`}</TooltipContent>
               </Tooltip>
             ),
@@ -380,7 +392,7 @@ const ConfigOverviewTab = (p: {
 
       <Section style={{ gridArea: 'health' }}>
         <div className="m-1 flex flex-row gap-4">
-          <div className="w-[5px] rounded-[3px]" style={{ background: statusColors[connector.status] }} />
+          <div className={cn('w-[5px] rounded-[3px]', statusColors[connector.status])} />
 
           <div className="flex flex-col">
             <div className="font-semibold text-heading-lg">{titleCase(connector.status)}</div>
@@ -391,7 +403,7 @@ const ConfigOverviewTab = (p: {
 
       <Section className="min-w-[500px] py-4" style={{ gridArea: 'tasks' }}>
         <div className="mt-2 mb-6 flex items-center gap-2">
-          <h3 className="font-semibold text-[1rem] text-strong uppercase">Tasks</h3>
+          <h3 className="font-semibold text-body-lg text-strong uppercase">Tasks</h3>
           <div className="font-normal opacity-50">
             ({connectClusterStore.getConnectorTasks(connectorName)?.length || 0})
           </div>
@@ -401,12 +413,11 @@ const ConfigOverviewTab = (p: {
           data={connectClusterStore.getConnectorTasks(connectorName) ?? []}
           pagination
           sorting
-          tableOptions={{ initialState: { pagination: { pageIndex: 0, pageSize: 10 } } }}
         />
       </Section>
 
       <Section className="py-4" style={{ gridArea: 'details' }}>
-        <h3 className="mt-2 mb-6 font-semibold text-[1rem] text-strong uppercase">Connector Details</h3>
+        <h3 className="mt-2 mb-6 font-semibold text-body-lg text-strong uppercase">Connector Details</h3>
 
         <ConnectorDetails clusterName={p.clusterName} connectClusterStore={connectClusterStore} connector={connector} />
       </Section>
@@ -416,9 +427,10 @@ const ConfigOverviewTab = (p: {
 
 const taskColumns: DataTableColumnDef<ClusterConnectorTaskInfo>[] = [
   {
-    header: 'Task',
+    id: 'taskId',
+    enableHiding: false,
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Task" />,
     accessorKey: 'taskId',
-    size: 200,
     cell: ({
       row: {
         original: { taskId },
@@ -426,12 +438,16 @@ const taskColumns: DataTableColumnDef<ClusterConnectorTaskInfo>[] = [
     }) => <Code nowrap>Task-{taskId}</Code>,
   },
   {
-    header: 'Status',
+    id: 'state',
+    enableHiding: false,
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Status" />,
     accessorKey: 'state',
     cell: ({ row: { original } }) => <TaskState observable={original} />,
   },
   {
-    header: 'Worker',
+    id: 'workerId',
+    enableHiding: false,
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Worker" />,
     accessorKey: 'workerId',
     cell: ({ row: { original } }) => <Code nowrap>{original.workerId}</Code>,
   },
@@ -449,7 +465,7 @@ const ConnectorErrorModal = (p: { error: ConnectorError }) => {
       {/* The whole banner opens the detail dialog; "View details" is the visible affordance for it. */}
       <Alert
         className="cursor-pointer items-center"
-        icon={isError ? <CircleAlertIcon /> : <TriangleAlertIcon />}
+        icon={isError ? <AlertIcon /> : <WarningIcon />}
         onClick={() => setIsOpen(true)}
         variant={isError ? 'destructive' : 'warning'}
       >
@@ -474,15 +490,13 @@ const ConnectorErrorModal = (p: { error: ConnectorError }) => {
             <DialogTitle>{p.error.title}</DialogTitle>
           </DialogHeader>
           <DialogBody>
-            <CodeBlock maxHeight="none" width="full">
-              <Pre>{p.error.content}</Pre>
-            </CodeBlock>
+            <SimpleCodeBlock code={p.error.content} language="json" maxHeight="none" width="full" />
           </DialogBody>
           <DialogFooter>
             {Boolean(hasConnectorLogs) && (
-              <Button className="mr-auto" onClick={() => appGlobal.historyPush(`/topics/${LOGS_TOPIC_NAME}`)}>
-                Show Logs
-              </Button>
+              <div className="mr-auto">
+                <Button onClick={() => appGlobal.historyPush(`/topics/${LOGS_TOPIC_NAME}`)}>Show Logs</Button>
+              </div>
             )}
             <Button onClick={() => setIsOpen(false)}>Close</Button>
           </DialogFooter>
@@ -745,12 +759,14 @@ const LogsTab = (p: {
             size="icon-xs"
             variant="ghost"
           >
-            {row.getIsExpanded() ? <ChevronDown className="size-4" /> : <ChevronRight className="size-4" />}
+            {row.getIsExpanded() ? <ChevronDownIcon className="size-4" /> : <ChevronRightIcon className="size-4" />}
           </Button>
         ) : null,
     },
     {
-      header: 'Timestamp',
+      id: 'timestamp',
+      enableHiding: false,
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Timestamp" />,
       accessorKey: 'timestamp',
       cell: ({
         row: {
@@ -796,23 +812,27 @@ const LogsTab = (p: {
             <InputStart>
               <SearchIcon className="size-4 text-muted-foreground" data-testid="search-field-search-icon" />
             </InputStart>
-            {logsQuickSearch !== '' && (
-              <InputEnd className="pointer-events-auto">
-                <Button
-                  aria-label="Clear search"
-                  data-testid="search-field-reset-icon"
-                  onClick={() => setLogsQuickSearch('')}
-                  size="icon-xs"
-                  variant="ghost"
-                >
-                  <XIcon />
-                </Button>
-              </InputEnd>
-            )}
+            {/* Always mounted: InputEnd never resets the padding it measured, and unmounting the
+                button under the click would drop focus to <body>. */}
+            <InputEnd className="pointer-events-auto">
+              <Button
+                aria-label="Clear search"
+                className={logsQuickSearch === '' ? 'invisible' : undefined}
+                data-testid="search-field-reset-icon"
+                disabled={logsQuickSearch === ''}
+                onClick={() => setLogsQuickSearch('')}
+                size="icon-xs"
+                variant="ghost"
+              >
+                <CloseIcon />
+              </Button>
+            </InputEnd>
           </Input>
-          <Button className="ml-auto" onClick={() => setRefreshCount((c) => c + 1)} variant="outline">
-            Refresh logs
-          </Button>
+          <div className="ml-auto">
+            <Button onClick={() => setRefreshCount((c) => c + 1)} variant="outline">
+              Refresh logs
+            </Button>
+          </div>
         </div>
 
         <DataTable<TopicMessage>

--- a/frontend/src/components/pages/connect/connector-details.tsx
+++ b/frontend/src/components/pages/connect/connector-details.tsx
@@ -10,7 +10,6 @@
  */
 
 import React, { useEffect, useRef, useState } from 'react';
-import type { LegacyColumnDef } from 'utils/legacy-data-table';
 
 import { ConfigPage } from './dynamic-ui/components';
 import { appGlobal } from '../../../state/app-global';
@@ -27,31 +26,22 @@ import {
 import { Code, TimestampDisplay } from '../../../utils/tsx-utils';
 import { PageComponent, type PageInitHelper } from '../page';
 import './helper';
+import { Alert, AlertDescription } from 'components/redpanda-ui/components/alert';
+import { Button } from 'components/redpanda-ui/components/button';
+import { CodeBlock, Pre } from 'components/redpanda-ui/components/code-block';
+import { DataTable, type DataTableColumnDef } from 'components/redpanda-ui/components/data-table';
 import {
-  Alert,
-  AlertIcon,
-  Box,
-  Button,
-  CodeBlock,
-  DataTable,
-  Flex,
-  Grid,
-  Heading,
-  ModalBody,
-  ModalCloseButton,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalOverlay,
-  Modal as RPModal,
-  SearchField,
-  Skeleton,
-  Tabs,
-  Text,
-  Tooltip,
-  useDisclosure,
-} from '@redpanda-data/ui';
-import type { SortingState } from '@tanstack/react-table';
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from 'components/redpanda-ui/components/dialog';
+import { Input, InputEnd, InputStart } from 'components/redpanda-ui/components/input';
+import { SkeletonText } from 'components/redpanda-ui/components/skeleton';
+import { Tooltip, TooltipContent, TooltipTrigger } from 'components/redpanda-ui/components/tooltip';
+import { ChevronDown, ChevronRight, CircleAlertIcon, SearchIcon, TriangleAlertIcon, XIcon } from 'lucide-react';
 
 import { getConnectorFriendlyName } from './connector-box-card';
 import { ConfirmModal, NotConfigured, statusColors, TaskState } from './helper';
@@ -62,6 +52,7 @@ import { sanitizeString } from '../../../utils/filter-helper';
 import { delay, encodeBase64, titleCase } from '../../../utils/utils';
 import PageContent from '../../misc/page-content';
 import Section from '../../misc/section';
+import Tabs from '../../misc/tabs/tabs';
 import { ExpandedMessage } from '../topics/Tab.Messages/message-display/expanded-message';
 import { MessagePreview } from '../topics/Tab.Messages/message-display/message-preview';
 
@@ -108,7 +99,7 @@ const KafkaConnectorMain = ({
   const setS = (patch: Partial<LocalConnectorState>) => setStateInternal((prev) => ({ ...prev, ...patch }));
 
   if (!connectClusterStore.isInitialized) {
-    return <Skeleton height={4} mt={5} noOfLines={20} />;
+    return <SkeletonText className="mt-5" lines={20} width="full" />;
   }
 
   const connectorStore = connectClusterStore.getConnectorStore(connectorName);
@@ -123,18 +114,13 @@ const KafkaConnectorMain = ({
   return (
     <>
       {/* [Pause] [Restart] [Delete] */}
-      <Flex alignItems="center" flexDirection="row" gap="3">
+      <div className="flex flex-row items-center gap-3">
         {/* [Pause/Resume] */}
         {connectClusterStore.validateConnectorState(connectorName, ['RUNNING', 'PAUSED']) ? (
-          <Tooltip
-            hasArrow={true}
-            isDisabled={canEdit === true}
-            label={"You don't have 'canEditConnectCluster' permissions for this connect cluster"}
-            placement="top"
-          >
+          <NoEditPermissionTooltip canEdit={canEdit}>
             <Button
-              isDisabled={!canEdit}
-              minWidth="32"
+              className="min-w-32"
+              disabled={!canEdit}
               onClick={() => {
                 setS({ pausingConnector: connector });
               }}
@@ -142,19 +128,14 @@ const KafkaConnectorMain = ({
             >
               {connectClusterStore.validateConnectorState(connectorName, ['RUNNING']) ? 'Pause' : 'Resume'}
             </Button>
-          </Tooltip>
+          </NoEditPermissionTooltip>
         ) : null}
 
         {/* [Restart] */}
-        <Tooltip
-          hasArrow={true}
-          isDisabled={canEdit === true}
-          label={"You don't have 'canEditConnectCluster' permissions for this connect cluster"}
-          placement="top"
-        >
+        <NoEditPermissionTooltip canEdit={canEdit}>
           <Button
-            isDisabled={!canEdit}
-            minWidth="32"
+            className="min-w-32"
+            disabled={!canEdit}
             onClick={() => {
               setS({ restartingConnector: connector });
             }}
@@ -162,92 +143,88 @@ const KafkaConnectorMain = ({
           >
             Restart
           </Button>
-        </Tooltip>
+        </NoEditPermissionTooltip>
 
         {/* [Delete] */}
-        <Tooltip
-          hasArrow={true}
-          isDisabled={canEdit === true}
-          label={"You don't have 'canEditConnectCluster' permissions for this connect cluster"}
-          placement="top"
-        >
+        <NoEditPermissionTooltip canEdit={canEdit}>
           <Button
-            colorScheme="red"
-            isDisabled={!canEdit}
-            minWidth="32"
+            className="min-w-32"
+            disabled={!canEdit}
             onClick={() => {
               setS({ deletingConnector: connectorName });
             }}
-            variant="outline"
+            variant="destructive-outline"
           >
             Delete
           </Button>
-        </Tooltip>
-      </Flex>
+        </NoEditPermissionTooltip>
+      </div>
 
       <Tabs
-        items={[
+        tabs={[
           {
             key: 'overview',
-            name: 'Overview',
-            component: (
-              <Box mt="8">
+            title: 'Overview',
+            content: (
+              <div className="mt-8">
                 <ConfigOverviewTab
                   clusterName={clusterName}
                   connectClusterStore={connectClusterStore}
                   connector={connector}
                 />
-              </Box>
+              </div>
             ),
           },
           {
             key: 'configuration',
-            name: 'Configuration',
-            component: (
-              <Box mt="8">
-                <Box maxWidth="800px">
+            title: 'Configuration',
+            content: (
+              <div className="mt-8">
+                <div className="max-w-[800px]">
                   {Boolean(connectorStore) && (
                     // biome-ignore lint/style/noNonNullAssertion: checked above with Boolean(connectorStore)
                     <ConfigPage connectorStore={connectorStore!} context="EDIT" />
                   )}
-                </Box>
+                </div>
 
                 {/* Update Config Button */}
-                <Flex m={4} mb={6}>
-                  <Tooltip
-                    hasArrow={true}
-                    isDisabled={!!canEdit}
-                    label="You don't have 'canEditConnectCluster' permissions for this connect cluster"
-                    placement="top"
-                  >
+                <div className="m-4 mb-6 flex">
+                  <NoEditPermissionTooltip canEdit={canEdit}>
                     <Button
-                      isDisabled={!canEdit}
+                      className="w-[200px]"
+                      disabled={!canEdit}
                       onClick={() => {
                         setS({ updatingConnector: { clusterName, connectorName } });
                       }}
-                      style={{ width: '200px' }}
                       variant="outline"
                     >
                       Update Config
                     </Button>
-                  </Tooltip>
-                </Flex>
-              </Box>
+                  </NoEditPermissionTooltip>
+                </div>
+              </div>
             ),
           },
           {
             key: 'logs',
-            name: 'Logs',
-            isDisabled: logsTopic ? false : `Logs topic '${LOGS_TOPIC_NAME}' does not exist.`,
-            component: (
-              <Box mt="8">
+            // Chakra's Tabs took the reason as `isDisabled`; the app wrapper takes a boolean, so
+            // the reason moves to a tooltip on the trigger.
+            disabled: !logsTopic,
+            title: logsTopic ? (
+              'Logs'
+            ) : (
+              <Tooltip>
+                <TooltipTrigger render={<span>Logs</span>} />
+                <TooltipContent side="top">{`Logs topic '${LOGS_TOPIC_NAME}' does not exist.`}</TooltipContent>
+              </Tooltip>
+            ),
+            content: (
+              <div className="mt-8">
                 <LogsTab clusterName={clusterName} connectClusterStore={connectClusterStore} connector={connector} />
-              </Box>
+              </div>
             ),
           },
         ]}
-        marginBlock="2"
-        size="lg"
       />
 
       {/* Pause/Resume Modal */}
@@ -387,130 +364,130 @@ const ConfigOverviewTab = (p: {
   const connectorName = connector.name;
 
   return (
-    <Grid
-      alignItems="start"
-      gap="6"
-      gridTemplateRows="auto"
-      templateAreas={`
-              "errors errors"
-              "health details"
-              "tasks details"
-          `}
+    <div
+      // The template areas are inline: Tailwind has no arbitrary grid-template-areas utility.
+      className="grid items-start gap-6"
+      style={{
+        gridTemplateAreas: '"errors errors" "health details" "tasks details"',
+        gridTemplateRows: 'auto',
+      }}
     >
-      <Flex flexDirection="column" gap="2" gridArea="errors">
+      <div className="flex flex-col gap-2" style={{ gridArea: 'errors' }}>
         {connector.errors.map((e) => (
           <ConnectorErrorModal error={e} key={e.title} />
         ))}
-      </Flex>
+      </div>
 
       <Section style={{ gridArea: 'health' }}>
-        <Flex flexDirection="row" gap="4" m="1">
-          <Box background={statusColors[connector.status]} borderRadius="3px" width="5px" />
+        <div className="m-1 flex flex-row gap-4">
+          <div className="w-[5px] rounded-[3px]" style={{ background: statusColors[connector.status] }} />
 
-          <Flex flexDirection="column">
-            <Text fontSize="3xl" fontWeight="semibold">
-              {titleCase(connector.status)}
-            </Text>
-            <Text opacity=".5">Status</Text>
-          </Flex>
-        </Flex>
+          <div className="flex flex-col">
+            <div className="font-semibold text-heading-lg">{titleCase(connector.status)}</div>
+            <div className="opacity-50">Status</div>
+          </div>
+        </div>
       </Section>
 
       <Section className="min-w-[500px] py-4" style={{ gridArea: 'tasks' }}>
-        <Flex alignItems="center" gap="2" mb="6" mt="2">
-          <Heading as="h3" color="blackAlpha.800" fontSize="1rem" fontWeight="semibold" textTransform="uppercase">
-            Tasks
-          </Heading>
-          <Text fontWeight="normal" opacity=".5">
+        <div className="mt-2 mb-6 flex items-center gap-2">
+          <h3 className="font-semibold text-[1rem] text-strong uppercase">Tasks</h3>
+          <div className="font-normal opacity-50">
             ({connectClusterStore.getConnectorTasks(connectorName)?.length || 0})
-          </Text>
-        </Flex>
+          </div>
+        </div>
         <DataTable<ClusterConnectorTaskInfo>
-          columns={[
-            {
-              header: 'Task',
-              accessorKey: 'taskId',
-              size: 200,
-              cell: ({
-                row: {
-                  original: { taskId },
-                },
-              }) => <Code nowrap>Task-{taskId}</Code>,
-            },
-            {
-              header: 'Status',
-              accessorKey: 'state',
-              cell: ({ row: { original } }) => <TaskState observable={original} />,
-            },
-            {
-              header: 'Worker',
-              accessorKey: 'workerId',
-              cell: ({ row: { original } }) => <Code nowrap>{original.workerId}</Code>,
-            },
-          ]}
+          columns={taskColumns}
           data={connectClusterStore.getConnectorTasks(connectorName) ?? []}
-          defaultPageSize={10}
           pagination
           sorting
+          tableOptions={{ initialState: { pagination: { pageIndex: 0, pageSize: 10 } } }}
         />
       </Section>
 
       <Section className="py-4" style={{ gridArea: 'details' }}>
-        <Heading
-          as="h3"
-          color="blackAlpha.800"
-          fontSize="1rem"
-          fontWeight="semibold"
-          mb="6"
-          mt="2"
-          textTransform="uppercase"
-        >
-          Connector Details
-        </Heading>
+        <h3 className="mt-2 mb-6 font-semibold text-[1rem] text-strong uppercase">Connector Details</h3>
 
         <ConnectorDetails clusterName={p.clusterName} connectClusterStore={connectClusterStore} connector={connector} />
       </Section>
-    </Grid>
+    </div>
   );
 };
 
-const ConnectorErrorModal = (p: { error: ConnectorError }) => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
+const taskColumns: DataTableColumnDef<ClusterConnectorTaskInfo>[] = [
+  {
+    header: 'Task',
+    accessorKey: 'taskId',
+    size: 200,
+    cell: ({
+      row: {
+        original: { taskId },
+      },
+    }) => <Code nowrap>Task-{taskId}</Code>,
+  },
+  {
+    header: 'Status',
+    accessorKey: 'state',
+    cell: ({ row: { original } }) => <TaskState observable={original} />,
+  },
+  {
+    header: 'Worker',
+    accessorKey: 'workerId',
+    cell: ({ row: { original } }) => <Code nowrap>{original.workerId}</Code>,
+  },
+];
 
-  const errorType = p.error.type === 'ERROR' ? 'error' : 'warning';
+const ConnectorErrorModal = (p: { error: ConnectorError }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const isError = p.error.type === 'ERROR';
 
   const hasConnectorLogs = api.topics?.any((x) => x.topicName === LOGS_TOPIC_NAME);
 
   return (
     <>
-      <Alert borderRadius="8px" height="12" onClick={onOpen} status={errorType} variant="solid">
-        <AlertIcon />
-        <Box whiteSpace="break-spaces" wordBreak="break-all">
-          {p.error.title}
-        </Box>
-        <Button colorScheme="gray" ml="auto" mt="1px" size="sm" variant="ghost">
-          View details
-        </Button>
+      {/* The whole banner opens the detail dialog; "View details" is the visible affordance for it. */}
+      <Alert
+        className="cursor-pointer items-center"
+        icon={isError ? <CircleAlertIcon /> : <TriangleAlertIcon />}
+        onClick={() => setIsOpen(true)}
+        variant={isError ? 'destructive' : 'warning'}
+      >
+        <AlertDescription className="w-full grid-flow-col items-center justify-between">
+          <div className="whitespace-break-spaces break-all">{p.error.title}</div>
+          <Button size="sm" variant="ghost">
+            View details
+          </Button>
+        </AlertDescription>
       </Alert>
 
-      <RPModal isOpen={isOpen} onClose={onClose} size="6xl">
-        <ModalOverlay />
-        <ModalContent>
-          <ModalHeader>{p.error.title}</ModalHeader>
-          <ModalCloseButton />
-          <ModalBody>
-            <CodeBlock codeString={p.error.content} language="json" showScroll={false} />
-          </ModalBody>
-          <ModalFooter gap={2}>
+      <Dialog
+        onOpenChange={(open) => {
+          if (!open) {
+            setIsOpen(false);
+          }
+        }}
+        open={isOpen}
+      >
+        <DialogContent size="full">
+          <DialogHeader>
+            <DialogTitle>{p.error.title}</DialogTitle>
+          </DialogHeader>
+          <DialogBody>
+            <CodeBlock maxHeight="none" width="full">
+              <Pre>{p.error.content}</Pre>
+            </CodeBlock>
+          </DialogBody>
+          <DialogFooter>
             {Boolean(hasConnectorLogs) && (
-              <Button mr="auto" onClick={() => appGlobal.historyPush(`/topics/${LOGS_TOPIC_NAME}`)}>
+              <Button className="mr-auto" onClick={() => appGlobal.historyPush(`/topics/${LOGS_TOPIC_NAME}`)}>
                 Show Logs
               </Button>
             )}
-            <Button onClick={onClose}>Close</Button>
-          </ModalFooter>
-        </ModalContent>
-      </RPModal>
+            <Button onClick={() => setIsOpen(false)}>Close</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 };
@@ -636,18 +613,43 @@ const ConnectorDetails = (p: {
   });
 
   return (
-    <Grid columnGap="10" rowGap="3" templateColumns="auto 1fr">
+    <div className="grid grid-cols-[auto_1fr] gap-x-10 gap-y-3">
       {displayEntries.map((x) => (
         <React.Fragment key={x.name}>
-          <Text fontWeight="semibold" whiteSpace="nowrap">
-            {x.name}
-          </Text>
-          <Text overflow="hidden" textOverflow="ellipsis" title={x.value} whiteSpace="nowrap">
+          <div className="whitespace-nowrap font-semibold">{x.name}</div>
+          <div className="overflow-hidden text-ellipsis whitespace-nowrap" title={x.value}>
             {x.value}
-          </Text>
+          </div>
         </React.Fragment>
       ))}
-    </Grid>
+    </div>
+  );
+};
+
+/**
+ * Wraps a control that is disabled without `canEditConnectCluster`, explaining why. Chakra's
+ * Tooltip took `isDisabled` to suppress itself; Base UI has no such prop, so the wrapper renders
+ * the child bare when the permission is present.
+ */
+const NoEditPermissionTooltip = ({
+  canEdit,
+  children,
+}: {
+  canEdit: boolean | null | undefined;
+  children: React.ReactElement;
+}) => {
+  if (canEdit) {
+    return children;
+  }
+
+  return (
+    <Tooltip>
+      {/* A disabled button fires no pointer events, so the tooltip hangs off a wrapper. */}
+      <TooltipTrigger render={<span className="inline-flex">{children}</span>} />
+      <TooltipContent side="top">
+        You don't have 'canEditConnectCluster' permissions for this connect cluster
+      </TooltipContent>
+    </Tooltip>
   );
 };
 
@@ -667,7 +669,6 @@ const LogsTab = (p: {
   });
   const { messages, isComplete } = logState;
   const [logsQuickSearch, setLogsQuickSearch] = useState('');
-  const [sorting, setSorting] = useState<SortingState>([]);
   const searchRef = useRef<MessageSearch | null>(null);
   const [refreshCount, setRefreshCount] = useState(0);
 
@@ -730,7 +731,24 @@ const LogsTab = (p: {
   };
 
   const paginationParams = usePaginationParams(messages.length, 10);
-  const messageTableColumns: LegacyColumnDef<TopicMessage>[] = [
+  const messageTableColumns: DataTableColumnDef<TopicMessage>[] = [
+    // Chakra's DataTable injected this column whenever `subComponent` was set; the Registry one does not.
+    {
+      id: 'expander',
+      size: 40,
+      enableSorting: false,
+      cell: ({ row }) =>
+        row.getCanExpand() ? (
+          <Button
+            aria-label={row.getIsExpanded() ? 'Collapse row' : 'Expand row'}
+            onClick={row.getToggleExpandedHandler()}
+            size="icon-xs"
+            variant="ghost"
+          >
+            {row.getIsExpanded() ? <ChevronDown className="size-4" /> : <ChevronRight className="size-4" />}
+          </Button>
+        ) : null,
+    },
     {
       header: 'Timestamp',
       accessorKey: 'timestamp',
@@ -764,24 +782,44 @@ const LogsTab = (p: {
 
   return (
     <>
-      <Box my="1rem">The logs below are for the last three hours.</Box>
+      <div className="my-4">The logs below are for the last three hours.</div>
 
       <Section className="min-w-[800px]">
-        <Flex mb="6">
-          <SearchField searchText={logsQuickSearch} setSearchText={setLogsQuickSearch} width="230px" />
-          <Button ml="auto" onClick={() => setRefreshCount((c) => c + 1)} variant="outline">
+        <div className="mb-6 flex">
+          <Input
+            containerClassName="max-w-[230px]"
+            onChange={(e) => setLogsQuickSearch(e.target.value)}
+            placeholder="Search..."
+            testId="search-field-input"
+            value={logsQuickSearch}
+          >
+            <InputStart>
+              <SearchIcon className="size-4 text-muted-foreground" data-testid="search-field-search-icon" />
+            </InputStart>
+            {logsQuickSearch !== '' && (
+              <InputEnd className="pointer-events-auto">
+                <Button
+                  aria-label="Clear search"
+                  data-testid="search-field-reset-icon"
+                  onClick={() => setLogsQuickSearch('')}
+                  size="icon-xs"
+                  variant="ghost"
+                >
+                  <XIcon />
+                </Button>
+              </InputEnd>
+            )}
+          </Input>
+          <Button className="ml-auto" onClick={() => setRefreshCount((c) => c + 1)} variant="outline">
             Refresh logs
           </Button>
-        </Flex>
+        </div>
 
         <DataTable<TopicMessage>
           columns={messageTableColumns}
           data={filteredMessages}
           emptyText="No messages"
           isLoading={!isComplete}
-          onSortingChange={setSorting}
-          pagination={paginationParams}
-          sorting={sorting}
           subComponent={({ row: { original } }) => (
             <ExpandedMessage
               loadLargeMessage={() =>
@@ -794,6 +832,7 @@ const LogsTab = (p: {
               msg={original}
             />
           )}
+          tableOptions={{ initialState: { pagination: paginationParams } }}
         />
       </Section>
     </>

--- a/frontend/src/components/pages/connect/connector-details.tsx
+++ b/frontend/src/components/pages/connect/connector-details.tsx
@@ -25,14 +25,13 @@ import {
   type TopicMessage,
 } from '../../../state/rest-interfaces';
 import { TimestampDisplay } from '../../../utils/tsx-utils';
-import { DEFAULT_TABLE_PAGE_SIZE } from '../../constants';
 import { SearchInput } from '../../misc/search-input';
 import { PageComponent, type PageInitHelper } from '../page';
 import './helper';
 import { AlertIcon, ChevronDownIcon, ChevronRightIcon, WarningIcon } from 'components/icons';
 import { Alert, AlertDescription } from 'components/redpanda-ui/components/alert';
 import { Button } from 'components/redpanda-ui/components/button';
-import { SimpleCodeBlock } from 'components/redpanda-ui/components/code-block';
+import { SyncCodeBlock } from 'components/redpanda-ui/components/code-block-dynamic';
 import {
   DataTable,
   type DataTableColumnDef,
@@ -62,8 +61,6 @@ import Tabs from '../../misc/tabs/tabs';
 import { ExpandedMessage } from '../topics/Tab.Messages/message-display/expanded-message';
 import { MessagePreview } from '../topics/Tab.Messages/message-display/message-preview';
 
-// Legacy table parity: 50 rows a page, pager only past that.
-const TABLE_OPTIONS = { initialState: { pagination: { pageIndex: 0, pageSize: DEFAULT_TABLE_PAGE_SIZE } } };
 // Stable identity keeps an expanded row on its message when the list is filtered or refreshed.
 const LOGS_TABLE_OPTIONS = {
   initialState: { pagination: { pageIndex: 0, pageSize: 10 } },
@@ -225,8 +222,7 @@ const KafkaConnectorMain = ({
           },
           {
             key: 'logs',
-            // Chakra's Tabs took the reason as `isDisabled`; the app wrapper takes a boolean, so
-            // the reason moves to a tooltip on the trigger.
+            // The Tabs wrapper takes a boolean; the reason goes in a tooltip on the trigger.
             disabled: !logsTopic,
             title: logsTopic ? (
               'Logs'
@@ -419,14 +415,14 @@ const ConfigOverviewTab = (p: {
         <DataTable<ClusterConnectorTaskInfo>
           columns={taskColumns}
           data={connectClusterStore.getConnectorTasks(connectorName) ?? []}
-          pagination={(connectClusterStore.getConnectorTasks(connectorName)?.length ?? 0) > DEFAULT_TABLE_PAGE_SIZE}
+          // Legacy parity: ten a page, pager only past that.
+          pagination={(connectClusterStore.getConnectorTasks(connectorName)?.length ?? 0) > 10}
           sorting
-          tableOptions={TABLE_OPTIONS}
         />
       </Section>
 
       <Section className="py-4" style={{ gridArea: 'details' }}>
-        <h3 className="mt-2 mb-6 font-semibold text-body-lg text-strong uppercase">Connector Details</h3>
+        <h3 className="mt-2 pb-6 font-semibold text-body-lg text-strong uppercase">Connector Details</h3>
 
         <ConnectorDetails clusterName={p.clusterName} connectClusterStore={connectClusterStore} connector={connector} />
       </Section>
@@ -497,7 +493,7 @@ const ConnectorErrorModal = (p: { error: ConnectorError }) => {
             <DialogTitle>{p.error.title}</DialogTitle>
           </DialogHeader>
           <DialogBody>
-            <SimpleCodeBlock code={p.error.content} language="json" maxHeight="none" width="full" />
+            <SyncCodeBlock code={p.error.content} lang="json" />
           </DialogBody>
           <DialogFooter>
             {Boolean(hasConnectorLogs) && (
@@ -755,7 +751,7 @@ const LogsTab = (p: {
   // this tab would do every 200 ms while logs stream (the sort menu could never stay open).
   const messageTableColumns: DataTableColumnDef<TopicMessage>[] = useMemo(
     () => [
-      // Chakra's DataTable injected this column whenever `subComponent` was set; the Registry one does not.
+      // The Registry DataTable renders no expander column for `subComponent`.
       {
         id: 'expander',
         enableSorting: false,
@@ -788,8 +784,12 @@ const LogsTab = (p: {
         ),
       },
       {
+        id: 'value',
         header: 'Value',
         accessorKey: 'value',
+        // A decoded preview; sorting the raw value means nothing.
+        enableSorting: false,
+        enableHiding: false,
         // The Registry DataTable ignores column sizes; a viewport-wide max-content hands this column the slack.
         cell: ({ row: { original } }) => (
           <div className="w-screen max-w-full">

--- a/frontend/src/components/pages/connect/connector-details.tsx
+++ b/frontend/src/components/pages/connect/connector-details.tsx
@@ -9,7 +9,8 @@
  * by the Apache License, Version 2.0
  */
 
-import React, { useEffect, useRef, useState } from 'react';
+import { InlineCode } from 'components/redpanda-ui/components/typography';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 import { ConfigPage } from './dynamic-ui/components';
 import { appGlobal } from '../../../state/app-global';
@@ -23,10 +24,12 @@ import {
   PropertyImportance,
   type TopicMessage,
 } from '../../../state/rest-interfaces';
-import { Code, TimestampDisplay } from '../../../utils/tsx-utils';
+import { TimestampDisplay } from '../../../utils/tsx-utils';
+import { DEFAULT_TABLE_PAGE_SIZE } from '../../constants';
+import { SearchInput } from '../../misc/search-input';
 import { PageComponent, type PageInitHelper } from '../page';
 import './helper';
-import { AlertIcon, ChevronDownIcon, ChevronRightIcon, CloseIcon, WarningIcon } from 'components/icons';
+import { AlertIcon, ChevronDownIcon, ChevronRightIcon, WarningIcon } from 'components/icons';
 import { Alert, AlertDescription } from 'components/redpanda-ui/components/alert';
 import { Button } from 'components/redpanda-ui/components/button';
 import { SimpleCodeBlock } from 'components/redpanda-ui/components/code-block';
@@ -43,15 +46,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from 'components/redpanda-ui/components/dialog';
-import { Input, InputEnd, InputStart } from 'components/redpanda-ui/components/input';
 import { SkeletonText } from 'components/redpanda-ui/components/skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from 'components/redpanda-ui/components/tooltip';
 import { cn } from 'components/redpanda-ui/lib/utils';
-import { SearchIcon } from 'lucide-react';
 
 import { getConnectorFriendlyName } from './connector-box-card';
 import { ConfirmModal, NotConfigured, statusColors, TaskState } from './helper';
-import usePaginationParams from '../../../hooks/use-pagination-params';
 import { PayloadEncoding } from '../../../protogen/redpanda/api/console/v1alpha1/common_pb';
 import { PartitionOffsetOrigin } from '../../../state/ui';
 import { sanitizeString } from '../../../utils/filter-helper';
@@ -61,6 +61,14 @@ import Section from '../../misc/section';
 import Tabs from '../../misc/tabs/tabs';
 import { ExpandedMessage } from '../topics/Tab.Messages/message-display/expanded-message';
 import { MessagePreview } from '../topics/Tab.Messages/message-display/message-preview';
+
+// Legacy table parity: 50 rows a page, pager only past that.
+const TABLE_OPTIONS = { initialState: { pagination: { pageIndex: 0, pageSize: DEFAULT_TABLE_PAGE_SIZE } } };
+// Stable identity keeps an expanded row on its message when the list is filtered or refreshed.
+const LOGS_TABLE_OPTIONS = {
+  initialState: { pagination: { pageIndex: 0, pageSize: 10 } },
+  getRowId: (message: TopicMessage) => `${message.partitionID}-${message.offset}`,
+};
 
 const LOGS_TOPIC_NAME = '__redpanda.connectors_logs';
 
@@ -411,8 +419,9 @@ const ConfigOverviewTab = (p: {
         <DataTable<ClusterConnectorTaskInfo>
           columns={taskColumns}
           data={connectClusterStore.getConnectorTasks(connectorName) ?? []}
-          pagination
+          pagination={(connectClusterStore.getConnectorTasks(connectorName)?.length ?? 0) > DEFAULT_TABLE_PAGE_SIZE}
           sorting
+          tableOptions={TABLE_OPTIONS}
         />
       </Section>
 
@@ -435,7 +444,7 @@ const taskColumns: DataTableColumnDef<ClusterConnectorTaskInfo>[] = [
       row: {
         original: { taskId },
       },
-    }) => <Code nowrap>Task-{taskId}</Code>,
+    }) => <InlineCode className="whitespace-nowrap">Task-{taskId}</InlineCode>,
   },
   {
     id: 'state',
@@ -449,7 +458,7 @@ const taskColumns: DataTableColumnDef<ClusterConnectorTaskInfo>[] = [
     enableHiding: false,
     header: ({ column }) => <DataTableColumnHeader column={column} title="Worker" />,
     accessorKey: 'workerId',
-    cell: ({ row: { original } }) => <Code nowrap>{original.workerId}</Code>,
+    cell: ({ row: { original } }) => <InlineCode className="whitespace-nowrap">{original.workerId}</InlineCode>,
   },
 ];
 
@@ -462,16 +471,14 @@ const ConnectorErrorModal = (p: { error: ConnectorError }) => {
 
   return (
     <>
-      {/* The whole banner opens the detail dialog; "View details" is the visible affordance for it. */}
       <Alert
-        className="cursor-pointer items-center"
+        className="items-center"
         icon={isError ? <AlertIcon /> : <WarningIcon />}
-        onClick={() => setIsOpen(true)}
         variant={isError ? 'destructive' : 'warning'}
       >
         <AlertDescription className="w-full grid-flow-col items-center justify-between">
           <div className="whitespace-break-spaces break-all">{p.error.title}</div>
-          <Button size="sm" variant="ghost">
+          <Button onClick={() => setIsOpen(true)} size="sm" variant="ghost">
             View details
           </Button>
         </AlertDescription>
@@ -744,50 +751,59 @@ const LogsTab = (p: {
     }
   };
 
-  const paginationParams = usePaginationParams(messages.length, 10);
-  const messageTableColumns: DataTableColumnDef<TopicMessage>[] = [
-    // Chakra's DataTable injected this column whenever `subComponent` was set; the Registry one does not.
-    {
-      id: 'expander',
-      size: 40,
-      enableSorting: false,
-      cell: ({ row }) =>
-        row.getCanExpand() ? (
-          <Button
-            aria-label={row.getIsExpanded() ? 'Collapse row' : 'Expand row'}
-            onClick={row.getToggleExpandedHandler()}
-            size="icon-xs"
-            variant="ghost"
-          >
-            {row.getIsExpanded() ? <ChevronDownIcon className="size-4" /> : <ChevronRightIcon className="size-4" />}
-          </Button>
-        ) : null,
-    },
-    {
-      id: 'timestamp',
-      enableHiding: false,
-      header: ({ column }) => <DataTableColumnHeader column={column} title="Timestamp" />,
-      accessorKey: 'timestamp',
-      cell: ({
-        row: {
-          original: { timestamp },
-        },
-      }) => <TimestampDisplay format="default" unixEpochMillisecond={timestamp} />,
-      size: 30,
-    },
-    {
-      header: 'Value',
-      accessorKey: 'value',
-      cell: ({ row: { original } }) => (
-        <MessagePreview
-          isCompactTopic={topic ? topic.cleanupPolicy.includes('compact') : false}
-          msg={original}
-          previewFields={() => []}
-        />
-      ),
-      size: Number.MAX_SAFE_INTEGER,
-    },
-  ];
+  // Memoised: a new columns array per render makes the table re-create every header and cell, which
+  // this tab would do every 200 ms while logs stream (the sort menu could never stay open).
+  const messageTableColumns: DataTableColumnDef<TopicMessage>[] = useMemo(
+    () => [
+      // Chakra's DataTable injected this column whenever `subComponent` was set; the Registry one does not.
+      {
+        id: 'expander',
+        enableSorting: false,
+        cell: ({ row }) =>
+          row.getCanExpand() ? (
+            <Button
+              aria-expanded={row.getIsExpanded()}
+              aria-label={row.getIsExpanded() ? 'Collapse row' : 'Expand row'}
+              onClick={row.getToggleExpandedHandler()}
+              size="icon-xs"
+              variant="ghost"
+            >
+              {row.getIsExpanded() ? <ChevronDownIcon className="size-4" /> : <ChevronRightIcon className="size-4" />}
+            </Button>
+          ) : null,
+      },
+      {
+        id: 'timestamp',
+        enableHiding: false,
+        header: ({ column }) => <DataTableColumnHeader column={column} title="Timestamp" />,
+        accessorKey: 'timestamp',
+        cell: ({
+          row: {
+            original: { timestamp },
+          },
+        }) => (
+          <span className="whitespace-nowrap">
+            <TimestampDisplay format="default" unixEpochMillisecond={timestamp} />
+          </span>
+        ),
+      },
+      {
+        header: 'Value',
+        accessorKey: 'value',
+        // The Registry DataTable ignores column sizes; a viewport-wide max-content hands this column the slack.
+        cell: ({ row: { original } }) => (
+          <div className="w-screen max-w-full">
+            <MessagePreview
+              isCompactTopic={topic ? topic.cleanupPolicy.includes('compact') : false}
+              msg={original}
+              previewFields={() => []}
+            />
+          </div>
+        ),
+      },
+    ],
+    [topic]
+  );
 
   const filteredMessages = messages.filter((x) => {
     if (!logsQuickSearch) {
@@ -802,32 +818,12 @@ const LogsTab = (p: {
 
       <Section className="min-w-[800px]">
         <div className="mb-6 flex">
-          <Input
-            containerClassName="max-w-[230px]"
-            onChange={(e) => setLogsQuickSearch(e.target.value)}
+          <SearchInput
+            containerClassName="w-[230px]"
+            onChange={setLogsQuickSearch}
             placeholder="Search..."
-            testId="search-field-input"
             value={logsQuickSearch}
-          >
-            <InputStart>
-              <SearchIcon className="size-4 text-muted-foreground" data-testid="search-field-search-icon" />
-            </InputStart>
-            {/* Always mounted: InputEnd never resets the padding it measured, and unmounting the
-                button under the click would drop focus to <body>. */}
-            <InputEnd className="pointer-events-auto">
-              <Button
-                aria-label="Clear search"
-                className={logsQuickSearch === '' ? 'invisible' : undefined}
-                data-testid="search-field-reset-icon"
-                disabled={logsQuickSearch === ''}
-                onClick={() => setLogsQuickSearch('')}
-                size="icon-xs"
-                variant="ghost"
-              >
-                <CloseIcon />
-              </Button>
-            </InputEnd>
-          </Input>
+          />
           <div className="ml-auto">
             <Button onClick={() => setRefreshCount((c) => c + 1)} variant="outline">
               Refresh logs
@@ -852,7 +848,7 @@ const LogsTab = (p: {
               msg={original}
             />
           )}
-          tableOptions={{ initialState: { pagination: paginationParams } }}
+          tableOptions={LOGS_TABLE_OPTIONS}
         />
       </Section>
     </>

--- a/frontend/src/components/pages/connect/connector-details.tsx
+++ b/frontend/src/components/pages/connect/connector-details.tsx
@@ -231,7 +231,7 @@ const KafkaConnectorMain = ({
             title: logsTopic ? (
               'Logs'
             ) : (
-              <Tooltip>
+              <Tooltip delayDuration={150}>
                 {/* The disabled trigger sets `aria-disabled:pointer-events-none`, which cascades —
                     without re-enabling them here the tooltip could never open. */}
                 <TooltipTrigger render={<span className="pointer-events-auto">Logs</span>} />
@@ -403,7 +403,7 @@ const ConfigOverviewTab = (p: {
           <div className={cn('w-[5px] rounded-full', statusColors[connector.status])} />
 
           <div className="flex flex-col">
-            <div className="font-semibold text-heading-lg">{titleCase(connector.status)}</div>
+            <div className="font-semibold text-heading-xl">{titleCase(connector.status)}</div>
             <div className="opacity-50">Status</div>
           </div>
         </div>
@@ -662,7 +662,7 @@ const NoEditPermissionTooltip = ({
   }
 
   return (
-    <Tooltip>
+    <Tooltip delayDuration={150}>
       {/* A disabled button fires no pointer events, so the tooltip hangs off a wrapper. */}
       <TooltipTrigger render={<span className="inline-flex">{children}</span>} />
       <TooltipContent side="top">
@@ -836,6 +836,7 @@ const LogsTab = (p: {
           data={filteredMessages}
           emptyText="No messages"
           isLoading={!isComplete}
+          pagination={filteredMessages.length > 0}
           subComponent={({ row: { original } }) => (
             <ExpandedMessage
               loadLargeMessage={() =>

--- a/frontend/src/components/pages/connect/connector-details.tsx
+++ b/frontend/src/components/pages/connect/connector-details.tsx
@@ -392,7 +392,7 @@ const ConfigOverviewTab = (p: {
 
       <Section style={{ gridArea: 'health' }}>
         <div className="m-1 flex flex-row gap-4">
-          <div className={cn('w-[5px] rounded-[3px]', statusColors[connector.status])} />
+          <div className={cn('w-[5px] rounded-full', statusColors[connector.status])} />
 
           <div className="flex flex-col">
             <div className="font-semibold text-heading-lg">{titleCase(connector.status)}</div>

--- a/frontend/src/components/pages/connect/connector-details.tsx
+++ b/frontend/src/components/pages/connect/connector-details.tsx
@@ -63,9 +63,13 @@ import { MessagePreview } from '../topics/Tab.Messages/message-display/message-p
 
 // Stable identity keeps an expanded row on its message when the list is filtered or refreshed.
 const LOGS_TABLE_OPTIONS = {
+  enableHiding: false,
   initialState: { pagination: { pageIndex: 0, pageSize: 10 } },
   getRowId: (message: TopicMessage) => `${message.partitionID}-${message.offset}`,
 };
+
+// Ten a page (the Registry default) is the legacy page size for this table.
+const TASKS_TABLE_OPTIONS = { enableHiding: false };
 
 const LOGS_TOPIC_NAME = '__redpanda.connectors_logs';
 
@@ -418,6 +422,7 @@ const ConfigOverviewTab = (p: {
           // Legacy parity: ten a page, pager only past that.
           pagination={(connectClusterStore.getConnectorTasks(connectorName)?.length ?? 0) > 10}
           sorting
+          tableOptions={TASKS_TABLE_OPTIONS}
         />
       </Section>
 
@@ -433,7 +438,6 @@ const ConfigOverviewTab = (p: {
 const taskColumns: DataTableColumnDef<ClusterConnectorTaskInfo>[] = [
   {
     id: 'taskId',
-    enableHiding: false,
     header: ({ column }) => <DataTableColumnHeader column={column} title="Task" />,
     accessorKey: 'taskId',
     cell: ({
@@ -444,14 +448,12 @@ const taskColumns: DataTableColumnDef<ClusterConnectorTaskInfo>[] = [
   },
   {
     id: 'state',
-    enableHiding: false,
     header: ({ column }) => <DataTableColumnHeader column={column} title="Status" />,
     accessorKey: 'state',
     cell: ({ row: { original } }) => <TaskState observable={original} />,
   },
   {
     id: 'workerId',
-    enableHiding: false,
     header: ({ column }) => <DataTableColumnHeader column={column} title="Worker" />,
     accessorKey: 'workerId',
     cell: ({ row: { original } }) => <InlineCode className="whitespace-nowrap">{original.workerId}</InlineCode>,
@@ -770,7 +772,6 @@ const LogsTab = (p: {
       },
       {
         id: 'timestamp',
-        enableHiding: false,
         header: ({ column }) => <DataTableColumnHeader column={column} title="Timestamp" />,
         accessorKey: 'timestamp',
         cell: ({
@@ -789,7 +790,6 @@ const LogsTab = (p: {
         accessorKey: 'value',
         // A decoded preview; sorting the raw value means nothing.
         enableSorting: false,
-        enableHiding: false,
         // The Registry DataTable ignores column sizes; a viewport-wide max-content hands this column the slack.
         cell: ({ row: { original } }) => (
           <div className="w-screen max-w-full">

--- a/frontend/src/components/pages/connect/create-connector.tsx
+++ b/frontend/src/components/pages/connect/create-connector.tsx
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
+import { AlertIcon, CloseIcon, FilterIcon, WarningIcon } from 'components/icons';
 import { Alert, AlertDescription } from 'components/redpanda-ui/components/alert';
 import { Button } from 'components/redpanda-ui/components/button';
 import { DataTable } from 'components/redpanda-ui/components/data-table';
@@ -17,7 +18,6 @@ import { Input, InputEnd, InputStart } from 'components/redpanda-ui/components/i
 import { SkeletonText } from 'components/redpanda-ui/components/skeleton';
 import { Spinner } from 'components/redpanda-ui/components/spinner';
 import { Link } from 'components/redpanda-ui/components/typography';
-import { CircleAlertIcon, FilterIcon, TriangleAlertIcon, XIcon } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { docsLinks } from 'utils/docs-links';
 import { showToast } from 'utils/toast.utils';
@@ -144,19 +144,21 @@ const ConnectorType = (p: {
                   <InputStart>
                     <FilterIcon className="size-4 text-muted-foreground" data-testid="search-field-search-icon" />
                   </InputStart>
-                  {textFilter !== '' && (
-                    <InputEnd className="pointer-events-auto">
-                      <Button
-                        aria-label="Clear search"
-                        data-testid="search-field-reset-icon"
-                        onClick={() => setTextFilter('')}
-                        size="icon-xs"
-                        variant="ghost"
-                      >
-                        <XIcon />
-                      </Button>
-                    </InputEnd>
-                  )}
+                  {/* Always mounted: InputEnd never resets the padding it measured, and unmounting
+                      the button under the click would drop focus to <body>. */}
+                  <InputEnd className="pointer-events-auto">
+                    <Button
+                      aria-label="Clear search"
+                      className={textFilter === '' ? 'invisible' : undefined}
+                      data-testid="search-field-reset-icon"
+                      disabled={textFilter === ''}
+                      onClick={() => setTextFilter('')}
+                      size="icon-xs"
+                      variant="ghost"
+                    >
+                      <CloseIcon />
+                    </Button>
+                  </InputEnd>
                 </Input>
               </div>
             </div>
@@ -502,7 +504,11 @@ const ConnectorWizard = ({ connectClusters, activeCluster }: ConnectorWizardProp
   const isLast = () => currentStep === steps.length - 1;
 
   if (!isStoreInitialized) {
-    return <SkeletonText className="mt-5" lines={20} width="full" />;
+    return (
+      <div className="mt-5">
+        <SkeletonText lines={20} width="full" />
+      </div>
+    );
   }
 
   return (
@@ -544,9 +550,10 @@ const ConnectorWizard = ({ connectClusters, activeCluster }: ConnectorWizardProp
         }}
       />
 
-      {/* Not closeable while the connector is being created, so no onOpenChange handler. */}
+      {/* Not closeable while the connector is being created: no onOpenChange handler, and the
+          close X has to be suppressed or it would render and do nothing. */}
       <Dialog open={isCreatingModalOpen}>
-        <DialogContent>
+        <DialogContent showCloseButton={false}>
           <DialogHeader>
             <DialogTitle>Creating connector...</DialogTitle>
           </DialogHeader>
@@ -613,45 +620,53 @@ function Review({
       ) : null}
 
       {isCreating ? (
-        <SkeletonText className="mt-5" lines={6} width="full" />
+        <div className="mt-5">
+          <SkeletonText lines={6} width="full" />
+        </div>
       ) : (
         <>
           {invalidValidationResult !== null ? <ValidationDisplay validationResult={invalidValidationResult} /> : null}
 
           {validationFailure ? (
-            <Alert className="my-4" icon={<CircleAlertIcon />} variant="destructive">
-              <AlertDescription>
-                <div>
-                  <h3 className="text-heading-xs">Validation attempt failed</h3>
-                  <div>{String(validationFailure)}</div>
-                </div>
-              </AlertDescription>
-            </Alert>
+            <div className="my-4">
+              <Alert icon={<AlertIcon />} variant="destructive">
+                <AlertDescription>
+                  <div>
+                    <h3 className="text-heading-xs">Validation attempt failed</h3>
+                    <div>{String(validationFailure)}</div>
+                  </div>
+                </AlertDescription>
+              </Alert>
+            </div>
           ) : null}
 
           {creationFailure ? (
-            <Alert className="my-4" icon={<CircleAlertIcon />} variant="destructive">
-              <AlertDescription>
-                <div>
-                  <h3 className="text-heading-xs">Creation attempt failed</h3>
-                  <div>{String(creationFailure)}</div>
-                </div>
-              </AlertDescription>
-            </Alert>
+            <div className="my-4">
+              <Alert icon={<AlertIcon />} variant="destructive">
+                <AlertDescription>
+                  <div>
+                    <h3 className="text-heading-xs">Creation attempt failed</h3>
+                    <div>{String(creationFailure)}</div>
+                  </div>
+                </AlertDescription>
+              </Alert>
+            </div>
           ) : null}
 
           {genericFailure ? (
-            <Alert className="my-4" icon={<CircleAlertIcon />} variant="destructive">
-              <AlertDescription>
-                <div>
-                  <h3 className="text-heading-xs">An error occurred</h3>
-                  <div>{String(genericFailure)}</div>
-                </div>
-              </AlertDescription>
-            </Alert>
+            <div className="my-4">
+              <Alert icon={<AlertIcon />} variant="destructive">
+                <AlertDescription>
+                  <div>
+                    <h3 className="text-heading-xs">An error occurred</h3>
+                    <div>{String(genericFailure)}</div>
+                  </div>
+                </AlertDescription>
+              </Alert>
+            </div>
           ) : null}
 
-          <h2 className="mt-4 font-medium text-[1.4em]">Connector Properties</h2>
+          <h2 className="mt-4 text-heading-sm">Connector Properties</h2>
           <div style={{ margin: '0 auto 1.5rem' }}>
             <KowlEditor
               height="600px"
@@ -675,7 +690,7 @@ function getDataSource(validationResult: ConnectorValidationResult) {
 
 function ValidationDisplay({ validationResult }: { validationResult: ConnectorValidationResult }) {
   return (
-    <Alert className="my-4 overflow-auto" icon={<TriangleAlertIcon />} variant="warning">
+    <Alert className="overflow-auto" icon={<WarningIcon />} variant="warning">
       <AlertDescription>
         <div>
           <h3 className="mb-4 text-heading-xs">Submitted configuration is invalid</h3>

--- a/frontend/src/components/pages/connect/create-connector.tsx
+++ b/frontend/src/components/pages/connect/create-connector.tsx
@@ -9,27 +9,15 @@
  * by the Apache License, Version 2.0
  */
 
-import {
-  Alert,
-  AlertDescription,
-  AlertIcon,
-  Box,
-  DataTable,
-  Flex,
-  Heading,
-  Link,
-  Modal,
-  ModalBody,
-  ModalContent,
-  ModalHeader,
-  ModalOverlay,
-  SearchField,
-  Skeleton,
-  Spinner,
-  Tabs,
-  Text,
-  useDisclosure,
-} from '@redpanda-data/ui';
+import { Alert, AlertDescription } from 'components/redpanda-ui/components/alert';
+import { Button } from 'components/redpanda-ui/components/button';
+import { DataTable } from 'components/redpanda-ui/components/data-table';
+import { Dialog, DialogBody, DialogContent, DialogHeader, DialogTitle } from 'components/redpanda-ui/components/dialog';
+import { Input, InputEnd, InputStart } from 'components/redpanda-ui/components/input';
+import { SkeletonText } from 'components/redpanda-ui/components/skeleton';
+import { Spinner } from 'components/redpanda-ui/components/spinner';
+import { Link } from 'components/redpanda-ui/components/typography';
+import { CircleAlertIcon, FilterIcon, TriangleAlertIcon, XIcon } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { docsLinks } from 'utils/docs-links';
 import { showToast } from 'utils/toast.utils';
@@ -47,6 +35,7 @@ import { HiddenRadioList } from '../../misc/hidden-radio-list';
 import KowlEditor from '../../misc/kowl-editor';
 import PageContent from '../../misc/page-content';
 import { SingleSelect } from '../../misc/select';
+import Tabs from '../../misc/tabs/tabs';
 import { Wizard, type WizardStep } from '../../misc/wizard';
 import { PageComponent, type PageInitHelper } from '../page';
 
@@ -113,11 +102,9 @@ const ConnectorType = (p: {
 
   const noResultsBox =
     filteredPlugins?.length > 0 ? null : (
-      <Flex alignItems="center" background="blackAlpha.100" borderRadius="8px" justifyContent="center" p="10">
-        <Text color="gray" fontSize="large">
-          No connectors that match the search filters
-        </Text>
-      </Flex>
+      <div className="flex items-center justify-center rounded-lg bg-surface-subtle p-10">
+        <div className="text-body-lg text-subtle">No connectors that match the search filters</div>
+      </div>
     );
 
   return (
@@ -125,7 +112,7 @@ const ConnectorType = (p: {
       {p.connectClusters.length > 1 && (
         <>
           <h2>Installation Target</h2>
-          <Box maxWidth={400}>
+          <div className="max-w-[400px]">
             <SingleSelect<string | undefined>
               onChange={p.onActiveClusterChange as (val: string | null | undefined) => void}
               options={p.connectClusters.map(({ clusterName }) => ({
@@ -134,52 +121,57 @@ const ConnectorType = (p: {
               }))}
               value={p.activeCluster ?? undefined}
             />
-          </Box>
+          </div>
         </>
       )}
 
       {Boolean(p.activeCluster) && (
         <>
-          <Flex direction="column" gap="1em">
-            <Box maxWidth="600px">
-              <Text>
+          <div className="flex flex-col gap-4">
+            <div className="max-w-[600px]">
+              <div className="text-body">
                 Select a managed connector. Connectors simplify importing and exporting data between Redpanda and
                 popular data sources. <Link href={docsLinks.cloud.managedConnectors}>Learn more</Link>
-              </Text>
+              </div>
 
-              <Box marginBlock="4" marginTop="8">
-                <SearchField
-                  icon="filter"
-                  placeholderText="Search"
-                  searchText={textFilter}
-                  setSearchText={setTextFilter}
-                />
-              </Box>
-            </Box>
-          </Flex>
+              <div className="my-4 mt-8">
+                <Input
+                  onChange={(e) => setTextFilter(e.target.value)}
+                  placeholder="Search"
+                  testId="search-field-input"
+                  value={textFilter}
+                >
+                  <InputStart>
+                    <FilterIcon className="size-4 text-muted-foreground" data-testid="search-field-search-icon" />
+                  </InputStart>
+                  {textFilter !== '' && (
+                    <InputEnd className="pointer-events-auto">
+                      <Button
+                        aria-label="Clear search"
+                        data-testid="search-field-reset-icon"
+                        onClick={() => setTextFilter('')}
+                        size="icon-xs"
+                        variant="ghost"
+                      >
+                        <XIcon />
+                      </Button>
+                    </InputEnd>
+                  )}
+                </Input>
+              </div>
+            </div>
+          </div>
 
+          {/* Filter-only tabs: the panels are empty and the card grid below reacts to the key. */}
           <Tabs
-            items={[
-              {
-                key: 'all',
-                name: 'All',
-                component: <></>,
-              },
-              {
-                key: 'export',
-                name: 'Export to',
-                component: <></>,
-              },
-              {
-                key: 'import',
-                name: 'Import from',
-                component: <></>,
-              },
-            ]}
-            marginBlock="2"
-            onChange={(_, key) => {
+            onChange={(key) => {
               setTabFilter(key as (typeof tabFilterModes)[number]);
             }}
+            tabs={[
+              { key: 'all', title: 'All', content: null },
+              { key: 'export', title: 'Export to', content: null },
+              { key: 'import', title: 'Import from', content: null },
+            ]}
           />
 
           <HiddenRadioList<ConnectorPlugin>
@@ -284,7 +276,9 @@ const ConnectorWizard = ({ connectClusters, activeCluster }: ConnectorWizardProp
   const setLoading = (v: boolean) => setLoadingState((prev) => ({ ...prev, loading: v }));
   const setIsStoreInitialized = (v: boolean) => setLoadingState((prev) => ({ ...prev, isStoreInitialized: v }));
   const [connectClusterStore, setConnectClusterStore] = useState(() => ConnectClusterStore.getInstance(activeCluster));
-  const { isOpen: isCreatingModalOpen, onOpen: openCreatingModal, onClose: closeCreatingModal } = useDisclosure();
+  const [isCreatingModalOpen, setIsCreatingModalOpen] = useState(false);
+  const openCreatingModal = () => setIsCreatingModalOpen(true);
+  const closeCreatingModal = () => setIsCreatingModalOpen(false);
 
   useEffect(() => {
     const init = async () => {
@@ -346,13 +340,13 @@ const ConnectorWizard = ({ connectClusters, activeCluster }: ConnectorWizardProp
           <CreateConnectorHeading plugin={selectedPlugin} />
 
           {selectedPlugin ? (
-            <Box maxWidth="800px">
+            <div className="max-w-[800px]">
               <ConfigPage
                 // biome-ignore lint/style/noNonNullAssertion: needed as refactoring child components would be very complex
                 connectorStore={connectClusterStore.getConnector(selectedPlugin.class, null, undefined)!}
                 context="CREATE"
               />
-            </Box>
+            </div>
           ) : (
             <div>no cluster or plugin selected</div>
           )}
@@ -508,7 +502,7 @@ const ConnectorWizard = ({ connectClusters, activeCluster }: ConnectorWizardProp
   const isLast = () => currentStep === steps.length - 1;
 
   if (!isStoreInitialized) {
-    return <Skeleton height={4} mt={5} noOfLines={20} />;
+    return <SkeletonText className="mt-5" lines={20} width="full" />;
   }
 
   return (
@@ -550,42 +544,36 @@ const ConnectorWizard = ({ connectClusters, activeCluster }: ConnectorWizardProp
         }}
       />
 
-      <Modal
-        isCentered
-        isOpen={isCreatingModalOpen}
-        onClose={() => {
-          // no op - modal is not closeable during connector creation
-        }}
-      >
-        <ModalOverlay backdropFilter="blur(5px)" bg="blackAlpha.300" />
-        <ModalContent>
-          <ModalHeader>Creating connector...</ModalHeader>
-          <ModalBody py="8">
-            <Flex alignItems="center" justifyContent="center">
-              <Spinner size="xl" />
-            </Flex>
-          </ModalBody>
-        </ModalContent>
-      </Modal>
+      {/* Not closeable while the connector is being created, so no onOpenChange handler. */}
+      <Dialog open={isCreatingModalOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Creating connector...</DialogTitle>
+          </DialogHeader>
+          <DialogBody className="py-8">
+            <div className="flex items-center justify-center">
+              <Spinner className="size-10" />
+            </div>
+          </DialogBody>
+        </DialogContent>
+      </Dialog>
     </>
   );
 };
 
 function CreateConnectorHeading(p: { plugin: ConnectorPlugin | null }) {
   if (!p.plugin) {
-    return <Heading>Creating Connector</Heading>;
+    return <h1 className="text-heading-xl">Creating Connector</h1>;
   }
 
-  // const { logo } = findConnectorMetadata(p.plugin.class) ?? {};
   const displayName = getConnectorFriendlyName(p.plugin.class);
 
   return (
-    <Heading alignItems="center" as="h1" display="flex" fontSize="2xl" gap=".5ch" mb="8">
+    <h1 className="mb-8 flex items-center gap-[0.5ch] text-heading-lg">
       Create Connector:
       {p.plugin.type === 'source' ? 'import data from ' : 'export data to '}
       {displayName}
-      {/* <Box width="28px" height="28px" mr="1">{logo}</Box> */}
-    </Heading>
+    </h1>
   );
 }
 
@@ -625,50 +613,45 @@ function Review({
       ) : null}
 
       {isCreating ? (
-        <Skeleton height={4} mt={5} noOfLines={6} />
+        <SkeletonText className="mt-5" lines={6} width="full" />
       ) : (
         <>
           {invalidValidationResult !== null ? <ValidationDisplay validationResult={invalidValidationResult} /> : null}
 
           {validationFailure ? (
-            <Alert my={4} status="error" variant="left-accent">
-              <AlertIcon />
+            <Alert className="my-4" icon={<CircleAlertIcon />} variant="destructive">
               <AlertDescription>
-                <Box>
-                  <Text as="h3">Validation attempt failed</Text>
-                  <Text>{String(validationFailure)}</Text>
-                </Box>
+                <div>
+                  <h3 className="text-heading-xs">Validation attempt failed</h3>
+                  <div>{String(validationFailure)}</div>
+                </div>
               </AlertDescription>
             </Alert>
           ) : null}
 
           {creationFailure ? (
-            <Alert my={4} status="error" variant="left-accent">
-              <AlertIcon />
+            <Alert className="my-4" icon={<CircleAlertIcon />} variant="destructive">
               <AlertDescription>
-                <Box>
-                  <Text as="h3">Creation attempt failed</Text>
-                  <Text>{String(creationFailure)}</Text>
-                </Box>
+                <div>
+                  <h3 className="text-heading-xs">Creation attempt failed</h3>
+                  <div>{String(creationFailure)}</div>
+                </div>
               </AlertDescription>
             </Alert>
           ) : null}
 
           {genericFailure ? (
-            <Alert my={4} status="error" variant="left-accent">
-              <AlertIcon />
+            <Alert className="my-4" icon={<CircleAlertIcon />} variant="destructive">
               <AlertDescription>
-                <Box>
-                  <Text as="h3">An error occurred</Text>
-                  <Text>{String(genericFailure)}</Text>
-                </Box>
+                <div>
+                  <h3 className="text-heading-xs">An error occurred</h3>
+                  <div>{String(genericFailure)}</div>
+                </div>
               </AlertDescription>
             </Alert>
           ) : null}
 
-          <Heading as="h2" fontSize="1.4em" fontWeight="500" mt="4">
-            Connector Properties
-          </Heading>
+          <h2 className="mt-4 font-medium text-[1.4em]">Connector Properties</h2>
           <div style={{ margin: '0 auto 1.5rem' }}>
             <KowlEditor
               height="600px"
@@ -692,12 +675,10 @@ function getDataSource(validationResult: ConnectorValidationResult) {
 
 function ValidationDisplay({ validationResult }: { validationResult: ConnectorValidationResult }) {
   return (
-    <Alert my={4} overflow="auto" status="warning" variant="left-accent">
+    <Alert className="my-4 overflow-auto" icon={<TriangleAlertIcon />} variant="warning">
       <AlertDescription>
-        <Box>
-          <Text as="h3" mb={4}>
-            Submitted configuration is invalid
-          </Text>
+        <div>
+          <h3 className="mb-4 text-heading-xs">Submitted configuration is invalid</h3>
           <DataTable<{
             name: string;
             value: string | null;
@@ -720,8 +701,10 @@ function ValidationDisplay({ validationResult }: { validationResult: ConnectorVa
               },
             ]}
             data={getDataSource(validationResult)}
+            pagination={false}
+            sorting={false}
           />
-        </Box>
+        </div>
       </AlertDescription>
     </Alert>
   );

--- a/frontend/src/components/pages/connect/create-connector.tsx
+++ b/frontend/src/components/pages/connect/create-connector.tsx
@@ -9,12 +9,10 @@
  * by the Apache License, Version 2.0
  */
 
-import { AlertIcon, CloseIcon, FilterIcon, WarningIcon } from 'components/icons';
-import { Alert, AlertDescription } from 'components/redpanda-ui/components/alert';
-import { Button } from 'components/redpanda-ui/components/button';
+import { AlertIcon, FilterIcon, WarningIcon } from 'components/icons';
+import { Alert, AlertDescription, AlertTitle } from 'components/redpanda-ui/components/alert';
 import { DataTable } from 'components/redpanda-ui/components/data-table';
 import { Dialog, DialogBody, DialogContent, DialogHeader, DialogTitle } from 'components/redpanda-ui/components/dialog';
-import { Input, InputEnd, InputStart } from 'components/redpanda-ui/components/input';
 import { SkeletonText } from 'components/redpanda-ui/components/skeleton';
 import { Spinner } from 'components/redpanda-ui/components/spinner';
 import { Link } from 'components/redpanda-ui/components/typography';
@@ -34,6 +32,7 @@ import { containsIgnoreCase, delay, TimeSince } from '../../../utils/utils';
 import { HiddenRadioList } from '../../misc/hidden-radio-list';
 import KowlEditor from '../../misc/kowl-editor';
 import PageContent from '../../misc/page-content';
+import { SearchInput } from '../../misc/search-input';
 import { SingleSelect } from '../../misc/select';
 import Tabs from '../../misc/tabs/tabs';
 import { Wizard, type WizardStep } from '../../misc/wizard';
@@ -135,31 +134,12 @@ const ConnectorType = (p: {
               </div>
 
               <div className="my-4 mt-8">
-                <Input
-                  onChange={(e) => setTextFilter(e.target.value)}
+                <SearchInput
+                  icon={<FilterIcon className="size-4" />}
+                  onChange={setTextFilter}
                   placeholder="Search"
-                  testId="search-field-input"
                   value={textFilter}
-                >
-                  <InputStart>
-                    <FilterIcon className="size-4 text-muted-foreground" data-testid="search-field-search-icon" />
-                  </InputStart>
-                  {/* Always mounted: InputEnd never resets the padding it measured, and unmounting
-                      the button under the click would drop focus to <body>. */}
-                  <InputEnd className="pointer-events-auto">
-                    <Button
-                      aria-label="Clear search"
-                      className={textFilter === '' ? 'invisible' : undefined}
-                      data-testid="search-field-reset-icon"
-                      disabled={textFilter === ''}
-                      onClick={() => setTextFilter('')}
-                      size="icon-xs"
-                      variant="ghost"
-                    >
-                      <CloseIcon />
-                    </Button>
-                  </InputEnd>
-                </Input>
+                />
               </div>
             </div>
           </div>
@@ -630,12 +610,8 @@ function Review({
           {validationFailure ? (
             <div className="my-4">
               <Alert icon={<AlertIcon />} variant="destructive">
-                <AlertDescription>
-                  <div>
-                    <h3 className="text-heading-xs">Validation attempt failed</h3>
-                    <div>{String(validationFailure)}</div>
-                  </div>
-                </AlertDescription>
+                <AlertTitle>Validation attempt failed</AlertTitle>
+                <AlertDescription>{String(validationFailure)}</AlertDescription>
               </Alert>
             </div>
           ) : null}
@@ -643,12 +619,8 @@ function Review({
           {creationFailure ? (
             <div className="my-4">
               <Alert icon={<AlertIcon />} variant="destructive">
-                <AlertDescription>
-                  <div>
-                    <h3 className="text-heading-xs">Creation attempt failed</h3>
-                    <div>{String(creationFailure)}</div>
-                  </div>
-                </AlertDescription>
+                <AlertTitle>Creation attempt failed</AlertTitle>
+                <AlertDescription>{String(creationFailure)}</AlertDescription>
               </Alert>
             </div>
           ) : null}
@@ -656,12 +628,8 @@ function Review({
           {genericFailure ? (
             <div className="my-4">
               <Alert icon={<AlertIcon />} variant="destructive">
-                <AlertDescription>
-                  <div>
-                    <h3 className="text-heading-xs">An error occurred</h3>
-                    <div>{String(genericFailure)}</div>
-                  </div>
-                </AlertDescription>
+                <AlertTitle>An error occurred</AlertTitle>
+                <AlertDescription>{String(genericFailure)}</AlertDescription>
               </Alert>
             </div>
           ) : null}
@@ -691,9 +659,9 @@ function getDataSource(validationResult: ConnectorValidationResult) {
 function ValidationDisplay({ validationResult }: { validationResult: ConnectorValidationResult }) {
   return (
     <Alert className="overflow-auto" icon={<WarningIcon />} variant="warning">
+      <AlertTitle>Submitted configuration is invalid</AlertTitle>
       <AlertDescription>
         <div>
-          <h3 className="mb-4 text-heading-xs">Submitted configuration is invalid</h3>
           <DataTable<{
             name: string;
             value: string | null;

--- a/frontend/src/components/pages/connect/create-connector.tsx
+++ b/frontend/src/components/pages/connect/create-connector.tsx
@@ -556,7 +556,7 @@ function CreateConnectorHeading(p: { plugin: ConnectorPlugin | null }) {
   const displayName = getConnectorFriendlyName(p.plugin.class);
 
   return (
-    <h1 className="mb-8 flex items-center gap-[0.5ch] text-heading-lg">
+    <h1 className="flex items-center gap-[0.5ch] pb-8 text-heading-lg">
       Create Connector:
       {p.plugin.type === 'source' ? 'import data from ' : 'export data to '}
       {displayName}

--- a/frontend/src/components/pages/connect/create-connector.tsx
+++ b/frontend/src/components/pages/connect/create-connector.tsx
@@ -556,7 +556,7 @@ function CreateConnectorHeading(p: { plugin: ConnectorPlugin | null }) {
   const displayName = getConnectorFriendlyName(p.plugin.class);
 
   return (
-    <h1 className="flex items-center gap-[0.5ch] pb-8 text-heading-lg">
+    <h1 className="flex items-center gap-[0.5ch] pb-8 text-heading-xl">
       Create Connector:
       {p.plugin.type === 'source' ? 'import data from ' : 'export data to '}
       {displayName}
@@ -605,7 +605,11 @@ function Review({
         </div>
       ) : (
         <>
-          {invalidValidationResult !== null ? <ValidationDisplay validationResult={invalidValidationResult} /> : null}
+          {invalidValidationResult !== null ? (
+            <div className="my-4">
+              <ValidationDisplay validationResult={invalidValidationResult} />
+            </div>
+          ) : null}
 
           {validationFailure ? (
             <div className="my-4">
@@ -634,7 +638,7 @@ function Review({
             </div>
           ) : null}
 
-          <h2 className="mt-4 text-heading-sm">Connector Properties</h2>
+          <h2 className="mt-4 text-heading-lg">Connector Properties</h2>
           <div style={{ margin: '0 auto 1.5rem' }}>
             <KowlEditor
               height="600px"

--- a/frontend/src/components/pages/connect/dynamic-ui/components.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/components.tsx
@@ -81,7 +81,7 @@ export const ConfigPage: React.FC<ConfigPageProps> = ({ connectorStore, context 
         >
           {(['form', 'json'] as const).map((mode) => (
             <div className="flex items-center gap-2" key={mode}>
-              <RadioGroupItem id={`settings-mode-${mode}`} value={mode} />
+              <RadioGroupItem id={`settings-mode-${mode}`} testId={`${mode}_field`} value={mode} />
               <Label className="cursor-pointer" htmlFor={`settings-mode-${mode}`}>
                 {mode === 'form' ? 'Form' : 'JSON'}
               </Label>

--- a/frontend/src/components/pages/connect/dynamic-ui/components.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/components.tsx
@@ -9,7 +9,10 @@
  * by the Apache License, Version 2.0
  */
 
-import { Box, RadioGroup, Skeleton, Switch } from '@redpanda-data/ui';
+import { Label } from 'components/redpanda-ui/components/label';
+import { RadioGroup, RadioGroupItem } from 'components/redpanda-ui/components/radio-group';
+import { SkeletonText } from 'components/redpanda-ui/components/skeleton';
+import { Switch } from 'components/redpanda-ui/components/switch';
 import { useCallback, useState, useSyncExternalStore } from 'react';
 
 import { ConnectorStepComponent } from './connector-step';
@@ -41,7 +44,7 @@ export const ConfigPage: React.FC<ConfigPageProps> = ({ connectorStore, context 
   }
 
   if (connectorStore.initPending) {
-    return <Skeleton height={4} mt={5} noOfLines={20} />;
+    return <SkeletonText className="mt-5" lines={20} width="full" />;
   }
 
   if (connectorStore.allGroups.length === 0) {
@@ -61,32 +64,43 @@ export const ConfigPage: React.FC<ConfigPageProps> = ({ connectorStore, context 
 
   return (
     <>
-      <Box mb="8">
+      <div className="mb-8">
         <RadioGroup
+          className="flex gap-4"
           name="settingsMode"
-          onChange={(x) => {
-            connectorStore.viewMode = x;
-            setViewMode(x as 'form' | 'json');
+          onValueChange={(next) => {
+            connectorStore.viewMode = next as 'form' | 'json';
+            setViewMode(next as 'form' | 'json');
           }}
-          options={[
-            { value: 'form', label: <Box mx="4">Form</Box> },
-            { value: 'json', label: <Box mx="4">JSON</Box> },
-          ]}
+          orientation="horizontal"
           value={viewMode}
-        />
-      </Box>
+        >
+          {(['form', 'json'] as const).map((mode) => (
+            <div className="flex items-center gap-2" key={mode}>
+              <RadioGroupItem id={`settings-mode-${mode}`} value={mode} />
+              <Label className="mx-4 cursor-pointer" htmlFor={`settings-mode-${mode}`}>
+                {mode === 'form' ? 'Form' : 'JSON'}
+              </Label>
+            </div>
+          ))}
+        </RadioGroup>
+      </div>
 
       {viewMode === 'form' ? (
         <>
-          <Switch
-            isChecked={showAdvancedOptions}
-            onChange={(s) => {
-              connectorStore.showAdvancedOptions = s.target.checked;
-              setShowAdvancedOptions(s.target.checked);
-            }}
-          >
-            Show advanced options
-          </Switch>
+          <div className="flex items-center gap-2">
+            <Switch
+              checked={showAdvancedOptions}
+              id="show-advanced-options"
+              onCheckedChange={(checked) => {
+                connectorStore.showAdvancedOptions = checked;
+                setShowAdvancedOptions(checked);
+              }}
+            />
+            <Label className="cursor-pointer" htmlFor="show-advanced-options">
+              Show advanced options
+            </Label>
+          </div>
 
           {steps.map(({ step, groups }) => (
             <ConnectorStepComponent

--- a/frontend/src/components/pages/connect/dynamic-ui/components.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/components.tsx
@@ -44,7 +44,11 @@ export const ConfigPage: React.FC<ConfigPageProps> = ({ connectorStore, context 
   }
 
   if (connectorStore.initPending) {
-    return <SkeletonText className="mt-5" lines={20} width="full" />;
+    return (
+      <div className="mt-5">
+        <SkeletonText lines={20} width="full" />
+      </div>
+    );
   }
 
   if (connectorStore.allGroups.length === 0) {
@@ -78,7 +82,7 @@ export const ConfigPage: React.FC<ConfigPageProps> = ({ connectorStore, context 
           {(['form', 'json'] as const).map((mode) => (
             <div className="flex items-center gap-2" key={mode}>
               <RadioGroupItem id={`settings-mode-${mode}`} value={mode} />
-              <Label className="mx-4 cursor-pointer" htmlFor={`settings-mode-${mode}`}>
+              <Label className="cursor-pointer" htmlFor={`settings-mode-${mode}`}>
                 {mode === 'form' ? 'Form' : 'JSON'}
               </Label>
             </div>

--- a/frontend/src/components/pages/connect/dynamic-ui/connector-step.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/connector-step.tsx
@@ -9,8 +9,6 @@
  * by the Apache License, Version 2.0
  */
 
-import { Box, Heading, Text } from '@redpanda-data/ui';
-
 import type { ConfigPageProps } from './components';
 import { PropertyGroupComponent } from './property-group';
 import type { PropertyGroup } from '../../../../state/connect/state';
@@ -33,16 +31,10 @@ export const ConnectorStepComponent = (props: {
   }
 
   return (
-    <Box>
-      <Heading as="h3" mb="4" mt="8" size="md">
-        {step.name}
-      </Heading>
+    <div>
+      <h3 className="mt-8 mb-4 text-heading-md">{step.name}</h3>
 
-      {Boolean(step.description) && (
-        <Text mb="4" size="sm">
-          {step.description}
-        </Text>
-      )}
+      {Boolean(step.description) && <p className="mb-4 text-body-sm">{step.description}</p>}
 
       {groups.map((g) => (
         <PropertyGroupComponent
@@ -54,6 +46,6 @@ export const ConnectorStepComponent = (props: {
           showAdvancedOptions={props.showAdvancedOptions}
         />
       ))}
-    </Box>
+    </div>
   );
 };

--- a/frontend/src/components/pages/connect/dynamic-ui/connector-step.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/connector-step.tsx
@@ -32,9 +32,9 @@ export const ConnectorStepComponent = (props: {
 
   return (
     <div>
-      <h3 className="mt-8 mb-4 text-heading-md">{step.name}</h3>
+      <h3 className="mt-8 text-heading-md">{step.name}</h3>
 
-      {Boolean(step.description) && <p className="mb-4 text-body-sm">{step.description}</p>}
+      {Boolean(step.description) && <p className="mt-4 text-body-sm">{step.description}</p>}
 
       {groups.map((g) => (
         <PropertyGroupComponent

--- a/frontend/src/components/pages/connect/dynamic-ui/forms/error-wrapper.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/forms/error-wrapper.tsx
@@ -8,8 +8,17 @@ import { ExpandableText } from '../../../../misc/expandable-text';
 const isRequiredError = (name: string) => `Required configuration "${name}" must be provided`;
 const isEmpty = (property: Property) => property.value === '' || property.value === null;
 
-export const ErrorWrapper = (props: PropsWithoutRef<{ property: Property; input: JSX.Element }>) => {
-  const { property, input } = props;
+export const ErrorWrapper = (
+  props: PropsWithoutRef<{
+    property: Property;
+    input: JSX.Element;
+    /** id of the control `input` renders, so the label can point at it as Chakra's FormControl did. */
+    inputId?: string;
+    /** BOOLEAN/RADIO_GROUP properties sat inline with their label under Chakra's FormField. */
+    orientation?: 'vertical' | 'horizontal';
+  }>
+) => {
+  const { property, input, inputId, orientation = 'vertical' } = props;
   const [currentErrorIndex, setCurrentErrorIndex] = useState(0);
   const isRequired = property.entry.definition.required;
   const showErrors = property.errors.length > 0;
@@ -29,12 +38,16 @@ export const ErrorWrapper = (props: PropsWithoutRef<{ property: Property; input:
         `onClick` on the field, as before: a property can carry several validation errors and the
         only way to see the rest is to click the field, which advances `currentErrorIndex`.
       */}
-      <Field data-invalid={isInvalid || undefined} onClick={cycleError}>
-        <FieldLabel required={isRequired}>{property.entry.definition.display_name}</FieldLabel>
-        {input}
+      <Field data-invalid={isInvalid || undefined} onClick={cycleError} orientation={orientation}>
+        <FieldLabel htmlFor={inputId} required={isRequired}>
+          {property.entry.definition.display_name}
+        </FieldLabel>
+        {/* Documentation between label and control, where Chakra's FormField put it. */}
         <FieldDescription>
           <ExpandableText maxChars={60}>{property.entry.definition.documentation}</ExpandableText>
         </FieldDescription>
+        {/* Wrapped so `Field`'s vertical `[&>*]:w-full` lands here and not on a Switch. */}
+        <div>{input}</div>
         {errorText ? <FieldError>{errorText}</FieldError> : null}
       </Field>
     </div>

--- a/frontend/src/components/pages/connect/dynamic-ui/forms/error-wrapper.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/forms/error-wrapper.tsx
@@ -1,4 +1,4 @@
-import { FormField } from '@redpanda-data/ui';
+import { Field, FieldDescription, FieldError, FieldLabel } from 'components/redpanda-ui/components/field';
 import type { JSX, PropsWithoutRef } from 'react';
 import { useState } from 'react';
 
@@ -20,18 +20,24 @@ export const ErrorWrapper = (props: PropsWithoutRef<{ property: Property; input:
 
   const cycleError = showErrors ? () => setCurrentErrorIndex((i) => i + 1) : undefined;
 
+  const errorText = isEmpty(property) && isRequired ? errorToShow || isRequiredError(property.name) : errorToShow;
+  const isInvalid = Boolean(errorToShow) || (isEmpty(property) && isRequired);
+
   return (
     <div>
-      <FormField
-        description={<ExpandableText maxChars={60}>{property.entry.definition.documentation}</ExpandableText>}
-        errorText={isEmpty(property) && isRequired ? errorToShow || isRequiredError(property.name) : errorToShow}
-        isInvalid={!!errorToShow || (isEmpty(property) && isRequired)}
-        isRequired={isRequired}
-        label={property.entry.definition.display_name}
-        onClick={cycleError}
-      >
+      {/*
+        `onClick` on the field, as before: a property can carry several validation errors and the
+        only way to see the rest is to click the field, which advances `currentErrorIndex`.
+      */}
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: cycling errors is a shortcut, not the only path — every error is reachable by fixing the field */}
+      <Field data-invalid={isInvalid || undefined} onClick={cycleError}>
+        <FieldLabel required={isRequired}>{property.entry.definition.display_name}</FieldLabel>
         {input}
-      </FormField>
+        <FieldDescription>
+          <ExpandableText maxChars={60}>{property.entry.definition.documentation}</ExpandableText>
+        </FieldDescription>
+        {errorText ? <FieldError>{errorText}</FieldError> : null}
+      </Field>
     </div>
   );
 };

--- a/frontend/src/components/pages/connect/dynamic-ui/forms/error-wrapper.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/forms/error-wrapper.tsx
@@ -29,7 +29,6 @@ export const ErrorWrapper = (props: PropsWithoutRef<{ property: Property; input:
         `onClick` on the field, as before: a property can carry several validation errors and the
         only way to see the rest is to click the field, which advances `currentErrorIndex`.
       */}
-      {/* biome-ignore lint/a11y/useKeyWithClickEvents: cycling errors is a shortcut, not the only path — every error is reachable by fixing the field */}
       <Field data-invalid={isInvalid || undefined} onClick={cycleError}>
         <FieldLabel required={isRequired}>{property.entry.definition.display_name}</FieldLabel>
         {input}

--- a/frontend/src/components/pages/connect/dynamic-ui/forms/error-wrapper.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/forms/error-wrapper.tsx
@@ -12,13 +12,11 @@ export const ErrorWrapper = (
   props: PropsWithoutRef<{
     property: Property;
     input: JSX.Element;
-    /** id of the control `input` renders, so the label can point at it as Chakra's FormControl did. */
+    /** id of the control `input` renders; the label points at it and is `${inputId}-label` for aria-labelledby. */
     inputId?: string;
-    /** BOOLEAN/RADIO_GROUP properties sat inline with their label under Chakra's FormField. */
-    orientation?: 'vertical' | 'horizontal';
   }>
 ) => {
-  const { property, input, inputId, orientation = 'vertical' } = props;
+  const { property, input, inputId } = props;
   const [currentErrorIndex, setCurrentErrorIndex] = useState(0);
   const isRequired = property.entry.definition.required;
   const showErrors = property.errors.length > 0;
@@ -38,11 +36,11 @@ export const ErrorWrapper = (
         `onClick` on the field, as before: a property can carry several validation errors and the
         only way to see the rest is to click the field, which advances `currentErrorIndex`.
       */}
-      <Field data-invalid={isInvalid || undefined} onClick={cycleError} orientation={orientation}>
-        <FieldLabel htmlFor={inputId} required={isRequired}>
+      <Field data-invalid={isInvalid || undefined} onClick={cycleError}>
+        <FieldLabel htmlFor={inputId} id={inputId ? `${inputId}-label` : undefined} required={isRequired}>
           {property.entry.definition.display_name}
         </FieldLabel>
-        {/* Documentation between label and control, where Chakra's FormField put it. */}
+        {/* Documentation sits between label and control. */}
         <FieldDescription>
           <ExpandableText maxChars={60}>{property.entry.definition.documentation}</ExpandableText>
         </FieldDescription>

--- a/frontend/src/components/pages/connect/dynamic-ui/forms/secret-input.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/forms/secret-input.tsx
@@ -1,15 +1,6 @@
-import {
-  Button,
-  type ButtonProps,
-  Flex,
-  Icon,
-  Input,
-  InputGroup,
-  InputRightElement,
-  Tooltip,
-  useBoolean,
-} from '@redpanda-data/ui';
-import { EyeIcon, EyeOffIcon } from 'components/icons';
+import { Button } from 'components/redpanda-ui/components/button';
+import { Input } from 'components/redpanda-ui/components/input';
+import { Tooltip, TooltipContent, TooltipTrigger } from 'components/redpanda-ui/components/tooltip';
 import { useRef, useState } from 'react';
 
 export type SecretInputProps = {
@@ -18,22 +9,26 @@ export type SecretInputProps = {
   updating: boolean;
 };
 
-const EditButton = ({ onClick }: Pick<ButtonProps, 'onClick'>) => (
-  <Tooltip hasArrow={true} label="Edit secret value" placement="top">
-    <Button onClick={onClick} variant="link">
-      Edit
-    </Button>
+const EditButton = ({ onClick }: { onClick: () => void }) => (
+  <Tooltip>
+    <TooltipTrigger
+      render={
+        <Button onClick={onClick} variant="link">
+          Edit
+        </Button>
+      }
+    />
+    <TooltipContent side="top">Edit secret value</TooltipContent>
   </Tooltip>
 );
 
-const ClearButton = ({ onClick }: Pick<ButtonProps, 'onClick'>) => (
+const ClearButton = ({ onClick }: { onClick: () => void }) => (
   <Button onClick={onClick} variant="link">
     Undo
   </Button>
 );
 
 export const SecretInput = ({ value, onChange, updating = false }: SecretInputProps) => {
-  const [visible, setVisible] = useBoolean();
   const initialValueRef = useRef(value);
   const [canEdit, setCanEdit] = useState(!updating);
   // Intentionally seeded from prop: localValue is edited independently during user interaction
@@ -54,35 +49,32 @@ export const SecretInput = ({ value, onChange, updating = false }: SecretInputPr
         setCanEdit(false);
         setLocalValue(initialValueRef.current);
         onChange(initialValueRef.current);
-        setVisible.off();
       }}
     />
   );
 
   return (
-    <Flex flexDirection="row" gap={2}>
-      <InputGroup>
-        <Input
-          onChange={(e) => {
-            setLocalValue(e.target.value);
-            if (onChange) {
-              onChange(e.target.value);
-            }
-          }}
-          readOnly={!canEdit}
-          type={visible ? 'text' : 'password'}
-          value={localValue}
-        />
-        {Boolean(canEdit) && (
-          <InputRightElement>
-            <Button onClick={() => setVisible.toggle()} variant="ghost">
-              <Icon as={visible ? EyeIcon : EyeOffIcon} color="gray.500" />
-            </Button>
-          </InputRightElement>
-        )}
-      </InputGroup>
+    <div className="flex flex-row gap-2">
+      {/*
+        The Registry Input owns the reveal toggle for `type="password"`, and disables it while the
+        field is read-only — which is the state an existing secret sits in before Edit. `key` is
+        what re-masks on Undo: the toggle's state lives inside the Input, so the transition out of
+        editing has to remount it or Undo would leave the restored secret in plain text.
+      */}
+      <Input
+        key={canEdit ? 'editing' : 'masked'}
+        onChange={(e) => {
+          setLocalValue(e.target.value);
+          if (onChange) {
+            onChange(e.target.value);
+          }
+        }}
+        readOnly={!canEdit}
+        type="password"
+        value={localValue}
+      />
       {Boolean(updating) && (canEdit ? clearButton : editButton)}
-    </Flex>
+    </div>
   );
 };
 

--- a/frontend/src/components/pages/connect/dynamic-ui/forms/secret-input.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/forms/secret-input.tsx
@@ -1,6 +1,6 @@
 import { Button } from 'components/redpanda-ui/components/button';
 import { Input } from 'components/redpanda-ui/components/input';
-import { Tooltip, TooltipContent, TooltipTrigger } from 'components/redpanda-ui/components/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from 'components/redpanda-ui/components/tooltip';
 import { useRef, useState } from 'react';
 
 export type SecretInputProps = {
@@ -10,16 +10,19 @@ export type SecretInputProps = {
 };
 
 const EditButton = ({ onClick }: { onClick: () => void }) => (
-  <Tooltip>
-    <TooltipTrigger
-      render={
-        <Button onClick={onClick} variant="link">
-          Edit
-        </Button>
-      }
-    />
-    <TooltipContent side="top">Edit secret value</TooltipContent>
-  </Tooltip>
+  // Without a provider the trigger falls back to Base UI's 600ms open delay; the app's is 150ms.
+  <TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button onClick={onClick} variant="link">
+            Edit
+          </Button>
+        }
+      />
+      <TooltipContent side="top">Edit secret value</TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
 );
 
 const ClearButton = ({ onClick }: { onClick: () => void }) => (

--- a/frontend/src/components/pages/connect/dynamic-ui/forms/secret-input.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/forms/secret-input.tsx
@@ -7,6 +7,7 @@ export type SecretInputProps = {
   id: string;
   value: string;
   onChange: (v: string) => void;
+  required?: boolean;
   updating: boolean;
 };
 
@@ -32,7 +33,7 @@ const ClearButton = ({ onClick }: { onClick: () => void }) => (
   </Button>
 );
 
-export const SecretInput = ({ id, value, onChange, updating = false }: SecretInputProps) => {
+export const SecretInput = ({ id, value, onChange, required, updating = false }: SecretInputProps) => {
   const initialValueRef = useRef(value);
   const [canEdit, setCanEdit] = useState(!updating);
   // Intentionally seeded from prop: localValue is edited independently during user interaction
@@ -75,6 +76,7 @@ export const SecretInput = ({ id, value, onChange, updating = false }: SecretInp
           }
         }}
         readOnly={!canEdit}
+        required={required}
         type="password"
         value={localValue}
       />

--- a/frontend/src/components/pages/connect/dynamic-ui/forms/secret-input.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/forms/secret-input.tsx
@@ -4,6 +4,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from 'compon
 import { useRef, useState } from 'react';
 
 export type SecretInputProps = {
+  id: string;
   value: string;
   onChange: (v: string) => void;
   updating: boolean;
@@ -31,7 +32,7 @@ const ClearButton = ({ onClick }: { onClick: () => void }) => (
   </Button>
 );
 
-export const SecretInput = ({ value, onChange, updating = false }: SecretInputProps) => {
+export const SecretInput = ({ id, value, onChange, updating = false }: SecretInputProps) => {
   const initialValueRef = useRef(value);
   const [canEdit, setCanEdit] = useState(!updating);
   // Intentionally seeded from prop: localValue is edited independently during user interaction
@@ -65,6 +66,7 @@ export const SecretInput = ({ value, onChange, updating = false }: SecretInputPr
         editing has to remount it or Undo would leave the restored secret in plain text.
       */}
       <Input
+        id={id}
         key={canEdit ? 'editing' : 'masked'}
         onChange={(e) => {
           setLocalValue(e.target.value);

--- a/frontend/src/components/pages/connect/dynamic-ui/forms/topic-input.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/forms/topic-input.tsx
@@ -101,7 +101,6 @@ export const TopicInput = (p: { properties: Property[]; connectorType: 'sink' | 
           />
         )}
 
-        {/* biome-ignore lint/a11y/useKeyWithClickEvents: cycling errors is a shortcut, not the only path */}
         {Boolean(showErrors) && <FieldError onClick={cycleError}>{errorToShow}</FieldError>}
       </Field>
     </div>

--- a/frontend/src/components/pages/connect/dynamic-ui/forms/topic-input.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/forms/topic-input.tsx
@@ -9,16 +9,11 @@
  * by the Apache License, Version 2.0
  */
 
-import {
-  Checkbox,
-  FormControl,
-  FormErrorMessage,
-  FormHelperText,
-  Grid,
-  Input,
-  isMultiValue,
-  Select,
-} from '@redpanda-data/ui';
+import { Checkbox } from 'components/redpanda-ui/components/checkbox';
+import { Field, FieldDescription, FieldError } from 'components/redpanda-ui/components/field';
+import { Input } from 'components/redpanda-ui/components/input';
+import { Label } from 'components/redpanda-ui/components/label';
+import { SimpleMultiSelect } from 'components/redpanda-ui/components/multi-select';
 import { useEffect, useMemo, useState } from 'react';
 
 import { api } from '../../../../../state/backend-api';
@@ -60,24 +55,30 @@ export const TopicInput = (p: { properties: Property[]; connectorType: 'sink' | 
       }
     : undefined;
 
+  const selectedTopics = property.value ? property.value.toString().split(',').filter(Boolean) : [];
+
   return (
-    <Grid gap="10" templateColumns="1fr">
-      <FormControl position="relative">
+    <div className="grid grid-cols-1 gap-10">
+      <Field className="relative">
         {propsMap.has('topics.regex') && (
-          <Checkbox
-            isChecked={isRegex}
-            onChange={(e) => {
-              setPropertyValue(property, '');
-              setSelected(e.target.checked ? 'topics.regex' : 'topics');
-            }}
-          >
-            Use regular expressions
-          </Checkbox>
+          <div className="flex items-center gap-2">
+            <Checkbox
+              checked={isRegex}
+              id="topics-use-regex"
+              onCheckedChange={(checked) => {
+                setPropertyValue(property, '');
+                setSelected(checked === true ? 'topics.regex' : 'topics');
+              }}
+            />
+            <Label className="cursor-pointer" htmlFor="topics-use-regex">
+              Use regular expressions
+            </Label>
+          </div>
         )}
 
-        <FormHelperText mb={15}>
+        <FieldDescription className="mb-4">
           <ExpandableText maxChars={60}>{property.entry.definition.documentation}</ExpandableText>
-        </FormHelperText>
+        </FieldDescription>
 
         {/* A 'source' connector imports data into the cluster. So we let the user choose the name of the topic directly  */}
         {isRegex || p.connectorType === 'source' ? (
@@ -90,35 +91,19 @@ export const TopicInput = (p: { properties: Property[]; connectorType: 'sink' | 
             value={String(property.value)}
           />
         ) : (
-          <Select
-            isMulti
-            onChange={(v) => {
-              if (isMultiValue(v)) {
-                setPropertyValue(property, v.map(({ value }) => value)?.join(',') ?? []);
-              }
+          <SimpleMultiSelect
+            onValueChange={(values) => {
+              setPropertyValue(property, values.join(','));
             }}
-            options={api.topics?.map((x) => ({ value: x.topicName, label: x.topicName })) ?? []}
-            value={
-              property.value
-                ? property.value
-                    ?.toString()
-                    .split(',')
-                    .map((val) => ({
-                      value: val,
-                      label: val,
-                    }))
-                : []
-            }
+            options={api.topics?.map((x) => x.topicName) ?? []}
+            value={selectedTopics}
+            width="full"
           />
         )}
 
-        {Boolean(showErrors) && <FormErrorMessage onClick={cycleError}>{errorToShow}</FormErrorMessage>}
-      </FormControl>
-
-      {/* <Box p="4" >
-                <h2>Matching Topics</h2>
-
-            </Box> */}
-    </Grid>
+        {/* biome-ignore lint/a11y/useKeyWithClickEvents: cycling errors is a shortcut, not the only path */}
+        {Boolean(showErrors) && <FieldError onClick={cycleError}>{errorToShow}</FieldError>}
+      </Field>
+    </div>
   );
 };

--- a/frontend/src/components/pages/connect/dynamic-ui/forms/topic-input.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/forms/topic-input.tsx
@@ -14,7 +14,7 @@ import { Field, FieldDescription, FieldError } from 'components/redpanda-ui/comp
 import { Input } from 'components/redpanda-ui/components/input';
 import { Label } from 'components/redpanda-ui/components/label';
 import { SimpleMultiSelect } from 'components/redpanda-ui/components/multi-select';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useId, useMemo, useState } from 'react';
 
 import { api } from '../../../../../state/backend-api';
 import type { Property } from '../../../../../state/connect/state';
@@ -29,6 +29,8 @@ const incrementErrorIndex = (property: Property) => {
 };
 
 export const TopicInput = (p: { properties: Property[]; connectorType: 'sink' | 'source' }) => {
+  // A TopicInput is rendered per property group, so a fixed id would collide.
+  const regexCheckboxId = useId();
   const propsMap = useMemo(() => new Map(p.properties.map((prop) => [prop.name, prop])), [p.properties]);
   const topicsRegex = p.properties.find((x) => x.name === 'topics.regex');
   const initialSelection = topicsRegex?.value ? 'topics.regex' : 'topics';
@@ -56,6 +58,9 @@ export const TopicInput = (p: { properties: Property[]; connectorType: 'sink' | 
     : undefined;
 
   const selectedTopics = property.value ? property.value.toString().split(',').filter(Boolean) : [];
+  // Union, not just `api.topics`: a chip for a topic that has since been deleted (or one rendered
+  // before the topic list resolves) is only removable if its value is among the options.
+  const topicOptions = [...new Set([...(api.topics?.map((x) => x.topicName) ?? []), ...selectedTopics])];
 
   return (
     <div className="grid grid-cols-1 gap-10">
@@ -64,19 +69,19 @@ export const TopicInput = (p: { properties: Property[]; connectorType: 'sink' | 
           <div className="flex items-center gap-2">
             <Checkbox
               checked={isRegex}
-              id="topics-use-regex"
+              id={regexCheckboxId}
               onCheckedChange={(checked) => {
                 setPropertyValue(property, '');
                 setSelected(checked === true ? 'topics.regex' : 'topics');
               }}
             />
-            <Label className="cursor-pointer" htmlFor="topics-use-regex">
+            <Label className="cursor-pointer" htmlFor={regexCheckboxId}>
               Use regular expressions
             </Label>
           </div>
         )}
 
-        <FieldDescription className="mb-4">
+        <FieldDescription>
           <ExpandableText maxChars={60}>{property.entry.definition.documentation}</ExpandableText>
         </FieldDescription>
 
@@ -95,7 +100,7 @@ export const TopicInput = (p: { properties: Property[]; connectorType: 'sink' | 
             onValueChange={(values) => {
               setPropertyValue(property, values.join(','));
             }}
-            options={api.topics?.map((x) => x.topicName) ?? []}
+            options={topicOptions}
             value={selectedTopics}
             width="full"
           />

--- a/frontend/src/components/pages/connect/dynamic-ui/list.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/list.tsx
@@ -10,9 +10,11 @@
  */
 
 import { DragDropContext, Draggable, Droppable, type DropResult, type ResponderProvided } from '@hello-pangea/dnd';
-import { Button, Input, Tooltip } from '@redpanda-data/ui';
 import { arrayMoveMutable } from 'array-move';
 import { CloseIcon, MenuIcon } from 'components/icons';
+import { Button } from 'components/redpanda-ui/components/button';
+import { Input } from 'components/redpanda-ui/components/input';
+import { Tooltip, TooltipContent, TooltipTrigger } from 'components/redpanda-ui/components/tooltip';
 import { type JSX, useEffect, useRef, useState } from 'react';
 
 const VALID_NAME_REGEX = /^[a-z][a-z_\d]*$/i;
@@ -41,44 +43,49 @@ const Item = ({ item, allItems, onUpdate, onDelete }: ItemProps): JSX.Element =>
 
   return (
     <>
-      {/* Input */}
-      <Tooltip hasArrow={true} isOpen={hasFocus} label="[Enter] confirm, [ESC] cancel" placement="top">
-        <Input
-          className="ghostInput"
-          onBlur={() => {
-            setHasFocus(false);
-          }}
-          onChange={(e) => setValuePending(e.target.value)}
-          onFocus={() => {
-            setValuePending(item.id);
-            setHasFocus(true);
-          }}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              // can we rename that entry?
-              if (allItems.some((x) => x.id === valuePending)) {
-                // no, already exists
-                e.stopPropagation();
-                return;
-              }
+      {/* Input. The hint is shown while the field has focus, not on hover, so the Tooltip is controlled. */}
+      <Tooltip open={hasFocus}>
+        <TooltipTrigger
+          render={
+            <Input
+              className="ghostInput"
+              onBlur={() => {
+                setHasFocus(false);
+              }}
+              onChange={(e) => setValuePending(e.target.value)}
+              onFocus={() => {
+                setValuePending(item.id);
+                setHasFocus(true);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  // can we rename that entry?
+                  if (allItems.some((x) => x.id === valuePending)) {
+                    // no, already exists
+                    e.stopPropagation();
+                    return;
+                  }
 
-              if (VALID_NAME_REGEX.test(valuePending) === false) {
-                // no, invalid characters
-                e.stopPropagation();
-                return;
-              }
+                  if (VALID_NAME_REGEX.test(valuePending) === false) {
+                    // no, invalid characters
+                    e.stopPropagation();
+                    return;
+                  }
 
-              onUpdate(valuePending);
-              (e.target as HTMLElement).blur();
-            } else if (e.key === 'Escape') {
-              (e.target as HTMLElement).blur();
-            }
-          }}
-          size="sm"
-          spellCheck={false}
-          style={{ flexGrow: 1, flexBasis: '400px' }}
-          value={hasFocus ? valuePending : item.id}
+                  onUpdate(valuePending);
+                  (e.target as HTMLElement).blur();
+                } else if (e.key === 'Escape') {
+                  (e.target as HTMLElement).blur();
+                }
+              }}
+              size="sm"
+              spellCheck={false}
+              style={{ flexGrow: 1, flexBasis: '400px' }}
+              value={hasFocus ? valuePending : item.id}
+            />
+          }
         />
+        <TooltipContent side="top">[Enter] confirm, [ESC] cancel</TooltipContent>
       </Tooltip>
 
       {/* Delete */}
@@ -161,7 +168,7 @@ export function CommaSeparatedStringList(props: {
             setNewEntry(null);
           }}
           style={{ padding: '0px 16px', height: '100%', minWidth: '120px' }}
-          variant="solid"
+          variant="primary"
         >
           Add
         </Button>

--- a/frontend/src/components/pages/connect/dynamic-ui/list.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/list.tsx
@@ -49,6 +49,7 @@ const Item = ({ item, allItems, onUpdate, onDelete }: ItemProps): JSX.Element =>
           render={
             <Input
               className="ghostInput"
+              containerClassName="grow basis-[400px]"
               onBlur={() => {
                 setHasFocus(false);
               }}
@@ -80,7 +81,6 @@ const Item = ({ item, allItems, onUpdate, onDelete }: ItemProps): JSX.Element =>
               }}
               size="sm"
               spellCheck={false}
-              style={{ flexGrow: 1, flexBasis: '400px' }}
               value={hasFocus ? valuePending : item.id}
             />
           }
@@ -136,6 +136,7 @@ export function CommaSeparatedStringList(props: {
       <div className="createEntryRow">
         <div className={`inputWrapper${newEntryError ? 'hasError' : ''}`} style={{ height: '100%' }}>
           <Input
+            containerClassName="h-full grow basis-[260px]"
             onChange={(e) => {
               const value = e.target.value;
               setNewEntry(value);
@@ -153,7 +154,6 @@ export function CommaSeparatedStringList(props: {
             }}
             placeholder={props.locale?.addInputPlaceholder ?? 'Enter a name...'}
             spellCheck={false}
-            style={{ flexGrow: 1, height: '100%', flexBasis: '260px' }}
             value={newEntry ?? ''}
           />
 
@@ -161,13 +161,13 @@ export function CommaSeparatedStringList(props: {
         </div>
 
         <Button
+          className="h-full min-w-[120px] px-4"
           disabled={newEntryError !== null || !newEntry || newEntry.trim().length === 0}
           onClick={() => {
             if (!newEntry) return;
             setData((prev) => [...prev, { id: newEntry }]);
             setNewEntry(null);
           }}
-          style={{ padding: '0px 16px', height: '100%', minWidth: '120px' }}
           variant="primary"
         >
           Add

--- a/frontend/src/components/pages/connect/dynamic-ui/list.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/list.tsx
@@ -99,6 +99,7 @@ const Item = ({ item, allItems, onUpdate, onDelete }: ItemProps): JSX.Element =>
 
 export function CommaSeparatedStringList(props: {
   defaultValue: string;
+  id?: string;
   onChange: (list: string) => void;
   locale?: {
     addInputPlaceholder?: string;
@@ -139,6 +140,7 @@ export function CommaSeparatedStringList(props: {
           <Input
             className="h-full"
             containerClassName="h-full grow basis-[260px]"
+            id={props.id}
             onChange={(e) => {
               const value = e.target.value;
               setNewEntry(value);

--- a/frontend/src/components/pages/connect/dynamic-ui/list.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/list.tsx
@@ -48,7 +48,8 @@ const Item = ({ item, allItems, onUpdate, onDelete }: ItemProps): JSX.Element =>
         <TooltipTrigger
           render={
             <Input
-              className="ghostInput"
+              // Border colour on the element: a layered !important beats the unlayered scss one.
+              className="ghostInput !border-transparent focus:!border-input"
               containerClassName="grow basis-[400px]"
               onBlur={() => {
                 setHasFocus(false);
@@ -136,6 +137,7 @@ export function CommaSeparatedStringList(props: {
       <div className="createEntryRow">
         <div className={`inputWrapper${newEntryError ? 'hasError' : ''}`} style={{ height: '100%' }}>
           <Input
+            className="h-full"
             containerClassName="h-full grow basis-[260px]"
             onChange={(e) => {
               const value = e.target.value;

--- a/frontend/src/components/pages/connect/dynamic-ui/property-component.test.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/property-component.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, test } from '@rstest/core';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useReducer } from 'react';
+
+import { PropertyComponent } from './property-component';
+import type { Property } from '../../../../state/connect/state';
+
+const makeProperty = (type: 'DOUBLE' | 'FLOAT' | 'PASSWORD', crud: 'create' | 'update' = 'create'): Property => ({
+  name: 'example',
+  entry: {
+    definition: {
+      name: 'example',
+      type,
+      required: false,
+      default_value: null,
+      importance: 'HIGH',
+      documentation: 'Example configuration',
+      width: 'MEDIUM',
+      display_name: 'Example',
+      dependents: [],
+      order: 0,
+    },
+    value: { name: 'example', value: null, recommended_values: [], errors: [], visible: true },
+    metadata: {},
+  },
+  value: type === 'PASSWORD' ? 'secret' : '1.5',
+  isHidden: false,
+  errors: [],
+  showErrors: false,
+  lastErrors: [],
+  currentErrorIndex: 0,
+  lastErrorValue: null,
+  propertyGroup: {
+    step: { name: 'General', groups: [], stepIndex: 0 },
+    group: { config_keys: [] },
+    properties: [],
+    filteredProperties: [],
+    propertiesWithErrors: [],
+  },
+  crud,
+  isDisabled: false,
+  notifyChange: () => undefined,
+});
+
+const Form = ({ property }: { property: Property }) => {
+  const [, refresh] = useReducer((value: number) => value + 1, 0);
+  property.notifyChange = refresh;
+  return <PropertyComponent property={property} />;
+};
+
+describe('connector property controls', () => {
+  test.each(['DOUBLE', 'FLOAT'] as const)('%s steppers preserve fractional configuration values', async (type) => {
+    const user = userEvent.setup();
+    const property = makeProperty(type);
+    render(<Form property={property} />);
+    await user.click(screen.getByRole('button', { name: 'Increment value' }));
+    expect(screen.getByRole('spinbutton', { name: 'Example' })).toHaveValue(2.5);
+    expect(property.value).toBe('2.5');
+    await user.click(screen.getByRole('button', { name: 'Decrement value' }));
+    expect(screen.getByRole('spinbutton', { name: 'Example' })).toHaveValue(1.5);
+    expect(property.value).toBe('1.5');
+  });
+
+  test('password label stays associated after edit and undo', async () => {
+    const user = userEvent.setup();
+    render(<Form property={makeProperty('PASSWORD', 'update')} />);
+    expect(screen.getByLabelText('Example')).toHaveValue('secret');
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
+    await user.click(screen.getByText('Example', { selector: 'label' }));
+    expect(screen.getByLabelText('Example')).toHaveFocus();
+    await user.type(screen.getByLabelText('Example'), 'replacement');
+    await user.click(screen.getByRole('button', { name: 'Undo' }));
+    expect(screen.getByLabelText('Example')).toHaveValue('secret');
+    expect(screen.getByLabelText('Example')).toHaveAttribute('type', 'password');
+  });
+});

--- a/frontend/src/components/pages/connect/dynamic-ui/property-component.test.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/property-component.test.tsx
@@ -67,6 +67,8 @@ describe('connector property controls', () => {
     render(<Form property={makeProperty('PASSWORD', 'update')} />);
     expect(screen.getByLabelText('Example')).toHaveValue('secret');
     await user.click(screen.getByRole('button', { name: 'Edit' }));
+    await user.click(screen.getByRole('button', { name: 'Show password' }));
+    expect(screen.getByLabelText('Example')).toHaveAttribute('type', 'text');
     await user.click(screen.getByText('Example', { selector: 'label' }));
     expect(screen.getByLabelText('Example')).toHaveFocus();
     await user.type(screen.getByLabelText('Example'), 'replacement');

--- a/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
@@ -50,6 +50,10 @@ export const PropertyComponent = (props: { property: Property }) => {
   );
 
   const v = p.value;
+  // Chakra's FormControl generated an id and wired the label to it; the Registry Field does not,
+  // so the id is derived here and handed to both the control and the label.
+  const fieldId = `property-${p.name}`;
+  const isInlineControl = def.type === 'BOOLEAN' || metadata?.component_type === 'RADIO_GROUP';
 
   switch (def.type) {
     case 'STRING':
@@ -63,6 +67,7 @@ export const PropertyComponent = (props: { property: Property }) => {
         inputComp = (
           <RadioGroup
             className="flex flex-wrap gap-4"
+            id={fieldId}
             name={p.name}
             onValueChange={(next) => {
               updatePropertyValue(p, next as Property['value']);
@@ -92,6 +97,7 @@ export const PropertyComponent = (props: { property: Property }) => {
         inputComp = (
           <div className="max-w-[260px]">
             <SingleSelect
+              id={fieldId}
               onChange={(e) => {
                 updatePropertyValue(p, e);
               }}
@@ -106,6 +112,7 @@ export const PropertyComponent = (props: { property: Property }) => {
           <Input
             defaultValue={def.default_value ?? undefined}
             disabled={props.property.isDisabled}
+            id={fieldId}
             onChange={(e) => {
               updatePropertyValue(p, e.target.value);
             }}
@@ -134,13 +141,23 @@ export const PropertyComponent = (props: { property: Property }) => {
     case 'DOUBLE':
     case 'FLOAT':
       inputComp = (
-        // Chakra's NumberInput emitted a number; a native number input emits a string, so coerce
-        // here or the config would carry `"3"` where the connector expects `3`.
         <Input
+          id={fieldId}
           onChange={(e) => {
-            updatePropertyValue(p, e.target.valueAsNumber);
+            // The *string*, not `valueAsNumber`: Chakra's NumberInput handed `onChange` its
+            // `valueAsString`, and `getConfigObject` both sends `p.value` as-is and compares it
+            // `===` against `default_value` to suppress untouched defaults. Storing a number here
+            // would change which properties get sent — and `sanitizeDefaultValue` only numbers the
+            // INT/LONG/SHORT defaults, so it would not even be consistent across the numeric types.
+            updatePropertyValue(p, e.target.value);
           }}
+          // Chakra's NumberInput shipped its steppers by default and the Registry Input needs
+          // asking. `step="any"` for the float types, which the Registry otherwise pins to 1 and
+          // the browser then marks non-integer values invalid.
+          showStepControls
+          step={def.type === 'DOUBLE' || def.type === 'FLOAT' ? 'any' : 1}
           type="number"
+          // Guarded only so a mid-edit empty field does not render the string "NaN".
           value={Number.isNaN(Number(v)) ? '' : Number(v)}
         />
       );
@@ -150,6 +167,7 @@ export const PropertyComponent = (props: { property: Property }) => {
       inputComp = (
         <Switch
           checked={Boolean(v)}
+          id={fieldId}
           onCheckedChange={(checked) => {
             updatePropertyValue(p, checked);
           }}
@@ -171,6 +189,7 @@ export const PropertyComponent = (props: { property: Property }) => {
         inputComp = (
           <Input
             defaultValue={def.default_value ?? undefined}
+            id={fieldId}
             onChange={(e) => {
               updatePropertyValue(p, e.target.value);
             }}
@@ -184,6 +203,7 @@ export const PropertyComponent = (props: { property: Property }) => {
       inputComp = (
         <Input
           defaultValue={def.default_value ?? undefined}
+          id={fieldId}
           onChange={(e) => {
             updatePropertyValue(p, e.target.value);
           }}
@@ -193,7 +213,16 @@ export const PropertyComponent = (props: { property: Property }) => {
       break;
   }
 
-  inputComp = <ErrorWrapper input={inputComp} property={p} />;
+  inputComp = (
+    <ErrorWrapper
+      input={inputComp}
+      inputId={fieldId}
+      // BOOLEAN and RADIO_GROUP sat inline with their label under Chakra's FormField, which
+      // special-cased a Switch child.
+      orientation={isInlineControl ? 'horizontal' : 'vertical'}
+      property={p}
+    />
+  );
   // Wrap name and input element
   return (
     <div className={`mt-6 ${inputSizeToClass[def.width]}`} data-testid={`property-${p.name}`}>

--- a/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
@@ -9,7 +9,10 @@
  * by the Apache License, Version 2.0
  */
 
-import { Box, Input, NumberInput, RadioGroup, Switch } from '@redpanda-data/ui';
+import { Input } from 'components/redpanda-ui/components/input';
+import { Label } from 'components/redpanda-ui/components/label';
+import { RadioGroup, RadioGroupItem } from 'components/redpanda-ui/components/radio-group';
+import { Switch } from 'components/redpanda-ui/components/switch';
 
 import { ErrorWrapper } from './forms/error-wrapper';
 import { SecretInput } from './forms/secret-input';
@@ -59,13 +62,26 @@ export const PropertyComponent = (props: { property: Property }) => {
             : recValues.map((recValue) => ({ value: recValue, label: String(recValue).toUpperCase() }));
         inputComp = (
           <RadioGroup
+            className="flex flex-wrap gap-4"
             name={p.name}
-            onChange={(e) => {
-              updatePropertyValue(p, e);
+            onValueChange={(next) => {
+              updatePropertyValue(p, next as Property['value']);
             }}
-            options={options}
+            orientation="horizontal"
             value={String(v || def.default_value)}
-          />
+          >
+            {options.map((option) => {
+              const id = `${p.name}-${option.value}`;
+              return (
+                <div className="flex items-center gap-2" key={String(option.value)}>
+                  <RadioGroupItem id={id} value={String(option.value)} />
+                  <Label className="cursor-pointer" htmlFor={id}>
+                    {option.label}
+                  </Label>
+                </div>
+              );
+            })}
+          </RadioGroup>
         );
         break;
       }
@@ -74,7 +90,7 @@ export const PropertyComponent = (props: { property: Property }) => {
         // Enum (recommended_values)
         const options = recValues.map((x: string) => ({ label: x, value: x }));
         inputComp = (
-          <Box maxWidth={260}>
+          <div className="max-w-[260px]">
             <SingleSelect
               onChange={(e) => {
                 updatePropertyValue(p, e);
@@ -82,14 +98,14 @@ export const PropertyComponent = (props: { property: Property }) => {
               options={options}
               value={v}
             />
-          </Box>
+          </div>
         );
       } else {
         // Input
         inputComp = (
           <Input
             defaultValue={def.default_value ?? undefined}
-            isDisabled={props.property.isDisabled}
+            disabled={props.property.isDisabled}
             onChange={(e) => {
               updatePropertyValue(p, e.target.value);
             }}
@@ -118,11 +134,14 @@ export const PropertyComponent = (props: { property: Property }) => {
     case 'DOUBLE':
     case 'FLOAT':
       inputComp = (
-        <NumberInput
+        // Chakra's NumberInput emitted a number; a native number input emits a string, so coerce
+        // here or the config would carry `"3"` where the connector expects `3`.
+        <Input
           onChange={(e) => {
-            updatePropertyValue(p, e);
+            updatePropertyValue(p, e.target.valueAsNumber);
           }}
-          value={Number(v)}
+          type="number"
+          value={Number.isNaN(Number(v)) ? '' : Number(v)}
         />
       );
       break;
@@ -130,9 +149,9 @@ export const PropertyComponent = (props: { property: Property }) => {
     case 'BOOLEAN':
       inputComp = (
         <Switch
-          isChecked={Boolean(v)}
-          onChange={(e) => {
-            updatePropertyValue(p, e.target.checked);
+          checked={Boolean(v)}
+          onCheckedChange={(checked) => {
+            updatePropertyValue(p, checked);
           }}
         />
       );
@@ -177,9 +196,9 @@ export const PropertyComponent = (props: { property: Property }) => {
   inputComp = <ErrorWrapper input={inputComp} property={p} />;
   // Wrap name and input element
   return (
-    <Box className={inputSizeToClass[def.width]} data-testid={`property-${p.name}`} mt="6">
+    <div className={`mt-6 ${inputSizeToClass[def.width]}`} data-testid={`property-${p.name}`}>
       {inputComp}
-    </Box>
+    </div>
   );
 };
 

--- a/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
@@ -79,7 +79,7 @@ export const PropertyComponent = (props: { property: Property }) => {
               const id = `${p.name}-${option.value}`;
               return (
                 <div className="flex items-center gap-2" key={String(option.value)}>
-                  <RadioGroupItem id={id} value={String(option.value)} />
+                  <RadioGroupItem id={id} testId={`${option.value}_field`} value={String(option.value)} />
                   <Label className="cursor-pointer" htmlFor={id}>
                     {option.label}
                   </Label>

--- a/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
@@ -50,10 +50,8 @@ export const PropertyComponent = (props: { property: Property }) => {
   );
 
   const v = p.value;
-  // Chakra's FormControl generated an id and wired the label to it; the Registry Field does not,
-  // so the id is derived here and handed to both the control and the label.
+  // Field generates no ids; the label and the control share this one.
   const fieldId = `property-${p.name}`;
-  const isInlineControl = def.type === 'BOOLEAN' || metadata?.component_type === 'RADIO_GROUP';
 
   switch (def.type) {
     case 'STRING':
@@ -66,8 +64,9 @@ export const PropertyComponent = (props: { property: Property }) => {
             : recValues.map((recValue) => ({ value: recValue, label: String(recValue).toUpperCase() }));
         inputComp = (
           <RadioGroup
+            aria-labelledby={`${fieldId}-label`}
+            // A radiogroup div is not labelable; it takes its name from the label instead of htmlFor.
             className="flex flex-wrap gap-4"
-            id={fieldId}
             name={p.name}
             onValueChange={(next) => {
               updatePropertyValue(p, next as Property['value']);
@@ -145,19 +144,14 @@ export const PropertyComponent = (props: { property: Property }) => {
         <Input
           id={fieldId}
           onChange={(e) => {
-            // The *string*, not `valueAsNumber`: Chakra's NumberInput handed `onChange` its
-            // `valueAsString`, and `getConfigObject` both sends `p.value` as-is and compares it
-            // `===` against `default_value` to suppress untouched defaults. Storing a number here
-            // would change which properties get sent — and `sanitizeDefaultValue` only numbers the
-            // INT/LONG/SHORT defaults, so it would not even be consistent across the numeric types.
+            // Store the string: getConfigObject sends p.value as-is and ===-compares it to default_value.
             updatePropertyValue(p, e.target.value);
           }}
-          // Match Chakra's default increment, including fractional starting values. Registry Input
-          // requires a finite numeric step: it coerces "any" to NaN before stepping.
+          // Registry Input coerces step with Number(); "any" would become NaN.
           showStepControls
           step={1}
           type="number"
-          // Guarded only so a mid-edit empty field does not render the string "NaN".
+          // Keep the input controlled with '' when the stored value is not numeric.
           value={Number.isNaN(Number(v)) ? '' : Number(v)}
         />
       );
@@ -213,16 +207,7 @@ export const PropertyComponent = (props: { property: Property }) => {
       break;
   }
 
-  inputComp = (
-    <ErrorWrapper
-      input={inputComp}
-      inputId={fieldId}
-      // BOOLEAN and RADIO_GROUP sat inline with their label under Chakra's FormField, which
-      // special-cased a Switch child.
-      orientation={isInlineControl ? 'horizontal' : 'vertical'}
-      property={p}
-    />
-  );
+  inputComp = <ErrorWrapper input={inputComp} inputId={fieldId} property={p} />;
   // Wrap name and input element
   return (
     <div className={`mt-6 ${inputSizeToClass[def.width]}`} data-testid={`property-${p.name}`}>

--- a/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
@@ -127,6 +127,7 @@ export const PropertyComponent = (props: { property: Property }) => {
     case 'PASSWORD':
       inputComp = (
         <SecretInput
+          id={fieldId}
           onChange={(e) => {
             updatePropertyValue(p, e);
           }}
@@ -151,11 +152,10 @@ export const PropertyComponent = (props: { property: Property }) => {
             // INT/LONG/SHORT defaults, so it would not even be consistent across the numeric types.
             updatePropertyValue(p, e.target.value);
           }}
-          // Chakra's NumberInput shipped its steppers by default and the Registry Input needs
-          // asking. `step="any"` for the float types, which the Registry otherwise pins to 1 and
-          // the browser then marks non-integer values invalid.
+          // Match Chakra's default increment, including fractional starting values. Registry Input
+          // requires a finite numeric step: it coerces "any" to NaN before stepping.
           showStepControls
-          step={def.type === 'DOUBLE' || def.type === 'FLOAT' ? 'any' : 1}
+          step={1}
           type="number"
           // Guarded only so a mid-edit empty field does not render the string "NaN".
           value={Number.isNaN(Number(v)) ? '' : Number(v)}

--- a/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/property-component.tsx
@@ -52,6 +52,7 @@ export const PropertyComponent = (props: { property: Property }) => {
   const v = p.value;
   // Field generates no ids; the label and the control share this one.
   const fieldId = `property-${p.name}`;
+  const isRequired = def.required;
 
   switch (def.type) {
     case 'STRING':
@@ -65,6 +66,7 @@ export const PropertyComponent = (props: { property: Property }) => {
         inputComp = (
           <RadioGroup
             aria-labelledby={`${fieldId}-label`}
+            aria-required={isRequired || undefined}
             // A radiogroup div is not labelable; it takes its name from the label instead of htmlFor.
             className="flex flex-wrap gap-4"
             name={p.name}
@@ -115,6 +117,7 @@ export const PropertyComponent = (props: { property: Property }) => {
             onChange={(e) => {
               updatePropertyValue(p, e.target.value);
             }}
+            required={isRequired}
             spellCheck={false}
             value={String(v)}
           />
@@ -130,6 +133,7 @@ export const PropertyComponent = (props: { property: Property }) => {
           onChange={(e) => {
             updatePropertyValue(p, e);
           }}
+          required={isRequired}
           updating={p.crud === 'update'}
           value={String(v ?? '')}
         />
@@ -147,6 +151,7 @@ export const PropertyComponent = (props: { property: Property }) => {
             // Store the string: getConfigObject sends p.value as-is and ===-compares it to default_value.
             updatePropertyValue(p, e.target.value);
           }}
+          required={isRequired}
           // Registry Input coerces step with Number(); "any" would become NaN.
           showStepControls
           step={1}
@@ -160,6 +165,7 @@ export const PropertyComponent = (props: { property: Property }) => {
     case 'BOOLEAN':
       inputComp = (
         <Switch
+          aria-required={isRequired || undefined}
           checked={Boolean(v)}
           id={fieldId}
           onCheckedChange={(checked) => {
@@ -174,6 +180,7 @@ export const PropertyComponent = (props: { property: Property }) => {
         inputComp = (
           <CommaSeparatedStringList
             defaultValue={String(v)}
+            id={fieldId}
             onChange={(x) => {
               updatePropertyValue(p, x);
             }}
@@ -187,6 +194,7 @@ export const PropertyComponent = (props: { property: Property }) => {
             onChange={(e) => {
               updatePropertyValue(p, e.target.value);
             }}
+            required={isRequired}
             value={String(v)}
           />
         );
@@ -201,6 +209,7 @@ export const PropertyComponent = (props: { property: Property }) => {
           onChange={(e) => {
             updatePropertyValue(p, e.target.value);
           }}
+          required={isRequired}
           value={String(v)}
         />
       );

--- a/frontend/src/components/pages/connect/dynamic-ui/property-group.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/property-group.tsx
@@ -9,7 +9,13 @@
  * by the Apache License, Version 2.0
  */
 
-import { Accordion, Box, Divider, Flex, Heading, Text } from '@redpanda-data/ui';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from 'components/redpanda-ui/components/accordion';
+import { Separator } from 'components/redpanda-ui/components/separator';
 import { Link } from 'components/redpanda-ui/components/typography';
 
 import type { ConfigPageProps } from './components';
@@ -46,46 +52,40 @@ export const PropertyGroupComponent = (props: {
           <PropertyComponent key={p.name} property={p} />
         ))}
 
-        <div style={{ gridColumn: 'span 4', paddingLeft: '8px' }}>
-          <Accordion
-            items={subGroups.map((subGroup) => ({
-              heading: (
-                <Flex alignItems="center" gap={4}>
-                  <span style={{ fontSize: '1.1em', fontWeight: 600, fontFamily: 'Open Sans' }}>
-                    {subGroup.group.name}
-                  </span>
-                  <span style={{ fontSize: '1.1em', fontWeight: 600, fontFamily: 'Open Sans' }}>
-                    {subGroup.group.name}
-                  </span>
-                  <span className="issuesTag">{subGroup.propertiesWithErrors.length} issues</span>
-                </Flex>
-              ),
-              description: (
-                <PropertyGroupComponent
-                  allGroups={props.allGroups}
-                  connectorType={props.connectorType}
-                  context={props.context}
-                  group={subGroup}
-                  showAdvancedOptions={props.showAdvancedOptions}
-                />
-              ),
-            }))}
-          />
+        <div className="col-span-4 pl-2">
+          <Accordion variant="contained">
+            {subGroups.map((subGroup) => (
+              <AccordionItem key={subGroup.group.name} value={subGroup.group.name ?? ''}>
+                <AccordionTrigger>
+                  <div className="flex items-center gap-4">
+                    {/* The group name was rendered twice here before the migration. */}
+                    <span className="font-semibold text-heading-sm">{subGroup.group.name}</span>
+                    <span className="issuesTag">{subGroup.propertiesWithErrors.length} issues</span>
+                  </div>
+                </AccordionTrigger>
+                <AccordionContent>
+                  <PropertyGroupComponent
+                    allGroups={props.allGroups}
+                    connectorType={props.connectorType}
+                    context={props.context}
+                    group={subGroup}
+                    showAdvancedOptions={props.showAdvancedOptions}
+                  />
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
         </div>
       </div>
     );
   }
   // Normal group
   return (
-    <Box>
-      {Boolean(g.group.name) && (
-        <Heading as="h3" mb="4" mt="8" size="md">
-          {g.group.name}
-        </Heading>
-      )}
+    <div>
+      {Boolean(g.group.name) && <h3 className="mt-8 mb-4 text-heading-md">{g.group.name}</h3>}
 
       {Boolean(g.group.description) && (
-        <Text>
+        <p className="text-body">
           {g.group.description}
           {g.group.documentation_link ? (
             <>
@@ -93,7 +93,7 @@ export const PropertyGroupComponent = (props: {
               <Link href={g.group.documentation_link}>Documentation</Link>
             </>
           ) : null}
-        </Text>
+        </p>
       )}
 
       <div>
@@ -112,7 +112,7 @@ export const PropertyGroupComponent = (props: {
             return <PropertyComponent key={p.name} property={p} />;
           })}
       </div>
-      <Divider my={10} />
-    </Box>
+      <Separator className="my-10" />
+    </div>
   );
 };

--- a/frontend/src/components/pages/connect/dynamic-ui/property-group.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/property-group.tsx
@@ -112,7 +112,9 @@ export const PropertyGroupComponent = (props: {
             return <PropertyComponent key={p.name} property={p} />;
           })}
       </div>
-      <Separator className="my-10" />
+      <div className="my-10">
+        <Separator />
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/pages/connect/dynamic-ui/property-group.tsx
+++ b/frontend/src/components/pages/connect/dynamic-ui/property-group.tsx
@@ -82,10 +82,10 @@ export const PropertyGroupComponent = (props: {
   // Normal group
   return (
     <div>
-      {Boolean(g.group.name) && <h3 className="mt-8 mb-4 text-heading-md">{g.group.name}</h3>}
+      {Boolean(g.group.name) && <h3 className="mt-8 text-heading-md">{g.group.name}</h3>}
 
       {Boolean(g.group.description) && (
-        <p className="text-body">
+        <p className="mt-4 text-body">
           {g.group.description}
           {g.group.documentation_link ? (
             <>

--- a/frontend/src/components/pages/connect/helper.tsx
+++ b/frontend/src/components/pages/connect/helper.tsx
@@ -14,6 +14,7 @@ import { Alert, AlertDescription } from 'components/redpanda-ui/components/alert
 import {
   AlertDialog,
   AlertDialogContent,
+  AlertDialogDescription,
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
@@ -27,10 +28,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from 'components/redpanda-ui/components/dialog';
-import { Empty, EmptyDescription, EmptyHeader } from 'components/redpanda-ui/components/empty';
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from 'components/redpanda-ui/components/empty';
 import { Popover, PopoverContent, PopoverTrigger } from 'components/redpanda-ui/components/popover';
 import { RedpandaLogo } from 'components/redpanda-ui/components/redpanda-logo';
-import { CircleAlertIcon } from 'lucide-react';
 import { type CSSProperties, type JSX, useState } from 'react';
 import { docsLinks } from 'utils/docs-links';
 import { showToast } from 'utils/toast.utils';
@@ -441,8 +447,9 @@ export const ConnectorClass = (props: { observable: { class: string } }) => {
 
       <Popover>
         <PopoverTrigger render={<button type="button">{displayName}</button>} />
-        <PopoverContent side="right">
-          <div style={{ maxWidth: '500px', minWidth: 'max-content', whiteSpace: 'pre-wrap' }}>{c}</div>
+        {/* PopoverContent is a fixed `w-72`; Chakra's `size="stretch"` sized to content. */}
+        <PopoverContent className="w-auto max-w-[500px]" side="right">
+          <div className="whitespace-pre-wrap">{c}</div>
         </PopoverContent>
       </Popover>
     </div>
@@ -522,27 +529,26 @@ export function NotConfigured() {
   return (
     <PageContent key="b">
       <Section>
-        <div className="flex flex-col items-center gap-4">
-          <Empty>
-            <EmptyHeader>
-              <EmptyDescription>Not Configured</EmptyDescription>
-            </EmptyHeader>
-          </Empty>
-          <p className="text-center text-body">
-            Kafka Connect is not configured in Redpanda Console.
-            <br />
-            Setup the connection details to your Kafka Connect cluster in your Redpanda Console config, to view and
-            control all your connectors and tasks.
-          </p>
-          <a
-            className={buttonVariants({ variant: 'primary' })}
-            href={docsLinks.selfManaged.console}
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Redpanda Console Config Documentation
-          </a>
-        </div>
+        {/* Same shape as the already-migrated SchemaNotConfiguredPage. */}
+        <Empty>
+          <EmptyHeader>
+            <EmptyTitle>Not configured</EmptyTitle>
+            <EmptyDescription>
+              Kafka Connect is not configured in Redpanda Console. Set up the connection details to your Kafka Connect
+              cluster in your Redpanda Console config, to view and control all your connectors and tasks.
+            </EmptyDescription>
+          </EmptyHeader>
+          <EmptyContent>
+            <a
+              className={buttonVariants({ variant: 'primary' })}
+              href={docsLinks.selfManaged.console}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Redpanda Console Config Documentation
+            </a>
+          </EmptyContent>
+        </Empty>
       </Section>
     </PageContent>
   );
@@ -645,11 +651,13 @@ export const ConfirmModal = <T,>(props: ConfirmModalProps<T>) => {
         <AlertDialogHeader>
           <AlertDialogTitle>Confirm</AlertDialogTitle>
         </AlertDialogHeader>
-        <div className="flex flex-col gap-2">
+        {/* min-h-0 + overflow-y-auto: AlertDialogContent is `overflow-hidden max-h-[85vh]`, so a
+            long API error would otherwise be clipped with no way to scroll to the footer. */}
+        <AlertDialogDescription className="flex min-h-0 flex-col gap-2 overflow-y-auto">
           {content}
           {err ? (
             <div className="mt-4">
-              <Alert icon={<CircleAlertIcon />} variant="destructive">
+              <Alert icon={<AlertIcon />} variant="destructive">
                 <AlertDescription>
                   <div>
                     <h3 className="text-heading-xs">{err.title}</h3>
@@ -659,7 +667,7 @@ export const ConfirmModal = <T,>(props: ConfirmModalProps<T>) => {
               </Alert>
             </div>
           ) : null}
-        </div>
+        </AlertDialogDescription>
         <AlertDialogFooter>
           {/* Cancel first, as `leastDestructiveRef` made it the initial focus. */}
           <Button onClick={cancel} variant="outline">
@@ -843,14 +851,19 @@ const pauseIcon = (
 export const mr05: CSSProperties = { marginRight: '.5em' };
 export const ml05: CSSProperties = { marginLeft: '.5em' };
 
-// Mapping from health status to chakra color variables
+/**
+ * Health status to a background utility.
+ *
+ * These were Chakra theme tokens (`green.500`), which only resolved through a Chakra style prop —
+ * as raw CSS they are invalid and the declaration is dropped, so the status stripe painted nothing.
+ */
 export const statusColors = {
-  HEALTHY: 'green.500',
-  UNHEALTHY: 'red.500',
-  DEGRADED: 'orange.500',
-  PAUSED: 'gray.500',
-  RESTARTING: 'blue.500',
-  UNASSIGNED: 'gray.500',
-  DESTROYED: 'red.500',
-  UNKNOWN: 'gray.500',
+  HEALTHY: 'bg-success-strong',
+  UNHEALTHY: 'bg-destructive-strong',
+  DEGRADED: 'bg-warning-strong',
+  PAUSED: 'bg-surface-disabled',
+  RESTARTING: 'bg-informative-strong',
+  UNASSIGNED: 'bg-surface-disabled',
+  DESTROYED: 'bg-destructive-strong',
+  UNKNOWN: 'bg-surface-disabled',
 } as Record<ConnectorStatus, string>;

--- a/frontend/src/components/pages/connect/helper.tsx
+++ b/frontend/src/components/pages/connect/helper.tsx
@@ -9,31 +9,29 @@
  * by the Apache License, Version 2.0
  */
 
+import { AlertIcon, CheckCircleIcon, HourglassIcon, PauseCircleIcon, WarningIcon } from 'components/icons';
+import { Alert, AlertDescription } from 'components/redpanda-ui/components/alert';
 import {
-  Alert,
-  AlertDescription,
   AlertDialog,
-  AlertDialogBody,
   AlertDialogContent,
   AlertDialogFooter,
   AlertDialogHeader,
-  AlertDialogOverlay,
-  Box,
-  Button,
-  Empty,
-  Modal,
-  ModalBody,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalOverlay,
-  Popover,
-  Text,
-  VStack,
-} from '@redpanda-data/ui';
-import { AlertIcon, CheckCircleIcon, HourglassIcon, PauseCircleIcon, WarningIcon } from 'components/icons';
+  AlertDialogTitle,
+} from 'components/redpanda-ui/components/alert-dialog';
+import { Button, buttonVariants } from 'components/redpanda-ui/components/button';
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from 'components/redpanda-ui/components/dialog';
+import { Empty, EmptyDescription, EmptyHeader } from 'components/redpanda-ui/components/empty';
+import { Popover, PopoverContent, PopoverTrigger } from 'components/redpanda-ui/components/popover';
 import { RedpandaLogo } from 'components/redpanda-ui/components/redpanda-logo';
-import { type CSSProperties, type JSX, useRef, useState } from 'react';
+import { CircleAlertIcon } from 'lucide-react';
+import { type CSSProperties, type JSX, useState } from 'react';
 import { docsLinks } from 'utils/docs-links';
 import { showToast } from 'utils/toast.utils';
 
@@ -441,13 +439,11 @@ export const ConnectorClass = (props: { observable: { class: string } }) => {
         </span>
       ) : null}
 
-      <Popover
-        content={<div style={{ maxWidth: '500px', minWidth: 'max-content', whiteSpace: 'pre-wrap' }}>{c}</div>}
-        hideCloseButton={true}
-        placement="right"
-        size="stretch"
-      >
-        {displayName}
+      <Popover>
+        <PopoverTrigger render={<button type="button">{displayName}</button>} />
+        <PopoverContent side="right">
+          <div style={{ maxWidth: '500px', minWidth: 'max-content', whiteSpace: 'pre-wrap' }}>{c}</div>
+        </PopoverContent>
       </Popover>
     </div>
   );
@@ -526,18 +522,27 @@ export function NotConfigured() {
   return (
     <PageContent key="b">
       <Section>
-        <VStack gap={4}>
-          <Empty description="Not Configured" />
-          <Text textAlign="center">
+        <div className="flex flex-col items-center gap-4">
+          <Empty>
+            <EmptyHeader>
+              <EmptyDescription>Not Configured</EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+          <p className="text-center text-body">
             Kafka Connect is not configured in Redpanda Console.
             <br />
             Setup the connection details to your Kafka Connect cluster in your Redpanda Console config, to view and
             control all your connectors and tasks.
-          </Text>
-          <a href={docsLinks.selfManaged.console} rel="noopener noreferrer" target="_blank">
-            <Button variant="solid">Redpanda Console Config Documentation</Button>
+          </p>
+          <a
+            className={buttonVariants({ variant: 'primary' })}
+            href={docsLinks.selfManaged.console}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Redpanda Console Config Documentation
           </a>
-        </VStack>
+        </div>
       </Section>
     </PageContent>
   );
@@ -557,7 +562,6 @@ type ConfirmModalProps<T> = {
 export const ConfirmModal = <T,>(props: ConfirmModalProps<T>) => {
   const [isPending, setIsPending] = useState(false);
   const [error, setError] = useState<string | Error | null>(null);
-  const cancelRef = useRef<HTMLButtonElement | null>(null);
 
   const renderError = (): { title: string; content: string } | undefined => {
     if (!error) {
@@ -629,36 +633,43 @@ export const ConfirmModal = <T,>(props: ConfirmModalProps<T>) => {
   const content = target && props.content(target);
 
   return (
-    <AlertDialog isOpen={target !== null} leastDestructiveRef={cancelRef} onClose={cancel}>
-      <AlertDialogOverlay>
-        <AlertDialogContent>
-          <AlertDialogHeader>Confirm</AlertDialogHeader>
-          <AlertDialogBody>
-            {content}
-            {err ? (
-              <Box mt={4}>
-                <Alert status="error" variant="left-accent">
-                  <AlertIcon />
-                  <AlertDescription>
-                    <Box>
-                      <Text as="h3">{err.title}</Text>
-                      <Text>{err.content}</Text>
-                    </Box>
-                  </AlertDescription>
-                </Alert>
-              </Box>
-            ) : null}
-          </AlertDialogBody>
-          <AlertDialogFooter gap={2}>
-            <Button onClick={cancel} ref={cancelRef} variant="outline">
-              No
-            </Button>
-            <Button isLoading={isPending} onClick={onOk}>
-              {error ? 'Retry' : 'Yes'}
-            </Button>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialogOverlay>
+    <AlertDialog
+      onOpenChange={(open) => {
+        if (!open) {
+          cancel();
+        }
+      }}
+      open={target !== null}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Confirm</AlertDialogTitle>
+        </AlertDialogHeader>
+        <div className="flex flex-col gap-2">
+          {content}
+          {err ? (
+            <div className="mt-4">
+              <Alert icon={<CircleAlertIcon />} variant="destructive">
+                <AlertDescription>
+                  <div>
+                    <h3 className="text-heading-xs">{err.title}</h3>
+                    <div>{err.content}</div>
+                  </div>
+                </AlertDescription>
+              </Alert>
+            </div>
+          ) : null}
+        </div>
+        <AlertDialogFooter>
+          {/* Cancel first, as `leastDestructiveRef` made it the initial focus. */}
+          <Button onClick={cancel} variant="outline">
+            No
+          </Button>
+          <Button isLoading={isPending} onClick={onOk}>
+            {error ? 'Retry' : 'Yes'}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
     </AlertDialog>
   );
 };
@@ -767,7 +778,6 @@ export const TaskState = (p: {
   if (task.trace) {
     errBtn = (
       <Button
-        colorScheme="red"
         onClick={() => showErr(task.trace)}
         style={{
           padding: '0px 12px',
@@ -776,7 +786,7 @@ export const TaskState = (p: {
           height: '30px',
           gap: '5px',
         }}
-        variant="outline"
+        variant="destructive-outline"
       >
         {stateContent}
         <span>(Show Error)</span>
@@ -785,22 +795,28 @@ export const TaskState = (p: {
 
     const close = () => showErr(undefined);
     errModal = (
-      <Modal isOpen={err !== null && err !== undefined} onClose={close}>
-        <ModalOverlay />
-        <ModalContent minW="5xl">
-          <ModalHeader>
-            {task.taskId === null ? 'Error in Connector' : `Error trace of task ${task.taskId}`}
-          </ModalHeader>
-          <ModalBody>
-            <Box className="codeBox" px={2} py={3} style={{ whiteSpace: 'pre', overflow: 'scroll' }} w="full">
-              {err}
-            </Box>
-          </ModalBody>
-          <ModalFooter gap={2}>
+      <Dialog
+        onOpenChange={(open) => {
+          if (!open) {
+            close();
+          }
+        }}
+        open={err !== null && err !== undefined}
+      >
+        <DialogContent size="full">
+          <DialogHeader>
+            <DialogTitle>
+              {task.taskId === null ? 'Error in Connector' : `Error trace of task ${task.taskId}`}
+            </DialogTitle>
+          </DialogHeader>
+          <DialogBody>
+            <div className="codeBox w-full overflow-scroll whitespace-pre px-2 py-3">{err}</div>
+          </DialogBody>
+          <DialogFooter>
             <Button onClick={close}>Close</Button>
-          </ModalFooter>
-        </ModalContent>
-      </Modal>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     );
 
     stateContent = errBtn;

--- a/frontend/src/components/pages/connect/helper.tsx
+++ b/frontend/src/components/pages/connect/helper.tsx
@@ -10,7 +10,7 @@
  */
 
 import { AlertIcon, CheckCircleIcon, HourglassIcon, PauseCircleIcon, WarningIcon } from 'components/icons';
-import { Alert, AlertDescription } from 'components/redpanda-ui/components/alert';
+import { Alert, AlertDescription, AlertTitle } from 'components/redpanda-ui/components/alert';
 import {
   AlertDialog,
   AlertDialogContent,
@@ -19,7 +19,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from 'components/redpanda-ui/components/alert-dialog';
-import { Button, buttonVariants } from 'components/redpanda-ui/components/button';
+import { Button } from 'components/redpanda-ui/components/button';
+import { SimpleCodeBlock } from 'components/redpanda-ui/components/code-block';
 import {
   Dialog,
   DialogBody,
@@ -37,7 +38,7 @@ import {
 } from 'components/redpanda-ui/components/empty';
 import { Popover, PopoverContent, PopoverTrigger } from 'components/redpanda-ui/components/popover';
 import { RedpandaLogo } from 'components/redpanda-ui/components/redpanda-logo';
-import { cn } from 'components/redpanda-ui/lib/utils';
+import { Stat } from 'components/redpanda-ui/components/stat';
 import { type CSSProperties, type JSX, useState } from 'react';
 import { docsLinks } from 'utils/docs-links';
 import { showToast } from 'utils/toast.utils';
@@ -78,7 +79,6 @@ import {
 import { ZeroSizeWrapper } from '../../../utils/tsx-utils';
 import PageContent from '../../misc/page-content';
 import Section from '../../misc/section';
-import { Statistic } from '../../misc/statistic';
 
 type ConnectorMetadata = {
   readonly className?: string; // match by exact match
@@ -447,7 +447,15 @@ export const ConnectorClass = (props: { observable: { class: string } }) => {
       ) : null}
 
       <Popover>
-        <PopoverTrigger render={<button type="button">{displayName}</button>} />
+        {/* Hover-to-open, as the Chakra popover was. */}
+        <PopoverTrigger
+          openOnHover
+          render={
+            <button className="cursor-help" type="button">
+              {displayName}
+            </button>
+          }
+        />
         {/* PopoverContent is a fixed `w-72`; Chakra's `size="stretch"` sized to content. */}
         <PopoverContent className="w-auto max-w-[500px]" side="right">
           <div className="whitespace-pre-wrap">{c}</div>
@@ -477,8 +485,8 @@ export const OverviewStatisticsCard = () => {
   return (
     <Section className="py-4">
       <div className="flex gap-8">
-        <Statistic title="Connect Clusters" value={totalClusters} />
-        <Statistic title="Total Connectors" value={totalConnectors} />
+        <Stat label="Connect Clusters" size="lg" value={totalClusters} />
+        <Stat label="Total Connectors" size="lg" value={totalConnectors} />
       </div>
     </Section>
   );
@@ -500,11 +508,11 @@ export const ClusterStatisticsCard = (p: { clusterName: string }) => {
   return (
     <Section className="py-4">
       <div className="flex gap-8">
-        <Statistic title="Cluster" value={cluster?.clusterName} />
+        <Stat label="Cluster" size="lg" value={cluster?.clusterName} />
 
-        <Statistic title="Connectors" value={`${runningConnectors} / ${totalConnectors}`} />
-        <Statistic title="Address" value={addr} />
-        <Statistic title="Version" value={version} />
+        <Stat label="Connectors" size="lg" value={`${runningConnectors} / ${totalConnectors}`} />
+        <Stat label="Address" size="lg" value={addr} />
+        <Stat label="Version" size="lg" value={version} />
       </div>
     </Section>
   );
@@ -517,10 +525,10 @@ export const ConnectorStatisticsCard = (p: { clusterName: string; connectorName:
   return (
     <Section className="py-4">
       <div className="flex gap-8">
-        <Statistic title="Cluster" value={cluster?.clusterName} />
-        <Statistic title="Connector" value={connector?.name} />
+        <Stat label="Cluster" size="lg" value={cluster?.clusterName} />
+        <Stat label="Connector" size="lg" value={connector?.name} />
 
-        <Statistic title="Tasks" value={`${connector?.runningTasks} / ${connector?.totalTasks}`} />
+        <Stat label="Tasks" size="lg" value={`${connector?.runningTasks} / ${connector?.totalTasks}`} />
       </div>
     </Section>
   );
@@ -540,14 +548,15 @@ export function NotConfigured() {
             </EmptyDescription>
           </EmptyHeader>
           <EmptyContent>
-            <a
-              className={cn(buttonVariants({ variant: 'primary' }), 'rounded-md')}
+            <Button
+              as="a"
               href={docsLinks.selfManaged.console}
               rel="noopener noreferrer"
               target="_blank"
+              variant="primary"
             >
               Redpanda Console Config Documentation
-            </a>
+            </Button>
           </EmptyContent>
         </Empty>
       </Section>
@@ -654,17 +663,13 @@ export const ConfirmModal = <T,>(props: ConfirmModalProps<T>) => {
         </AlertDialogHeader>
         {/* min-h-0 + overflow-y-auto: AlertDialogContent is `overflow-hidden max-h-[85vh]`, so a
             long API error would otherwise be clipped with no way to scroll to the footer. */}
-        <AlertDialogDescription className="flex min-h-0 flex-col gap-2 overflow-y-auto">
+        <AlertDialogDescription className="min-h-0 overflow-y-auto text-foreground">
           {content}
           {err ? (
             <div className="mt-4">
               <Alert icon={<AlertIcon />} variant="destructive">
-                <AlertDescription>
-                  <div>
-                    <h3 className="text-heading-xs">{err.title}</h3>
-                    <div>{err.content}</div>
-                  </div>
-                </AlertDescription>
+                <AlertTitle>{err.title}</AlertTitle>
+                <AlertDescription>{err.content}</AlertDescription>
               </Alert>
             </div>
           ) : null}
@@ -815,11 +820,11 @@ export const TaskState = (p: {
         <DialogContent size="full">
           <DialogHeader>
             <DialogTitle>
-              {task.taskId === null ? 'Error in Connector' : `Error trace of task ${task.taskId}`}
+              {task.taskId === undefined ? 'Error in Connector' : `Error trace of task ${task.taskId}`}
             </DialogTitle>
           </DialogHeader>
           <DialogBody>
-            <div className="codeBox w-full overflow-scroll whitespace-pre px-2 py-3">{err}</div>
+            <SimpleCodeBlock code={err ?? ''} language="text" maxHeight="none" width="full" />
           </DialogBody>
           <DialogFooter>
             <Button onClick={close}>Close</Button>
@@ -852,19 +857,15 @@ const pauseIcon = (
 export const mr05: CSSProperties = { marginRight: '.5em' };
 export const ml05: CSSProperties = { marginLeft: '.5em' };
 
-/**
- * Health status to a background utility.
- *
- * These were Chakra theme tokens (`green.500`), which only resolved through a Chakra style prop —
- * as raw CSS they are invalid and the declaration is dropped, so the status stripe painted nothing.
- */
+/** Health status to a background utility; the backend also reports STOPPED. */
 export const statusColors = {
   HEALTHY: 'bg-success-strong',
   UNHEALTHY: 'bg-destructive-strong',
   DEGRADED: 'bg-warning-strong',
-  PAUSED: 'bg-surface-disabled',
+  PAUSED: 'bg-disabled',
+  STOPPED: 'bg-disabled',
   RESTARTING: 'bg-informative-strong',
-  UNASSIGNED: 'bg-surface-disabled',
+  UNASSIGNED: 'bg-disabled',
   DESTROYED: 'bg-destructive-strong',
-  UNKNOWN: 'bg-surface-disabled',
+  UNKNOWN: 'bg-disabled',
 } as Record<ConnectorStatus, string>;

--- a/frontend/src/components/pages/connect/helper.tsx
+++ b/frontend/src/components/pages/connect/helper.tsx
@@ -37,6 +37,7 @@ import {
 } from 'components/redpanda-ui/components/empty';
 import { Popover, PopoverContent, PopoverTrigger } from 'components/redpanda-ui/components/popover';
 import { RedpandaLogo } from 'components/redpanda-ui/components/redpanda-logo';
+import { cn } from 'components/redpanda-ui/lib/utils';
 import { type CSSProperties, type JSX, useState } from 'react';
 import { docsLinks } from 'utils/docs-links';
 import { showToast } from 'utils/toast.utils';
@@ -540,7 +541,7 @@ export function NotConfigured() {
           </EmptyHeader>
           <EmptyContent>
             <a
-              className={buttonVariants({ variant: 'primary' })}
+              className={cn(buttonVariants({ variant: 'primary' }), 'rounded-md')}
               href={docsLinks.selfManaged.console}
               rel="noopener noreferrer"
               target="_blank"

--- a/frontend/src/components/pages/connect/helper.tsx
+++ b/frontend/src/components/pages/connect/helper.tsx
@@ -19,7 +19,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from 'components/redpanda-ui/components/alert-dialog';
-import { Button } from 'components/redpanda-ui/components/button';
+import { Button, buttonVariants } from 'components/redpanda-ui/components/button';
 import { SimpleCodeBlock } from 'components/redpanda-ui/components/code-block';
 import {
   Dialog,
@@ -39,6 +39,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from 'components/redpanda-ui/components/popover';
 import { RedpandaLogo } from 'components/redpanda-ui/components/redpanda-logo';
 import { Stat } from 'components/redpanda-ui/components/stat';
+import { cn } from 'components/redpanda-ui/lib/utils';
 import { type CSSProperties, type JSX, useState } from 'react';
 import { docsLinks } from 'utils/docs-links';
 import { showToast } from 'utils/toast.utils';
@@ -548,15 +549,14 @@ export function NotConfigured() {
             </EmptyDescription>
           </EmptyHeader>
           <EmptyContent>
-            <Button
-              as="a"
+            <a
+              className={cn(buttonVariants({ variant: 'primary' }), 'rounded-md')}
               href={docsLinks.selfManaged.console}
               rel="noopener noreferrer"
               target="_blank"
-              variant="primary"
             >
               Redpanda Console Config Documentation
-            </Button>
+            </a>
           </EmptyContent>
         </Empty>
       </Section>
@@ -679,7 +679,7 @@ export const ConfirmModal = <T,>(props: ConfirmModalProps<T>) => {
           <Button onClick={cancel} variant="outline">
             No
           </Button>
-          <Button isLoading={isPending} onClick={onOk}>
+          <Button aria-label={error ? 'Retry' : 'Yes'} isLoading={isPending} onClick={onOk}>
             {error ? 'Retry' : 'Yes'}
           </Button>
         </AlertDialogFooter>

--- a/frontend/src/components/pages/connect/helper.tsx
+++ b/frontend/src/components/pages/connect/helper.tsx
@@ -447,7 +447,7 @@ export const ConnectorClass = (props: { observable: { class: string } }) => {
       ) : null}
 
       <Popover>
-        {/* Hover-to-open, as the Chakra popover was. */}
+        {/* Hover-to-open; Base UI defaults to click. */}
         <PopoverTrigger
           openOnHover
           render={
@@ -675,7 +675,7 @@ export const ConfirmModal = <T,>(props: ConfirmModalProps<T>) => {
           ) : null}
         </AlertDialogDescription>
         <AlertDialogFooter>
-          {/* Cancel first, as `leastDestructiveRef` made it the initial focus. */}
+          {/* Cancel first: Base UI focuses the first tabbable. */}
           <Button onClick={cancel} variant="outline">
             No
           </Button>

--- a/frontend/src/components/pages/connect/overview.tsx
+++ b/frontend/src/components/pages/connect/overview.tsx
@@ -12,7 +12,7 @@
 import { create } from '@bufbuild/protobuf';
 import ErrorResult from 'components/misc/error-result';
 import { Badge } from 'components/redpanda-ui/components/badge';
-import { DataTable } from 'components/redpanda-ui/components/data-table';
+import { DataTable, DataTableColumnHeader } from 'components/redpanda-ui/components/data-table';
 import { Tooltip, TooltipContent, TooltipTrigger } from 'components/redpanda-ui/components/tooltip';
 import { Link } from 'components/redpanda-ui/components/typography';
 import { WaitingRedpanda } from 'components/redpanda-ui/components/waiting-redpanda';
@@ -432,7 +432,9 @@ class TabTasks extends Component {
       <DataTable<TaskType>
         columns={[
           {
-            header: 'Connector',
+            id: 'name',
+            enableHiding: false,
+            header: ({ column }) => <DataTableColumnHeader column={column} title="Connector" />,
             accessorKey: 'name', // Assuming 'name' is correct based on your initial dataIndex
             cell: ({ row: { original } }) => (
               // biome-ignore lint/a11y/useKeyWithClickEvents: pre-existing behavior, previously hidden inside the deprecated <Text> wrapper
@@ -452,20 +454,29 @@ class TabTasks extends Component {
             size: 300,
           },
           {
-            header: 'Task ID',
+            id: 'taskId',
+            enableHiding: false,
+            header: ({ column }) => <DataTableColumnHeader column={column} title="Task ID" />,
             accessorKey: 'taskId',
-            size: 50,
           },
           {
-            header: 'State',
+            id: 'state',
+            enableHiding: false,
+            header: ({ column }) => <DataTableColumnHeader column={column} title="State" />,
             accessorKey: 'state',
             cell: ({ row: { original } }) => <TaskState observable={original} />,
           },
           {
-            header: 'Worker',
+            id: 'workerId',
+            enableHiding: false,
+            header: ({ column }) => <DataTableColumnHeader column={column} title="Worker" />,
             accessorKey: 'workerId',
           },
           {
+            id: 'cluster',
+            // Read off the joined cluster, so there is no accessor to sort on.
+            enableSorting: false,
+            enableHiding: false,
             header: 'Cluster',
             cell: ({ row: { original } }) => <Code nowrap>{original.cluster.clusterName}</Code>,
           },

--- a/frontend/src/components/pages/connect/overview.tsx
+++ b/frontend/src/components/pages/connect/overview.tsx
@@ -10,9 +10,10 @@
  */
 
 import { create } from '@bufbuild/protobuf';
-import { Box, DataTable, Tooltip } from '@redpanda-data/ui';
 import ErrorResult from 'components/misc/error-result';
 import { Badge } from 'components/redpanda-ui/components/badge';
+import { DataTable } from 'components/redpanda-ui/components/data-table';
+import { Tooltip, TooltipContent, TooltipTrigger } from 'components/redpanda-ui/components/tooltip';
 import { Link } from 'components/redpanda-ui/components/typography';
 import { WaitingRedpanda } from 'components/redpanda-ui/components/waiting-redpanda';
 import { Component, type FunctionComponent, useCallback, useMemo, useState } from 'react';
@@ -145,12 +146,12 @@ class KafkaConnectOverview extends PageComponent<{
       {
         key: ConnectView.RedpandaConnect,
         title: (
-          <Box minWidth="180px">
+          <div className="min-w-[180px]">
             Redpanda Connect{' '}
             <Badge className="ml-2" tone="default" variant="subtle">
               Recommended
             </Badge>
-          </Box>
+          </div>
         ),
         content: (
           <div className="mb-4 flex flex-col gap-4">
@@ -172,7 +173,7 @@ class KafkaConnectOverview extends PageComponent<{
       },
       {
         key: ConnectView.KafkaConnect,
-        title: <Box minWidth="180px">Kafka Connect</Box>,
+        title: <div className="min-w-[180px]">Kafka Connect</div>,
         content: (
           <div className="flex flex-col gap-4">
             <div className="text-body">
@@ -232,9 +233,16 @@ class TabClusters extends Component {
             cell: ({ row: { original: r } }) => {
               if (r.error) {
                 return (
-                  <Tooltip hasArrow={true} label={r.error} placement="top">
-                    <span style={mr05}>{errIcon}</span>
-                    {r.clusterName}
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <span>
+                          <span style={mr05}>{errIcon}</span>
+                          {r.clusterName}
+                        </span>
+                      }
+                    />
+                    <TooltipContent side="top">{r.error}</TooltipContent>
                   </Tooltip>
                 );
               }
@@ -320,7 +328,7 @@ const TabConnectors = () => {
   }, []);
 
   return (
-    <Box>
+    <div>
       <SearchBar<ConnectorType>
         dataSource={dataSource}
         filterText={searchText}
@@ -336,27 +344,32 @@ const TabConnectors = () => {
             accessorKey: 'name',
             size: 35, // Assuming '35%' is approximated to '35'
             cell: ({ row: { original } }) => (
-              <Tooltip hasArrow={true} label={original.name} placement="top">
-                <span
-                  className="hoverLink"
-                  onClick={() =>
-                    appGlobal.historyPush(
-                      `/connect-clusters/${encodeURIComponent(original.cluster.clusterName)}/${encodeURIComponent(original.name)}`
-                    )
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <span
+                      className="hoverLink"
+                      onClick={() =>
+                        appGlobal.historyPush(
+                          `/connect-clusters/${encodeURIComponent(original.cluster.clusterName)}/${encodeURIComponent(original.name)}`
+                        )
+                      }
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          appGlobal.historyPush(
+                            `/connect-clusters/${encodeURIComponent(original.cluster.clusterName)}/${encodeURIComponent(original.name)}`
+                          );
+                        }
+                      }}
+                      role="button"
+                      style={{ display: 'inline-block', width: '100%' }}
+                      tabIndex={0}
+                    >
+                      {original.name}
+                    </span>
                   }
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      appGlobal.historyPush(
-                        `/connect-clusters/${encodeURIComponent(original.cluster.clusterName)}/${encodeURIComponent(original.name)}`
-                      );
-                    }
-                  }}
-                  role="button"
-                  style={{ display: 'inline-block', width: '100%' }}
-                  tabIndex={0}
-                >
-                  {original.name}
-                </span>
+                />
+                <TooltipContent side="top">{original.name}</TooltipContent>
               </Tooltip>
             ),
           },
@@ -390,7 +403,7 @@ const TabConnectors = () => {
         pagination
         sorting={false}
       />
-    </Box>
+    </div>
   );
 };
 

--- a/frontend/src/components/pages/connect/overview.tsx
+++ b/frontend/src/components/pages/connect/overview.tsx
@@ -52,8 +52,11 @@ import { PipelineListPage } from '../rp-connect/pipeline/list';
 import RpConnectPipelinesList from '../rp-connect/pipelines-list';
 import { RedpandaConnectIntro } from '../rp-connect/redpanda-connect-intro';
 
-// Legacy table parity: 50 rows a page, pager only past that.
-const TABLE_OPTIONS = { initialState: { pagination: { pageIndex: 0, pageSize: DEFAULT_TABLE_PAGE_SIZE } } };
+// Legacy table parity: 50 rows a page, pager only past that. No column-visibility UI, so hiding is off.
+const TABLE_OPTIONS = {
+  enableHiding: false,
+  initialState: { pagination: { pageIndex: 0, pageSize: DEFAULT_TABLE_PAGE_SIZE } },
+};
 
 const ConnectView = {
   KafkaConnect: 'kafka-connect',
@@ -422,7 +425,6 @@ interface TaskType extends ClusterConnectorTaskInfo {
 const TASK_COLUMNS: DataTableColumnDef<TaskType>[] = [
   {
     id: 'name',
-    enableHiding: false,
     header: ({ column }) => <DataTableColumnHeader column={column} title="Connector" />,
     accessorKey: 'connectorName',
     cell: ({ row: { original } }) => (
@@ -443,20 +445,17 @@ const TASK_COLUMNS: DataTableColumnDef<TaskType>[] = [
   },
   {
     id: 'taskId',
-    enableHiding: false,
     header: ({ column }) => <DataTableColumnHeader column={column} title="Task ID" />,
     accessorKey: 'taskId',
   },
   {
     id: 'state',
-    enableHiding: false,
     header: ({ column }) => <DataTableColumnHeader column={column} title="State" />,
     accessorKey: 'state',
     cell: ({ row: { original } }) => <TaskState observable={original} />,
   },
   {
     id: 'workerId',
-    enableHiding: false,
     header: ({ column }) => <DataTableColumnHeader column={column} title="Worker" />,
     accessorKey: 'workerId',
   },
@@ -464,7 +463,6 @@ const TASK_COLUMNS: DataTableColumnDef<TaskType>[] = [
     id: 'cluster',
     // Read off the joined cluster, so there is no accessor to sort on.
     enableSorting: false,
-    enableHiding: false,
     header: 'Cluster',
     cell: ({ row: { original } }) => (
       <InlineCode className="whitespace-nowrap">{original.cluster.clusterName}</InlineCode>

--- a/frontend/src/components/pages/connect/overview.tsx
+++ b/frontend/src/components/pages/connect/overview.tsx
@@ -14,7 +14,7 @@ import ErrorResult from 'components/misc/error-result';
 import { Badge } from 'components/redpanda-ui/components/badge';
 import { DataTable, DataTableColumnHeader } from 'components/redpanda-ui/components/data-table';
 import { Tooltip, TooltipContent, TooltipTrigger } from 'components/redpanda-ui/components/tooltip';
-import { Link } from 'components/redpanda-ui/components/typography';
+import { InlineCode, Link } from 'components/redpanda-ui/components/typography';
 import { WaitingRedpanda } from 'components/redpanda-ui/components/waiting-redpanda';
 import { Component, type FunctionComponent, useCallback, useMemo, useState } from 'react';
 import { useKafkaConnectConnectorsQuery } from 'react-query/api/kafka-connect';
@@ -37,7 +37,8 @@ import { api, rpcnSecretManagerApi } from '../../../state/backend-api';
 import type { ClusterConnectorInfo, ClusterConnectors, ClusterConnectorTaskInfo } from '../../../state/rest-interfaces';
 import { Features, useSupportedFeaturesStore } from '../../../state/supported-features';
 import { uiSettings } from '../../../state/ui';
-import { Code, DefaultSkeleton } from '../../../utils/tsx-utils';
+import { DefaultSkeleton } from '../../../utils/tsx-utils';
+import { DEFAULT_TABLE_PAGE_SIZE } from '../../constants';
 import PageContent from '../../misc/page-content';
 import SearchBar from '../../misc/search-bar';
 import Section from '../../misc/section';
@@ -46,6 +47,9 @@ import { PageComponent, type PageInitHelper } from '../page';
 import { PipelineListPage } from '../rp-connect/pipeline/list';
 import RpConnectPipelinesList from '../rp-connect/pipelines-list';
 import { RedpandaConnectIntro } from '../rp-connect/redpanda-connect-intro';
+
+// Legacy table parity: 50 rows a page, pager only past that.
+const TABLE_OPTIONS = { initialState: { pagination: { pageIndex: 0, pageSize: DEFAULT_TABLE_PAGE_SIZE } } };
 
 const ConnectView = {
   KafkaConnect: 'kafka-connect',
@@ -229,7 +233,6 @@ class TabClusters extends Component {
           {
             header: 'Cluster',
             accessorKey: 'clusterName',
-            size: Number.POSITIVE_INFINITY,
             cell: ({ row: { original: r } }) => {
               if (r.error) {
                 return (
@@ -272,21 +275,20 @@ class TabClusters extends Component {
           },
           {
             accessorKey: 'connectors',
-            size: 150,
             header: 'Connectors',
             cell: ({ row: { original } }) => <ConnectorsColumn observable={original} />,
           },
           {
             id: 'tasks',
             accessorKey: 'connectors',
-            size: 150,
             header: 'Tasks',
             cell: ({ row: { original } }) => <TasksColumn observable={original} />,
           },
         ]}
         data={clusters}
-        pagination
+        pagination={clusters.length > DEFAULT_TABLE_PAGE_SIZE}
         sorting={false}
+        tableOptions={TABLE_OPTIONS}
       />
     );
   }
@@ -342,7 +344,6 @@ const TabConnectors = () => {
           {
             header: 'Connector',
             accessorKey: 'name',
-            size: 35, // Assuming '35%' is approximated to '35'
             cell: ({ row: { original } }) => (
               <Tooltip>
                 <TooltipTrigger
@@ -381,27 +382,27 @@ const TabConnectors = () => {
           {
             header: 'Type',
             accessorKey: 'type',
-            size: 100,
           },
           {
             header: 'State',
             accessorKey: 'state',
-            size: 120,
             cell: ({ row: { original } }) => <TaskState observable={original} />,
           },
           {
             header: 'Tasks',
-            size: 120,
             cell: ({ row: { original } }) => <TasksColumn observable={original} />,
           },
           {
             header: 'Cluster',
-            cell: ({ row: { original } }) => <Code nowrap>{original.cluster.clusterName}</Code>,
+            cell: ({ row: { original } }) => (
+              <InlineCode className="whitespace-nowrap">{original.cluster.clusterName}</InlineCode>
+            ),
           },
         ]}
         data={filteredResults}
-        pagination
+        pagination={filteredResults.length > DEFAULT_TABLE_PAGE_SIZE}
         sorting={false}
+        tableOptions={TABLE_OPTIONS}
       />
     </div>
   );
@@ -435,7 +436,7 @@ class TabTasks extends Component {
             id: 'name',
             enableHiding: false,
             header: ({ column }) => <DataTableColumnHeader column={column} title="Connector" />,
-            accessorKey: 'name', // Assuming 'name' is correct based on your initial dataIndex
+            accessorKey: 'connectorName',
             cell: ({ row: { original } }) => (
               // biome-ignore lint/a11y/useKeyWithClickEvents: pre-existing behavior, previously hidden inside the deprecated <Text> wrapper
               // biome-ignore lint/a11y/noStaticElementInteractions: pre-existing behavior, previously hidden inside the deprecated <Text> wrapper
@@ -451,7 +452,6 @@ class TabTasks extends Component {
                 {original.connectorName}
               </div>
             ),
-            size: 300,
           },
           {
             id: 'taskId',
@@ -478,12 +478,15 @@ class TabTasks extends Component {
             enableSorting: false,
             enableHiding: false,
             header: 'Cluster',
-            cell: ({ row: { original } }) => <Code nowrap>{original.cluster.clusterName}</Code>,
+            cell: ({ row: { original } }) => (
+              <InlineCode className="whitespace-nowrap">{original.cluster.clusterName}</InlineCode>
+            ),
           },
         ]}
         data={allTasks}
-        pagination
+        pagination={allTasks.length > DEFAULT_TABLE_PAGE_SIZE}
         sorting
+        tableOptions={TABLE_OPTIONS}
       />
     );
   }

--- a/frontend/src/components/pages/connect/overview.tsx
+++ b/frontend/src/components/pages/connect/overview.tsx
@@ -243,7 +243,7 @@ class TabClusters extends Component {
             cell: ({ row: { original: r } }) => {
               if (r.error) {
                 return (
-                  <Tooltip>
+                  <Tooltip delayDuration={150}>
                     <TooltipTrigger
                       render={
                         <span>
@@ -352,7 +352,7 @@ const TabConnectors = () => {
             header: 'Connector',
             accessorKey: 'name',
             cell: ({ row: { original } }) => (
-              <Tooltip>
+              <Tooltip delayDuration={150}>
                 <TooltipTrigger
                   render={
                     <span

--- a/frontend/src/components/pages/connect/overview.tsx
+++ b/frontend/src/components/pages/connect/overview.tsx
@@ -12,7 +12,11 @@
 import { create } from '@bufbuild/protobuf';
 import ErrorResult from 'components/misc/error-result';
 import { Badge } from 'components/redpanda-ui/components/badge';
-import { DataTable, DataTableColumnHeader } from 'components/redpanda-ui/components/data-table';
+import {
+  DataTable,
+  type DataTableColumnDef,
+  DataTableColumnHeader,
+} from 'components/redpanda-ui/components/data-table';
 import { Tooltip, TooltipContent, TooltipTrigger } from 'components/redpanda-ui/components/tooltip';
 import { InlineCode, Link } from 'components/redpanda-ui/components/typography';
 import { WaitingRedpanda } from 'components/redpanda-ui/components/waiting-redpanda';
@@ -414,6 +418,60 @@ interface TaskType extends ClusterConnectorTaskInfo {
   connectorName: string;
 }
 
+// Module-level so the sortable headers keep their identity across the tab's re-renders.
+const TASK_COLUMNS: DataTableColumnDef<TaskType>[] = [
+  {
+    id: 'name',
+    enableHiding: false,
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Connector" />,
+    accessorKey: 'connectorName',
+    cell: ({ row: { original } }) => (
+      // biome-ignore lint/a11y/useKeyWithClickEvents: pre-existing behavior, previously hidden inside the deprecated <Text> wrapper
+      // biome-ignore lint/a11y/noStaticElementInteractions: pre-existing behavior, previously hidden inside the deprecated <Text> wrapper
+      // biome-ignore lint/a11y/noNoninteractiveElementInteractions: pre-existing behavior, previously hidden inside the deprecated <Text> wrapper
+      <div
+        className="hoverLink whitespace-break-spaces break-words text-body"
+        onClick={() =>
+          appGlobal.historyPush(
+            `/connect-clusters/${encodeURIComponent(original.cluster.clusterName)}/${encodeURIComponent(original.connectorName)}`
+          )
+        }
+      >
+        {original.connectorName}
+      </div>
+    ),
+  },
+  {
+    id: 'taskId',
+    enableHiding: false,
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Task ID" />,
+    accessorKey: 'taskId',
+  },
+  {
+    id: 'state',
+    enableHiding: false,
+    header: ({ column }) => <DataTableColumnHeader column={column} title="State" />,
+    accessorKey: 'state',
+    cell: ({ row: { original } }) => <TaskState observable={original} />,
+  },
+  {
+    id: 'workerId',
+    enableHiding: false,
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Worker" />,
+    accessorKey: 'workerId',
+  },
+  {
+    id: 'cluster',
+    // Read off the joined cluster, so there is no accessor to sort on.
+    enableSorting: false,
+    enableHiding: false,
+    header: 'Cluster',
+    cell: ({ row: { original } }) => (
+      <InlineCode className="whitespace-nowrap">{original.cluster.clusterName}</InlineCode>
+    ),
+  },
+];
+
 class TabTasks extends Component {
   render() {
     const clusters = api.connectConnectors?.clusters;
@@ -431,58 +489,7 @@ class TabTasks extends Component {
 
     return (
       <DataTable<TaskType>
-        columns={[
-          {
-            id: 'name',
-            enableHiding: false,
-            header: ({ column }) => <DataTableColumnHeader column={column} title="Connector" />,
-            accessorKey: 'connectorName',
-            cell: ({ row: { original } }) => (
-              // biome-ignore lint/a11y/useKeyWithClickEvents: pre-existing behavior, previously hidden inside the deprecated <Text> wrapper
-              // biome-ignore lint/a11y/noStaticElementInteractions: pre-existing behavior, previously hidden inside the deprecated <Text> wrapper
-              // biome-ignore lint/a11y/noNoninteractiveElementInteractions: pre-existing behavior, previously hidden inside the deprecated <Text> wrapper
-              <div
-                className="hoverLink whitespace-break-spaces break-words text-body"
-                onClick={() =>
-                  appGlobal.historyPush(
-                    `/connect-clusters/${encodeURIComponent(original.cluster.clusterName)}/${encodeURIComponent(original.connectorName)}`
-                  )
-                }
-              >
-                {original.connectorName}
-              </div>
-            ),
-          },
-          {
-            id: 'taskId',
-            enableHiding: false,
-            header: ({ column }) => <DataTableColumnHeader column={column} title="Task ID" />,
-            accessorKey: 'taskId',
-          },
-          {
-            id: 'state',
-            enableHiding: false,
-            header: ({ column }) => <DataTableColumnHeader column={column} title="State" />,
-            accessorKey: 'state',
-            cell: ({ row: { original } }) => <TaskState observable={original} />,
-          },
-          {
-            id: 'workerId',
-            enableHiding: false,
-            header: ({ column }) => <DataTableColumnHeader column={column} title="Worker" />,
-            accessorKey: 'workerId',
-          },
-          {
-            id: 'cluster',
-            // Read off the joined cluster, so there is no accessor to sort on.
-            enableSorting: false,
-            enableHiding: false,
-            header: 'Cluster',
-            cell: ({ row: { original } }) => (
-              <InlineCode className="whitespace-nowrap">{original.cluster.clusterName}</InlineCode>
-            ),
-          },
-        ]}
+        columns={TASK_COLUMNS}
         data={allTasks}
         pagination={allTasks.length > DEFAULT_TABLE_PAGE_SIZE}
         sorting

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -1776,7 +1776,9 @@ $easeInOutCirc: cubic-bezier(0.785, 0.135, 0.15, 0.86);
 
       // Normal
       .ghostInput:not(:focus-within) {
-        border-color: transparent;
+        // `!important` to match: the Registry Input sets `!border-input`, so a plain declaration
+        // here loses and the "ghost" input renders permanently bordered.
+        border-color: transparent !important;
         background-color: transparent;
 
         transition: border-color 350ms ease-out, background-color 100ms ease-out;

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -1747,7 +1747,7 @@ $easeInOutCirc: cubic-bezier(0.785, 0.135, 0.15, 0.86);
       align-items: center;
       gap: 4px;
 
-      background: hsl(0deg, 0%, 97%);
+      background: var(--color-surface-recess);
 
       height: 32px;
       // padding: 0px 4px;
@@ -1764,7 +1764,7 @@ $easeInOutCirc: cubic-bezier(0.785, 0.135, 0.15, 0.86);
         width: 28px;
         margin-left: 2px;
         padding-top: 1px;
-        color: hsl(0deg, 0%, 70%);
+        color: var(--color-subtle);
 
         transform: scale(0.8);
       }
@@ -1801,7 +1801,7 @@ $easeInOutCirc: cubic-bezier(0.785, 0.135, 0.15, 0.86);
         // margin-right: 4px;
         padding-right: 2px;
 
-        color: hsl(0deg, 0%, 70%);
+        color: var(--color-subtle);
         cursor: pointer;
 
         opacity: 0; // only visible on hover
@@ -1812,8 +1812,8 @@ $easeInOutCirc: cubic-bezier(0.785, 0.135, 0.15, 0.86);
         }
 
         &:hover {
-          color: hsl(0, 0%, 45%);
-          background: hsl(0, 0%, 95%);
+          color: var(--color-foreground);
+          background: var(--color-surface-subtle);
         }
       }
 

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -1776,9 +1776,7 @@ $easeInOutCirc: cubic-bezier(0.785, 0.135, 0.15, 0.86);
 
       // Normal
       .ghostInput:not(:focus-within) {
-        // `!important` to match: the Registry Input sets `!border-input`, so a plain declaration
-        // here loses and the "ghost" input renders permanently bordered.
-        border-color: transparent !important;
+        // The border colour is a Tailwind class on the element; unlayered !important would lose to it.
         background-color: transparent;
 
         transition: border-color 350ms ease-out, background-color 100ms ease-out;


### PR DESCRIPTION
## Chakra exit · Phase 2 (route by route) · PR 11 of 14

Part of the [Chakra exit plan and live tracker](https://claude.ai/code/artifact/1861e21c-624b-4270-98ad-9921b22c2498). Branch `chakra-exit/11-connect-pages`, **stacked on #2637** (the dynamic-ui engine these pages render); re-targets `master` after that merges. Re-stacked onto the rebased #2637 on 2026-09-09.

Six Connect files (~3,200 LOC — the largest area in the codebase). The shared `misc/search-input` this branch used to carry has since landed on `master` via #2633/#2636, so it is no longer part of this diff — these pages just consume it.

### Suggested reading order
`connector-box-card` and `cluster-details` are the shallow ones, then `overview`, then `helper` (shared building blocks all three pages import), then `connector-details` and `create-connector`.

### The hunks that carry judgement
- **`helper.tsx` `ConfirmModal`** — Chakra's AlertDialog took `leastDestructiveRef={cancelRef}` to put initial focus on "No". Base UI has no such prop, so the ref goes and Cancel is placed first in the footer, which is what gets it the focus. It is also an `AlertDialogDescription` with `min-h-0 overflow-y-auto`: `AlertDialogContent` is `overflow-hidden max-h-[85vh]`, so a long API error had been clipped with the No/Retry footer pushed out of view.
- **`connector-details` `NoEditPermissionTooltip`** — Chakra's Tooltip took `isDisabled` to suppress itself when the permission was present; Base UI has none, so the wrapper renders its child bare instead. It also wraps the trigger in a span: a disabled button fires no pointer events, so the tooltip would never open.
- **The Logs tab's disabled reason** — Chakra's `Tabs` took `isDisabled` as a *reason string*. The app's Tabs wrapper takes a boolean, so the reason moves to a tooltip on the trigger. The disabled trigger sets `aria-disabled:pointer-events-none`, which cascades, so the span re-enables them or the tooltip is unreachable — which is the whole point of moving the reason there.
- **`create-connector`'s filter tabs render empty panels**; the card grid below reacts to the tab key. Called out in a comment so it does not read as a mistake. Its "Creating connector..." dialog has no `onOpenChange` by design, and `showCloseButton={false}` — `DialogContent` renders one by default and it would do nothing.
- **The connector-details overview grid keeps `gridTemplateAreas` inline** — Tailwind has no arbitrary utility for it.

### Caught in review
- **The connector status stripe painted nothing, for every status.** `statusColors` held Chakra theme tokens (`green.500`), which only resolve through a Chakra style prop — as raw CSS the declaration is invalid and the browser drops it. They are `bg-*-strong` utilities now.
- **Four tables lost click-to-sort.** Chakra painted the affordance on every header itself; restored with `DataTableColumnHeader`, with `enableSorting: false` on the derived columns and `enableHiding: false` throughout (no `DataTableViewOptions` on these pages, so a hidden column could not come back).
- **"Create connector" stopped being a button.** `tests/shared/connector.utils.ts` clicks it with `getByRole('button')`, which the original `<Link><Button>` produced — so the nesting is back. Note this is the *opposite* contract to the debug-bundle and license links, which their own helpers read as links: the test decides, per call site.
- `PopoverContent` is a fixed `w-72` where Chakra's `size="stretch"` sized to content, so long fully-qualified connector classes spilled outside the popup; the connector-error dialog lost its JSON highlighting; `NotConfigured` now matches the already-migrated `SchemaNotConfiguredPage` shape.

### Effect
Files importing `@redpanda-data/ui`: **42 → 36** on top of #2637 (so 50 → 36 for the two together), and `pages/connect` is fully clear. (Earlier revisions of this body quoted 73 → 67, against the pre-Phase-2 master.)

### Gates
Re-run on the re-stacked branch (2026-09-09): `type:check` clean · unit **62 files / 882 tests** · integration **132 files / 1316 tests**, all passing · `lint:check` on the 16 changed files reports **12 errors, every one pre-existing** — each maps rule-for-rule and file-for-file onto master's copy of the same file (`useExhaustiveDependencies` ×2, `useBlockStatements` ×3, `useSemanticElements` ×2, `noUselessConstructor`, `noVoid`, `noShadow`). The branch also *clears* master's two `noRestrictedImports` errors on these files. `connector.spec.ts` + `connect-cluster.spec.ts` exercise these end to end.

### Second review round (2026-09-08)
- Logs tab: the columns array was rebuilt on every 200 ms poll tick, which re-created every header and cell (the sort menu could never stay open) — memoised; rows are keyed by partition+offset; the Registry ignores column `size`, so the Value column takes the slack explicitly. "View details" carries the click instead of the whole banner.
- Both search boxes are the shared `misc/search-input`, now imported from `master` (it landed with #2633/#2636; this branch no longer carries a copy).
- `helper.tsx`: the connector-class popover opens on hover as before (`openOnHover`); the confirm dialog's description was a flex column that stacked its inline sentence; the trace dialog title checks `undefined`, not `null`; the trace box is a `SimpleCodeBlock`; `statusColors` covers STOPPED and uses the disabled fill token; the docs CTA is a Registry Button; `Statistic` → `Stat`, `Code` → `InlineCode`.
- Alerts use `AlertTitle` (five places). The Tasks tab sorts on `connectorName` — the accessor pointed at a field that does not exist. The plugin list and the three overview tabs paginate like the legacy DataTable (50 a page, pager only past that).

### Final review (2026-09-08)
- The connector-error dialog highlights its JSON again (`SyncCodeBlock`). Heading spacing uses padding — written while `mb-*` on bare headings was still inert; **#2636 has since landed that layer fix**, so the padding is now belt-and-braces rather than required.
- Connectors list and tasks table stay at ten a page (their legacy `defaultPageSize`), pager only past that. Tasks tab columns are module-level so sort menus survive re-renders; the logs Value column is not sortable.
- Not counted as coverage: `connector.spec.ts` is skipped upstream and its logs locator predates the Registry table. The error banner opens through "View details" only (was: anywhere on the banner).

### Table polish (2026-09-08)
- Hiding is off at table level (`TABLE_OPTIONS.enableHiding: false`) instead of per column, so a column added later cannot bring the header menu's "Hide" item back.

### Fourth review round (2026-09-08)
- The four new tooltips open at the app's 150 ms `delayDuration`, not Base UI's 600.
- The confirm dialog's pending button keeps its accessible name (`aria-label`) while it shows a spinner.
- Heading rungs match the Chakra sizes they replaced: the create heading and status card go back to `xl`, "Connector Properties" to `lg`.
- The validation warning keeps the `my-4` its sibling alerts have.
- The logs table shows its pager only when it has rows, as the legacy table did.
- The not-configured docs CTA is an anchor again (`buttonVariants` + `rounded-md` — radius lives on `Button`, so a bare `buttonVariants()` anchor renders square).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


