### PR TITLE
fe/e2e: run entrp variant on the RP trial license

### DIFF
--- a/frontend/tests/README.md
+++ b/frontend/tests/README.md
@@ -373,7 +373,7 @@ The E2E test setup uses Playwright's lifecycle hooks:
   - Starts the backend container
   - Returns a teardown that reuses the live Testcontainers handles
   - Stops and removes Docker containers
-  - Removes Docker networks, temporary licenses, and state files
+  - Removes Docker networks and state files
 
 - **`shared/global-teardown.mjs`**: Manual crash-recovery fallback
   - Cleans serialized resources left by a process that could not run normal teardown

--- a/frontend/tests/TESTCONTAINERS.md
+++ b/frontend/tests/TESTCONTAINERS.md
@@ -78,9 +78,9 @@ All containers run on a shared Docker network created by testcontainers:
 **`tests/config/console.enterprise.config.yaml`** - Enterprise backend configuration:
 - Same as OSS config, plus:
   - `authentication.basic.enabled: true` - Basic auth for enterprise features
-  - `licenseFilepath: /etc/console/redpanda.license` - License file path in container
+  - No `licenseFilepath`: Console asks the Redpanda cluster for its license and runs on the built-in 30-day trial every fresh cluster starts with
   - `authorization.roleBindings` - Role-based access control
-- License file sourced from: `console-enterprise/frontend/tests/config/redpanda.license`
+- Optional: set `REDPANDA_LICENSE_PATH` to a license file to run against a real license instead (passed to Console as `REDPANDA_LICENSE`)
 
 ### Setup Script
 **`tests/shared/global-setup.mjs`**:
@@ -105,7 +105,7 @@ All containers run on a shared Docker network created by testcontainers:
    - Mounts appropriate config file:
      - OSS: `console.config.yaml`
      - Enterprise: `console.enterprise.config.yaml`
-   - For Enterprise mode: Mounts `redpanda.license` from `console-enterprise/`
+   - For Enterprise mode: passes the `REDPANDA_LICENSE_PATH` license (if set) to the container; otherwise Console uses the cluster's built-in trial license
    - Waits for port 3000 to be ready
    - Waits for frontend to serve HTML
 4. **State Management**:
@@ -114,7 +114,7 @@ All containers run on a shared Docker network created by testcontainers:
 ### Teardown
 **`tests/shared/global-setup.mjs`** returns the normal teardown:
 - Stops every tracked container in parallel through live Testcontainers handles
-- Removes the Docker network and temporary license directories
+- Removes the Docker network
 - Cleans up the state file
 
 **`tests/shared/global-teardown.mjs`** is the manual crash-recovery fallback. It

--- a/frontend/tests/scripts/discover-variants.mjs
+++ b/frontend/tests/scripts/discover-variants.mjs
@@ -6,42 +6,11 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const testsDir = resolve(__dirname, '..');
 
-// Default license file path for enterprise variants
-const DEFAULT_LICENSE_PATH = resolve(
-  __dirname,
-  '../../../../console-enterprise/frontend/tests/config/redpanda.license'
-);
-
-/**
- * Check if a variant can run based on its requirements
- * @param {object} config - Variant configuration
- * @returns {{canRun: boolean, reason: string|null}}
- */
-function checkVariantRequirements(config) {
-  // Check if license is required and available
-  if (config.requiresLicense) {
-    const licensePath = process.env.REDPANDA_LICENSE_PATH || DEFAULT_LICENSE_PATH;
-    const hasLicenseEnv = Boolean(process.env.ENTERPRISE_LICENSE_CONTENT);
-    const hasLicenseFile = existsSync(licensePath);
-
-    if (!(hasLicenseEnv || hasLicenseFile)) {
-      return {
-        canRun: false,
-        reason: `License required but not found. Set ENTERPRISE_LICENSE_CONTENT env var or place license at ${licensePath}`,
-      };
-    }
-  }
-
-  return { canRun: true, reason: null };
-}
-
 /**
  * Discovers all test variants by scanning for test-variant-* directories
- * @param {{includeUnrunnable?: boolean}} options
- * @returns {Array<{name: string, path: string, config: object, canRun: boolean, skipReason: string|null}>}
+ * @returns {Array<{name: string, dirName: string, path: string, config: object}>}
  */
