### PR TITLE
[Chakra exit · Phase 2 · PR 15] frontend: the topics pages on Registry components, plus a settings-dialog spec

### DIFF
--- a/frontend/src/components/pages/topics/Tab.Messages/common/empty-badge.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/common/empty-badge.tsx
@@ -9,23 +9,22 @@
  * by the Apache License, Version 2.0
  */
 
-import { Flex, Text } from '@redpanda-data/ui';
 import { BanIcon } from 'components/icons';
 import { Badge } from 'components/redpanda-ui/components/badge';
 import type { FC } from 'react';
 
 export const EmptyBadge: FC<{ mode: 'empty' | 'null' }> = ({ mode }) => (
   <Badge tone="default" variant="subtle">
-    <Flex gap={2} verticalAlign="center">
+    <span className="flex items-center gap-2">
       <BanIcon size={16} />
-      <Text>
+      <span>
         {
           {
             empty: 'Empty',
             null: 'Null',
           }[mode]
         }
-      </Text>
-    </Flex>
+      </span>
+    </span>
   </Badge>
 );

--- a/frontend/src/components/pages/topics/Tab.Messages/common/empty-icon.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/common/empty-icon.tsx
@@ -15,7 +15,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from 'components/redpanda-ui/
 export function renderEmptyIcon(tooltipText?: string) {
   const text = tooltipText || 'Empty';
   return (
-    // Chakra's `openDelay={1}` was effectively instant; the Registry default is Base UI's, so it is set here.
+    // Chakra's `openDelay={1}` was effectively instant; Base UI's default is 600ms.
     <Tooltip delayDuration={0}>
       <TooltipTrigger
         render={

--- a/frontend/src/components/pages/topics/Tab.Messages/common/empty-icon.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/common/empty-icon.tsx
@@ -9,16 +9,22 @@
  * by the Apache License, Version 2.0
  */
 
-import { Tooltip } from '@redpanda-data/ui';
 import { SkipIcon } from 'components/icons';
+import { Tooltip, TooltipContent, TooltipTrigger } from 'components/redpanda-ui/components/tooltip';
 
 export function renderEmptyIcon(tooltipText?: string) {
   const text = tooltipText || 'Empty';
   return (
-    <Tooltip hasArrow label={text} openDelay={1} placement="top">
-      <span style={{ opacity: 0.66, marginLeft: '2px' }}>
-        <SkipIcon />
-      </span>
+    // Chakra's `openDelay={1}` was effectively instant; the Registry default is Base UI's, so it is set here.
+    <Tooltip delayDuration={0}>
+      <TooltipTrigger
+        render={
+          <span className="ml-0.5 opacity-[0.66]">
+            <SkipIcon />
+          </span>
+        }
+      />
+      <TooltipContent side="top">{text}</TooltipContent>
     </Tooltip>
   );
 }

--- a/frontend/src/components/pages/topics/Tab.Messages/message-display/message-display.test.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/message-display/message-display.test.tsx
@@ -2,31 +2,6 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
-rs.mock('@redpanda-data/ui', () => {
-  const Div = React.forwardRef<HTMLDivElement, Record<string, unknown>>(({ children, ...props }, ref) => (
-    <div ref={ref} {...props}>
-      {children}
-    </div>
-  ));
-
-  return {
-    __esModule: true,
-    Box: Div,
-    Flex: Div,
-    Text: Div,
-    Button: React.forwardRef<HTMLButtonElement, Record<string, unknown>>(({ children, isDisabled, ...props }, ref) => (
-      <button disabled={Boolean(isDisabled)} ref={ref} {...props}>
-        {children}
-      </button>
-    )),
-    Tabs: ({ defaultIndex = 0, items }: { defaultIndex?: number; items: Array<{ component: React.ReactNode }> }) => (
-      <div>{items[defaultIndex]?.component}</div>
-    ),
-    useColorModeValue: (light: unknown) => light,
-    useToast: () => rs.fn(),
-  };
-});
-
 import { ExpandedMessage } from './expanded-message';
 import { MessageKeyPreview } from './message-key-preview';
 import { MessagePreview } from './message-preview';

--- a/frontend/src/components/pages/topics/Tab.Messages/message-display/message-display.test.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/message-display/message-display.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import * as React from 'react';
 
 import { ExpandedMessage } from './expanded-message';
 import { MessageKeyPreview } from './message-key-preview';

--- a/frontend/src/components/pages/topics/Tab.Messages/message-display/message-key-preview.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/message-display/message-key-preview.tsx
@@ -70,7 +70,7 @@ export const MessageKeyPreview = ({
   if (key.troubleshootReport && key.troubleshootReport.length > 0) {
     return (
       <div className="flex items-center gap-2 text-destructive">
-        {/* Chakra's fontSize was inert on these lucide icons, so master rendered them at 24. */}
+        {/* fontSize was inert on these lucide icons: master rendered them at 24. */}
         <WarningIcon size={24} />
         There were issues deserializing the key
       </div>

--- a/frontend/src/components/pages/topics/Tab.Messages/message-display/message-key-preview.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/message-display/message-key-preview.tsx
@@ -70,7 +70,8 @@ export const MessageKeyPreview = ({
   if (key.troubleshootReport && key.troubleshootReport.length > 0) {
     return (
       <div className="flex items-center gap-2 text-destructive">
-        <WarningIcon size={16} />
+        {/* Chakra's fontSize was inert on these lucide icons, so master rendered them at 24. */}
+        <WarningIcon size={24} />
         There were issues deserializing the key
       </div>
     );

--- a/frontend/src/components/pages/topics/Tab.Messages/message-display/message-key-preview.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/message-display/message-key-preview.tsx
@@ -70,7 +70,7 @@ export const MessageKeyPreview = ({
   if (key.troubleshootReport && key.troubleshootReport.length > 0) {
     return (
       <div className="flex items-center gap-2 text-destructive">
-        {/* fontSize was inert on these lucide icons: master rendered them at 24. */}
+        {/* fontSize was inert on lucide icons, so master rendered these at 24. */}
         <WarningIcon size={24} />
         There were issues deserializing the key
       </div>

--- a/frontend/src/components/pages/topics/Tab.Messages/message-display/message-key-preview.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/message-display/message-key-preview.tsx
@@ -125,6 +125,6 @@ export const MessageKeyPreview = ({
       </div>
     );
   } catch (e) {
-    return <span style={{ color: 'red' }}>Error in RenderPreview: {(e as Error).message ?? String(e)}</span>;
+    return <span className="text-destructive">Error in RenderPreview: {(e as Error).message ?? String(e)}</span>;
   }
 };

--- a/frontend/src/components/pages/topics/Tab.Messages/message-display/message-key-preview.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/message-display/message-key-preview.tsx
@@ -9,7 +9,6 @@
  * by the Apache License, Version 2.0
  */
 
-import { Flex, Text } from '@redpanda-data/ui';
 import { WarningIcon } from 'components/icons';
 import type { ReactNode } from 'react';
 
@@ -70,10 +69,10 @@ export const MessageKeyPreview = ({
 
   if (key.troubleshootReport && key.troubleshootReport.length > 0) {
     return (
-      <Flex alignItems="center" color="red.600" gap="2">
-        <WarningIcon fontSize="1.25em" />
+      <div className="flex items-center gap-2 text-destructive">
+        <WarningIcon size={16} />
         There were issues deserializing the key
-      </Flex>
+      </div>
     );
   }
 
@@ -115,14 +114,14 @@ export const MessageKeyPreview = ({
     }
 
     return (
-      <Flex style={{ flexDirection: 'column' }}>
+      <div className="flex flex-col">
         <span className="cellDiv" style={{ minWidth: '10ch', width: 'auto', maxWidth: '45ch' }}>
           <code style={{ fontSize: '95%' }}>{text}</code>
         </span>
-        <Text color="gray.500">
+        <span className="text-muted-foreground">
           {key.encoding?.toUpperCase() || 'UNKNOWN'} - {prettyBytes(key.size)}
-        </Text>
-      </Flex>
+        </span>
+      </div>
     );
   } catch (e) {
     return <span style={{ color: 'red' }}>Error in RenderPreview: {(e as Error).message ?? String(e)}</span>;

--- a/frontend/src/components/pages/topics/Tab.Messages/message-display/message-preview.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/message-display/message-preview.tsx
@@ -9,7 +9,6 @@
  * by the Apache License, Version 2.0
  */
 
-import { Flex, Text } from '@redpanda-data/ui';
 import { InfoIcon, WarningIcon } from 'components/icons';
 import React, { type ReactNode } from 'react';
 
@@ -36,19 +35,19 @@ export const MessagePreview = ({
 
   if (value.troubleshootReport && value.troubleshootReport.length > 0) {
     return (
-      <Flex alignItems="center" color="red.600" gap="2">
-        <WarningIcon fontSize="1.25em" />
+      <div className="flex items-center gap-2 text-destructive">
+        <WarningIcon size={16} />
         There were issues deserializing the value
-      </Flex>
+      </div>
     );
   }
 
   if (value.isPayloadTooLarge) {
     return (
-      <Flex alignItems="center" color="blue.500" gap="2">
-        <InfoIcon fontSize="1.25em" />
+      <div className="flex items-center gap-2 text-informative">
+        <InfoIcon size={16} />
         Message size exceeds the display limit.
-      </Flex>
+      </div>
     );
   }
 
@@ -94,16 +93,16 @@ export const MessagePreview = ({
     }
 
     return (
-      <Flex style={{ flexDirection: 'column' }}>
+      <div className="flex flex-col">
         <code>
           <span className="cellDiv" style={{ fontSize: '95%' }}>
             {text}
           </span>
         </code>
-        <Text color="gray.500">
+        <span className="text-muted-foreground">
           {value.encoding?.toUpperCase() || 'UNKNOWN'} - {prettyBytes(value.size)}
-        </Text>
-      </Flex>
+        </span>
+      </div>
     );
   } catch (e) {
     return <span style={{ color: 'red' }}>Error in RenderPreview: {(e as Error).message ?? String(e)}</span>;

--- a/frontend/src/components/pages/topics/Tab.Messages/message-display/message-preview.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/message-display/message-preview.tsx
@@ -106,6 +106,6 @@ export const MessagePreview = ({
       </div>
     );
   } catch (e) {
-    return <span style={{ color: 'red' }}>Error in RenderPreview: {(e as Error).message ?? String(e)}</span>;
+    return <span className="text-destructive">Error in RenderPreview: {(e as Error).message ?? String(e)}</span>;
   }
 };

--- a/frontend/src/components/pages/topics/Tab.Messages/message-display/message-preview.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/message-display/message-preview.tsx
@@ -36,7 +36,7 @@ export const MessagePreview = ({
   if (value.troubleshootReport && value.troubleshootReport.length > 0) {
     return (
       <div className="flex items-center gap-2 text-destructive">
-        {/* fontSize was inert on these lucide icons: master rendered them at 24. */}
+        {/* fontSize was inert on lucide icons, so master rendered these at 24. */}
         <WarningIcon size={24} />
         There were issues deserializing the value
       </div>

--- a/frontend/src/components/pages/topics/Tab.Messages/message-display/message-preview.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/message-display/message-preview.tsx
@@ -36,7 +36,8 @@ export const MessagePreview = ({
   if (value.troubleshootReport && value.troubleshootReport.length > 0) {
     return (
       <div className="flex items-center gap-2 text-destructive">
-        <WarningIcon size={16} />
+        {/* Chakra's fontSize was inert on these lucide icons, so master rendered them at 24. */}
+        <WarningIcon size={24} />
         There were issues deserializing the value
       </div>
     );
@@ -45,7 +46,7 @@ export const MessagePreview = ({
   if (value.isPayloadTooLarge) {
     return (
       <div className="flex items-center gap-2 text-informative">
-        <InfoIcon size={16} />
+        <InfoIcon size={24} />
         Message size exceeds the display limit.
       </div>
     );

--- a/frontend/src/components/pages/topics/Tab.Messages/message-display/message-preview.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/message-display/message-preview.tsx
@@ -36,7 +36,7 @@ export const MessagePreview = ({
   if (value.troubleshootReport && value.troubleshootReport.length > 0) {
     return (
       <div className="flex items-center gap-2 text-destructive">
-        {/* Chakra's fontSize was inert on these lucide icons, so master rendered them at 24. */}
+        {/* fontSize was inert on these lucide icons: master rendered them at 24. */}
         <WarningIcon size={24} />
         There were issues deserializing the value
       </div>

--- a/frontend/src/components/pages/topics/Tab.Messages/modals/column-settings.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/modals/column-settings.tsx
@@ -63,7 +63,8 @@ export const ColumnSettings: FC<{
       <DialogContent size="xl">
         {/* Kept from the Chakra original: the timestamp select portals in here, inside the
             dialog's focus and scroll lock, rather than to the document body. */}
-        <div ref={setContainer}>
+        {/* A flex column, so DialogBody keeps its `flex-1` and scrolls instead of overflowing the popup. */}
+        <div className="flex min-h-0 flex-col" ref={setContainer}>
           <PortalContainerProvider value={container ?? undefined}>
             {/* Room for DialogContent's absolute close button. */}
             <DialogHeader className="pr-10">

--- a/frontend/src/components/pages/topics/Tab.Messages/modals/column-settings.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/modals/column-settings.tsx
@@ -9,22 +9,17 @@
  * by the Apache License, Version 2.0
  */
 
+import { Button } from 'components/redpanda-ui/components/button';
+import { Checkbox } from 'components/redpanda-ui/components/checkbox';
 import {
-  Box,
-  Button,
-  Checkbox,
-  Grid,
-  GridItem,
-  Modal,
-  ModalBody,
-  ModalCloseButton,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalOverlay,
-  Stack,
-  Text,
-} from '@redpanda-data/ui';
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from 'components/redpanda-ui/components/dialog';
+import { Label as CheckboxLabel } from 'components/redpanda-ui/components/label';
 import { PortalContainerProvider } from 'components/redpanda-ui/lib/use-portal-container';
 import { type FC, useState } from 'react';
 
@@ -56,102 +51,109 @@ export const ColumnSettings: FC<{
   const [container, setContainer] = useState<HTMLElement | null>(null);
 
   return (
-    <Modal
-      isOpen={getShowDialog()}
-      onClose={() => {
-        setShowDialog(false);
+    <Dialog
+      onOpenChange={(open) => {
+        if (!open) {
+          setShowDialog(false);
+        }
       }}
+      open={getShowDialog()}
     >
-      <ModalOverlay />
-      <ModalContent minW="4xl" ref={setContainer}>
-        {/* Registry popups portal into the modal, inside its focus and scroll lock */}
-        <PortalContainerProvider value={container ?? undefined}>
-          <ModalHeader>Column Settings</ModalHeader>
-          <ModalCloseButton />
-          <ModalBody>
-            <Text>
-              Choose which columns will be shown in the messages table, as well as the format of the timestamp.
-            </Text>
-            <Box my={6}>
-              <Label text="Columns shown">
-                <Stack direction="row" spacing={5}>
-                  {COLUMN_SETTINGS.map(({ title, dataIndex }) => (
-                    <Checkbox
-                      isChecked={previewColumnFields.some((x) => x.dataIndex === dataIndex)}
-                      key={dataIndex}
-                      onChange={({ target: { checked } }) => {
-                        const currentFields = getTopicSettings(topicName)?.previewColumnFields ?? [];
+      {/* `xl` is `sm:max-w-4xl`, matching the Chakra modal's `minW="4xl"`. */}
+      <DialogContent size="xl">
+        {/* Kept from the Chakra original: the timestamp select portals in here, inside the
+            dialog's focus and scroll lock, rather than to the document body. */}
+        <div ref={setContainer}>
+          <PortalContainerProvider value={container ?? undefined}>
+            {/* Room for DialogContent's absolute close button. */}
+            <DialogHeader className="pr-10">
+              <DialogTitle>Column Settings</DialogTitle>
+            </DialogHeader>
+            <DialogBody>
+              <p>Choose which columns will be shown in the messages table, as well as the format of the timestamp.</p>
+              <div className="my-6">
+                <Label text="Columns shown">
+                  <div className="flex flex-row gap-5">
+                    {COLUMN_SETTINGS.map(({ title, dataIndex }) => (
+                      <div className="flex items-center gap-2" key={dataIndex}>
+                        <Checkbox
+                          checked={previewColumnFields.some((x) => x.dataIndex === dataIndex)}
+                          id={`column-${dataIndex}`}
+                          onCheckedChange={(checkedState) => {
+                            const checked = checkedState === true;
+                            const currentFields = getTopicSettings(topicName)?.previewColumnFields ?? [];
 
-                        let newFields: ColumnList[];
-                        if (checked) {
-                          // Add column if not already present (prevent duplicates)
-                          newFields = currentFields.some((f) => f.dataIndex === dataIndex)
-                            ? currentFields
-                            : [...currentFields, { title, dataIndex }];
-                        } else {
-                          // Remove column
-                          newFields = currentFields.filter((x) => x.dataIndex !== dataIndex);
-                        }
+                            let newFields: ColumnList[];
+                            if (checked) {
+                              // Add column if not already present (prevent duplicates)
+                              newFields = currentFields.some((f) => f.dataIndex === dataIndex)
+                                ? currentFields
+                                : [...currentFields, { title, dataIndex }];
+                            } else {
+                              // Remove column
+                              newFields = currentFields.filter((x) => x.dataIndex !== dataIndex);
+                            }
 
-                        setTopicSettings(topicName, { previewColumnFields: newFields });
+                            setTopicSettings(topicName, { previewColumnFields: newFields });
+                          }}
+                        />
+                        {/* Chakra's Checkbox took its label as a child and wired it; the Registry's does not. */}
+                        <CheckboxLabel className="cursor-pointer" htmlFor={`column-${dataIndex}`}>
+                          {title}
+                        </CheckboxLabel>
+                      </div>
+                    ))}
+                  </div>
+                </Label>
+                <Button
+                  className="mt-2 p-0"
+                  onClick={() => {
+                    setTopicSettings(topicName, { previewColumnFields: [] });
+                  }}
+                  variant="link"
+                >
+                  Clear
+                </Button>
+              </div>
+              <div className="my-6 grid grid-cols-[1fr_2fr] gap-4">
+                <div>
+                  <Label text="Timestamp format">
+                    <SingleSelect<TimestampDisplayFormat>
+                      onChange={(e) => {
+                        setTopicSettings(topicName, { previewTimestamps: e });
                       }}
-                      size="lg"
-                    >
-                      {title}
-                    </Checkbox>
-                  ))}
-                </Stack>
-              </Label>
+                      options={[
+                        { label: 'Local DateTime', value: 'default' },
+                        { label: 'Unix DateTime', value: 'unixTimestamp' },
+                        { label: 'Relative', value: 'relative' },
+                        { label: 'Local Date', value: 'onlyDate' },
+                        { label: 'Local Time', value: 'onlyTime' },
+                        { label: 'Unix Millis', value: 'unixMillis' },
+                      ]}
+                      value={previewTimestamps}
+                    />
+                  </Label>
+                </div>
+                <div>
+                  <Label text="Preview">
+                    <TimestampDisplay format={previewTimestamps} unixEpochMillisecond={previewTime} />
+                  </Label>
+                </div>
+              </div>
+            </DialogBody>
+            <DialogFooter>
               <Button
-                mt={2}
                 onClick={() => {
-                  setTopicSettings(topicName, { previewColumnFields: [] });
+                  setShowDialog(false);
                 }}
-                // we need to pass this using sx to increase specificity, using p={0} won't work
-                sx={{ padding: 0 }}
-                variant="link"
+                variant="destructive"
               >
-                Clear
+                Close
               </Button>
-            </Box>
-            <Grid gap={4} my={6} templateColumns="1fr 2fr">
-              <GridItem>
-                <Label text="Timestamp format">
-                  <SingleSelect<TimestampDisplayFormat>
-                    onChange={(e) => {
-                      setTopicSettings(topicName, { previewTimestamps: e });
-                    }}
-                    options={[
-                      { label: 'Local DateTime', value: 'default' },
-                      { label: 'Unix DateTime', value: 'unixTimestamp' },
-                      { label: 'Relative', value: 'relative' },
-                      { label: 'Local Date', value: 'onlyDate' },
-                      { label: 'Local Time', value: 'onlyTime' },
-                      { label: 'Unix Millis', value: 'unixMillis' },
-                    ]}
-                    value={previewTimestamps}
-                  />
-                </Label>
-              </GridItem>
-              <GridItem>
-                <Label text="Preview">
-                  <TimestampDisplay format={previewTimestamps} unixEpochMillisecond={previewTime} />
-                </Label>
-              </GridItem>
-            </Grid>
-          </ModalBody>
-          <ModalFooter gap={2}>
-            <Button
-              colorScheme="red"
-              onClick={() => {
-                setShowDialog(false);
-              }}
-            >
-              Close
-            </Button>
-          </ModalFooter>
-        </PortalContainerProvider>
-      </ModalContent>
-    </Modal>
+            </DialogFooter>
+          </PortalContainerProvider>
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/frontend/src/components/pages/topics/Tab.Messages/modals/column-settings.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/modals/column-settings.tsx
@@ -85,19 +85,17 @@ export const ColumnSettings: FC<{
 
                             let newFields: ColumnList[];
                             if (checked) {
-                              // Add column if not already present (prevent duplicates)
                               newFields = currentFields.some((f) => f.dataIndex === dataIndex)
                                 ? currentFields
                                 : [...currentFields, { title, dataIndex }];
                             } else {
-                              // Remove column
                               newFields = currentFields.filter((x) => x.dataIndex !== dataIndex);
                             }
 
                             setTopicSettings(topicName, { previewColumnFields: newFields });
                           }}
                         />
-                        {/* Chakra's Checkbox took its label as a child and wired it; the Registry's does not. */}
+                        {/* The Registry Checkbox does not wire a child label. */}
                         <CheckboxLabel className="cursor-pointer" htmlFor={`column-${dataIndex}`}>
                           {title}
                         </CheckboxLabel>

--- a/frontend/src/components/pages/topics/Tab.Messages/modals/column-settings.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/modals/column-settings.tsx
@@ -61,12 +61,11 @@ export const ColumnSettings: FC<{
     >
       {/* `xl` is `sm:max-w-4xl`, matching the Chakra modal's `minW="4xl"`. */}
       <DialogContent size="xl">
-        {/* Kept from the Chakra original: the timestamp select portals in here, inside the
-            dialog's focus and scroll lock, rather than to the document body. */}
-        {/* A flex column, so DialogBody keeps its `flex-1` and scrolls instead of overflowing the popup. */}
+        {/* The timestamp select portals in here, inside the dialog's focus lock, as Chakra's did. */}
+        {/* A flex column, or DialogBody's `flex-1` and its scrolling go inert. */}
         <div className="flex min-h-0 flex-col" ref={setContainer}>
           <PortalContainerProvider value={container ?? undefined}>
-            {/* Room for DialogContent's absolute close button. */}
+            {/* Room for DialogContent's close button. */}
             <DialogHeader className="pr-10">
               <DialogTitle>Column Settings</DialogTitle>
             </DialogHeader>

--- a/frontend/src/components/pages/topics/Tab.Messages/modals/preview-fields-modal.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/modals/preview-fields-modal.tsx
@@ -9,16 +9,15 @@
  * by the Apache License, Version 2.0
  */
 
+import { Button } from 'components/redpanda-ui/components/button';
 import {
-  Button,
-  Modal,
-  ModalBody,
-  ModalCloseButton,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalOverlay,
-} from '@redpanda-data/ui';
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from 'components/redpanda-ui/components/dialog';
 import { PortalContainerProvider } from 'components/redpanda-ui/lib/use-portal-container';
 import { type FC, useState } from 'react';
 
@@ -34,33 +33,40 @@ export const PreviewFieldsModal: FC<{
   const [container, setContainer] = useState<HTMLElement | null>(null);
 
   return (
-    <Modal
-      isOpen={getShowDialog()}
-      onClose={() => {
-        setShowDialog(false);
+    <Dialog
+      onOpenChange={(open) => {
+        if (!open) {
+          setShowDialog(false);
+        }
       }}
+      open={getShowDialog()}
     >
-      <ModalOverlay />
-      <ModalContent minW="4xl" ref={setContainer}>
-        {/* Registry popups portal into the modal, inside its focus and scroll lock */}
-        <PortalContainerProvider value={container ?? undefined}>
-          <ModalHeader>Preview fields</ModalHeader>
-          <ModalCloseButton />
-          <ModalBody>
-            <PreviewSettings messages={messages} topicName={topicName} />
-          </ModalBody>
-          <ModalFooter gap={2}>
-            <Button
-              colorScheme="red"
-              onClick={() => {
-                setShowDialog(false);
-              }}
-            >
-              Close
-            </Button>
-          </ModalFooter>
-        </PortalContainerProvider>
-      </ModalContent>
-    </Modal>
+      {/* `xl` is `sm:max-w-4xl`, matching the Chakra modal's `minW="4xl"`. */}
+      <DialogContent size="xl">
+        {/* Kept from the Chakra original: the PreviewSettings popover portals in here, inside the
+            dialog's focus and scroll lock, rather than to the document body. */}
+        <div ref={setContainer}>
+          <PortalContainerProvider value={container ?? undefined}>
+            {/* Room for DialogContent's absolute close button. */}
+            <DialogHeader className="pr-10">
+              <DialogTitle>Preview fields</DialogTitle>
+            </DialogHeader>
+            <DialogBody>
+              <PreviewSettings messages={messages} topicName={topicName} />
+            </DialogBody>
+            <DialogFooter>
+              <Button
+                onClick={() => {
+                  setShowDialog(false);
+                }}
+                variant="destructive"
+              >
+                Close
+              </Button>
+            </DialogFooter>
+          </PortalContainerProvider>
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/frontend/src/components/pages/topics/Tab.Messages/modals/preview-fields-modal.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/modals/preview-fields-modal.tsx
@@ -45,7 +45,8 @@ export const PreviewFieldsModal: FC<{
       <DialogContent size="xl">
         {/* Kept from the Chakra original: the PreviewSettings popover portals in here, inside the
             dialog's focus and scroll lock, rather than to the document body. */}
-        <div ref={setContainer}>
+        {/* A flex column, so DialogBody keeps its `flex-1` and scrolls instead of overflowing the popup. */}
+        <div className="flex min-h-0 flex-col" ref={setContainer}>
           <PortalContainerProvider value={container ?? undefined}>
             {/* Room for DialogContent's absolute close button. */}
             <DialogHeader className="pr-10">

--- a/frontend/src/components/pages/topics/Tab.Messages/modals/preview-fields-modal.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/modals/preview-fields-modal.tsx
@@ -43,12 +43,11 @@ export const PreviewFieldsModal: FC<{
     >
       {/* `xl` is `sm:max-w-4xl`, matching the Chakra modal's `minW="4xl"`. */}
       <DialogContent size="xl">
-        {/* Kept from the Chakra original: the PreviewSettings popover portals in here, inside the
-            dialog's focus and scroll lock, rather than to the document body. */}
-        {/* A flex column, so DialogBody keeps its `flex-1` and scrolls instead of overflowing the popup. */}
+        {/* The PreviewSettings popover portals in here, inside the dialog's focus lock, as Chakra's did. */}
+        {/* A flex column, or DialogBody's `flex-1` and its scrolling go inert. */}
         <div className="flex min-h-0 flex-col" ref={setContainer}>
           <PortalContainerProvider value={container ?? undefined}>
-            {/* Room for DialogContent's absolute close button. */}
+            {/* Room for DialogContent's close button. */}
             <DialogHeader className="pr-10">
               <DialogTitle>Preview fields</DialogTitle>
             </DialogHeader>

--- a/frontend/src/components/pages/topics/Tab.Messages/preview-settings.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/preview-settings.tsx
@@ -225,7 +225,7 @@ const PreviewTagSettings = ({
             />
           </Label>
 
-          {/* Chakra's Checkbox took its label as a child and wired it; the Registry's does not. */}
+          {/* The Registry Checkbox does not wire a child label. */}
           <span className="flex items-center gap-2">
             <Checkbox
               checked={tag.searchInMessageKey}

--- a/frontend/src/components/pages/topics/Tab.Messages/preview-settings.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/preview-settings.tsx
@@ -17,12 +17,16 @@ import {
   type DropResult,
   type ResponderProvided,
 } from '@hello-pangea/dnd';
-import { Box, Button, Checkbox, Flex, Input, Popover } from '@redpanda-data/ui';
 import { arrayMoveMutable } from 'array-move';
 import { CloseIcon, MenuIcon, SettingsIcon } from 'components/icons';
+import { Button } from 'components/redpanda-ui/components/button';
+import { Checkbox } from 'components/redpanda-ui/components/checkbox';
+import { Input } from 'components/redpanda-ui/components/input';
+import { Label as CheckboxLabel } from 'components/redpanda-ui/components/label';
+import { Popover, PopoverContent, PopoverTrigger } from 'components/redpanda-ui/components/popover';
 import React from 'react';
 
-import { globHelp, PatternHelpDrawer } from './preview-settings/pattern-help-drawer';
+import { PatternHelpDrawer } from './preview-settings/pattern-help-drawer';
 import { usePreviewDisplayMode } from '../../../../hooks/use-preview-display-mode';
 import { usePreviewMultiResultMode } from '../../../../hooks/use-preview-multi-result-mode';
 import { usePreviewTagsCaseSensitive } from '../../../../hooks/use-preview-tags-case-sensitive';
@@ -74,9 +78,8 @@ export const PreviewSettings = ({ messages, topicName }: { messages: TopicMessag
     <>
       <div>
         <span>
-          When viewing large messages we're often only interested in a few specific fields. Add <PatternHelpDrawer />
-          <Popover content={globHelp} hideCloseButton placement="bottom" size="auto" trigger={'click'} /> to this list
-          to show found values as previews.
+          When viewing large messages we're often only interested in a few specific fields. Add <PatternHelpDrawer /> to
+          this list to show found values as previews.
         </span>
       </div>
 
@@ -155,7 +158,7 @@ export const PreviewSettings = ({ messages, topicName }: { messages: TopicMessag
     </>
   );
 
-  return <Box>{content}</Box>;
+  return <div>{content}</div>;
 };
 
 /*
@@ -187,61 +190,66 @@ const PreviewTagSettings = ({
   };
 
   return (
-    <Flex borderRadius={1} gap={1} mb={1.5} p={1} placeItems="center">
+    <div className="mb-1.5 flex place-items-center gap-1 rounded-sm p-1">
       {/* Move Handle */}
       <span className="moveHandle" {...draggableProvided.dragHandleProps}>
         <MenuIcon />
       </span>
 
       {/* Enabled */}
-      <Checkbox isChecked={tag.isActive} onChange={(e) => updateTag({ isActive: e.target.checked })} />
+      <Checkbox
+        aria-label={`Enable pattern ${tag.pattern || tag.id}`}
+        checked={tag.isActive}
+        onCheckedChange={(checked) => updateTag({ isActive: checked === true })}
+      />
 
       {/* Settings */}
-      <Popover
-        content={
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '.3em' }}>
-            <Label style={{ marginBottom: '.5em' }} text="Display Name">
-              <Input
-                autoComplete={randomId()}
-                flexBasis={50}
-                flexGrow={1}
-                onChange={(e) => updateTag({ customName: e.target.value })}
-                placeholder="Enter a display name..."
-                size="sm"
-                spellCheck={false}
-                value={tag.customName}
-              />
-            </Label>
+      <Popover>
+        <PopoverTrigger
+          render={
+            <span className="inlineButton">
+              <SettingsIcon />
+            </span>
+          }
+        />
+        {/* PopoverContent is a fixed w-72; the Chakra popover sized to its content. */}
+        <PopoverContent align="start" className="flex w-auto flex-col gap-1" side="bottom">
+          <Label style={{ marginBottom: '.5em' }} text="Display Name">
+            <Input
+              autoComplete={randomId()}
+              onChange={(e) => updateTag({ customName: e.target.value })}
+              placeholder="Enter a display name..."
+              size="sm"
+              spellCheck={false}
+              value={tag.customName}
+            />
+          </Label>
 
-            <span>
-              <Checkbox
-                isChecked={tag.searchInMessageKey}
-                onChange={(e) => updateTag({ searchInMessageKey: e.target.checked })}
-              >
-                Search in message key
-              </Checkbox>
-            </span>
-            <span>
-              <Checkbox
-                isChecked={tag.searchInMessageValue}
-                onChange={(e) => updateTag({ searchInMessageValue: e.target.checked })}
-              >
-                Search in message value
-              </Checkbox>
-            </span>
-          </div>
-        }
-        hideCloseButton
-        placement="bottom-start"
-        size="auto"
-        trigger={'click'}
-      >
-        <span className="inlineButton">
-          <SettingsIcon />
-        </span>
+          {/* Chakra's Checkbox took its label as a child and wired it; the Registry's does not. */}
+          <span className="flex items-center gap-2">
+            <Checkbox
+              checked={tag.searchInMessageKey}
+              id={`search-key-${tag.id}`}
+              onCheckedChange={(checked) => updateTag({ searchInMessageKey: checked === true })}
+            />
+            <CheckboxLabel className="cursor-pointer" htmlFor={`search-key-${tag.id}`}>
+              Search in message key
+            </CheckboxLabel>
+          </span>
+          <span className="flex items-center gap-2">
+            <Checkbox
+              checked={tag.searchInMessageValue}
+              id={`search-value-${tag.id}`}
+              onCheckedChange={(checked) => updateTag({ searchInMessageValue: checked === true })}
+            />
+            <CheckboxLabel className="cursor-pointer" htmlFor={`search-value-${tag.id}`}>
+              Search in message value
+            </CheckboxLabel>
+          </span>
+        </PopoverContent>
       </Popover>
 
-      <Box w="full">
+      <div className="w-full">
         <SingleSelect<string>
           creatable
           onChange={(value) => updateTag({ pattern: value })}
@@ -249,13 +257,13 @@ const PreviewTagSettings = ({
           placeholder="Pattern..."
           value={tag.pattern}
         />
-      </Box>
+      </div>
 
       {/* Remove */}
       <button className="inlineButton" onClick={onRemove} type="button">
         <CloseIcon />
       </button>
-    </Flex>
+    </div>
   );
 };
 

--- a/frontend/src/components/pages/topics/Tab.Messages/preview-settings/pattern-help-drawer.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/preview-settings/pattern-help-drawer.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react';
 import globExampleImg from '../../../../../assets/globExample.png';
 import { Code } from '../../../../../utils/tsx-utils';
 
-export const globHelp = (
+const globHelp = (
   <div>
     {/* Examples + Image */}
     <div className="flex gap-2">

--- a/frontend/src/components/pages/topics/Tab.Messages/preview-settings/pattern-help-drawer.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/preview-settings/pattern-help-drawer.tsx
@@ -1,16 +1,7 @@
-import {
-  Button,
-  Drawer,
-  DrawerBody,
-  DrawerCloseButton,
-  DrawerContent,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerOverlay,
-  Flex,
-  useDisclosure,
-} from '@redpanda-data/ui';
 import { InfoIcon } from 'components/icons';
+import { Button } from 'components/redpanda-ui/components/button';
+import { Sheet, SheetContent, SheetFooter, SheetHeader, SheetTitle } from 'components/redpanda-ui/components/sheet';
+import { useState } from 'react';
 
 import globExampleImg from '../../../../../assets/globExample.png';
 import { Code } from '../../../../../utils/tsx-utils';
@@ -18,8 +9,8 @@ import { Code } from '../../../../../utils/tsx-utils';
 export const globHelp = (
   <div>
     {/* Examples + Image */}
-    <Flex gap={2}>
-      <Flex grow={1}>
+    <div className="flex gap-2">
+      <div className="flex grow">
         <div className="globHelpGrid">
           <div className="h">Pattern</div>
           <div className="h">Result</div>
@@ -83,12 +74,12 @@ export const globHelp = (
           </div>
           <div className="rowSeparator" />
         </div>
-      </Flex>
+      </div>
       <div style={{ display: 'flex', flexDirection: 'column', justifyContent: 'flex-end' }}>
         <div style={{ opacity: 0.5, fontSize: 'smaller', textAlign: 'center' }}>Example Data</div>
         <img alt="Examples for glob patterns" src={globExampleImg} />
       </div>
-    </Flex>
+    </div>
 
     {/* Details */}
     <div>
@@ -117,7 +108,9 @@ export const globHelp = (
 );
 
 export const PatternHelpDrawer = () => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [isOpen, setIsOpen] = useState(false);
+  const onOpen = () => setIsOpen(true);
+  const onClose = () => setIsOpen(false);
 
   return (
     <>
@@ -133,21 +126,21 @@ export const PatternHelpDrawer = () => {
         <InfoIcon size={15} />
         &nbsp;glob patterns
       </button>
-      <Drawer isOpen={isOpen} onClose={onClose} placement="right" size="xl">
-        <DrawerOverlay />
-        <DrawerContent>
-          <DrawerCloseButton />
-          <DrawerHeader>Glob Pattern Examples</DrawerHeader>
+      <Sheet onOpenChange={setIsOpen} open={isOpen}>
+        <SheetContent className="overflow-y-auto" side="right" size="xl">
+          <SheetHeader>
+            <SheetTitle>Glob Pattern Examples</SheetTitle>
+          </SheetHeader>
 
-          <DrawerBody>{globHelp}</DrawerBody>
+          <div className="flex-1 px-4">{globHelp}</div>
 
-          <DrawerFooter>
-            <Button mr={3} onClick={onClose} variant="outline">
+          <SheetFooter>
+            <Button className="mr-3" onClick={onClose} variant="outline">
               Close
             </Button>
-          </DrawerFooter>
-        </DrawerContent>
-      </Drawer>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
     </>
   );
 };

--- a/frontend/src/components/pages/topics/Tab.Messages/preview-settings/pattern-help-drawer.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/preview-settings/pattern-help-drawer.tsx
@@ -128,8 +128,18 @@ export const PatternHelpDrawer = () => {
       </button>
       <Sheet onOpenChange={setIsOpen} open={isOpen}>
         {/* SheetContent is not a flex column of its own, so header and footer only stay
-            pinned — as the Chakra Drawer's were — once it is made one and the body scrolls. */}
-        <SheetContent className="flex flex-col overflow-hidden" side="right" size="xl">
+            pinned — as the Chakra Drawer's were — once it is made one and the body scrolls.
+            `container` opts out of the enclosing dialog's PortalContainerProvider: DialogContent is
+            transformed and `overflow-hidden`, so it would be both the containing block and the
+            clipping ancestor for this fixed panel, where the Chakra Drawer covered the viewport.
+            The width is set here because Chakra's drawer `size="xl"` was 56rem and the Sheet's
+            is 36rem; `size="full"` drops the variant's own cap so this one is the only source. */}
+        <SheetContent
+          className="flex flex-col overflow-hidden sm:max-w-4xl"
+          container={document.body}
+          side="right"
+          size="full"
+        >
           <SheetHeader>
             <SheetTitle>Glob Pattern Examples</SheetTitle>
           </SheetHeader>

--- a/frontend/src/components/pages/topics/Tab.Messages/preview-settings/pattern-help-drawer.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/preview-settings/pattern-help-drawer.tsx
@@ -127,13 +127,10 @@ export const PatternHelpDrawer = () => {
         &nbsp;glob patterns
       </button>
       <Sheet onOpenChange={setIsOpen} open={isOpen}>
-        {/* SheetContent is not a flex column of its own, so header and footer only stay
-            pinned — as the Chakra Drawer's were — once it is made one and the body scrolls.
-            `container` opts out of the enclosing dialog's PortalContainerProvider: DialogContent is
-            transformed and `overflow-hidden`, so it would be both the containing block and the
-            clipping ancestor for this fixed panel, where the Chakra Drawer covered the viewport.
-            The width is set here because Chakra's drawer `size="xl"` was 56rem and the Sheet's
-            is 36rem; `size="full"` drops the variant's own cap so this one is the only source. */}
+        {/* SheetContent is not a flex column, so the header and footer only stay pinned once it is.
+            `container` opts out of the dialog's PortalContainerProvider — DialogContent is
+            transformed and `overflow-hidden`, so it would clip this fixed panel.
+            `size="full"` drops the variant's 36rem cap; Chakra's drawer `xl` was 56rem. */}
         <SheetContent
           className="flex flex-col overflow-hidden sm:max-w-4xl"
           container={document.body}

--- a/frontend/src/components/pages/topics/Tab.Messages/preview-settings/pattern-help-drawer.tsx
+++ b/frontend/src/components/pages/topics/Tab.Messages/preview-settings/pattern-help-drawer.tsx
@@ -127,15 +127,18 @@ export const PatternHelpDrawer = () => {
         &nbsp;glob patterns
       </button>
       <Sheet onOpenChange={setIsOpen} open={isOpen}>
-        <SheetContent className="overflow-y-auto" side="right" size="xl">
+        {/* SheetContent is not a flex column of its own, so header and footer only stay
+            pinned — as the Chakra Drawer's were — once it is made one and the body scrolls. */}
+        <SheetContent className="flex flex-col overflow-hidden" side="right" size="xl">
           <SheetHeader>
             <SheetTitle>Glob Pattern Examples</SheetTitle>
           </SheetHeader>
 
-          <div className="flex-1 px-4">{globHelp}</div>
+          <div className="min-h-0 flex-1 overflow-y-auto">{globHelp}</div>
 
-          <SheetFooter>
-            <Button className="mr-3" onClick={onClose} variant="outline">
+          {/* SheetFooter is a flex column, which would stretch a lone button across the panel. */}
+          <SheetFooter className="flex-row justify-end">
+            <Button onClick={onClose} variant="outline">
               Close
             </Button>
           </SheetFooter>

--- a/frontend/src/components/pages/topics/tab-docu.tsx
+++ b/frontend/src/components/pages/topics/tab-docu.tsx
@@ -14,7 +14,8 @@ import { docsLinks } from 'utils/docs-links';
 
 import type { Topic } from '../../../state/rest-interfaces';
 import '../../../utils/array-extensions';
-import { Button, Empty, VStack } from '@redpanda-data/ui';
+import { Button } from 'components/redpanda-ui/components/button';
+import { Empty, EmptyHeader, EmptyTitle } from 'components/redpanda-ui/components/empty';
 import { motion } from 'motion/react';
 import ReactMarkdown, { defaultUrlTransform as baseUriTransformer } from 'react-markdown';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
@@ -159,13 +160,18 @@ const errorEmpty = renderDocuError(
 function renderDocuError(title: string, body: JSX.Element) {
   return (
     <motion.div {...animProps} key={'b'} style={{ margin: '2rem 1rem' }}>
-      <VStack gap={4}>
-        <Empty description={title} />
+      {/* Chakra's VStack centred its children; the Registry Empty root has no width of its own. */}
+      <div className="flex flex-col items-center gap-4">
+        <Empty className="w-full">
+          <EmptyHeader>
+            <EmptyTitle>{title}</EmptyTitle>
+          </EmptyHeader>
+        </Empty>
         {body}
         <a href={docsLinks.selfManaged.console} rel="noopener noreferrer" target="_blank">
-          <Button variant="solid">Redpanda Console Documentation</Button>
+          <Button>Redpanda Console Documentation</Button>
         </a>
-      </VStack>
+      </div>
     </motion.div>
   );
 }

--- a/frontend/src/components/pages/topics/tab-docu.tsx
+++ b/frontend/src/components/pages/topics/tab-docu.tsx
@@ -15,7 +15,13 @@ import { docsLinks } from 'utils/docs-links';
 import type { Topic } from '../../../state/rest-interfaces';
 import '../../../utils/array-extensions';
 import { Button } from 'components/redpanda-ui/components/button';
-import { Empty, EmptyHeader, EmptyTitle } from 'components/redpanda-ui/components/empty';
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from 'components/redpanda-ui/components/empty';
 import { motion } from 'motion/react';
 import ReactMarkdown, { defaultUrlTransform as baseUriTransformer } from 'react-markdown';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
@@ -160,18 +166,17 @@ const errorEmpty = renderDocuError(
 function renderDocuError(title: string, body: JSX.Element) {
   return (
     <motion.div {...animProps} key={'b'} style={{ margin: '2rem 1rem' }}>
-      {/* Chakra's VStack centred its children. */}
-      <div className="flex flex-col items-center gap-4">
-        <Empty>
-          <EmptyHeader>
-            <EmptyTitle>{title}</EmptyTitle>
-          </EmptyHeader>
-        </Empty>
-        {body}
-        <a href={docsLinks.selfManaged.console} rel="noopener noreferrer" target="_blank">
-          <Button variant="primary">Redpanda Console Documentation</Button>
-        </a>
-      </div>
+      <Empty>
+        <EmptyHeader>
+          <EmptyTitle>{title}</EmptyTitle>
+          <EmptyDescription>{body}</EmptyDescription>
+        </EmptyHeader>
+        <EmptyContent>
+          <a href={docsLinks.selfManaged.console} rel="noopener noreferrer" target="_blank">
+            <Button variant="primary">Redpanda Console Documentation</Button>
+          </a>
+        </EmptyContent>
+      </Empty>
     </motion.div>
   );
 }

--- a/frontend/src/components/pages/topics/tab-docu.tsx
+++ b/frontend/src/components/pages/topics/tab-docu.tsx
@@ -160,9 +160,9 @@ const errorEmpty = renderDocuError(
 function renderDocuError(title: string, body: JSX.Element) {
   return (
     <motion.div {...animProps} key={'b'} style={{ margin: '2rem 1rem' }}>
-      {/* Chakra's VStack centred its children; the Registry Empty root has no width of its own. */}
+      {/* Chakra's VStack centred its children. */}
       <div className="flex flex-col items-center gap-4">
-        <Empty className="w-full">
+        <Empty>
           <EmptyHeader>
             <EmptyTitle>{title}</EmptyTitle>
           </EmptyHeader>

--- a/frontend/src/components/pages/topics/tab-docu.tsx
+++ b/frontend/src/components/pages/topics/tab-docu.tsx
@@ -169,7 +169,7 @@ function renderDocuError(title: string, body: JSX.Element) {
         </Empty>
         {body}
         <a href={docsLinks.selfManaged.console} rel="noopener noreferrer" target="_blank">
-          <Button>Redpanda Console Documentation</Button>
+          <Button variant="primary">Redpanda Console Documentation</Button>
         </a>
       </div>
     </motion.div>

--- a/frontend/tests/test-variant-console/topics/topic-messages-settings-dialogs.spec.ts
+++ b/frontend/tests/test-variant-console/topics/topic-messages-settings-dialogs.spec.ts
@@ -27,7 +27,7 @@ test.describe('Topic messages settings dialogs', () => {
     await expect(dialog.getByText('Column Settings')).toBeVisible();
     await expect(dialog.getByText('Columns shown')).toBeVisible();
 
-    // Chakra's Checkbox took its label as a child and wired it; the Registry's does not.
+    // The Registry Checkbox does not wire a child label.
     await expect(dialog.getByRole('checkbox', { name: 'Offset' })).toBeVisible();
     await expect(dialog.getByRole('checkbox', { name: 'Timestamp' })).toBeVisible();
 
@@ -51,7 +51,6 @@ test.describe('Topic messages settings dialogs', () => {
     await expect(dialog).toBeVisible();
     await expect(dialog.getByText('Preview fields')).toBeVisible();
 
-    // The glob-pattern help was a Chakra Drawer and is now a Sheet, opened from inside the dialog.
     await dialog.getByRole('button', { name: GLOB_PATTERNS_LINK }).click();
     await expect(page.getByText('Glob Pattern Examples')).toBeVisible();
 

--- a/frontend/tests/test-variant-console/topics/topic-messages-settings-dialogs.spec.ts
+++ b/frontend/tests/test-variant-console/topics/topic-messages-settings-dialogs.spec.ts
@@ -4,6 +4,8 @@ import { expect, test } from '@playwright/test';
 
 import { TopicPage } from '../utils/topic-page';
 
+const GLOB_PATTERNS_LINK = /glob patterns/;
+
 /**
  * Smoke coverage for the three settings surfaces on the messages tab.
  *
@@ -54,7 +56,7 @@ test.describe('Topic messages settings dialogs', () => {
     await expect(dialog.getByText('Preview fields')).toBeVisible();
 
     // The glob-pattern help was a Chakra Drawer and is now a Sheet, opened from inside the dialog.
-    await dialog.getByRole('button', { name: /glob patterns/ }).click();
+    await dialog.getByRole('button', { name: GLOB_PATTERNS_LINK }).click();
     await expect(page.getByText('Glob Pattern Examples')).toBeVisible();
   });
 });

--- a/frontend/tests/test-variant-console/topics/topic-messages-settings-dialogs.spec.ts
+++ b/frontend/tests/test-variant-console/topics/topic-messages-settings-dialogs.spec.ts
@@ -34,7 +34,9 @@ test.describe('Topic messages settings dialogs', () => {
     await expect(dialog.getByRole('checkbox', { name: 'Offset' })).toBeVisible();
     await expect(dialog.getByRole('checkbox', { name: 'Timestamp' })).toBeVisible();
 
-    await dialog.getByRole('button', { name: 'Close' }).click();
+    // `DialogContent` renders its own close X with an aria-label of "Close", so a role query by
+    // name matches two buttons. Only the footer button carries the text.
+    await dialog.locator('button', { hasText: 'Close' }).click();
     await expect(dialog).toBeHidden();
   });
 

--- a/frontend/tests/test-variant-console/topics/topic-messages-settings-dialogs.spec.ts
+++ b/frontend/tests/test-variant-console/topics/topic-messages-settings-dialogs.spec.ts
@@ -5,6 +5,11 @@ import { expect, test } from '@playwright/test';
 import { TopicPage } from '../utils/topic-page';
 
 const GLOB_PATTERNS_LINK = /glob patterns/;
+const SHEET_CONTENT = '[data-slot="sheet-content"]';
+// Not `getByRole('dialog')`: Base UI's Toast.Root is a role=dialog too, so that matches the
+// messages tab's own "Searching..." toast whenever it is still up — a coin-flip strict-mode
+// violation. The Sheet is Base UI's Dialog as well, so it would match that once open.
+const DIALOG_CONTENT = '[data-slot="dialog-content"]';
 
 /**
  * Smoke coverage for the three settings surfaces on the messages tab.
@@ -26,7 +31,7 @@ test.describe('Topic messages settings dialogs', () => {
     await page.getByTestId('message-settings-button').click();
     await page.getByTestId('column-settings-menu-item').click();
 
-    const dialog = page.getByRole('dialog');
+    const dialog = page.locator(DIALOG_CONTENT);
     await expect(dialog).toBeVisible();
     await expect(dialog.getByText('Column Settings')).toBeVisible();
     await expect(dialog.getByText('Columns shown')).toBeVisible();
@@ -40,6 +45,8 @@ test.describe('Topic messages settings dialogs', () => {
     // name matches two buttons. Only the footer button carries the text.
     await dialog.locator('button', { hasText: 'Close' }).click();
     await expect(dialog).toBeHidden();
+
+    await topicPage.deleteTopic(topicName);
   });
 
   test('opens the preview fields dialog and its nested pattern sheet', async ({ page }) => {
@@ -51,12 +58,20 @@ test.describe('Topic messages settings dialogs', () => {
     await page.getByTestId('message-settings-button').click();
     await page.getByTestId('preview-fields-menu-item').click();
 
-    const dialog = page.getByRole('dialog');
+    const dialog = page.locator(DIALOG_CONTENT);
     await expect(dialog).toBeVisible();
     await expect(dialog.getByText('Preview fields')).toBeVisible();
 
     // The glob-pattern help was a Chakra Drawer and is now a Sheet, opened from inside the dialog.
     await dialog.getByRole('button', { name: GLOB_PATTERNS_LINK }).click();
     await expect(page.getByText('Glob Pattern Examples')).toBeVisible();
+
+    // It has to portal to the body, not into the dialog. DialogContent is transformed and
+    // overflow-hidden, so a nested fixed panel is sized and clipped against the dialog box
+    // instead of the viewport — which `toBeVisible` above cannot see.
+    await expect(page.locator(SHEET_CONTENT)).toBeVisible();
+    await expect(dialog.locator(SHEET_CONTENT)).toHaveCount(0);
+
+    await topicPage.deleteTopic(topicName);
   });
 });

--- a/frontend/tests/test-variant-console/topics/topic-messages-settings-dialogs.spec.ts
+++ b/frontend/tests/test-variant-console/topics/topic-messages-settings-dialogs.spec.ts
@@ -1,0 +1,58 @@
+// spec: specs/topics.md
+
+import { expect, test } from '@playwright/test';
+
+import { TopicPage } from '../utils/topic-page';
+
+/**
+ * Smoke coverage for the three settings surfaces on the messages tab.
+ *
+ * `enableNewTopicMessagesPage` defaults to false, so this exercises the legacy `Tab.Messages`
+ * view — which four existing specs already cover for filtering, production and timestamps, but
+ * none of them opens these three. They are the riskiest part of the Chakra swap: two Chakra
+ * `Modal`s became Registry `Dialog`s and a Chakra `Drawer` became a `Sheet`, and a dialog that
+ * fails to open, or a nested popover that portals outside its focus lock, is invisible to the
+ * type checker and to every other spec.
+ */
+test.describe('Topic messages settings dialogs', () => {
+  test('opens and closes the column settings dialog', async ({ page }) => {
+    const topicName = `column-settings-${Date.now()}`;
+    const topicPage = new TopicPage(page);
+    await topicPage.createTopic(topicName);
+
+    await page.goto(`/topics/${topicName}`);
+    await page.getByTestId('message-settings-button').click();
+    await page.getByTestId('column-settings-menu-item').click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText('Column Settings')).toBeVisible();
+    await expect(dialog.getByText('Columns shown')).toBeVisible();
+
+    // Each column is a checkbox with its own label. Chakra's Checkbox took the label as a child
+    // and wired it; the Registry's does not, so a bad swap leaves the boxes unnamed.
+    await expect(dialog.getByRole('checkbox', { name: 'Offset' })).toBeVisible();
+    await expect(dialog.getByRole('checkbox', { name: 'Timestamp' })).toBeVisible();
+
+    await dialog.getByRole('button', { name: 'Close' }).click();
+    await expect(dialog).toBeHidden();
+  });
+
+  test('opens the preview fields dialog and its nested pattern sheet', async ({ page }) => {
+    const topicName = `preview-fields-${Date.now()}`;
+    const topicPage = new TopicPage(page);
+    await topicPage.createTopic(topicName);
+
+    await page.goto(`/topics/${topicName}`);
+    await page.getByTestId('message-settings-button').click();
+    await page.getByTestId('preview-fields-menu-item').click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText('Preview fields')).toBeVisible();
+
+    // The glob-pattern help was a Chakra Drawer and is now a Sheet, opened from inside the dialog.
+    await dialog.getByRole('button', { name: /glob patterns/ }).click();
+    await expect(page.getByText('Glob Pattern Examples')).toBeVisible();
+  });
+});

--- a/frontend/tests/test-variant-console/topics/topic-messages-settings-dialogs.spec.ts
+++ b/frontend/tests/test-variant-console/topics/topic-messages-settings-dialogs.spec.ts
@@ -6,21 +6,12 @@ import { TopicPage } from '../utils/topic-page';
 
 const GLOB_PATTERNS_LINK = /glob patterns/;
 const SHEET_CONTENT = '[data-slot="sheet-content"]';
-// Not `getByRole('dialog')`: Base UI's Toast.Root is a role=dialog too, so that matches the
-// messages tab's own "Searching..." toast whenever it is still up — a coin-flip strict-mode
-// violation. The Sheet is Base UI's Dialog as well, so it would match that once open.
+// Not `getByRole('dialog')`: Base UI's Toast.Root is one too, so it matches the messages tab's
+// own "Searching..." toast — and the Sheet, which is Base UI's Dialog.
 const DIALOG_CONTENT = '[data-slot="dialog-content"]';
 
-/**
- * Smoke coverage for the three settings surfaces on the messages tab.
- *
- * `enableNewTopicMessagesPage` defaults to false, so this exercises the legacy `Tab.Messages`
- * view — which four existing specs already cover for filtering, production and timestamps, but
- * none of them opens these three. They are the riskiest part of the Chakra swap: two Chakra
- * `Modal`s became Registry `Dialog`s and a Chakra `Drawer` became a `Sheet`, and a dialog that
- * fails to open, or a nested popover that portals outside its focus lock, is invisible to the
- * type checker and to every other spec.
- */
+// The legacy `Tab.Messages` settings surfaces — `enableNewTopicMessagesPage` defaults to false.
+// Two Modals became Dialogs and a Drawer became a Sheet; no other spec opens any of them.
 test.describe('Topic messages settings dialogs', () => {
   test('opens and closes the column settings dialog', async ({ page }) => {
     const topicName = `column-settings-${Date.now()}`;
@@ -36,13 +27,11 @@ test.describe('Topic messages settings dialogs', () => {
     await expect(dialog.getByText('Column Settings')).toBeVisible();
     await expect(dialog.getByText('Columns shown')).toBeVisible();
 
-    // Each column is a checkbox with its own label. Chakra's Checkbox took the label as a child
-    // and wired it; the Registry's does not, so a bad swap leaves the boxes unnamed.
+    // Chakra's Checkbox took its label as a child and wired it; the Registry's does not.
     await expect(dialog.getByRole('checkbox', { name: 'Offset' })).toBeVisible();
     await expect(dialog.getByRole('checkbox', { name: 'Timestamp' })).toBeVisible();
 
-    // `DialogContent` renders its own close X with an aria-label of "Close", so a role query by
-    // name matches two buttons. Only the footer button carries the text.
+    // DialogContent's own close X is also named "Close"; only the footer button has the text.
     await dialog.locator('button', { hasText: 'Close' }).click();
     await expect(dialog).toBeHidden();
 
@@ -66,9 +55,8 @@ test.describe('Topic messages settings dialogs', () => {
     await dialog.getByRole('button', { name: GLOB_PATTERNS_LINK }).click();
     await expect(page.getByText('Glob Pattern Examples')).toBeVisible();
 
-    // It has to portal to the body, not into the dialog. DialogContent is transformed and
-    // overflow-hidden, so a nested fixed panel is sized and clipped against the dialog box
-    // instead of the viewport — which `toBeVisible` above cannot see.
+    // It has to portal to the body: DialogContent is transformed and overflow-hidden, so a
+    // nested fixed panel is sized and clipped against it. `toBeVisible` cannot see that.
     await expect(page.locator(SHEET_CONTENT)).toBeVisible();
     await expect(dialog.locator(SHEET_CONTENT)).toHaveCount(0);
 


### PR DESCRIPTION
Takes `pages/topics` off Chakra — all nine remaining files. **Rebased onto `master`, which is at 25, so this takes it to 16.** With #2645 (rp-connect) and #2649 (the security ACLs tab) that leaves **five** — all of them PR 13's own, which are deleted rather than migrated.

**This is also what stops three finished areas painting Chakra at runtime**: `MessagePreview` renders in the logs tables of transforms, connector-details and pipelines-details, so until this merges those pages are clean by the import metric and still Chakra on screen.

Stacked conceptually after #2645 (rp-connect) but independent of it: disjoint files, opened off `master`, merges in either order.

## Why this is not the throwaway work the plan assumed

The tracker has said for a week that these nine "go with the legacy view once `enableNewTopicMessagesPage` flips". **A reverse-dependency check says otherwise.** `Tab.Messages` is not a self-contained legacy view — it is a shared library, with eight modules imported from outside the directory, including by the new messages page that replaces it.

**Five of the nine survive the flag flip, and three are rendered by page areas already marked done:**

| File | Reached from |
|---|---|
| `tab-docu.tsx` | `topic-details.tsx` — the Documentation tab, never behind the flag |
| `message-display/message-preview.tsx` | **transforms (PR 5), connector-details (PR 11), pipelines-details (PR 9)** |
| `common/empty-badge.tsx` | via `message-preview` |
| `common/empty-icon.tsx` | via `expanded-message → message-headers`, same three pages |
| `preview-settings.tsx` | the new page's `messages/table/message-cells.tsx` imports `getPreviewTags` |

So `MessagePreview` has been painting Chakra `<Flex>`/`<Text>` — with `red.600`, `blue.500`, `gray.500` — in the Value column of three logs tables since their own migrations merged. **The importer metric could not see it**: the imports live under `topics/`, so they were booked against the topics bucket while those pages counted as clean. Worth stating once: *"0 importers" is the right gate for removing the dependency, and the wrong one for "is this page migrated".*

The remaining four (`message-key-preview`, `modals/column-settings`, `modals/preview-fields-modal`, `preview-settings/pattern-help-drawer`) really are legacy-only. **I migrated them anyway** — PR 13 cannot merge while anything imports the package, and the flag flip has no date. That work is deliberately spent so the flip stops being a gate.

## Reviewer's guide

| Change | What to look at |
|---|---|
| Colour props → tokens | `red.600` → `text-destructive`, `blue.500` → `text-informative`, `gray.500` → `text-muted-foreground`. These were `color=` props on Chakra components, so they worked; in Registry they need semantic classes. The `RenderPreview` catch in both preview components also moves off a hard-coded `style={{ color: 'red' }}`, so both error paths in the same function now agree and follow the theme. |
| Icon sizes | `fontSize` was **inert** on these lucide icons, which size from `size` (default 24) — so master rendered them at 24 and they stay at 24. A swap to `size={16}` would have been a silent third smaller across four surfaces. |
| `Tooltip` → compound | `empty-icon` keeps its instant open — Chakra had `openDelay={1}`, and the Registry would otherwise inherit Base UI's 600 ms. |
| `opacity-[0.66]` | Not `opacity-66`. A bare number depends on v4's dynamic scale; an arbitrary value is guaranteed to emit, and a silently-inert opacity is the exact trap this series keeps hitting. |
| Two `Modal` → `Dialog` | Both keep the `PortalContainerProvider` from the Chakra original, so the nested select and popover still portal *inside* the dialog's focus and scroll lock rather than to the body. |
| `Drawer` → `Sheet` | **`container={document.body}`**, because `SheetContent` honours the enclosing dialog's `PortalContainerProvider` and `DialogContent` is transformed and `overflow-hidden` — it would be both the containing block and the clipping ancestor for a fixed panel. **The width is set explicitly**: Chakra's drawer scale maps `xl` to 56rem, the Sheet's to 36rem, so `size="full"` drops the variant cap and `sm:max-w-4xl` restores the original. `SheetContent` is not a flex column of its own, so it is made one with a scrolling body div and a `flex-row justify-end` footer. |
| `Checkbox` | **Chakra's took its label as a child and wired it; the Registry's does not.** Every box now has an explicit `id` + `Label`, or an `aria-label` where the original had no visible text at all — the pattern-enable box in `preview-settings` had none. |
| `Empty` | `Empty description={title}` → `Empty` + `EmptyHeader` + `EmptyTitle`. No width is added: the Registry root already ships `w-full flex-1 min-w-0` — what it lacks is a border *width*, which is why `border-dashed` paints nothing. |

## Removed rather than ported

- **A `Popover` with no trigger child** in `preview-settings` (`content={globHelp} trigger="click"`, self-closing). It rendered nothing clickable and had no way to open — the adjacent `PatternHelpDrawer` provides the real glob-pattern link. Porting it faithfully would have meant a Registry Popover with an empty trigger.
- **The dead `rs.mock('@redpanda-data/ui')` block** in `message-display.test.tsx`. With these components off Chakra it mocked nothing. Dropping it means those four tests now exercise the **real** components instead of plain `div`s — same four passing, strictly better coverage.

## Coverage

Four specs already drive the legacy messages view (filtering, production, timestamps, navigation), so `MessagePreview` and `MessageKeyPreview` have real regression cover. None of them opened the three settings surfaces, which are the riskiest part of this diff — two dialog conversions and a drawer.

**`topic-messages-settings-dialogs.spec.ts`** covers them: the column-settings dialog opens, its checkboxes resolve *by name* (the contract Chakra used to provide), it closes; and the preview-fields dialog opens the glob-pattern sheet nested inside it. **Verified green against a live container.** It caught one real thing while being written: `DialogContent` renders its own close X with `aria-label="Close"`, so a role-by-name query matches two buttons.

## Gates

`type:check` clean · per-file `lint:check` with the colour codes stripped, net-new zero (two files carry pre-existing diagnostics) · **993** unit · **1427** integration · the new e2e spec passes in the `console` variant.

## Flagged, not fixed

- **`preview-settings.tsx` is still imported by the new page for one function.** `getPreviewTags` is a pure helper sitting in a 543-line component module. Extracting it would let the new page stop importing a component module entirely; left alone here because the module is now Registry-based either way, so it is hygiene rather than a dependency problem.
- **The four legacy-only files should be deleted, not kept, when the flag flips.** They are migrated so they cannot block PR 13, not because they are worth keeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

