### PR TITLE
UX-1469: fix breadcrumb navigation while topic messages are loading

### DIFF
--- a/frontend/src/components/layout/header.test.tsx
+++ b/frontend/src/components/layout/header.test.tsx
@@ -13,12 +13,13 @@ import { describe, expect, it, rs } from '@rstest/core';
 import { render, screen } from '@testing-library/react';
 import type { PropsWithChildren, ReactNode } from 'react';
 
-const { getMatchedRoutes } = rs.hoisted(() => ({
+const { getMatchedRoutes, mockPageBreadcrumbs } = rs.hoisted(() => ({
   getMatchedRoutes: rs.fn(() => [[{ options: { staticData: { breadcrumbOnlyHeader: true } } }], {}, undefined]),
+  mockPageBreadcrumbs: [] as { title: string; linkTo: string }[],
 }));
 
 rs.mock('@tanstack/react-router', () => ({
-  Link: ({ children }: PropsWithChildren) => <a href="/">{children}</a>,
+  Link: ({ children, to }: PropsWithChildren<{ to: string }>) => <a href={to}>{children}</a>,
   useLocation: () => ({ pathname: '/sql' }),
   useMatchRoute: () => () => false,
   useRouter: () => ({ getMatchedRoutes }),
@@ -53,7 +54,7 @@ rs.mock('../../state/ui-state', () => ({
     selector: (state: {
       _pageTitle: string;
       backLink: null;
-      pageBreadcrumbs: never[];
+      pageBreadcrumbs: { title: string; linkTo: string }[];
       selectedClusterName: null;
       shouldHidePageHeader: boolean;
     }) => T
@@ -61,7 +62,7 @@ rs.mock('../../state/ui-state', () => ({
     selector({
       _pageTitle: 'Cluster details',
       backLink: null,
-      pageBreadcrumbs: [],
+      pageBreadcrumbs: mockPageBreadcrumbs,
       selectedClusterName: null,
       shouldHidePageHeader: false,
     }),
@@ -75,6 +76,7 @@ rs.mock('../redpanda-ui/components/breadcrumb', () => ({
   BreadcrumbItem: ({ children }: PropsWithChildren) => children,
   BreadcrumbLink: ({ render: content }: { render: ReactNode }) => content,
   BreadcrumbList: ({ children }: PropsWithChildren) => children,
+  BreadcrumbPage: ({ children }: PropsWithChildren) => <span data-testid="breadcrumb-page">{children}</span>,
   BreadcrumbSeparator: () => null,
 }));
 
@@ -89,5 +91,20 @@ describe('AppPageHeader', () => {
     render(<AppPageHeader />);
 
     expect(screen.queryByRole('heading', { name: 'Cluster details' })).not.toBeInTheDocument();
+  });
+
+  // Regression: the current page's crumb used to be a real link back to its own
+  // bare path, which drops query params (filters, pagination, active tab) when
+  // clicked. It must render as non-navigable text instead.
+  it('renders every breadcrumb but the last as a link, and the last as plain text', () => {
+    mockPageBreadcrumbs.push({ title: 'Topics', linkTo: '/topics' }, { title: 'my-topic', linkTo: '/topics/my-topic' });
+
+    render(<AppPageHeader />);
+
+    expect(screen.getByRole('link', { name: 'Topics' })).toHaveAttribute('href', '/topics');
+    expect(screen.queryByRole('link', { name: 'my-topic' })).not.toBeInTheDocument();
+    expect(screen.getByTestId('breadcrumb-page')).toHaveTextContent('my-topic');
+
+    mockPageBreadcrumbs.length = 0;
   });
 });

--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -25,6 +25,7 @@ import {
   BreadcrumbItem,
   BreadcrumbLink,
   BreadcrumbList,
+  BreadcrumbPage,
   BreadcrumbSeparator,
 } from '../redpanda-ui/components/breadcrumb';
 import { Button as RegistryButton } from '../redpanda-ui/components/button';
@@ -55,7 +56,14 @@ function BreadcrumbHeaderRow({ useNewSidebar, breadcrumbItems }: BreadcrumbHeade
                 <Fragment key={`${index}-${item.linkTo}`}>
                   {index > 0 && <BreadcrumbSeparator />}
                   <BreadcrumbItem>
-                    <BreadcrumbLink render={<Link to={item.linkTo}>{item.title}</Link>} />
+                    {index === breadcrumbItems.length - 1 ? (
+                      // The current page's crumb isn't a link: it points at the exact URL
+                      // we're already on, and re-navigating to that bare path (no search/hash)
+                      // would drop the page's query params (filters, pagination, active tab).
+                      <BreadcrumbPage>{item.title}</BreadcrumbPage>
+                    ) : (
+                      <BreadcrumbLink render={<Link to={item.linkTo}>{item.title}</Link>} />
+                    )}
                   </BreadcrumbItem>
                 </Fragment>
               ))}

--- a/frontend/src/components/pages/topics/Tab.Messages/index.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/index.tsx
@@ -194,6 +194,22 @@ function onCopyValue(original: TopicMessage) {
     .catch(navigatorClipboardErrorHandler);
 }
 
+// A rejection during a search that's being torn down by navigation isn't guaranteed to be a
+// proper Error, so never assume `.message` exists on it.
+function getSearchErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  if (typeof error === 'string' && error) {
+    return error;
+  }
+  return 'Unknown error';
+}
+
+function toDisplayError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(getSearchErrorMessage(error));
+}
+
 function onCopyKey(original: TopicMessage) {
   navigator.clipboard
     .writeText(getPayloadAsString((original.key.payload ?? original.key.rawBytes) as string | Uint8Array | object))
@@ -714,14 +730,19 @@ export const TopicMessageView: FC<TopicMessageViewProps> = (props) => {
         setSearchState((prev) => ({ ...prev, messageSearch: search }));
         const startTime = Date.now();
 
-        const result = await search.startSearch(request, abortSignal).catch((err: Error) => {
-          const msg = err.message ?? String(err);
+        const result = await search.startSearch(request, abortSignal).catch((err: unknown) => {
           // biome-ignore lint/suspicious/noConsole: intentional console usage
-          console.error(`error in searchTopicMessages: ${msg}`);
-          setFetchError(err);
-          setSearchPhase(null);
+          console.error(`error in searchTopicMessages: ${getSearchErrorMessage(err)}`);
+          if (isMountedRef.current) {
+            setFetchError(toDisplayError(err));
+            setSearchPhase(null);
+          }
           return [];
         });
+
+        if (!isMountedRef.current) {
+          return result;
+        }
 
         const endTime = Date.now();
         setSearchState((prev) => ({ ...prev, messages: result, windowStartPage: 0 }));
@@ -737,9 +758,11 @@ export const TopicMessageView: FC<TopicMessageViewProps> = (props) => {
         return result;
       } catch (error: unknown) {
         // biome-ignore lint/suspicious/noConsole: intentional console usage
-        console.error(`error in searchTopicMessages: ${(error as Error).message ?? String(error)}`);
-        setFetchError(error as Error);
-        setSearchPhase(null);
+        console.error(`error in searchTopicMessages: ${getSearchErrorMessage(error)}`);
+        if (isMountedRef.current) {
+          setFetchError(toDisplayError(error));
+          setSearchPhase(null);
+        }
         return [];
       }
     },
@@ -904,7 +927,7 @@ export const TopicMessageView: FC<TopicMessageViewProps> = (props) => {
           (err: unknown) => {
             const shouldReport = isMountedRef.current && !abortController.signal.aborted;
             if (shouldReport) {
-              toast.error('Failed to load more messages', { description: (err as Error).message });
+              toast.error('Failed to load more messages', { description: getSearchErrorMessage(err) });
             }
             return { type: 'error' as const, shouldReport };
           }
@@ -1708,7 +1731,7 @@ export const TopicMessageView: FC<TopicMessageViewProps> = (props) => {
           <AlertDescription>
             <div>Check and modify the request before resubmitting.</div>
             <div className="mt-4">
-              <div className="codeBox">{(fetchError as Error).message ?? String(fetchError)}</div>
+              <div className="codeBox">{fetchError.message}</div>
             </div>
             <Button className="mt-4" onClick={() => executeMessageSearch()}>
               Retry Search

--- a/frontend/src/components/routes/route-error.test.tsx
+++ b/frontend/src/components/routes/route-error.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { render, screen } from '@testing-library/react';
+
+const mockRouter = { invalidate: rs.fn() };
+
+rs.mock('@tanstack/react-router', () => ({
+  useRouter: () => mockRouter,
+}));
+
+import { RouteError } from './route-error';
+
+describe('RouteError', () => {
+  test('shows a real Error message', () => {
+    render(<RouteError error={new Error('boom')} />);
+
+    expect(screen.getByText('boom')).toBeVisible();
+  });
+
+  // Regression test: clicking away (e.g. a breadcrumb) while a request is in flight
+  // can unmount the page and leave a non-Error rejection reason behind. The boundary
+  // must never render the literal text "undefined".
+  test('falls back to a generic message for a non-Error value', () => {
+    render(<RouteError error={undefined} />);
+
+    expect(screen.getByText('An unexpected error occurred.')).toBeVisible();
+    expect(screen.queryByText('undefined')).not.toBeInTheDocument();
+  });
+
+  test('falls back to a generic message for an Error with no message', () => {
+    render(<RouteError error={new Error()} />);
+
+    expect(screen.getByText('An unexpected error occurred.')).toBeVisible();
+  });
+});

--- a/frontend/src/components/routes/route-error.tsx
+++ b/frontend/src/components/routes/route-error.tsx
@@ -15,7 +15,19 @@ import { Button } from 'components/redpanda-ui/components/button';
 import errorBananaSlip from '../../assets/redpanda/ErrorBananaSlip.svg';
 
 type RouteErrorProps = {
-  error: Error;
+  error: unknown;
+};
+
+// Router error boundaries can receive a rejection/throw that isn't a proper Error
+// (e.g. an aborted request during navigation), so never assume `error.message` exists.
+const getRouteErrorMessage = (error: unknown): string => {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  if (typeof error === 'string' && error) {
+    return error;
+  }
+  return 'An unexpected error occurred.';
 };
 
 /**
@@ -29,7 +41,7 @@ export const RouteError = ({ error }: RouteErrorProps) => {
     <div className="flex h-[60vh] flex-col items-center justify-center gap-4">
       <img alt="Error" className="h-[140px]" src={errorBananaSlip} />
       <h2 className="font-semibold text-heading-xl">Something went wrong</h2>
-      <p className="max-w-md text-center text-body text-muted-foreground">{error.message}</p>
+      <p className="max-w-md text-center text-body text-muted-foreground">{getRouteErrorMessage(error)}</p>
       <Button onClick={() => router.invalidate()} variant="outline">
         Try again
       </Button>

--- a/frontend/src/routes/topics/$topicName/index.test.tsx
+++ b/frontend/src/routes/topics/$topicName/index.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file https://github.com/redpanda-data/redpanda/blob/dev/licenses/bsl.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+import { describe, expect, test } from '@rstest/core';
+
+import { Route } from './index';
+
+// Regression test: navigating away from the Messages tab (e.g. clicking the "Topics"
+// breadcrumb) while a nuqs query-param update is still queued can flush that update
+// after the route changed, re-navigating here with topicName literally "undefined".
+// This must bounce back to the topic list instead of rendering a 404.
+describe('topic details route', () => {
+  test('redirects /topics/undefined back to the topic list', () => {
+    expect.assertions(3);
+
+    try {
+      Route.options.beforeLoad?.({ params: { topicName: 'undefined' } } as never);
+    } catch (error) {
+      const redirect = error as Response & {
+        options: { replace: boolean; to: string };
+      };
+
+      expect(redirect.status).toBe(307);
+      expect(redirect.options.to).toBe('/topics');
+      expect(redirect.options.replace).toBe(true);
+    }
+  });
+
+  test('does not redirect a real topic name', () => {
+    expect(() => Route.options.beforeLoad?.({ params: { topicName: 'my-real-topic' } } as never)).not.toThrow();
+  });
+});

--- a/frontend/src/routes/topics/$topicName/index.tsx
+++ b/frontend/src/routes/topics/$topicName/index.tsx
@@ -9,7 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
-import { createFileRoute, useParams } from '@tanstack/react-router';
+import { createFileRoute, redirect, useParams } from '@tanstack/react-router';
 import { DEFAULT_TABLE_PAGE_SIZE } from 'components/constants';
 import { z } from 'zod';
 
@@ -25,6 +25,17 @@ const searchSchema = z.object({
 export const Route = createFileRoute('/topics/$topicName/')({
   staticData: {
     title: 'Topic Details',
+  },
+  // Guards a nuqs/router race: navigating away from this route (e.g. clicking the
+  // "Topics" breadcrumb) while a query-param update is still queued can cause that
+  // update to flush after the route already changed, re-navigating here with a
+  // stale relative `from` and no resolvable topicName — TanStack Router then
+  // interpolates the literal string "undefined" into the path. Bounce back to the
+  // topic list instead of rendering a confusing "topic undefined does not exist" 404.
+  beforeLoad: ({ params }) => {
+    if (params.topicName === 'undefined') {
+      throw redirect({ to: '/topics', replace: true });
+    }
   },
   validateSearch: searchSchema,
   component: TopicDetailsWrapper,


### PR DESCRIPTION
## Summary
- The current topic's own breadcrumb was a real link to its bare path (no search/hash), so clicking it dropped query params (filters, pagination, active tab). It now renders as non-navigable text, like a standard breadcrumb "current page" crumb.
- Clicking the parent "Topics" breadcrumb while a message search is still in flight could race a queued `nuqs` URL update: the update flushes ~50-90ms later using a now-stale relative route match, and TanStack Router silently interpolates the literal string `"undefined"` into the path, landing on `/topics/undefined` (404). The topic details route now guards against `topicName === 'undefined'` and redirects back to `/topics`.
- Hardened error-message handling in the topic message search (`Tab.Messages/index.tsx`) and the default route error boundary (`route-error.tsx`) so a non-`Error` rejection never renders the literal text `undefined` to the user.

## Test plan
- [x] `bun run type:check`
- [x] `bun run lint`
- [x] `bun run test:integration -- components/layout/header`
- [x] `bun run test:integration -- route-error`
- [x] `bun run test:integration -- topics/\$topicName`
- [x] `bun run test:integration -- Tab.Messages`