-export function discoverVariants(options = {}) {
-  const { includeUnrunnable = false } = options;
+export function discoverVariants() {
   const variants = [];
 
   const entries = readdirSync(testsDir, { withFileTypes: true });
@@ -54,18 +23,12 @@ export function discoverVariants(options = {}) {
       if (existsSync(configPath)) {
         try {
           const config = JSON.parse(readFileSync(configPath, 'utf-8'));
-          const { canRun, reason } = checkVariantRequirements(config);
-
-          if (canRun || includeUnrunnable) {
-            variants.push({
-              name: config.name,
-              dirName: entry.name,
-              path: variantPath,
-              config,
-              canRun,
-              skipReason: reason,
-            });
-          }
+          variants.push({
+            name: config.name,
+            dirName: entry.name,
+            path: variantPath,
+            config,
+          });
         } catch (error) {
           console.error(`Error reading variant config at ${configPath}:`, error.message);
         }
@@ -84,16 +47,7 @@ export function discoverVariants(options = {}) {
  * @returns {object|null}
  */
 export function getVariant(name) {
-  // First check all variants (including unrunnable) to give better error messages
-  const allVariants = discoverVariants({ includeUnrunnable: true });
-  const variant = allVariants.find((v) => v.name === name);
-
-  if (variant && !variant.canRun) {
-    console.error(`Variant "${name}" found but cannot run: ${variant.skipReason}`);
-    process.exit(1);
-  }
-
-  return variant || null;
+  return discoverVariants().find((v) => v.name === name) ?? null;
 }
 
 /**

--- a/frontend/tests/scripts/run-all-variants.mjs
+++ b/frontend/tests/scripts/run-all-variants.mjs
@@ -57,47 +57,31 @@ async function runVariant(variant, playwrightArgs = []) {
       const status = code === 0 ? 'PASSED' : 'FAILED';
       console.log(`[${variant.name}] ${status} (${elapsed}s)`);
       if (logStream) logStream.end();
-      resolve({ variant: variant.name, code, skipped: false });
+      resolve({ variant: variant.name, code });
     });
     child.on('error', (error) => {
       console.error(`[${variant.name}] Error: ${error.message}`);
       if (logStream) logStream.end();
-      resolve({ variant: variant.name, code: 1, skipped: false });
+      resolve({ variant: variant.name, code: 1 });
     });
   });
 }
 
 async function runAllVariants(playwrightArgs = []) {
-  // Get all variants including unrunnable ones for display
-  const allVariants = discoverVariants({ includeUnrunnable: true });
+  const variants = discoverVariants();
 
-  if (allVariants.length === 0) {
+  if (variants.length === 0) {
     console.error('No variants found. Make sure test-variant-* directories exist with config/variant.json');
     process.exit(1);
   }
 
-  const runnableVariants = allVariants.filter((v) => v.canRun);
-  const skippedVariants = allVariants.filter((v) => !v.canRun);
-
-  console.log(`Found ${allVariants.length} variant(s): ${allVariants.map((v) => v.name).join(', ')}`);
-
-  if (skippedVariants.length > 0) {
-    console.log(`\nSkipping ${skippedVariants.length} variant(s) due to missing requirements:`);
-    for (const variant of skippedVariants) {
-      console.log(`  - ${variant.name}: ${variant.skipReason}`);
-    }
-  }
-
-  if (runnableVariants.length === 0) {
-    console.error('\nNo runnable variants found');
-    process.exit(1);
-  }
+  console.log(`Found ${variants.length} variant(s): ${variants.map((v) => v.name).join(', ')}`);
 
   // Pre-build backend Docker images once before launching variants in parallel.
   // This avoids race conditions where multiple variants try to copy frontend assets
   // and build the same Docker image concurrently.
   console.log('\nPre-building backend Docker image(s)...');
-  const needsEnterprise = runnableVariants.some((v) => v.config.isEnterprise);
+  const needsEnterprise = variants.some((v) => v.config.isEnterprise);
   const ossImageTag = await buildBackendImage(false);
   process.env.E2E_PREBUILT_IMAGE_TAG = ossImageTag;
 
@@ -106,15 +90,10 @@ async function runAllVariants(playwrightArgs = []) {
     process.env.E2E_PREBUILT_IMAGE_TAG_ENTERPRISE = enterpriseImageTag;
   }
 
-  console.log(`\nRunning ${runnableVariants.length} variant(s) in parallel...`);
+  console.log(`\nRunning ${variants.length} variant(s) in parallel...`);
 
   // Run all variants in parallel — each uses different ports and Docker networks
-  const results = await Promise.all(runnableVariants.map((variant) => runVariant(variant, playwrightArgs)));
-
-  // Add skipped variants to results
-  for (const variant of skippedVariants) {
-    results.push({ variant: variant.name, code: 0, skipped: true, skipReason: variant.skipReason });
-  }
+  const results = await Promise.all(variants.map((variant) => runVariant(variant, playwrightArgs)));
 
   // Summary
   console.log(`\n${'='.repeat(60)}`);
@@ -123,15 +102,11 @@ async function runAllVariants(playwrightArgs = []) {
 
   let hasFailures = false;
   for (const result of results) {
-    if (result.skipped) {
-      console.log(`  \u23ED ${result.variant}: SKIPPED`);
-    } else {
-      const status = result.code === 0 ? 'PASSED' : 'FAILED';
-      const icon = result.code === 0 ? '\u2714' : '\u2718';
-      console.log(`  ${icon} ${result.variant}: ${status}`);
-      if (result.code !== 0) {
-        hasFailures = true;
-      }
+    const status = result.code === 0 ? 'PASSED' : 'FAILED';
+    const icon = result.code === 0 ? '\u2714' : '\u2718';
+    console.log(`  ${icon} ${result.variant}: ${status}`);
+    if (result.code !== 0) {
+      hasFailures = true;
     }
   }
 
@@ -140,7 +115,7 @@ async function runAllVariants(playwrightArgs = []) {
   // On failure in CI, dump the log files for failed variants
   if (hasFailures && process.env.CI) {
     for (const result of results) {
-      if (!result.skipped && result.code !== 0) {
+      if (result.code !== 0) {
         const logPath = join(reportsDir, `${result.variant}.log`);
         console.log(`\n${'='.repeat(60)}`);
         console.log(`Logs for failed variant: ${result.variant}`);
@@ -167,7 +142,7 @@ async function runAllVariants(playwrightArgs = []) {
     process.exit(1);
   }
 
-  console.log('All runnable variants passed');
+  console.log('All variants passed');
 }
 
 // CLI

--- a/frontend/tests/shared/console.dest.config.yaml
+++ b/frontend/tests/shared/console.dest.config.yaml
@@ -29,8 +29,6 @@ server:
   listenPort: 3000
   allowedOrigins: ["http://localhost:3001"]
 
-licenseFilepath: /etc/console/redpanda.license
-
 authorization:
   roleBindings:
     - roleName: admin

--- a/frontend/tests/shared/global-setup.mjs
+++ b/frontend/tests/shared/global-setup.mjs
@@ -589,6 +589,34 @@ export async function buildBackendImage(isEnterprise) {
   return imageTag;
 }
 
+/**
+ * Resolves the environment for the Console Enterprise backend container.
+ *
+ * By default the enterprise backend runs without a Console license. Its config
+ * has no `licenseFilepath`, so Console asks the Redpanda cluster for its license
+ * and picks up the built-in 30-day trial that every fresh cluster starts with
+ * (Redpanda >= 24.3). The e2e clusters are created from scratch on every run,
+ * so that trial is always valid and CI needs no license secret.
+ *
+ * Set REDPANDA_LICENSE_PATH to a license file to run against a real license
+ * instead, e.g. for license-specific tests. Its contents are passed to Console
+ * through the REDPANDA_LICENSE environment variable the backend reads at startup.
+ *
+ * @returns {Record<string, string>} Environment variables for the backend container
+ */
+function resolveEnterpriseLicenseEnv() {
+  const licensePath = process.env.REDPANDA_LICENSE_PATH;
+  if (!licensePath) {
+    console.log("No REDPANDA_LICENSE_PATH set, Console will use the Redpanda cluster's built-in trial license");
+    return {};
+  }
+  if (!existsSync(licensePath)) {
+    throw new Error(`REDPANDA_LICENSE_PATH is set but no file exists at: ${licensePath}`);
+  }
+  console.log(`Using Console Enterprise license from REDPANDA_LICENSE_PATH: ${licensePath}`);
+  return { REDPANDA_LICENSE: readFileSync(licensePath, 'utf-8').trim() };
+}
+
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: (21) nested test environment setup with multiple configuration checks
 async function startBackendServer(network, isEnterprise, imageTag, state, variantName, configFile, ports) {
   console.log('Starting backend server container...');
@@ -607,44 +635,7 @@ async function startBackendServer(network, isEnterprise, imageTag, state, varian
     },
   ];
 
-  // Mount license file for enterprise mode
-  if (isEnterprise) {
-    let licensePath;
-    const fs = await import('node:fs');
-
-    // Check if license is provided as GitHub secret (environment variable)
-    if (process.env.ENTERPRISE_LICENSE_CONTENT) {
-      console.log('Using ENTERPRISE_LICENSE_CONTENT from environment variable (GitHub secret)');
-      // Write the license content to a temporary file
-      const { mkdtempSync, writeFileSync } = await import('node:fs');
-      const { tmpdir } = await import('node:os');
-      const tempDir = mkdtempSync(`${tmpdir()}/redpanda-license-`);
-      licensePath = `${tempDir}/redpanda.license`;
-      writeFileSync(licensePath, process.env.ENTERPRISE_LICENSE_CONTENT);
-      state.tempPaths.push(tempDir);
-      console.log(`✓ License written to temporary file: ${licensePath}`);
-    } else {
-      // Default to relative path based on backend directory
-      const backendDir = process.env.ENTERPRISE_BACKEND_DIR
-        ? resolve(process.env.ENTERPRISE_BACKEND_DIR)
-        : resolve(__dirname, '../../../../console-enterprise/backend');
-
-      const defaultLicensePath = resolve(backendDir, '../frontend/tests/config/redpanda.license');
-      licensePath = process.env.REDPANDA_LICENSE_PATH || defaultLicensePath;
-      console.log(`Enterprise license path: ${licensePath}`);
-
-      if (!fs.existsSync(licensePath)) {
-        throw new Error(`License file not found at: ${licensePath}`);
-      }
-      console.log('✓ License file found');
-    }
-
-    bindMounts.push({
-      source: licensePath,
-      target: '/etc/console/redpanda.license',
-      mode: 'ro',
-    });
-  }
+  const environment = isEnterprise ? resolveEnterpriseLicenseEnv() : {};
 
   console.log('Creating container with bind mounts:');
   bindMounts.forEach((mount, i) => {
@@ -668,6 +659,7 @@ async function startBackendServer(network, isEnterprise, imageTag, state, varian
       .withNetworkMode(network.getName())
       .withExposedPorts({ container: 3000, host: ports.backend })
       .withBindMounts(bindMounts)
+      .withEnvironment(environment)
       .withCommand(['--config.filepath=/etc/console/config.yaml'])
       // Testcontainers 12 prefers an image healthcheck when present. Preserve
       // the backend's established port-readiness contract across the upgrade.
@@ -923,35 +915,7 @@ async function startBackendServerWithConfig({
     },
   ];
 
-  if (isEnterprise) {
-    let licensePath;
-    const fs = await import('node:fs');
-
-    if (process.env.ENTERPRISE_LICENSE_CONTENT) {
-      const { mkdtempSync, writeFileSync } = await import('node:fs');
-      const { tmpdir } = await import('node:os');
-      const tempDir = mkdtempSync(`${tmpdir()}/redpanda-license-`);
-      licensePath = `${tempDir}/redpanda.license`;
-      writeFileSync(licensePath, process.env.ENTERPRISE_LICENSE_CONTENT);
-      state.tempPaths.push(tempDir);
-    } else {
-      const defaultLicensePath = resolve(
-        __dirname,
-        '../../../../console-enterprise/frontend/tests/config/redpanda.license'
-      );
-      licensePath = process.env.REDPANDA_LICENSE_PATH || defaultLicensePath;
-
-      if (!fs.existsSync(licensePath)) {
-        throw new Error(`License file not found at: ${licensePath}`);
-      }
-    }
-
-    bindMounts.push({
-      source: licensePath,
-      target: '/etc/console/redpanda.license',
-      mode: 'ro',
-    });
-  }
+  const environment = isEnterprise ? resolveEnterpriseLicenseEnv() : {};
 
   let containerId;
   try {
@@ -960,6 +924,7 @@ async function startBackendServerWithConfig({
       .withNetworkAliases(networkAlias)
       .withExposedPorts({ container: 3000, host: externalPort })
       .withBindMounts(bindMounts)
+      .withEnvironment(environment)
       .withCommand(['--config.filepath=/etc/console/config.yaml'])
       .withWaitStrategy(Wait.forListeningPorts())
       .start();

--- a/frontend/tests/test-variant-console-enterprise/config/console.config.yaml
+++ b/frontend/tests/test-variant-console-enterprise/config/console.config.yaml
@@ -35,8 +35,6 @@ server:
   listenPort: 3000
   allowedOrigins: ["http://localhost:3000", "http://localhost:3001"]
 
-licenseFilepath: /etc/console/redpanda.license
-
 authorization:
   roleBindings:
     - roleName: admin

--- a/frontend/tests/test-variant-console-enterprise/config/variant.json
+++ b/frontend/tests/test-variant-console-enterprise/config/variant.json
@@ -4,7 +4,6 @@
   "isEnterprise": true,
   "needsShadowlink": true,
   "needsAuth": true,
-  "requiresLicense": true,
   "ports": {
     "backend": 3100,
     "backendDest": 3101,


### PR DESCRIPTION
The enterprise variant mounted a Console license
file into the backend container, sourced in CI
from a GitHub secret. Once that license expired,
the backend exited at startup (expired license
with enterprise features enabled) before the
harness could capture its logs, and every run
failed with "container ... is not running".

The e2e brokers never had a license installed.
They run on the built-in 30-day trial that every
fresh Redpanda cluster starts with (24.3+), and
Console Enterprise falls back to the cluster's
license when its own config has none. Drop
`licenseFilepath` from both enterprise configs so
Console picks up that trial, and remove the
license mount and the "skip variant when no
license" plumbing that existed only for it.

REDPANDA_LICENSE_PATH stays as an explicit
override for license-specific work, e.g. against
a long-lived local cluster whose trial expired.
Its contents reach the container as
REDPANDA_LICENSE, which the backend reads at
startup.