### PR TITLE
UX-1488: hide the overview trial banner when the cluster holds an active Enterprise licence

### DIFF
--- a/frontend/src/components/license/license-utils.test.tsx
+++ b/frontend/src/components/license/license-utils.test.tsx
@@ -7,6 +7,7 @@ import {
   ListEnterpriseFeaturesResponse_FeatureSchema,
 } from '../../protogen/redpanda/api/console/v1alpha1/license_pb';
 import {
+  coreHasActiveEnterpriseLicense,
   coreHasEnterpriseFeatures,
   getPrettyTimeToExpiration,
   licenseIsExpired,
@@ -22,9 +23,11 @@ import { rs } from '@rstest/core';
 import { api } from '../../state/backend-api';
 import { renderWithRouter } from '../../test-utils';
 import { LicenseNotification } from './license-notification';
+import { OverviewLicenseNotification } from './overview-license-notification';
 
 const DATE_FORMAT_REGEX = /\d{2}\/\d{2}\/\d{4}/;
 const LICENSE_EXPIRE_MESSAGE_REGEX = /Your Redpanda Enterprise license will expire in 27 days/;
+const TRIAL_NOTICE_REGEX = /This cluster is on an Enterprise trial/;
 const { mockLocation } = rs.hoisted(() => ({ mockLocation: { pathname: '/overview' } }));
 
 /**
@@ -52,6 +55,9 @@ rs.mock('../../state/backend-api', () => {
       return true;
     },
     listLicenses: () => Promise.resolve(),
+    refreshClusterOverview: () => Promise.resolve(),
+    isRedpanda: true,
+    clusterOverview: {},
     enterpriseFeaturesUsed: [
       { name: 'rbac', enabled: true },
       { name: 'datalake_iceberg', enabled: false },
@@ -193,6 +199,41 @@ describe('licenseUtils', () => {
 
     test('should return false for a community license', () => {
       expect(licenseSoonToExpire(mockLicenseCommunity)).toBe(false);
+    });
+  });
+
+  describe('coreHasActiveEnterpriseLicense', () => {
+    const coreEnterprise = (daysOffset: number) =>
+      create(LicenseSchema, {
+        source: License_Source.REDPANDA_CORE,
+        type: License_Type.ENTERPRISE,
+        expiresAt: BigInt(getUnixTimestampWithExpiration(daysOffset)),
+      });
+
+    test('should return true for an unexpired enterprise license on the cluster', () => {
+      expect(coreHasActiveEnterpriseLicense([mockLicenseCommunity, coreEnterprise(90)])).toBe(true);
+    });
+
+    test('should return false when the cluster enterprise license has expired', () => {
+      expect(coreHasActiveEnterpriseLicense([coreEnterprise(-1)])).toBe(false);
+    });
+
+    test('should return false when only Console holds an enterprise license', () => {
+      const consoleEnterprise = create(LicenseSchema, {
+        source: License_Source.REDPANDA_CONSOLE,
+        type: License_Type.ENTERPRISE,
+        expiresAt: BigInt(getUnixTimestampWithExpiration(90)),
+      });
+      expect(coreHasActiveEnterpriseLicense([consoleEnterprise])).toBe(false);
+    });
+
+    test('should return false for a trial on the cluster', () => {
+      const coreTrial = create(LicenseSchema, {
+        source: License_Source.REDPANDA_CORE,
+        type: License_Type.TRIAL,
+        expiresAt: BigInt(getUnixTimestampWithExpiration(30)),
+      });
+      expect(coreHasActiveEnterpriseLicense([coreTrial])).toBe(false);
     });
   });
 
@@ -394,6 +435,48 @@ describe('licenseUtils', () => {
         'href',
         '/upload-license'
       );
+    });
+  });
+
+  describe('OverviewLicenseNotification Banner', () => {
+    const bakedInTrial = (source: License_Source, daysOffset = 30) =>
+      create(LicenseSchema, {
+        source,
+        type: License_Type.TRIAL,
+        organization: 'Redpanda Built-In Evaluation Period',
+        expiresAt: BigInt(getUnixTimestampWithExpiration(daysOffset)),
+      });
+
+    const enterprise = (source: License_Source, daysOffset: number) =>
+      create(LicenseSchema, {
+        source,
+        type: License_Type.ENTERPRISE,
+        expiresAt: BigInt(getUnixTimestampWithExpiration(daysOffset)),
+      });
+
+    test('shows the trial notice while the cluster is on its built-in trial', () => {
+      api.licenses = [bakedInTrial(License_Source.REDPANDA_CONSOLE), bakedInTrial(License_Source.REDPANDA_CORE)];
+      const screen = renderWithRouter(<OverviewLicenseNotification />, { route: '/overview' });
+      expect(screen.getByRole('alert')).toHaveTextContent(TRIAL_NOTICE_REGEX);
+    });
+
+    test('hides the trial notice once the cluster holds an active enterprise license', () => {
+      // Console keeps the trial it copied from the cluster at boot; the cluster has since been licensed.
+      api.licenses = [bakedInTrial(License_Source.REDPANDA_CONSOLE), enterprise(License_Source.REDPANDA_CORE, 90)];
+      const screen = renderWithRouter(<OverviewLicenseNotification />, { route: '/overview' });
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    test('keeps the trial notice when the cluster enterprise license has expired', () => {
+      api.licenses = [bakedInTrial(License_Source.REDPANDA_CONSOLE), enterprise(License_Source.REDPANDA_CORE, -1)];
+      const screen = renderWithRouter(<OverviewLicenseNotification />, { route: '/overview' });
+      expect(screen.getByRole('alert')).toHaveTextContent(TRIAL_NOTICE_REGEX);
+    });
+
+    test('keeps the trial notice when only Console holds an enterprise license', () => {
+      api.licenses = [enterprise(License_Source.REDPANDA_CONSOLE, 90), bakedInTrial(License_Source.REDPANDA_CORE)];
+      const screen = renderWithRouter(<OverviewLicenseNotification />, { route: '/overview' });
+      expect(screen.getByRole('alert')).toHaveTextContent(TRIAL_NOTICE_REGEX);
     });
   });
 });

--- a/frontend/src/components/license/license-utils.tsx
+++ b/frontend/src/components/license/license-utils.tsx
@@ -199,6 +199,15 @@ export const licenseCanExpire = (license: License): boolean => license.type !== 
 export const isLicenseWithEnterpriseAccess = (license: License): boolean =>
   license.type === License_Type.TRIAL || license.type === License_Type.ENTERPRISE;
 
+/** True when the Redpanda cluster itself holds an unexpired Enterprise licence. */
+export const coreHasActiveEnterpriseLicense = (licenses: License[]): boolean =>
+  licenses.some(
+    (license) =>
+      license.source === License_Source.REDPANDA_CORE &&
+      license.type === License_Type.ENTERPRISE &&
+      !licenseIsExpired(license)
+  );
+
 /**
  * Gets the license with the latest expiration time from a list of licenses.
  *

--- a/frontend/src/components/license/overview-license-notification.tsx
+++ b/frontend/src/components/license/overview-license-notification.tsx
@@ -5,6 +5,7 @@ import { type FC, type ReactElement, useEffect, useState } from 'react';
 
 import {
   consoleHasEnterpriseFeature,
+  coreHasActiveEnterpriseLicense,
   DISABLE_SSO_DOCS_LINK,
   ENTERPRISE_FEATURES_DOCS_LINK,
   getEnterpriseCTALink,
@@ -280,6 +281,11 @@ export const OverviewLicenseNotification: FC = () => {
   }
 
   if (trialLicenses.length === 0) {
+    return null;
+  }
+
+  // The cluster's own Enterprise licence supersedes any trial notice.
+  if (coreHasActiveEnterpriseLicense(licenses)) {
     return null;
   }
 


### PR DESCRIPTION
Fixes [UX-1488](https://redpandadata.atlassian.net/browse/UX-1488).

## What the reporter saw

The overview page listed two licences, **Console Trial** (expiring in 30 days) and **Redpanda Enterprise** (expiring in 90 days), while the banner above the stats said *"This cluster is on an Enterprise trial. Register for an additional 30 days of enterprise features."*

## Why

Two things combine:

- **Console's own licence is a boot-time snapshot.** console-enterprise runs `CheckLicense` once in `main.go`; when no licence is configured it copies the *cluster's* licence (organisation, type, expiry) as Console's own, and that value is what `ListLicenses` reports under source `REDPANDA_CONSOLE`. A cluster that was on its built-in 30-day trial when Console started keeps reporting "Console Trial" after an Enterprise licence is uploaded, until Console restarts.
- **The banner only looked at trial licences.** `OverviewLicenseNotification` filtered the list to `License_Type.TRIAL` before deciding what to say, so the Enterprise licence on the core never entered the decision and a licensed cluster was told it was on a trial.

## The change

- `license-utils.tsx`: new `coreHasActiveEnterpriseLicense(licenses)` — true for an unexpired `ENTERPRISE` licence with source `REDPANDA_CORE`.
- `overview-license-notification.tsx`: return `null` when that holds, so the trial notice never shows over an Enterprise-licensed cluster.

Deliberately **core-only**: a Console-side Enterprise licence with the cluster still on its trial keeps the notice, because the copy is about *this cluster*. An expired core Enterprise licence does not suppress it either; the global `LicenseNotification` owns expired-Enterprise messaging.

## Not a Chakra-exit regression

The logic dates from `cec4becba` ("Trial license banners", 2025-07-21). The Phase 2 PR that touched this file (#2634) only swapped `Box` / `Flex` / `Alert` for Registry primitives; the diff has no logic change.

## Tests

`license-utils.test.tsx`: four unit tests for the helper and four render tests for `OverviewLicenseNotification` (built-in trial alone → notice shown; trial + active core Enterprise → hidden; trial + expired core Enterprise → shown; Console Enterprise + core trial → shown). The shared `backend-api` mock gained `isRedpanda`, `clusterOverview` and `refreshClusterOverview`, which the component reads.

## Gates

`bun run type:check` clean · `lint:check` clean on both source files (the test file carries the same pre-existing test-globals diagnostics as `master`) · unit 882 passed · integration 1318 passed.

## Follow-up (not in this PR)

The frontend can only mask the stale snapshot. console-enterprise should re-check the licence after boot (or on `ListLicenses`) so Console's own entry follows an uploaded Enterprise licence without a restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[UX-1488]: https://redpandadata.atlassian.net/browse/UX-1488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