### PR TITLE
frontend: stop the reassignment wizard failing silently when the bandwidth throttle is set

### DIFF
--- a/frontend/src/components/pages/reassign-partitions/reassign-partitions.tsx
+++ b/frontend/src/components/pages/reassign-partitions/reassign-partitions.tsx
@@ -523,7 +523,9 @@ class ReassignPartitions extends PageComponent {
             // Reset settings, go back to first page
             this.resetSelectionAndPage(true, false);
           }
-        } catch (_err) {
+        } catch (err) {
+          // biome-ignore lint/suspicious/noConsole: the toast promises console detail
+          console.error('start partition reassignment failed', err);
           showToast({
             status: 'error',
             description: 'Error starting partition reassignment.\nSee console for more information.',
@@ -597,9 +599,16 @@ class ReassignPartitions extends PageComponent {
       });
       this.setReassignError(startedCount, errors);
       return false;
-    } catch (_err) {
+    } catch (err) {
       closeToast(toastRef);
-
+      // biome-ignore lint/suspicious/noConsole: the toast promises console detail
+      console.error('startReassignment failed', err);
+      showToast({
+        status: 'error',
+        title: 'Could not start the reassignment',
+        description: err instanceof Error ? err.message : String(err),
+        duration: 6000,
+      });
       return false;
     }
   }
@@ -676,8 +685,18 @@ class ReassignPartitions extends PageComponent {
         duration: 2500,
       });
       return true;
-    } catch (_err) {
+    } catch (err) {
       closeToast(toastRef);
+      // The per-broker patch fails outright on Redpanda ("Setting broker properties on named
+      // brokers is unsupported"), so the message itself is what an operator needs.
+      // biome-ignore lint/suspicious/noConsole: the toast promises console detail
+      console.error('setTrafficLimit failed', err);
+      showToast({
+        status: 'error',
+        title: 'Could not set the bandwidth throttle',
+        description: err instanceof Error ? err.message : String(err),
+        duration: 6000,
+      });
       return false;
     }
   }


### PR DESCRIPTION
## "Start Reassignment" fails silently whenever the bandwidth throttle is above the slider minimum

Found by @eblairmckee while testing #2639 against a 3-broker cluster, and **pre-existing** — none of these lines is a Chakra-exit hunk, so it is split out of that PR rather than folded into an approved swap. One file, three `catch` blocks.

### The symptom

Click **Start Reassignment** with any throttle above the slider's minimum: a toast flashes for a fraction of a second, then nothing. No error, no alert, nothing in the console, and the wizard stays on step 3. Re-clicking behaves the same. The only way to submit is to drag the slider to its minimum.

### Why it fails, and why it is silent

`setTrafficLimit` patches `leader.replication.throttled.rate` / `follower.replication.throttled.rate` per broker. Redpanda does not support per-broker property patches — it uses cluster config — so every broker comes back with an error, **inside an HTTP 200**:

```
PATCH /api/operations/configs → HTTP 200
{"patchedConfigs":[
  {"error":"INVALID_CONFIG: Setting broker properties on named brokers is unsupported","resourceName":"0","resourceType":4},
  {"error":"INVALID_CONFIG: Setting broker properties on named brokers is unsupported","resourceName":"1","resourceType":4},
  {"error":"INVALID_CONFIG: Setting broker properties on named brokers is unsupported","resourceName":"2","resourceType":4}]}
```

The code detects it correctly and then drops it, three layers deep:

- `setTrafficLimit` — `catch (_err) { closeToast(toastRef); return false; }`. That `closeToast` is the flash: the loading toast opens, then closes.
- `startReassignment` — `if (!success) { return false; }`, no message. Its own catch has the same shape.
- `onNextPage` — `if (success) { … }` with no `else`.

The sibling handler's copy even promises "See console for more information" while nothing was ever logged.

### What this changes

Both catches surface the error and log it. The `INVALID_CONFIG` text is genuinely useful to an operator, so it is passed through rather than replaced with a generic string, and `onNextPage`'s handler now logs the detail its own copy promises. No happy-path behaviour changes: every `return false` path already had a toast except these two.

### Deliberately not here

**Whether the throttle should be offered on Redpanda at all is a product call.** It cannot work there, for every broker, every time — and this feature already branches on `api.isRedpanda` (the non-Redpanda warning under Active Reassignments), so disabling the slider with a short explanation is a small change. It would stop people reaching an unreachable path, but it is a product decision rather than a bug fix, so it is left alone here.

### Gates

`type:check` clean · `test:unit` 882 · `test:integration` 1316 · `lint:check` on the changed file reports the same three pre-existing errors as master's copy of it (verified against a probe of `origin/master`), no net-new · `bun run lint` leaves the tree clean.

Not covered by a test: the failure needs a live Redpanda cluster to reproduce, and the change is error-path plumbing rather than logic. Verified by reading the response shape from @eblairmckee's repro above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
